### PR TITLE
Move Scribe collector/config to zipkin-scribe

### DIFF
--- a/zipkin-scribe/config/collector-dev.scala
+++ b/zipkin-scribe/config/collector-dev.scala
@@ -22,7 +22,7 @@ import com.twitter.logging.config._
 import com.twitter.ostrich.admin.{TimeSeriesCollectorFactory, JsonStatsLoggerFactory, StatsFactory}
 
 // development mode.
-new ZipkinCollectorConfig {
+new ScribeZipkinCollectorConfig {
 
   serverPort = 9410
   adminPort  = 9900

--- a/zipkin-scribe/src/main/scala/com/twitter/zipkin/collector/Main.scala
+++ b/zipkin-scribe/src/main/scala/com/twitter/zipkin/collector/Main.scala
@@ -1,6 +1,6 @@
 /*
  * Copyright 2012 Twitter Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/zipkin-scribe/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorService.scala
+++ b/zipkin-scribe/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorService.scala
@@ -74,7 +74,7 @@ class ScribeCollectorService(config: ZipkinCollectorConfig, val writeQueue: Writ
       return TryLater
     }
 
-    Stats.addMetric("scribe_size", logEntries.map(_.message).foldLeft(0)((size, str) => size + str.size))
+    Stats.addMetric("scribe_size", logEntries.map(_.message).foldLeft(0)((size,str) => size + str.size))
 
     if (logEntries.isEmpty) {
       Stats.incr("collector.empty_logentry")

--- a/zipkin-scribe/src/main/scala/com/twitter/zipkin/config/ScribeCollectorServerConfig.scala
+++ b/zipkin-scribe/src/main/scala/com/twitter/zipkin/config/ScribeCollectorServerConfig.scala
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.twitter.zipkin.config.collector
+package com.twitter.zipkin.config
 
 import com.twitter.finagle.builder.{ServerBuilder, Server}
 import com.twitter.finagle.thrift.ThriftServerFramedCodec
 import com.twitter.logging.Logger
 import com.twitter.ostrich.admin.ServiceTracker
 import com.twitter.zipkin.collector.ScribeCollectorService
-import com.twitter.zipkin.config.ZipkinCollectorConfig
 import com.twitter.zipkin.gen
 import org.apache.thrift.protocol.TBinaryProtocol
+import com.twitter.zipkin.config.collector.CollectorServerConfig
 
-class ScribeCollectorServerConfig(config: ZipkinCollectorConfig) extends CollectorServerConfig {
+class ScribeCollectorServerConfig(config: ScribeZipkinCollectorConfig) extends CollectorServerConfig {
 
   val log = Logger.get(Logger.getClass)
 
@@ -35,7 +35,7 @@ class ScribeCollectorServerConfig(config: ZipkinCollectorConfig) extends Collect
     log.info("Starting collector service on addr " + config.serverAddr)
 
     /* Start the service */
-    val service = new ScribeCollectorService(config, categories)
+    val service = new ScribeCollectorService(config, config.writeQueue, categories)
     service.start()
     ServiceTracker.register(service)
 

--- a/zipkin-scribe/src/main/scala/com/twitter/zipkin/config/ScribeZipkinCollectorConfig.scala
+++ b/zipkin-scribe/src/main/scala/com/twitter/zipkin/config/ScribeZipkinCollectorConfig.scala
@@ -1,0 +1,7 @@
+package com.twitter.zipkin.config
+
+import com.twitter.zipkin.config.collector.CollectorServerConfig
+
+trait ScribeZipkinCollectorConfig extends ZipkinCollectorConfig {
+  val serverConfig: CollectorServerConfig = new ScribeCollectorServerConfig(this)
+}

--- a/zipkin-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
+++ b/zipkin-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
@@ -1,6 +1,6 @@
 /*
  * Copyright 2012 Twitter Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -20,14 +20,16 @@ import com.twitter.scrooge.BinaryThriftStructSerializer
 import com.twitter.util.Future
 import com.twitter.zipkin.common.{Span, Annotation}
 import com.twitter.zipkin.config.sampler.AdjustableRateConfig
-import com.twitter.zipkin.config.ZipkinCollectorConfig
 import com.twitter.zipkin.gen
+import com.twitter.zipkin.adapter.ThriftAdapter
 import org.specs.Specification
 import org.specs.mock.{ClassMocker, JMocker}
-import com.twitter.zipkin.adapter.ThriftAdapter
+import com.twitter.zipkin.config.{ScribeZipkinCollectorConfig}
 
-class CollectorServiceSpec extends Specification with JMocker with ClassMocker {
-  val serializer = new BinaryThriftStructSerializer[gen.Span] { def codec = gen.Span }
+class ScribeCollectorServiceSpec extends Specification with JMocker with ClassMocker {
+  val serializer = new BinaryThriftStructSerializer[gen.Span] {
+    def codec = gen.Span
+  }
 
   val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)), Nil)
   val validList = List(gen.LogEntry("b3", serializer.toString(ThriftAdapter(validSpan))))
@@ -39,18 +41,22 @@ class CollectorServiceSpec extends Specification with JMocker with ClassMocker {
   val queue = mock[WriteQueue]
   val zkSampleRateConfig = mock[AdjustableRateConfig]
 
-  val config = new ZipkinCollectorConfig {
+  val config = new ScribeZipkinCollectorConfig {
     def writeQueueConfig = null
+
     def zkConfig = null
+
     def indexConfig = null
+
     def storageConfig = null
+
     def methodConfig = null
 
     override lazy val writeQueue = queue
     override lazy val sampleRateConfig = zkSampleRateConfig
   }
 
-  def scribeCollectorService = new ScribeCollectorService(config, Set("b3")) {
+  def scribeCollectorService = new ScribeCollectorService(config, config.writeQueue, Set("b3")) {
     running = true
   }
 
@@ -59,7 +65,7 @@ class CollectorServiceSpec extends Specification with JMocker with ClassMocker {
       val cs = scribeCollectorService
 
       expect {
-        one(queue).add(List(base64)) willReturn(true)
+        one(queue).add(List(base64)) willReturn (true)
       }
 
       gen.ResultCode.Ok mustEqual cs.log(validList)()
@@ -69,7 +75,7 @@ class CollectorServiceSpec extends Specification with JMocker with ClassMocker {
       val cs = scribeCollectorService
 
       expect {
-        one(queue).add(List(base64)) willReturn(false)
+        one(queue).add(List(base64)) willReturn (false)
       }
 
       gen.ResultCode.TryLater mustEqual cs.log(validList)()

--- a/zipkin-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
+++ b/zipkin-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
@@ -20,11 +20,11 @@ import com.twitter.scrooge.BinaryThriftStructSerializer
 import com.twitter.util.Future
 import com.twitter.zipkin.common.{Span, Annotation}
 import com.twitter.zipkin.config.sampler.AdjustableRateConfig
+import com.twitter.zipkin.config.ScribeZipkinCollectorConfig
 import com.twitter.zipkin.gen
 import com.twitter.zipkin.adapter.ThriftAdapter
 import org.specs.Specification
 import org.specs.mock.{ClassMocker, JMocker}
-import com.twitter.zipkin.config.{ScribeZipkinCollectorConfig}
 
 class ScribeCollectorServiceSpec extends Specification with JMocker with ClassMocker {
   val serializer = new BinaryThriftStructSerializer[gen.Span] {
@@ -43,13 +43,9 @@ class ScribeCollectorServiceSpec extends Specification with JMocker with ClassMo
 
   val config = new ScribeZipkinCollectorConfig {
     def writeQueueConfig = null
-
     def zkConfig = null
-
     def indexConfig = null
-
     def storageConfig = null
-
     def methodConfig = null
 
     override lazy val writeQueue = queue
@@ -65,7 +61,7 @@ class ScribeCollectorServiceSpec extends Specification with JMocker with ClassMo
       val cs = scribeCollectorService
 
       expect {
-        one(queue).add(List(base64)) willReturn (true)
+        one(queue).add(List(base64)) willReturn(true)
       }
 
       gen.ResultCode.Ok mustEqual cs.log(validList)()
@@ -75,7 +71,7 @@ class ScribeCollectorServiceSpec extends Specification with JMocker with ClassMo
       val cs = scribeCollectorService
 
       expect {
-        one(queue).add(List(base64)) willReturn (false)
+        one(queue).add(List(base64)) willReturn(false)
       }
 
       gen.ResultCode.TryLater mustEqual cs.log(validList)()

--- a/zipkin-scribe/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
+++ b/zipkin-scribe/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
@@ -23,14 +23,14 @@ class ConfigSpec extends Specification {
   "/config" should {
     val eval = new Eval
 
-    "validate query configs" in {
-      val queryConfigFiles = Seq(
-        "/query-dev.scala"
+    "validate collector configs" in {
+      val configFiles = Seq(
+        "/collector-dev.scala"
       ) map { TempFile.fromResourcePath(_) }
 
-      for (file <- queryConfigFiles) {
+      for (file <- configFiles) {
         file.getName() in {
-          val config = eval[ZipkinQueryConfig](file)
+          val config = eval[ScribeZipkinCollectorConfig](file)
           config must notBeNull
           config.validate() //must not(throwA[Exception])
           val service = config()

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/collector/CollectorService.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/collector/CollectorService.scala
@@ -17,4 +17,19 @@ package com.twitter.zipkin.collector
 
 import com.twitter.ostrich.admin.Service
 
-trait CollectorService extends Service
+trait CollectorService extends Service {
+
+  val writeQueue: WriteQueue
+
+  @volatile var running = false
+
+  def start() {
+    running = true
+  }
+
+  def shutdown() {
+    running = false
+    writeQueue.flushAll()
+    writeQueue.shutdown()
+  }
+}

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/config/ZipkinCollectorConfig.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/config/ZipkinCollectorConfig.scala
@@ -20,7 +20,7 @@ import com.twitter.zipkin.collector.{WriteQueue, ZipkinCollector}
 import com.twitter.zipkin.collector.filter.{DefaultClientIndexingFilter, IndexingFilter}
 import com.twitter.zipkin.collector.processor.{OstrichProcessor, IndexProcessor, StorageProcessor, Processor}
 import com.twitter.zipkin.collector.sampler.{AdaptiveSampler, ZooKeeperGlobalSampler, GlobalSampler}
-import com.twitter.zipkin.config.collector.{ScribeCollectorServerConfig, CollectorServerConfig}
+import com.twitter.zipkin.config.collector.CollectorServerConfig
 import com.twitter.zipkin.config.sampler._
 import com.twitter.zipkin.config.zookeeper.{ZooKeeperClientConfig, ZooKeeperConfig}
 import com.twitter.common.zookeeper.ZooKeeperClient
@@ -106,7 +106,7 @@ trait ZipkinCollectorConfig extends ZipkinConfig[ZipkinCollector] {
 
   lazy val serverAddr = new InetSocketAddress(InetAddress.getLocalHost, serverPort)
 
-  val serverConfig: CollectorServerConfig = new ScribeCollectorServerConfig(this)
+  val serverConfig: CollectorServerConfig
 
   def apply(runtime: RuntimeEnvironment): ZipkinCollector = {
     new ZipkinCollector(this)

--- a/zipkin-test/src/test/resources/TestCollector.scala
+++ b/zipkin-test/src/test/resources/TestCollector.scala
@@ -21,9 +21,10 @@ import com.twitter.conversions.time._
 import com.twitter.logging.LoggerFactory
 import com.twitter.logging.config._
 import com.twitter.ostrich.admin.{TimeSeriesCollectorFactory, JsonStatsLoggerFactory, StatsFactory}
+import com.twitter.zipkin.config.ScribeZipkinCollectorConfig
 
 // test mode.
-new ZipkinCollectorConfig {
+new ScribeZipkinCollectorConfig {
 
   serverPort = 9410
   adminPort  = 9900


### PR DESCRIPTION
Move the Scribe specific code to a new module: `zipkin-scribe` including:
- ScribeCollectorService
- ScribeCollectorService related configs
- collector-dev config
- Main class
- related tests

The collector can no longer be run from `zipkin-server`.
