### PR TITLE
Bump versions, Cassandra fix

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -87,9 +87,9 @@ object Zipkin extends Build {
     )
 
   val CASSIE_VERSION  = "0.22.0"
-  val FINAGLE_VERSION = "5.0.0"
-  val OSTRICH_VERSION = "8.0.1"
-  val UTIL_VERSION    = "5.0.3"
+  val FINAGLE_VERSION = "5.1.0"
+  val OSTRICH_VERSION = "8.1.0"
+  val UTIL_VERSION    = "5.2.0"
 
   lazy val common =
     Project(

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/config/CassandraIndexConfig.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/config/CassandraIndexConfig.scala
@@ -138,7 +138,7 @@ trait CassandraIndexConfig extends IndexConfig {
     log.info("Connected to Cassandra")
     new CassandraIndex() {
       val config               = cassandraConfig
-      val keyspace             = _keyspace
+      keyspace                 = _keyspace
       val serviceSpanNameIndex = _serviceSpanNameIndex
       val serviceNameIndex     = _serviceNameIndex
       val annotationsIndex     = _annotationsIndex

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/config/CassandraStorageConfig.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/config/CassandraStorageConfig.scala
@@ -49,7 +49,7 @@ trait CassandraStorageConfig extends StorageConfig {
     new CassandraStorage() {
       val cassandraConfig = _storageConfig.cassandraConfig
       val storageConfig = _storageConfig
-      val keyspace = _keyspace
+      keyspace = _keyspace
       val traces = _traces
     }
   }

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/ZipkinQuery.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/ZipkinQuery.scala
@@ -16,7 +16,6 @@ package com.twitter.zipkin.query
  *  limitations under the License.
  *
  */
-import adjusters.Adjuster
 import com.twitter.logging.Logger
 import org.apache.thrift.protocol.TBinaryProtocol
 import com.twitter.zipkin.storage.{Index, Storage}

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/Cassandra.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/Cassandra.scala
@@ -21,12 +21,13 @@ import com.twitter.logging.Logger
 trait Cassandra {
   val log = Logger.get
 
-  val keyspace: Keyspace
+  var keyspace: Keyspace = null
 
   def close() {
     if (keyspace != null) {
       log.info("Closing CassandraStorage connections")
       keyspace.close()
+      keyspace = null
     }
   }
 }

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraIndex.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraIndex.scala
@@ -34,7 +34,6 @@ import com.twitter.zipkin.Constants
 trait CassandraIndex extends Index with Cassandra {
 
   val config: CassandraConfig
-  val keyspace: Keyspace
 
   /* Index `ColumnFamily`s */
   val serviceSpanNameIndex : ColumnFamily[String, Long, Long]

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraStorage.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraStorage.scala
@@ -32,8 +32,6 @@ trait CassandraStorage extends Storage with Cassandra {
 
   val storageConfig: CassandraStorageConfig
 
-  val keyspace: Keyspace
-
   val traces: ColumnFamily[Long, String, gen.Span]
 
   // storing the span in the traces cf

--- a/zipkin-server/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraIndexSpec.scala
+++ b/zipkin-server/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraIndexSpec.scala
@@ -94,7 +94,6 @@ class CassandraIndexSpec extends Specification with JMocker with ClassMocker {
 
       val cs = new CassandraIndex() {
         val config = _config
-        val keyspace = null
         val serviceSpanNameIndex = null
         val serviceNameIndex = null
         val annotationsIndex = _annotationsIndex
@@ -144,7 +143,6 @@ class CassandraIndexSpec extends Specification with JMocker with ClassMocker {
 
       val cass = new CassandraIndex() {
         val config = new CassandraConfig{}
-        val keyspace = null
         val serviceSpanNameIndex = null
         val serviceNameIndex = null
         val annotationsIndex = null
@@ -174,7 +172,6 @@ class CassandraIndexSpec extends Specification with JMocker with ClassMocker {
 
       val cass = new CassandraIndex() {
         val config = new CassandraConfig{}
-        val keyspace = null
         val serviceSpanNameIndex = null
         val serviceNameIndex = null
         val annotationsIndex = null


### PR DESCRIPTION
- Bump to
  - finagle 5.1.0
  - ostrich 8.1.0
  - util 5.2.0
- Only close a cassie keyspace if it has not already been closed
