### PR TITLE
Make changes needed to build on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ scala:
 jdk:
   - openjdk6
   - openjdk7
-  - oraclejdk7
+script: "bin/sbt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ jdk:
   - openjdk6
   - openjdk7
   - oraclejdk7
+script: "env SBT_PROXY_REPO=http://maven.travis-ci.org bin/sbt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ jdk:
   - openjdk6
   - openjdk7
   - oraclejdk7
-script: "env SBT_PROXY_REPO=http://maven.travis-ci.org bin/sbt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ scala:
 jdk:
   - openjdk6
   - openjdk7
-script: "bin/sbt"
+script: "bin/sbt test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ scala:
 jdk:
   - openjdk6
   - openjdk7
-script: "bin/sbt test"
+script: "env SBT_TRAVIS_CI=true bin/sbt test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: scala
 scala:
   - 2.9.1
 jdk:
-  - openjdk6
   - openjdk7
 script: "env SBT_TRAVIS_CI=true bin/sbt test"

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ A Scribe store for Zipkin might look something like this.
 Note that the above uses the Twitter version of Scribe with support for using ZooKeeper to find the hosts to send the category to. You can also use a DNS entry for the collectors or something similar.
 
 ### Zipkin servers
-We've developed Zipkin with <a href="http://www.scala-lang.org/downloads">Scala 2.9.1</a>, <a href="http://www.scala-sbt.org/download.html">SBT 0.11.2</a>, and JDK6.
+We've developed Zipkin with <a href="http://www.scala-lang.org/downloads">Scala 2.9.1</a>, <a href="http://www.scala-sbt.org/download.html">SBT 0.11.2</a>, and JDK7.
 
 1. `git clone https://github.com/twitter/zipkin.git`
 1. `cd zipkin`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Zipkin is a distributed tracing system that helps us gather timing data for all the disparate services at Twitter.
 It manages both the collection and lookup of this data through a Collector and a Query service.
-We closely modelled Zipkin after the <a href="http://research.google.com/pubs/pub36356.html">Google Dapper</a> paper. Follow <a href="https://twitter.com/zipkinproject">@zipkinproject</a> for updates.
+We closely modelled Zipkin after the <a href="http://research.google.com/pubs/pub36356.html">Google Dapper</a> paper. Follow <a href="https://twitter.com/zipkinproject">@zipkinproject</a> for updates. [![Build Status](https://secure.travis-ci.org/twitter/zipkin.png)](http://travis-ci.org/twitter/zipkin)
 
 ## Why distributed tracing?
 Collecting traces helps developers gain deeper knowledge about how certain requests perform in a distributed system.

--- a/bin/sbt
+++ b/bin/sbt
@@ -29,11 +29,11 @@ java -ea                          \
        -XX:+UseConcMarkSweepGC         \
        -XX:+CMSParallelRemarkEnabled   \
        -XX:+CMSClassUnloadingEnabled   \
-       -XX:MaxPermSize=1024m           \
+       -XX:MaxPermSize=512m           \
        -XX:SurvivorRatio=128           \
        -XX:MaxTenuringThreshold=0      \
        -Xss8M                          \
-       -Xms512M                        \
-       -Xmx3G                          \
+       -Xms225M                        \
+       -Xmx512mb                       \
        -server                         \
        -jar $sbtjar "$@"

--- a/bin/sbt
+++ b/bin/sbt
@@ -29,11 +29,11 @@ java -ea                          \
        -XX:+UseConcMarkSweepGC         \
        -XX:+CMSParallelRemarkEnabled   \
        -XX:+CMSClassUnloadingEnabled   \
-       -XX:MaxPermSize=512m           \
+       -XX:MaxPermSize=512M            \
        -XX:SurvivorRatio=128           \
        -XX:MaxTenuringThreshold=0      \
        -Xss8M                          \
        -Xms225M                        \
-       -Xmx512mb                       \
+       -Xmx512M                        \
        -server                         \
        -jar $sbtjar "$@"

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -27,6 +27,8 @@ object Zipkin extends Build {
       ),
       resolvers ++= (proxyRepo match {
         case None => Seq(
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype",
           "elephant-bird repo" at "http://oss.sonatype.org/content/repositories/comtwitter-286",
           "Concurrent Maven Repo" at "http://conjars.org/repo")
         case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
@@ -57,6 +59,12 @@ object Zipkin extends Build {
       CompileThrift.newSettings).settings(
     name := "zipkin-test",
     version := "0.2.0-SNAPSHOT",
+    resolvers ++= (proxyRepo match {
+      case None => Seq(
+        "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
+        "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+      case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
+    }),
     libraryDependencies ++= Seq(
       /* Test dependencies */
       "org.scala-tools.testing" % "specs_2.9.1"  % "1.6.9" % "test",
@@ -78,7 +86,12 @@ object Zipkin extends Build {
         CompileThrift.newSettings).settings(
       name := "zipkin-thrift",
       version := "0.2.0-SNAPSHOT",
-
+      resolvers ++= (proxyRepo match {
+        case None => Seq(
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+        case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
+      }),
       libraryDependencies ++= Seq(
         "org.apache.thrift" % "libthrift" % "0.5.0",
         "org.slf4j" % "slf4j-api" % "1.5.8"
@@ -100,7 +113,12 @@ object Zipkin extends Build {
         SubversionPublisher.newSettings
     ).settings(
       version := "0.2.0-SNAPSHOT",
-
+      resolvers ++= (proxyRepo match {
+        case None => Seq(
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+        case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
+      }),
       libraryDependencies ++= Seq(
         "com.twitter" % "finagle-thrift"    % FINAGLE_VERSION,
         "com.twitter" % "finagle-zipkin"    % FINAGLE_VERSION,
@@ -127,7 +145,12 @@ object Zipkin extends Build {
         CompileThriftScrooge.newSettings
     ).settings(
       version := "0.2.0-SNAPSHOT",
-
+      resolvers ++= (proxyRepo match {
+        case None => Seq(
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+        case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
+      }),
       libraryDependencies ++= Seq(
         "com.twitter" % "finagle-ostrich4"  % FINAGLE_VERSION,
         "com.twitter" % "finagle-thrift"    % FINAGLE_VERSION,
@@ -165,7 +188,12 @@ object Zipkin extends Build {
         SubversionPublisher.newSettings
     ).settings(
       version := "0.2.0-SNAPSHOT",
-
+      resolvers ++= (proxyRepo match {
+        case None => Seq(
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+        case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
+      }),
       libraryDependencies ++= Seq(
         "com.twitter" % "cassie-core"       % CASSIE_VERSION intransitive(),
         "com.twitter" % "cassie-serversets" % CASSIE_VERSION intransitive(),
@@ -212,7 +240,12 @@ object Zipkin extends Build {
         SubversionPublisher.newSettings
     ).settings(
       version := "0.2.0-SNAPSHOT",
-
+      resolvers ++= (proxyRepo match {
+        case None => Seq(
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+        case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
+      }),
       libraryDependencies ++= Seq(
         /* Test dependencies */
         "org.scala-tools.testing" % "specs_2.9.1"  % "1.6.9" % "test",

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -38,7 +38,7 @@ object Zipkin extends Build {
 
       // configure resolvers for the build
       resolvers <<= (resolvers, travisCiResolvers) { (resolvers, travisCiResolvers) =>
-        travisCiResolvers ++ resolvers
+        resolvers ++ travisCiResolvers
       },
 
       // don't add any special resolvers.

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -38,7 +38,7 @@ object Zipkin extends Build {
 
       // configure resolvers for the build
       resolvers <<= (resolvers, travisCiResolvers) { (resolvers, travisCiResolvers) =>
-        resolvers ++ travisCiResolvers
+        travisCiResolvers ++ resolvers
       },
 
       // don't add any special resolvers.

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -27,8 +27,8 @@ object Zipkin extends Build {
       ),
       resolvers ++= (proxyRepo match {
         case None => Seq(
-          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
-          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype",
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/",
           "elephant-bird repo" at "http://oss.sonatype.org/content/repositories/comtwitter-286",
           "Concurrent Maven Repo" at "http://conjars.org/repo")
         case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
@@ -61,8 +61,8 @@ object Zipkin extends Build {
     version := "0.2.0-SNAPSHOT",
     resolvers ++= (proxyRepo match {
       case None => Seq(
-        "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
-        "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+        "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
+        "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/")
       case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
     }),
     libraryDependencies ++= Seq(
@@ -88,8 +88,8 @@ object Zipkin extends Build {
       version := "0.2.0-SNAPSHOT",
       resolvers ++= (proxyRepo match {
         case None => Seq(
-          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
-          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/")
         case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
       }),
       libraryDependencies ++= Seq(
@@ -115,8 +115,8 @@ object Zipkin extends Build {
       version := "0.2.0-SNAPSHOT",
       resolvers ++= (proxyRepo match {
         case None => Seq(
-          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
-          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/")
         case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
       }),
       libraryDependencies ++= Seq(
@@ -147,8 +147,8 @@ object Zipkin extends Build {
       version := "0.2.0-SNAPSHOT",
       resolvers ++= (proxyRepo match {
         case None => Seq(
-          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
-          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/")
         case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
       }),
       libraryDependencies ++= Seq(
@@ -190,8 +190,8 @@ object Zipkin extends Build {
       version := "0.2.0-SNAPSHOT",
       resolvers ++= (proxyRepo match {
         case None => Seq(
-          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
-          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/")
         case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
       }),
       libraryDependencies ++= Seq(
@@ -242,8 +242,8 @@ object Zipkin extends Build {
       version := "0.2.0-SNAPSHOT",
       resolvers ++= (proxyRepo match {
         case None => Seq(
-          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
-          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype")
+          "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
+          "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/")
         case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
       }),
       libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,6 +13,7 @@ resolvers <<= (resolvers) { r =>
       "scala-tools" at "http://scala-tools.org/repo-releases/",
       "maven" at "http://repo1.maven.org/maven2/",
       "freemarker" at "http://freemarker.sourceforge.net/maven2/",
+      "travisci" at "http://maven.travis-ci.org/",
       Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
     )
   }) ++ Seq("local" at ("file:" + System.getProperty("user.home") + "/.m2/repository/"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,11 +9,12 @@ resolvers <<= (resolvers) { r =>
     Seq("proxy-repo" at url)
   } getOrElse {
     r ++ Seq(
+      "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
+      "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype",
       "twitter.com" at "http://maven.twttr.com/",
       "scala-tools" at "http://scala-tools.org/repo-releases/",
       "maven" at "http://repo1.maven.org/maven2/",
       "freemarker" at "http://freemarker.sourceforge.net/maven2/",
-      "travisci" at "http://maven.travis-ci.org/",
       Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
     )
   }) ++ Seq("local" at ("file:" + System.getProperty("user.home") + "/.m2/repository/"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,8 +9,8 @@ resolvers <<= (resolvers) { r =>
     Seq("proxy-repo" at url)
   } getOrElse {
     r ++ Seq(
-      "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central",
-      "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype",
+      "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
+      "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/",
       "twitter.com" at "http://maven.twttr.com/",
       "scala-tools" at "http://scala-tools.org/repo-releases/",
       "maven" at "http://repo1.maven.org/maven2/",


### PR DESCRIPTION
Adds the travis-ci maven repositories for faster downloads.

Reduces sbt memory used so it doesn't try to grab more than the travis-ci nodes have. If this poses a problem elsewhere we can just have a specific travis-ci sbt script.
