### PR TITLE
Fix build.properties output package

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -201,6 +201,7 @@ object Zipkin extends Build {
       ),
 
       PackageDist.packageDistZipName := "zipkin-server.zip",
+      BuildProperties.buildPropertiesPackage := "com.twitter.zipkin",
 
       /* Add configs to resource path for ConfigSpec */
       unmanagedResourceDirectories in Test <<= baseDirectory {
@@ -230,6 +231,7 @@ object Zipkin extends Build {
       ),
 
       PackageDist.packageDistZipName := "zipkin-scribe.zip",
+      BuildProperties.buildPropertiesPackage := "com.twitter.zipkin",
 
       /* Add configs to resource path for ConfigSpec */
       unmanagedResourceDirectories in Test <<= baseDirectory {


### PR DESCRIPTION
Sets correct package `com.twitter.zipkin` for build.properties. This fixes the issue where curling `host:post/server_info.txt` returns unknown values.
