### PR TITLE
Top annotations

### DIFF
--- a/zipkin-scribe/config/collector-dev.scala
+++ b/zipkin-scribe/config/collector-dev.scala
@@ -54,6 +54,10 @@ new ScribeZipkinCollectorConfig {
     def cassandraConfig = _cassandraConfig
   }
 
+  def aggregatesConfig = new CassandraAggregatesConfig {
+    def cassandraConfig = _cassandraConfig
+  }
+
   override def adaptiveSamplerConfig = new NullAdaptiveSamplerConfig {}
 
   def zkConfig = new ZooKeeperConfig {

--- a/zipkin-scribe/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorService.scala
+++ b/zipkin-scribe/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorService.scala
@@ -103,6 +103,34 @@ class ScribeCollectorService(config: ZipkinCollectorConfig, val writeQueue: Writ
     }
   }
 
+  def storeTopAnnotations(serviceName: String, annotations: Seq[String]): Future[Unit] = {
+    Stats.incr("collector.storeTopAnnotations")
+    log.info("storeTopAnnotations: " + serviceName + "; " + annotations)
+
+    Stats.timeFutureMillis("collector.storeTopAnnotations") {
+      config.aggregates.storeTopAnnotations(serviceName, annotations)
+    } rescue {
+      case e: Exception =>
+        log.error(e, "storeTopAnnotations failed")
+        Stats.incr("collector.storeTopAnnotations")
+        Future.exception(gen.AdjustableRateException(e.toString))
+    }
+  }
+
+  def storeTopKeyValueAnnotations(serviceName: String, annotations: Seq[String]): Future[Unit] = {
+    Stats.incr("collector.storeTopKeyValueAnnotations")
+    log.info("storeTopKeyValueAnnotations: " + serviceName + ";" + annotations)
+
+    Stats.timeFutureMillis("collector.storeTopKeyValueAnnotations") {
+      config.aggregates.storeTopKeyValueAnnotations(serviceName, annotations)
+    } rescue {
+      case e: Exception =>
+        log.error(e, "storeTopKeyValueAnnotations failed")
+        Stats.incr("collector.storeTopKeyValueAnnotations")
+        Future.exception(gen.AdjustableRateException(e.toString))
+    }
+  }
+
   @throws(classOf[gen.AdjustableRateException])
   def setSampleRate(sampleRate: Double): Future[Unit] = {
     Stats.incr("collector.set_sample_rate")

--- a/zipkin-server/config/query-dev.scala
+++ b/zipkin-server/config/query-dev.scala
@@ -46,6 +46,10 @@ new ZipkinQueryConfig {
     def cassandraConfig = _cassandraConfig
   }
 
+  def aggregatesConfig = new CassandraAggregatesConfig {
+    def cassandraConfig = _cassandraConfig
+  }
+
   def zkConfig = new ZooKeeperConfig {
     servers = List("localhost:2181")
   }

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/config/AggregatesConfig.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/config/AggregatesConfig.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.zipkin.config
+
+import com.twitter.util.Config
+import com.twitter.zipkin.storage.{NullAggregates, Aggregates}
+
+trait AggregatesConfig extends Config[Aggregates]
+
+class NullAggregatesConfig extends AggregatesConfig {
+  def apply(): Aggregates = new NullAggregates
+}

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/config/CassandraAggregatesConfig.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/config/CassandraAggregatesConfig.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.zipkin.config
+
+import com.twitter.zipkin.storage.cassandra.CassandraAggregates
+import com.twitter.cassie.codecs.{LongCodec, Utf8Codec}
+import com.twitter.cassie.{ColumnFamily, ReadConsistency, WriteConsistency}
+
+trait CassandraAggregatesConfig extends AggregatesConfig { self =>
+
+  def cassandraConfig: CassandraConfig
+  var topAnnotationsCf: String = "TopAnnotations"
+
+  def apply(): CassandraAggregates = {
+    val _topAnnotations = cassandraConfig.keyspace.columnFamily[String, Long, String](
+      topAnnotationsCf,Utf8Codec, LongCodec, Utf8Codec
+    ).consistency(WriteConsistency.One).consistency(ReadConsistency.One)
+
+    new CassandraAggregates {
+      val topAnnotations: ColumnFamily[String, Long, String] = _topAnnotations
+    }
+  }
+}

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/config/ZipkinCollectorConfig.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/config/ZipkinCollectorConfig.scala
@@ -15,7 +15,7 @@
  */
 package com.twitter.zipkin.config
 
-import com.twitter.zipkin.storage.{Index, Storage}
+import com.twitter.zipkin.storage.{Aggregates, Index, Storage}
 import com.twitter.zipkin.collector.{WriteQueue, ZipkinCollector}
 import com.twitter.zipkin.collector.filter.{DefaultClientIndexingFilter, IndexingFilter}
 import com.twitter.zipkin.collector.sampler.{AdaptiveSampler, ZooKeeperGlobalSampler, GlobalSampler}
@@ -61,6 +61,10 @@ trait ZipkinCollectorConfig extends ZipkinConfig[ZipkinCollector] {
   /* Index */
   def indexConfig: IndexConfig
   lazy val index: Index = indexConfig.apply()
+
+  /* Aggregates */
+  def aggregatesConfig: AggregatesConfig
+  lazy val aggregates: Aggregates = aggregatesConfig.apply()
 
   /* ZooKeeper */
   def zkConfig: ZooKeeperConfig

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/config/ZipkinQueryConfig.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/config/ZipkinQueryConfig.scala
@@ -17,7 +17,7 @@ package com.twitter.zipkin.config
 
 import com.twitter.zipkin.query.ZipkinQuery
 import com.twitter.zipkin.gen
-import com.twitter.zipkin.storage.{Index, Storage}
+import com.twitter.zipkin.storage.{Aggregates, Index, Storage}
 import com.twitter.common.zookeeper.{ServerSetImpl, ZooKeeperClient}
 import com.twitter.finagle.zipkin.thrift.ZipkinTracer
 import com.twitter.ostrich.admin.RuntimeEnvironment
@@ -42,6 +42,9 @@ trait ZipkinQueryConfig extends ZipkinConfig[ZipkinQuery] {
   def indexConfig: IndexConfig
   lazy val index: Index = indexConfig.apply()
 
+  def aggregatesConfig: AggregatesConfig
+  lazy val aggregates: Aggregates = aggregatesConfig.apply()
+
   def zkConfig: ZooKeeperConfig
 
   def zkClientConfig = new ZooKeeperClientConfig {
@@ -55,6 +58,6 @@ trait ZipkinQueryConfig extends ZipkinConfig[ZipkinQuery] {
     ZipkinTracer(statsReceiver = statsReceiver, sampleRate = 1f)
 
   def apply(runtime: RuntimeEnvironment) = {
-    new ZipkinQuery(this, serverSet, storage, index)
+    new ZipkinQuery(this, serverSet, storage, index, aggregates)
   }
 }

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/ZipkinQuery.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/ZipkinQuery.scala
@@ -18,7 +18,7 @@ package com.twitter.zipkin.query
  */
 import com.twitter.logging.Logger
 import org.apache.thrift.protocol.TBinaryProtocol
-import com.twitter.zipkin.storage.{Index, Storage}
+import com.twitter.zipkin.storage.{Aggregates, Index, Storage}
 import com.twitter.zipkin.gen
 import com.twitter.finagle.thrift.ThriftServerFramedCodec
 import com.twitter.finagle.zookeeper.ZookeeperServerSetCluster
@@ -29,7 +29,7 @@ import com.twitter.zipkin.config.ZipkinQueryConfig
 import com.twitter.common.zookeeper.ServerSet
 
 class ZipkinQuery(
-  config: ZipkinQueryConfig, serverSet: ServerSet, storage: Storage, index: Index
+  config: ZipkinQueryConfig, serverSet: ServerSet, storage: Storage, index: Index, aggregates: Aggregates
 ) extends Service {
 
   val log = Logger.get(getClass.getName)
@@ -41,7 +41,7 @@ class ZipkinQuery(
     log.info("Starting query thrift service on addr " + serverAddr)
     val cluster = new ZookeeperServerSetCluster(serverSet)
 
-    val queryService = new QueryService(storage, index, config.adjusterMap)
+    val queryService = new QueryService(storage, index, aggregates, config.adjusterMap)
     queryService.start()
     ServiceTracker.register(queryService)
 

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/storage/Aggregates.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/storage/Aggregates.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.zipkin.storage
+
+import com.twitter.util.Future
+
+/**
+ * Storage and retrieval interface for aggregates that may be computed offline and reloaded into
+ * online storage
+ */
+trait Aggregates {
+  def getTopAnnotations(serviceName: String): Future[Seq[String]]
+  def getTopKeyValueAnnotations(serviceName: String): Future[Seq[String]]
+
+  def storeTopAnnotations(serviceName: String, a: Seq[String]): Future[Unit]
+  def storeTopKeyValueAnnotations(serviceName: String, a: Seq[String]): Future[Unit]
+}
+
+class NullAggregates extends Aggregates {
+  def getTopAnnotations(serviceName: String)         = Future(Seq.empty[String])
+  def getTopKeyValueAnnotations(serviceName: String) = Future(Seq.empty[String])
+
+  def storeTopAnnotations(serviceName: String, a: Seq[String]): Future[Unit]         = Future.Unit
+  def storeTopKeyValueAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = Future.Unit
+}

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregates.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregates.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.zipkin.storage.cassandra
+
+import com.twitter.util.Future
+import com.twitter.zipkin.storage.Aggregates
+import scala.collection.JavaConverters._
+import com.twitter.cassie.{Column, ColumnFamily}
+
+/**
+ * Cassandra backed aggregates store
+ *
+ * For each service, we store top annotations and top key value annotations
+ * for use at query time.
+ *
+ * Top annotations are a sequence of the most popular time-based annotation strings
+ * Top key value annotations are a sequence of the most popular _keys_ among key value annotations
+ */
+trait CassandraAggregates extends Aggregates with Cassandra {
+
+  val topAnnotations: ColumnFamily[String, Long, String]
+
+  val Delimiter: String = ":"
+
+  /**
+   * Get the top annotations for a service name
+   */
+  def getTopAnnotations(serviceName: String): Future[Seq[String]] = {
+    getAnnotations(topAnnotationRowKey(serviceName))
+  }
+
+  /**
+   * Get the top key value annotation keys for a service name
+   */
+  def getTopKeyValueAnnotations(serviceName: String): Future[Seq[String]] = {
+    getAnnotations(topKeyValueRowKey(serviceName))
+  }
+
+  /**
+   * Override the top annotations for a service
+   */
+  def storeTopAnnotations(serviceName: String, annotations: Seq[String]): Future[Unit] = {
+    storeAnnotations(topAnnotationRowKey(serviceName), annotations)
+  }
+
+  /**
+   * Override the top key value annotation keys for a service
+   */
+  def storeTopKeyValueAnnotations(serviceName: String, annotations: Seq[String]): Future[Unit] = {
+    storeAnnotations(topKeyValueRowKey(serviceName), annotations)
+  }
+
+  private[cassandra] def getAnnotations(key: String): Future[Seq[String]] = {
+    topAnnotations.getRow(key).map {
+      _.values().asScala.map { _.value }.toSeq
+    }
+  }
+
+  /** Synchronize these so we don't do concurrent writes from the same box */
+  private[cassandra] def storeAnnotations(key: String, annotations: Seq[String]): Future[Unit] = synchronized {
+    val remove = topAnnotations.removeRow(key)
+    val batch = topAnnotations.batch()
+    annotations.zipWithIndex.foreach { case (annotation: String, index: Int) =>
+      batch.insert(key, new Column[Long, String](index, annotation))
+    }
+    remove()
+    Future.join(Seq(batch.execute()))
+  }
+
+
+  private[cassandra] def topAnnotationRowKey(serviceName: String) =
+    serviceName + Delimiter + "annotation"
+
+  private[cassandra] def topKeyValueRowKey(serviceName: String) =
+    serviceName + Delimiter + "kv"
+}

--- a/zipkin-server/src/schema/cassandra-schema.txt
+++ b/zipkin-server/src/schema/cassandra-schema.txt
@@ -12,3 +12,5 @@ create column family ServiceSpanNameIndex with comparator = LongType;
 create column family ServiceNameIndex with comparator = LongType;
 create column family AnnotationsIndex with comparator = LongType;
 create column family DurationIndex with comparator = LongType;
+
+create column family TopAnnotations with comparator = LongType;

--- a/zipkin-server/src/test/resources/CassandraAggregatesConfig.scala
+++ b/zipkin-server/src/test/resources/CassandraAggregatesConfig.scala
@@ -1,0 +1,25 @@
+/*
+* Copyright 2012 Twitter Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import com.twitter.zipkin.config.{CassandraConfig, CassandraAggregatesConfig}
+
+new CassandraAggregatesConfig {
+  var cassandraConfig = new CassandraConfig {
+    nodes = Set("localhost")
+    mapHosts = false
+    useServerSets = false
+    port = 6579
+  }
+}

--- a/zipkin-server/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregatesSpec.scala
+++ b/zipkin-server/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregatesSpec.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.zipkin.storage.cassandra
+
+import com.twitter.cassie.{Column, ColumnFamily}
+import com.twitter.cassie.tests.util.FakeCassandra
+import com.twitter.io.TempFile
+import com.twitter.ostrich.admin.RuntimeEnvironment
+import com.twitter.util.{Eval, Future}
+import com.twitter.zipkin.config.CassandraAggregatesConfig
+import org.specs.mock.{ClassMocker, JMocker}
+import org.specs.Specification
+import scala.collection.JavaConverters._
+
+class CassandraAggregatesSpec extends Specification with JMocker with ClassMocker {
+
+  val mockCf = mock[ColumnFamily[String, Long, String]]
+
+  def cassandraAggregates = new CassandraAggregates {
+    val topAnnotations = mockCf
+  }
+
+  def column(name: Long, value: String) = new Column[Long, String](name, value)
+
+  "CassandraAggregates" should {
+    val topAnnsSeq = Seq("finagle.retry", "finagle.timeout", "annotation1", "annotation2")
+    val topAnns = topAnnsSeq.zipWithIndex.map { case (ann, index) =>
+      index.toLong -> column(index, ann)
+    }.toMap.asJava
+
+    "retrieval" in {
+      "getTopAnnotations" in {
+        val agg = cassandraAggregates
+        val serviceName = "mockingbird"
+        val rowKey = agg.topAnnotationRowKey(serviceName)
+
+        expect {
+          one(mockCf).getRow(rowKey) willReturn Future.value(topAnns)
+        }
+
+        agg.getTopAnnotations(serviceName)() mustEqual topAnnsSeq
+      }
+
+      "getTopKeyValueAnnotations" in {
+        val agg = cassandraAggregates
+        val serviceName = "mockingbird"
+        val rowKey = agg.topKeyValueRowKey(serviceName)
+
+        expect {
+          one(mockCf).getRow(rowKey) willReturn Future.value(topAnns)
+        }
+
+        agg.getTopKeyValueAnnotations(serviceName)() mustEqual topAnnsSeq
+      }
+    }
+
+    "storage" in {
+      object FakeServer extends FakeCassandra
+      var agg: CassandraAggregates = null
+      val serviceName = "mockingbird"
+
+      doBefore {
+        FakeServer.start()
+        val test = TempFile.fromResourcePath("/CassandraAggregatesConfig.scala")
+        val env = RuntimeEnvironment(this, Array("-f", test.toString))
+        val config = new Eval().apply[CassandraAggregatesConfig](env.configFile)
+        config.cassandraConfig.port = FakeServer.port.get
+        agg = config.apply()
+      }
+
+      doAfter {
+        agg.close()
+        FakeServer.stop()
+      }
+
+      "storeTopAnnotations" in {
+        agg.storeTopAnnotations(serviceName, topAnnsSeq).apply()
+        agg.getTopAnnotations(serviceName).apply() mustEqual topAnnsSeq
+      }
+
+      "storeTopKeyValueAnnotations" in {
+        agg.storeTopKeyValueAnnotations(serviceName, topAnnsSeq).apply()
+        agg.getTopKeyValueAnnotations(serviceName).apply() mustEqual topAnnsSeq
+      }
+
+      "clobber old entries" in {
+        val anns1 = Seq("a1", "a2", "a3", "a4")
+        val anns2 = Seq("a5", "a6")
+
+        agg.storeTopAnnotations(serviceName, anns1).apply()
+        agg.getTopAnnotations(serviceName).apply() mustEqual anns1
+
+        agg.storeTopAnnotations(serviceName, anns2).apply()
+        agg.getTopAnnotations(serviceName).apply() mustEqual anns2
+      }
+    }
+  }
+}

--- a/zipkin-test/src/test/resources/TestCollector.scala
+++ b/zipkin-test/src/test/resources/TestCollector.scala
@@ -57,6 +57,10 @@ new ScribeZipkinCollectorConfig {
     def cassandraConfig = _cassandraConfig
   }
 
+  def aggregatesConfig = new CassandraAggregatesConfig {
+    def cassandraConfig = _cassandraConfig
+  }
+
   override def adaptiveSamplerConfig = new NullAdaptiveSamplerConfig {}
   
   // sample it all

--- a/zipkin-test/src/test/resources/TestQuery.scala
+++ b/zipkin-test/src/test/resources/TestQuery.scala
@@ -46,6 +46,10 @@ new ZipkinQueryConfig {
     def cassandraConfig = _cassandraConfig
   }
 
+  def aggregatesConfig = new CassandraAggregatesConfig {
+    def cassandraConfig = _cassandraConfig
+  }
+
   def zkConfig = new ZooKeeperConfig {
     servers = List("localhost:2181")
   }

--- a/zipkin-test/src/test/scala/com/twitter/zipkin/ZipkinSpec.scala
+++ b/zipkin-test/src/test/scala/com/twitter/zipkin/ZipkinSpec.scala
@@ -86,7 +86,7 @@ class ZipkinSpec extends Specification with JMocker with ClassMocker {
       collector = new ZipkinCollector(collectorConfig)
       collector.start()
 
-      query = new ZipkinQuery(queryConfig, nullServerSetsImpl, queryConfig.storage, queryConfig.index)
+      query = new ZipkinQuery(queryConfig, nullServerSetsImpl, queryConfig.storage, queryConfig.index, queryConfig.aggregates)
       query.start()
 
       queryTransport = ClientBuilder()

--- a/zipkin-thrift/src/main/thrift/zipkinCollector.thrift
+++ b/zipkin-thrift/src/main/thrift/zipkinCollector.thrift
@@ -20,7 +20,15 @@ exception AdjustableRateException {
   1: string msg
 }
 
+exception StoreAggregatesException {
+  1: string msg
+}
+
 service ZipkinCollector extends scribe.scribe {
+
+    /** Aggregates methods */
+    void storeTopAnnotations(1: string service_name, 2: list<string> annotations) throws (1: StoreAggregatesException e);
+    void storeTopKeyValueAnnotations(1: string service_name, 2: list<string> annotations) throws (1: StoreAggregatesException e);
 
     //************** ZK config changes **************
 

--- a/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
@@ -186,4 +186,8 @@ service ZipkinQuery {
      * Get the data ttl. This is the number of seconds we keep the data around before deleting it.
      */
     i32 getDataTimeToLive() throws (1: QueryException qe);
+
+    /** Aggregates related */
+    list<string> getTopAnnotations(1: string service_name) throws (1: QueryException qe);
+    list<string> getTopKeyValueAnnotations(1: string service_name) throws (1: QueryException qe);
 }


### PR DESCRIPTION
Add collector and query support for adding "top annotation" data that may be computed offline
- New collector endpoints
  - `storeTopAnnotations`
  - `storeTopKeyValueAnnotations`
- New query endpoints
  - `getTopAnnotations`
  - `getTopKeyValueAnnotations`
