### PR TITLE
fixed zipkin-web to actually return values from servers

### DIFF
--- a/zipkin-web/app/controllers/traces_controller.rb
+++ b/zipkin-web/app/controllers/traces_controller.rb
@@ -119,16 +119,18 @@ class TracesController < ApplicationController
 
   def top_annotations
     service_name = params[:service_name] || ""
-    top_annotations = ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
-      client.getTopAnnotations(service_name)
+    top_annotations = nil
+    ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
+      top_annotations = client.getTopAnnotations(service_name)
     end
     render :json => top_annotations || []
   end
 
   def top_kv_annotations
     service_name = params[:service_name] || ""
-    top_annotations = ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
-      client.getTopKeyValueAnnotations(service_name)
+    top_annotations = nil
+    ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
+      top_annotations = client.getTopKeyValueAnnotations(service_name)
     end
     render :json => top_annotations || []
   end

--- a/zipkin-web/app/models/index.rb
+++ b/zipkin-web/app/models/index.rb
@@ -23,27 +23,33 @@ class Index
     end_ts = secondsToMicroseconds(end_ts)
     order = opts[:order] || ORDER_DEFAULT
 
+    tmp = nil
     ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
-      client.getTraceIdsBySpanName(service_name, span_name, end_ts, limit, order)
+      tmp = client.getTraceIdsBySpanName(service_name, span_name, end_ts, limit, order)
     end
+    tmp
   end
 
   def self.get_trace_ids_by_service_name(service_name, end_ts, limit, opts = {})
     end_ts = secondsToMicroseconds(end_ts)
     order = opts[:order] || ORDER_DEFAULT
 
+    tmp = nil
     ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
-      client.getTraceIdsByServiceName(service_name, end_ts, limit, order)
+      tmp = client.getTraceIdsByServiceName(service_name, end_ts, limit, order)
     end
+    tmp
   end
 
   def self.get_trace_ids_by_annotation(service_name, annotation, value, end_ts, limit, opts = {})
     end_ts = secondsToMicroseconds(end_ts)
     order = opts[:order] || ORDER_DEFAULT
 
+    tmp = nil
     ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
-      client.getTraceIdsByAnnotation(service_name, annotation, value, end_ts, limit, order)
+      tmp = client.getTraceIdsByAnnotation(service_name, annotation, value, end_ts, limit, order)
     end
+    tmp
   end
 
   private

--- a/zipkin-web/app/models/names.rb
+++ b/zipkin-web/app/models/names.rb
@@ -17,15 +17,19 @@ require 'ipaddr'
 class Names
 
   def self.get_service_names
+    tmp = nil
     ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
-      client.getServiceNames().sort
+      tmp = client.getServiceNames().sort
     end
+    tmp
   end
 
   def self.get_span_names(service_name)
+    tmp = nil
     ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
-      client.getSpanNames(service_name).sort
+      tmp = client.getSpanNames(service_name).sort
     end
+    tmp
   end
 
 end

--- a/zipkin-web/app/models/trace_combo.rb
+++ b/zipkin-web/app/models/trace_combo.rb
@@ -42,10 +42,12 @@ class TraceCombo
   end
 
   def self.get_trace_combos_by_ids(trace_ids, adjusters, opts = {})
+    tmp = nil
     ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
       combos = client.getTraceCombosByIds(trace_ids.collect { |id| id.to_i }, adjusters)
-      combos.collect { |combo| TraceCombo.from_thrift(combo) }
+      tmp = combos.collect { |combo| TraceCombo.from_thrift(combo) }
     end
+    tmp
   end
 
 end

--- a/zipkin-web/app/models/trace_summary.rb
+++ b/zipkin-web/app/models/trace_summary.rb
@@ -60,11 +60,13 @@ class TraceSummary
   end
 
   def self.get_trace_summaries_by_ids(trace_ids, adjusters, opts={})
+    tmp = nil
     ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
       ids = trace_ids.collect { |id| id.to_i }
       summaries = client.getTraceSummariesByIds(ids, adjusters)
-      summaries.collect { |summary| TraceSummary.from_thrift(summary) }
+      tmp = summaries.collect { |summary| TraceSummary.from_thrift(summary) }
     end
+    tmp
   end
 
   def start_timestamp_ms

--- a/zipkin-web/app/models/trace_timeline.rb
+++ b/zipkin-web/app/models/trace_timeline.rb
@@ -44,12 +44,14 @@ class TraceTimeline
   end
 
   def self.get_trace_timelines_by_ids(trace_ids, opts = {})
+    tmp = nil
     ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
       adjusters = [] # [Zipkin::Adjust::TIME_SKEW] #TODO config
       ids = trace_ids.collect { |id| id.to_i }
       timelines = client.getTraceTimelinesByIds(ids, adjusters)
-      timelines.collect { |timeline| TraceTimeline.from_thrift(timeline) }
+      tmp = timelines.collect { |timeline| TraceTimeline.from_thrift(timeline) }
     end
+    tmp
   end
 
   def start_timestamp

--- a/zipkin-web/app/models/ztrace.rb
+++ b/zipkin-web/app/models/ztrace.rb
@@ -121,11 +121,13 @@ class ZTrace
   end
 
   def self.get_traces_by_ids(trace_ids, opts = {})
+    tmp = nil
     ZipkinQuery::Client.with_transport(Rails.configuration.zookeeper) do |client|
       adjusters = [] #[Zipkin::Adjust::TIME_SKEW] #TODO config
       traces = client.getTracesByIds(trace_ids.collect { |id| id.to_i }, adjusters)
-      traces.collect { |trace| ZTrace.from_thrift(trace) }
+      tmp = traces.collect { |trace| ZTrace.from_thrift(trace) }
     end
+    tmp
   end
 
   # what is the default ttl we set traces to?


### PR DESCRIPTION
Ruby 1.9.3 fixed a problem where do loops were sometimes not returning their last value.  However, for compatibility with 1.9.2, the with_transport do loops need their last value to be assigned to a variable with a greater scope than the do loop, ie to be initialized outside of the do loop and then assigned within.  Either the necessary ruby version should be specified in the documentation, or this fix needs to be pulled in.
