### PR TITLE
Add duration to annotations.

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Annotation.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Annotation.scala
@@ -16,12 +16,15 @@
  */
 package com.twitter.zipkin.common
 
+import com.twitter.util.Duration
+
 /**
  * @param timestamp when was this annotation created? microseconds from epoch
  * @param value description of what happened at the timestamp could for example be "cache miss for key: x"
  * @param host host this annotation was created on
+ * @param duration how long did the operation this annotation represent take?
  */
-case class Annotation(timestamp: Long, value: String, host: Option[Endpoint])
+case class Annotation(timestamp: Long, value: String, host: Option[Endpoint], duration: Option[Duration] = None)
   extends Ordered[Annotation]{
   def serviceName = host.map(_.serviceName).getOrElse("Unknown service name")
 
@@ -37,6 +40,8 @@ case class Annotation(timestamp: Long, value: String, host: Option[Endpoint])
       this.value compare that.value
     else if (this.host != that.host)
       this.host.getOrElse {return -1} compare that.host.getOrElse {return 1}
+    else if (this.duration != that.duration)
+      this.duration.getOrElse {return -1} compare that.duration.getOrElse {return 1}
     else
       0
   }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/AnnotationSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/AnnotationSpec.scala
@@ -17,6 +17,7 @@
 package com.twitter.zipkin.common
 
 import org.specs.Specification
+import com.twitter.conversions.time._
 
 class AnnotationSpec extends Specification {
   "Annotation" should {
@@ -30,15 +31,17 @@ class AnnotationSpec extends Specification {
     }
 
     "compare correctly" in {
-      val ann1 = Annotation(1, "a", None)
+      val ann1 = Annotation(1, "a", None, None)
       val ann2 = Annotation(2, "a", None)
       val ann3 = Annotation(1, "b", None)
       val ann4 = Annotation(1, "a", Some(Endpoint(1, 2, "service")))
+      val ann5 = Annotation(1, "a", None, Some(1.second))
 
       ann1.compare(ann1) mustEqual 0
       ann1.compare(ann2) must beLessThan(0)
       ann1.compare(ann3) must beLessThan(0)
       ann1.compare(ann4) must beLessThan(0)
+      ann1.compare(ann5) must beLessThan(0)
     }
   }
 }

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/adapter/ThriftAdapter.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/adapter/ThriftAdapter.scala
@@ -18,6 +18,8 @@ package com.twitter.zipkin.adapter
 
 import com.twitter.zipkin.gen
 import com.twitter.zipkin.common._
+import com.twitter.util.Duration
+import java.util.concurrent.TimeUnit
 
 object ThriftAdapter extends Adapter {
   type annotationType = gen.Annotation
@@ -35,12 +37,12 @@ object ThriftAdapter extends Adapter {
     if ("".equals(a.value))
       throw new IllegalArgumentException("Annotation must have a value: %s".format(a.toString))
 
-    new Annotation(a.timestamp, a.value, a.host.map { this(_) })
+    new Annotation(a.timestamp, a.value, a.host.map { this(_) }, a.duration.map(Duration(_, TimeUnit.MICROSECONDS)))
   }
 
   /* Annotation to Thrift */
   def apply(a: Annotation): annotationType = {
-    gen.Annotation(a.timestamp, a.value, a.host.map { this(_) })
+    gen.Annotation(a.timestamp, a.value, a.host.map { this(_) }, a.duration.map(_.inMicroseconds.toInt))
   }
 
   /* AnnotationType from Thrift */

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftAdapterSpec.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftAdapterSpec.scala
@@ -18,6 +18,8 @@ package com.twitter.zipkin.adapter
 
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.gen
+import com.twitter.conversions.time._
+
 import org.specs.Specification
 import org.specs.mock.{ClassMocker, JMocker}
 import java.nio.ByteBuffer
@@ -28,6 +30,12 @@ class ThriftAdapterSpec extends Specification with JMocker with ClassMocker {
     "convert Annotation" in {
       "to thrift and back" in {
         val expectedAnn: Annotation = Annotation(123, "value", Some(Endpoint(123, 123, "service")))
+        val thriftAnn: gen.Annotation = ThriftAdapter(expectedAnn)
+        val actualAnn: Annotation = ThriftAdapter(thriftAnn)
+        expectedAnn mustEqual actualAnn
+      }
+      "to thrift and back, with duration" in {
+        val expectedAnn: Annotation = Annotation(123, "value", Some(Endpoint(123, 123, "service")), Some(1.seconds))
         val thriftAnn: gen.Annotation = ThriftAdapter(expectedAnn)
         val actualAnn: Annotation = ThriftAdapter(thriftAnn)
         expectedAnn mustEqual actualAnn

--- a/zipkin-thrift/src/main/thrift/zipkinCore.thrift
+++ b/zipkin-thrift/src/main/thrift/zipkinCore.thrift
@@ -33,7 +33,8 @@ struct Endpoint {
 struct Annotation {
   1: i64 timestamp                 // microseconds from epoch
   2: string value                  // what happened at the timestamp?
-  3: optional Endpoint host                 // host this happened on
+  3: optional Endpoint host        // host this happened on
+  4: optional i32 duration         // how long did the operation take? microseconds
 }
 
 enum AnnotationType { BOOL, BYTES, I16, I32, I64, DOUBLE, STRING }


### PR DESCRIPTION
Useful for timing blocks of code or other operations that don't warrant a full Span.
