### PR TITLE
Replace the word submit on the lookup page with something more relevant

### DIFF
--- a/zipkin-finatra/src/main/resources/templates/index.mustache
+++ b/zipkin-finatra/src/main/resources/templates/index.mustache
@@ -58,7 +58,7 @@
       </div>
 
       <div class="sidebar-block filter-block-contents filter-submit">
-        <button class="btn primary" disabled>Submit</button>
+        <button class="btn primary" disabled>Find traces</button>
         <a data-toggle="modal" href="#lookup-help-modal" class="btn"><i class="icon-info-sign"></i></a>
         <a id="static-search-link" class="hide pull-right">link</a>
       </div>

--- a/zipkin-web/app/views/traces/index.html.erb
+++ b/zipkin-web/app/views/traces/index.html.erb
@@ -67,7 +67,7 @@
       </div>
 
       <div class="sidebar-block filter-block-contents filter-submit">
-        <button class="btn primary" disabled>Submit</button>
+        <button class="btn primary" disabled>Find traces</button>
         <a data-toggle="modal" href="#lookup-help-modal" class="btn"><i class="icon-info-sign"></i></a>
         <a id="static-search-link" class="hide pull-right">link</a>
       </div>


### PR DESCRIPTION
Submit doesn't really say what it does. I settled on "Find traces" but I'm open to suggestions. Look up traces? Just "Look up"? Don't want to call it Search since we don't really search as much as look things up in a very strict manner.
