### PR TITLE
Common refactor

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/adapter/Adapter.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/adapter/Adapter.scala
@@ -32,7 +32,6 @@ trait Adapter {
   type binaryAnnotationType  /* corresponds to com.twitter.zipkin.common.BinaryAnnotation */
   type endpointType          /* corresponds to com.twitter.zipkin.common.Endpoint         */
   type spanType              /* corresponds to com.twitter.zipkin.common.Span             */
-  type traceSummaryType      /* corresponds to com.twitter.zipkin.common.TraceSummary     */
 
   def apply(a: annotationType): Annotation
   def apply(a: Annotation): annotationType
@@ -48,7 +47,4 @@ trait Adapter {
 
   def apply(s: spanType): Span
   def apply(s: Span): spanType
-
-  def apply(t: traceSummaryType): TraceSummary
-  def apply(t: TraceSummary): traceSummaryType
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/adapter/QueryAdapter.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/adapter/QueryAdapter.scala
@@ -15,8 +15,7 @@
  */
 package com.twitter.zipkin.adapter
 
-import com.twitter.zipkin.common.Trace
-import com.twitter.zipkin.query.{TraceCombo, TraceTimeline, TimelineAnnotation}
+import com.twitter.zipkin.query._
 
 /**
  * Adapter for query related structs
@@ -25,6 +24,7 @@ trait QueryAdapter {
   type timelineAnnotationType /* corresponds to com.twitter.zipkin.query.TimelineAnnotation */
   type traceTimelineType      /* corresponds to com.twitter.zipkin.query.TraceTimeline */
   type traceComboType         /* corresponds to com.twitter.zipkin.query.TraceCombo */
+  type traceSummaryType      /* corresponds to com.twitter.zipkin.common.TraceSummary     */
   type traceType              /* corresponds to com.twitter.zipkin.query.Trace */
 
   def apply(t: timelineAnnotationType): TimelineAnnotation
@@ -35,6 +35,9 @@ trait QueryAdapter {
 
   def apply(t: traceComboType): TraceCombo
   def apply(t: TraceCombo): traceComboType
+
+  def apply(t: traceSummaryType): TraceSummary
+  def apply(t: TraceSummary): traceSummaryType
 
   def apply(t: traceType): Trace
   def apply(t: Trace): traceType

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/query/Trace.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/query/Trace.scala
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.twitter.zipkin.common
+package com.twitter.zipkin.query
 
+import com.twitter.finagle.tracing.{Trace => FTrace}
 import com.twitter.logging.Logger
+import com.twitter.zipkin.common.{BinaryAnnotation, Endpoint, Span}
 import java.nio.ByteBuffer
 import scala.collection.mutable
-import com.twitter.finagle.tracing.{Trace => FTrace}
-import com.twitter.zipkin.query.SpanTreeEntry
 
 /**
  * A chunk of time, between a start and an end.

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/query/TraceCombo.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/query/TraceCombo.scala
@@ -15,8 +15,6 @@
  */
 package com.twitter.zipkin.query
 
-import com.twitter.zipkin.common.{Trace, TraceSummary}
-
 object TraceCombo {
   def apply(trace: Trace): TraceCombo = {
     TraceCombo(trace, TraceSummary(trace), TraceTimeline(trace), trace.toSpanDepths)

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/query/TraceSummary.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/query/TraceSummary.scala
@@ -14,9 +14,10 @@
  *  limitations under the License.
  *
  */
-package com.twitter.zipkin.common
+package com.twitter.zipkin.query
 
 import scala.collection.Map
+import com.twitter.zipkin.common.Endpoint
 
 object TraceSummary {
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/query/TraceTimeline.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/query/TraceTimeline.scala
@@ -15,7 +15,7 @@
  */
 package com.twitter.zipkin.query
 
-import com.twitter.zipkin.common.{Trace, Endpoint, BinaryAnnotation}
+import com.twitter.zipkin.common.{Endpoint, BinaryAnnotation}
 
 object TraceTimeline {
   def apply(trace: Trace): Option[TraceTimeline] = {

--- a/zipkin-finatra/src/main/scala/com/twitter/zipkin/adapter/JsonAdapter.scala
+++ b/zipkin-finatra/src/main/scala/com/twitter/zipkin/adapter/JsonAdapter.scala
@@ -1,7 +1,7 @@
 package com.twitter.zipkin.adapter
 
 import com.twitter.zipkin.common._
-import com.twitter.zipkin.common.json.{JsonTraceSummary, JsonBinaryAnnotation, JsonSpan}
+import com.twitter.zipkin.common.json.{JsonBinaryAnnotation, JsonSpan}
 
 /**
  * Adapter to make common classes compatible with Jackson/Jerkson JSON generation
@@ -12,7 +12,6 @@ object JsonAdapter extends Adapter {
   type binaryAnnotationType = JsonBinaryAnnotation
   type endpointType = Endpoint
   type spanType = JsonSpan
-  type traceSummaryType = JsonTraceSummary
 
   /* No change between JSON and common types */
   def apply(a: annotationType): Annotation = a
@@ -60,14 +59,6 @@ object JsonAdapter extends Adapter {
       s.duration.get,
       s.annotations.sortWith((a,b) => a.timestamp < b.timestamp),
       s.binaryAnnotations.map(JsonAdapter(_)))
-  }
-
-  def apply(t: traceSummaryType): TraceSummary = {
-    TraceSummary(t.traceId.toLong, t.startTimestamp, t.endTimestamp, t.durationMicro, t.serviceCounts, t.endpoints)
-  }
-
-  def apply(t: TraceSummary): traceSummaryType =  {
-    JsonTraceSummary(t.traceId.toString, t.startTimestamp, t.endTimestamp, t.durationMicro, t.serviceCounts.toMap, t.endpoints)
   }
 }
 

--- a/zipkin-finatra/src/main/scala/com/twitter/zipkin/adapter/JsonQueryAdapter.scala
+++ b/zipkin-finatra/src/main/scala/com/twitter/zipkin/adapter/JsonQueryAdapter.scala
@@ -1,8 +1,7 @@
 package com.twitter.zipkin.adapter
 
-import com.twitter.zipkin.common.Trace
-import com.twitter.zipkin.common.json.{JsonTimelineAnnotation, JsonTrace, JsonTraceCombo, JsonTraceTimeline}
-import com.twitter.zipkin.query.{TraceCombo, TraceTimeline, TimelineAnnotation}
+import com.twitter.zipkin.common.json._
+import com.twitter.zipkin.query._
 
 /**
  * JS doesn't like Longs so we need to convert them to strings
@@ -11,6 +10,7 @@ object JsonQueryAdapter extends QueryAdapter {
   type timelineAnnotationType = JsonTimelineAnnotation
   type traceTimelineType = JsonTraceTimeline
   type traceComboType = JsonTraceCombo
+  type traceSummaryType = JsonTraceSummary
   type traceType = JsonTrace
 
   /* no change between json and common */
@@ -44,7 +44,7 @@ object JsonQueryAdapter extends QueryAdapter {
   def apply(t: traceComboType): TraceCombo = {
     TraceCombo(
       JsonQueryAdapter(t.trace),
-      t.traceSummary.map(JsonAdapter(_)),
+      t.traceSummary.map(JsonQueryAdapter(_)),
       t.traceTimeline.map(JsonQueryAdapter(_)),
       t.spanDepths)
   }
@@ -53,9 +53,17 @@ object JsonQueryAdapter extends QueryAdapter {
   def apply(t: TraceCombo): traceComboType = {
     JsonTraceCombo(
       JsonQueryAdapter(t.trace),
-      t.traceSummary.map(JsonAdapter(_)),
+      t.traceSummary.map(JsonQueryAdapter(_)),
       t.traceTimeline.map(JsonQueryAdapter(_)),
       t.spanDepths)
+  }
+
+  def apply(t: traceSummaryType): TraceSummary = {
+    TraceSummary(t.traceId.toLong, t.startTimestamp, t.endTimestamp, t.durationMicro, t.serviceCounts, t.endpoints)
+  }
+
+  def apply(t: TraceSummary): traceSummaryType =  {
+    JsonTraceSummary(t.traceId.toString, t.startTimestamp, t.endTimestamp, t.durationMicro, t.serviceCounts.toMap, t.endpoints)
   }
 
   /* json to common */

--- a/zipkin-finatra/src/main/scala/com/twitter/zipkin/common/json/JsonTraceSummary.scala
+++ b/zipkin-finatra/src/main/scala/com/twitter/zipkin/common/json/JsonTraceSummary.scala
@@ -1,6 +1,7 @@
 package com.twitter.zipkin.common.json
 
-import com.twitter.zipkin.common.{Endpoint, TraceSummary}
+import com.twitter.zipkin.common.Endpoint
+import com.twitter.zipkin.query.TraceSummary
 
 object JsonTraceSummary {
   def apply(t: TraceSummary): JsonTraceSummary =

--- a/zipkin-finatra/src/main/scala/com/twitter/zipkin/web/App.scala
+++ b/zipkin-finatra/src/main/scala/com/twitter/zipkin/web/App.scala
@@ -95,7 +95,7 @@ class App(config: ZipkinWebConfig, client: gen.ZipkinQuery.FinagledClient) exten
         case _ => {
           client.getTraceSummariesByIds(ids, adjusters).map {
             _.map { summary =>
-              JsonAdapter(ThriftAdapter(summary))
+              JsonQueryAdapter(ThriftQueryAdapter(summary))
             }
           }
         }

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/adapter/ThriftAdapter.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/adapter/ThriftAdapter.scala
@@ -16,9 +16,9 @@
  */
 package com.twitter.zipkin.adapter
 
+import com.twitter.util.Duration
 import com.twitter.zipkin.gen
 import com.twitter.zipkin.common._
-import com.twitter.util.Duration
 import java.util.concurrent.TimeUnit
 
 object ThriftAdapter extends Adapter {
@@ -27,7 +27,6 @@ object ThriftAdapter extends Adapter {
   type binaryAnnotationType = gen.BinaryAnnotation
   type endpointType = gen.Endpoint
   type spanType = gen.Span
-  type traceSummaryType = gen.TraceSummary
 
   /* Annotation from Thrift */
   def apply(a: annotationType): Annotation = {
@@ -115,18 +114,5 @@ object ThriftAdapter extends Adapter {
   def apply(s: Span): spanType = {
     gen.Span(s.traceId, s.name, s.id, s.parentId, s.annotations.map { this(_) },
       s.binaryAnnotations.map { this(_) }, s.debug)
-  }
-
-  /* TraceSummary from Thrift */
-  def apply(t: traceSummaryType): TraceSummary = {
-    new TraceSummary(t.traceId, t.startTimestamp, t.endTimestamp,
-      t.durationMicro, t.serviceCounts,
-      t.endpoints.map(ThriftAdapter(_)).toList)
-  }
-
-  /* TraceSummary to Thrift */
-  def apply(t: TraceSummary): traceSummaryType = {
-    gen.TraceSummary(t.traceId, t.startTimestamp, t.endTimestamp,
-      t.durationMicro, t.serviceCounts, t.endpoints.map(ThriftAdapter(_)))
   }
 }

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/adapter/ThriftQueryAdapter.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/adapter/ThriftQueryAdapter.scala
@@ -16,13 +16,13 @@
 package com.twitter.zipkin.adapter
 
 import com.twitter.zipkin.gen
-import com.twitter.zipkin.query.{TraceCombo, TraceTimeline, TimelineAnnotation}
-import com.twitter.zipkin.common.Trace
+import com.twitter.zipkin.query._
 
 object ThriftQueryAdapter extends QueryAdapter {
   type timelineAnnotationType = gen.TimelineAnnotation
   type traceTimelineType = gen.TraceTimeline
   type traceComboType = gen.TraceCombo
+  type traceSummaryType = gen.TraceSummary
   type traceType = gen.Trace
 
   /* TimelineAnnotation from Thrift */
@@ -71,7 +71,7 @@ object ThriftQueryAdapter extends QueryAdapter {
   def apply(t: traceComboType): TraceCombo = {
     TraceCombo(
       ThriftQueryAdapter(t.`trace`),
-      t.`summary`.map(ThriftAdapter(_)),
+      t.`summary`.map(ThriftQueryAdapter(_)),
       t.`timeline`.map(ThriftQueryAdapter(_)),
       t.`spanDepths`.map(_.toMap))
   }
@@ -80,9 +80,22 @@ object ThriftQueryAdapter extends QueryAdapter {
   def apply(t: TraceCombo): traceComboType = {
     gen.TraceCombo(
       ThriftQueryAdapter(t.trace),
-      t.traceSummary.map(ThriftAdapter(_)),
+      t.traceSummary.map(ThriftQueryAdapter(_)),
       t.traceTimeline.map(ThriftQueryAdapter(_)),
       t.spanDepths)
+  }
+
+  /* TraceSummary from Thrift */
+  def apply(t: traceSummaryType): TraceSummary = {
+    new TraceSummary(t.traceId, t.startTimestamp, t.endTimestamp,
+      t.durationMicro, t.serviceCounts,
+      t.endpoints.map(ThriftAdapter(_)).toList)
+  }
+
+  /* TraceSummary to Thrift */
+  def apply(t: TraceSummary): traceSummaryType = {
+    gen.TraceSummary(t.traceId, t.startTimestamp, t.endTimestamp,
+      t.durationMicro, t.serviceCounts, t.endpoints.map(ThriftAdapter(_)))
   }
 
   /* Trace from Thrift */

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftAdapterSpec.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftAdapterSpec.scala
@@ -105,16 +105,5 @@ class ThriftAdapterSpec extends Specification with JMocker with ClassMocker {
         ThriftAdapter(noBinaryAnnotationsSpan) mustEqual Span(0, "name", 0, None, List(), Seq())
       }
     }
-
-    "convert TraceSummary" in {
-      "to thrift and back" in {
-        val expectedTraceSummary = TraceSummary(123, 10000, 10300, 300, Map("service1" -> 1),
-          List(Endpoint(123, 123, "service1")))
-        val thriftTraceSummary = ThriftAdapter(expectedTraceSummary)
-        val actualTraceSummary = ThriftAdapter(thriftTraceSummary)
-        expectedTraceSummary mustEqual actualTraceSummary
-      }
-    }
   }
-
 }

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftQueryAdapterSpec.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftQueryAdapterSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.twitter.zipkin.adapter
+
+import com.twitter.zipkin.common.Endpoint
+import com.twitter.zipkin.query.TraceSummary
+import org.specs.mock.{JMocker, ClassMocker}
+import org.specs.Specification
+
+class ThriftQueryAdapterSpec extends Specification with JMocker with ClassMocker {
+
+  "ThriftQueryAdapter" should {
+    "convert TraceSummary" in {
+      "to thrift and back" in {
+        val expectedTraceSummary = TraceSummary(123, 10000, 10300, 300, Map("service1" -> 1),
+          List(Endpoint(123, 123, "service1")))
+        val thriftTraceSummary = ThriftQueryAdapter(expectedTraceSummary)
+        val actualTraceSummary = ThriftQueryAdapter(thriftTraceSummary)
+        expectedTraceSummary mustEqual actualTraceSummary
+      }
+    }
+  }
+}

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
@@ -28,7 +28,6 @@ import com.twitter.zipkin.storage.{Aggregates, TraceIdDuration, Index, Storage}
 import java.nio.ByteBuffer
 import org.apache.thrift.TException
 import scala.collection.Set
-import com.twitter.zipkin.common.TraceSummary
 import com.twitter.zipkin.adapter.{ThriftQueryAdapter, ThriftAdapter}
 
 /**

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/adjusters/Adjuster.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/adjusters/Adjuster.scala
@@ -16,7 +16,7 @@
  */
 package com.twitter.zipkin.query.adjusters
 
-import com.twitter.zipkin.common.Trace
+import com.twitter.zipkin.query.Trace
 
 trait Adjuster {
 

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjuster.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjuster.scala
@@ -16,12 +16,11 @@
  */
 package com.twitter.zipkin.query.adjusters
 
-import com.twitter.zipkin.gen
-import scala.collection.Map
-import com.twitter.zipkin.common._
 import com.twitter.finagle.tracing.{Trace => FTrace}
-import com.twitter.zipkin.query.SpanTreeEntry
-
+import com.twitter.zipkin.common._
+import com.twitter.zipkin.gen
+import com.twitter.zipkin.query.{Trace, SpanTreeEntry}
+import scala.collection.Map
 
 class TimeSkewAdjuster extends Adjuster {
 

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/storage/Storage.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/storage/Storage.scala
@@ -16,8 +16,9 @@
  */
 package com.twitter.zipkin.storage
 
-import com.twitter.zipkin.common.{Trace, Span}
 import com.twitter.util.{Duration, Future}
+import com.twitter.zipkin.common.Span
+import com.twitter.zipkin.query.Trace
 
 trait Storage {
 

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraStorage.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraStorage.scala
@@ -19,12 +19,13 @@ import com.twitter.zipkin.storage.Storage
 import com.twitter.util.{Duration, Future}
 import com.twitter.zipkin.gen
 import com.twitter.ostrich.stats.Stats
-import com.twitter.cassie.{Order, Column, ColumnFamily, Keyspace}
-import com.twitter.zipkin.common.{Trace, Span}
+import com.twitter.cassie.{Order, Column, ColumnFamily}
+import com.twitter.zipkin.common.Span
 import com.twitter.conversions.time._
 import scala.collection.JavaConverters._
 import com.twitter.zipkin.config.{CassandraConfig, CassandraStorageConfig}
 import com.twitter.zipkin.adapter.ThriftAdapter
+import com.twitter.zipkin.query.Trace
 
 trait CassandraStorage extends Storage with Cassandra {
 

--- a/zipkin-server/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
+++ b/zipkin-server/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
@@ -20,7 +20,7 @@ import org.specs.Specification
 import com.twitter.zipkin.gen
 import collection.mutable
 import java.nio.ByteBuffer
-import com.twitter.zipkin.query.SpanTreeEntry
+import com.twitter.zipkin.query.{TraceSummary, SpanTreeEntry}
 import com.twitter.zipkin.adapter.{ThriftQueryAdapter, ThriftAdapter}
 
 class TraceSpec extends Specification {

--- a/zipkin-server/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
+++ b/zipkin-server/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
@@ -20,7 +20,7 @@ import org.specs.Specification
 import com.twitter.zipkin.gen
 import collection.mutable
 import java.nio.ByteBuffer
-import com.twitter.zipkin.query.{TraceSummary, SpanTreeEntry}
+import com.twitter.zipkin.query.{Timespan, Trace, TraceSummary, SpanTreeEntry}
 import com.twitter.zipkin.adapter.{ThriftQueryAdapter, ThriftAdapter}
 
 class TraceSpec extends Specification {

--- a/zipkin-server/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
+++ b/zipkin-server/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
@@ -162,7 +162,7 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
         one(storage).getTracesByIds(List(traceId)) willReturn Future(List(trace1))
       }
 
-      val ts = List(ThriftAdapter(TraceSummary(1, 100, 150, 50, Map("service1" -> 1), List(ep1))))
+      val ts = List(ThriftQueryAdapter(TraceSummary(1, 100, 150, 50, Map("service1" -> 1), List(ep1))))
       ts mustEqual qs.getTraceSummariesByIds(List(traceId), List())()
     }
 
@@ -178,7 +178,7 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
         one(storage).getTracesByIds(List(traceId)) willReturn Future(List(trace1))
       }
       val trace = ThriftQueryAdapter(trace1)
-      val summary = ThriftAdapter(TraceSummary(1, 100, 150, 50, Map("service1" -> 1), List(ep1)))
+      val summary = ThriftQueryAdapter(TraceSummary(1, 100, 150, 50, Map("service1" -> 1), List(ep1)))
       val timeline = TraceTimeline(trace1).map(ThriftQueryAdapter(_))
       val combo = gen.TraceCombo(trace, Some(summary), timeline, Some(Map(666L -> 1)))
       Seq(combo) mustEqual qs.getTraceCombosByIds(List(traceId), List())()

--- a/zipkin-server/src/test/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjusterSpec.scala
+++ b/zipkin-server/src/test/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjusterSpec.scala
@@ -20,7 +20,8 @@ import org.specs.Specification
 import org.specs.mock.{ClassMocker, JMocker}
 import scala.collection._
 import com.twitter.zipkin.gen
-import com.twitter.zipkin.common.{Endpoint, Trace, Annotation, Span}
+import com.twitter.zipkin.common.{Endpoint, Annotation, Span}
+import com.twitter.zipkin.query.Trace
 
 class TimeSkewAdjusterSpec extends Specification with JMocker with ClassMocker {
   val endpoint1 = Some(Endpoint(123, 123, "service"))

--- a/zipkin-server/src/test/scala/com/twitter/zipkin/query/conversions/TraceTimelineSpec.scala
+++ b/zipkin-server/src/test/scala/com/twitter/zipkin/query/conversions/TraceTimelineSpec.scala
@@ -15,15 +15,13 @@
  */
 package com.twitter.zipkin.query.conversions
 
+import com.twitter.zipkin.adapter.ThriftAdapter
+import com.twitter.zipkin.common._
+import com.twitter.zipkin.gen
+import com.twitter.zipkin.query.{Trace, TimelineAnnotation, TraceTimeline}
 import org.specs.Specification
 import org.specs.mock.{ClassMocker, JMocker}
-import com.twitter.zipkin.gen
-
-import scala.collection.JavaConversions._
 import java.nio.ByteBuffer
-import com.twitter.zipkin.adapter.ThriftAdapter
-import com.twitter.zipkin.query.{TimelineAnnotation, TraceTimeline}
-import com.twitter.zipkin.common._
 
 class TraceTimelineSpec extends Specification with JMocker with ClassMocker {
 


### PR DESCRIPTION
- Move `Trace`, `TraceSummary` from `common` package to `query` since they are only used in the query service.
- Cleanup from the move
