### PR TITLE
Trace spec refactor

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/AnnotationType.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/AnnotationType.scala
@@ -16,4 +16,14 @@
  */
 package com.twitter.zipkin.common
 
+object AnnotationType {
+  case object Bool extends AnnotationType(0, "Bool")
+  case object Bytes extends AnnotationType(1, "Bytes")
+  case object I16 extends AnnotationType(2, "I16")
+  case object I32 extends AnnotationType(3, "I32")
+  case object I64 extends AnnotationType(4, "I64")
+  case object Double extends AnnotationType(5, "Double")
+  case object String extends AnnotationType(6, "String")
+}
+
 case class AnnotationType(value: Int, name: String)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
@@ -1,6 +1,6 @@
 /*
  * Copyright 2012 Twitter Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -159,7 +159,7 @@ class TraceSpec extends Specification {
         Annotation(300, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))),
         Annotation(150, Constants.ServerRecv, Some(Endpoint(456, 456, "service2"))),
         Annotation(200, Constants.ServerSend, Some(Endpoint(456, 456, "service2")))
-        )
+      )
 
       val spanToMerge1 = Span(12345, "methodcall2", span2Id, Some(span1Id), ann1, Nil)
       val spanToMerge2 = Span(12345, "methodcall2", span2Id, Some(span1Id), ann2, Nil)

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftQueryAdapterSpec.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftQueryAdapterSpec.scala
@@ -16,14 +16,26 @@
  */
 package com.twitter.zipkin.adapter
 
-import com.twitter.zipkin.common.Endpoint
-import com.twitter.zipkin.query.TraceSummary
+import com.twitter.zipkin.common.{Annotation, Span, Endpoint}
+import com.twitter.zipkin.query.{Trace, TraceSummary}
 import org.specs.mock.{JMocker, ClassMocker}
 import org.specs.Specification
 
 class ThriftQueryAdapterSpec extends Specification with JMocker with ClassMocker {
 
   "ThriftQueryAdapter" should {
+
+    "convert Trace" in {
+      "to thrift and back" in {
+        val span = Span(12345, "methodcall", 666, None,
+          List(Annotation(1, "boaoo", None)), Nil)
+        val expectedTrace = Trace(List[Span](span))
+        val thriftTrace = ThriftQueryAdapter(expectedTrace)
+        val actualTrace = ThriftQueryAdapter(thriftTrace)
+        expectedTrace mustEqual actualTrace
+      }
+    }
+
     "convert TraceSummary" in {
       "to thrift and back" in {
         val expectedTraceSummary = TraceSummary(123, 10000, 10300, 300, Map("service1" -> 1),

--- a/zipkin-server/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
+++ b/zipkin-server/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
@@ -16,12 +16,11 @@
  */
 package com.twitter.zipkin.common
 
-import org.specs.Specification
 import com.twitter.zipkin.gen
+import com.twitter.zipkin.query.{Timespan, Trace, TraceSummary, SpanTreeEntry}
 import collection.mutable
 import java.nio.ByteBuffer
-import com.twitter.zipkin.query.{Timespan, Trace, TraceSummary, SpanTreeEntry}
-import com.twitter.zipkin.adapter.{ThriftQueryAdapter, ThriftAdapter}
+import org.specs.Specification
 
 class TraceSpec extends Specification {
 
@@ -49,15 +48,6 @@ class TraceSpec extends Specification {
   val trace = Trace(List[Span](span1, span2, span3, span4))
 
   "Trace" should {
-    "convert to thrift and back" in {
-      val span = Span(12345, "methodcall", 666, None,
-        List(Annotation(1, "boaoo", None)), Nil)
-      val expectedTrace = Trace(List[Span](span))
-      val thriftTrace = ThriftQueryAdapter(expectedTrace)
-      val actualTrace = ThriftQueryAdapter(thriftTrace)
-      expectedTrace mustEqual actualTrace
-    }
-
     "get duration of trace" in {
       val annotations = List(Annotation(100, gen.Constants.CLIENT_SEND, Some(Endpoint(123, 123, "service1"))),
         Annotation(200, gen.Constants.CLIENT_RECV, Some(Endpoint(123, 123, "service1"))))
@@ -120,9 +110,9 @@ class TraceSpec extends Specification {
     }
 
     "getBinaryAnnotations" in {
-      val ba1 = BinaryAnnotation("key1", ByteBuffer.wrap("value1".getBytes), ThriftAdapter(gen.AnnotationType.String), None)
+      val ba1 = BinaryAnnotation("key1", ByteBuffer.wrap("value1".getBytes), AnnotationType.String, None)
       val span1 = Span(1L, "", 1L, None, List(), List(ba1))
-      val ba2 = BinaryAnnotation("key2", ByteBuffer.wrap("value2".getBytes), ThriftAdapter(gen.AnnotationType.String), None)
+      val ba2 = BinaryAnnotation("key2", ByteBuffer.wrap("value2".getBytes), AnnotationType.String, None)
       val span2 = Span(1L, "", 2L, None, List(), List(ba2))
 
       val trace = Trace(List[Span](span1, span2))

--- a/zipkin-server/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
+++ b/zipkin-server/src/test/scala/com/twitter/zipkin/common/TraceSpec.scala
@@ -16,7 +16,7 @@
  */
 package com.twitter.zipkin.common
 
-import com.twitter.zipkin.gen
+import com.twitter.zipkin.Constants
 import com.twitter.zipkin.query.{Timespan, Trace, TraceSummary, SpanTreeEntry}
 import collection.mutable
 import java.nio.ByteBuffer
@@ -25,14 +25,14 @@ import org.specs.Specification
 class TraceSpec extends Specification {
 
   // TODO these don't actually make any sense
-  val annotations1 = List(Annotation(100, gen.Constants.CLIENT_SEND, Some(Endpoint(123, 123, "service1"))),
-    Annotation(150, gen.Constants.CLIENT_RECV, Some(Endpoint(456, 456, "service1"))))
-  val annotations2 = List(Annotation(200, gen.Constants.CLIENT_SEND, Some(Endpoint(456, 456, "service2"))),
-    Annotation(250, gen.Constants.CLIENT_RECV, Some(Endpoint(123, 123, "service2"))))
-  val annotations3 = List(Annotation(300, gen.Constants.CLIENT_SEND, Some(Endpoint(456, 456, "service2"))),
-    Annotation(350, gen.Constants.CLIENT_RECV, Some(Endpoint(666, 666, "service2"))))
-  val annotations4 = List(Annotation(400, gen.Constants.CLIENT_SEND, Some(Endpoint(777, 777, "service3"))),
-    Annotation(500, gen.Constants.CLIENT_RECV, Some(Endpoint(888, 888, "service3"))))
+  val annotations1 = List(Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
+    Annotation(150, Constants.ClientRecv, Some(Endpoint(456, 456, "service1"))))
+  val annotations2 = List(Annotation(200, Constants.ClientSend, Some(Endpoint(456, 456, "service2"))),
+    Annotation(250, Constants.ClientRecv, Some(Endpoint(123, 123, "service2"))))
+  val annotations3 = List(Annotation(300, Constants.ClientSend, Some(Endpoint(456, 456, "service2"))),
+    Annotation(350, Constants.ClientRecv, Some(Endpoint(666, 666, "service2"))))
+  val annotations4 = List(Annotation(400, Constants.ClientSend, Some(Endpoint(777, 777, "service3"))),
+    Annotation(500, Constants.ClientRecv, Some(Endpoint(888, 888, "service3"))))
 
   val span1Id = 666L
   val span2Id = 777L
@@ -49,20 +49,20 @@ class TraceSpec extends Specification {
 
   "Trace" should {
     "get duration of trace" in {
-      val annotations = List(Annotation(100, gen.Constants.CLIENT_SEND, Some(Endpoint(123, 123, "service1"))),
-        Annotation(200, gen.Constants.CLIENT_RECV, Some(Endpoint(123, 123, "service1"))))
+      val annotations = List(Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
+        Annotation(200, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
       val span = Span(12345, "methodcall", 666, None,
         annotations, Nil)
       100 mustEqual Trace(List(span)).duration
     }
 
     "get duration of trace without root span" in {
-      val annotations = List(Annotation(100, gen.Constants.CLIENT_SEND, Some(Endpoint(123, 123, "service1"))),
-        Annotation(200, gen.Constants.CLIENT_RECV, Some(Endpoint(123, 123, "service1"))))
+      val annotations = List(Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
+        Annotation(200, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
       val span = Span(12345, "methodcall", 666, Some(123),
         annotations, Nil)
-      val annotations2 = List(Annotation(150, gen.Constants.CLIENT_SEND, Some(Endpoint(123, 123, "service1"))),
-        Annotation(160, gen.Constants.CLIENT_RECV, Some(Endpoint(123, 123, "service1"))))
+      val annotations2 = List(Annotation(150, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
+        Annotation(160, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
       val span2 = Span(12345, "methodcall", 666, Some(123),
         annotations2, Nil)
       100 mustEqual Trace(List(span, span2)).duration
@@ -149,16 +149,16 @@ class TraceSpec extends Specification {
     }
 
     "merge spans" in {
-      val ann1 = List(Annotation(100, gen.Constants.CLIENT_SEND, Some(Endpoint(123, 123, "service1"))),
-        Annotation(300, gen.Constants.CLIENT_RECV, Some(Endpoint(123, 123, "service1"))))
-      val ann2 = List(Annotation(150, gen.Constants.SERVER_RECV, Some(Endpoint(456, 456, "service2"))),
-        Annotation(200, gen.Constants.SERVER_SEND, Some(Endpoint(456, 456, "service2"))))
+      val ann1 = List(Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
+        Annotation(300, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
+      val ann2 = List(Annotation(150, Constants.ServerRecv, Some(Endpoint(456, 456, "service2"))),
+        Annotation(200, Constants.ServerSend, Some(Endpoint(456, 456, "service2"))))
 
       val annMerged = List(
-        Annotation(100, gen.Constants.CLIENT_SEND, Some(Endpoint(123, 123, "service1"))),
-        Annotation(300, gen.Constants.CLIENT_RECV, Some(Endpoint(123, 123, "service1"))),
-        Annotation(150, gen.Constants.SERVER_RECV, Some(Endpoint(456, 456, "service2"))),
-        Annotation(200, gen.Constants.SERVER_SEND, Some(Endpoint(456, 456, "service2")))
+        Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
+        Annotation(300, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))),
+        Annotation(150, Constants.ServerRecv, Some(Endpoint(456, 456, "service2"))),
+        Annotation(200, Constants.ServerSend, Some(Endpoint(456, 456, "service2")))
         )
 
       val spanToMerge1 = Span(12345, "methodcall2", span2Id, Some(span1Id), ann1, Nil)


### PR DESCRIPTION
- Move Thrift conversion spec to ThriftQueryAdapter
- Replace thrift/scrooge dependencies with comparable common dependencies
- Move TraceSpec to zipkin-common
