### PR TITLE
Fixup Scribe script, and add a localhost Finatra config

### DIFF
--- a/zipkin-finatra/config/web-localhost.scala
+++ b/zipkin-finatra/config/web-localhost.scala
@@ -1,0 +1,31 @@
+/*
+* Copyright 2012 Twitter Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import com.twitter.zipkin.config.ZipkinWebConfig
+import com.twitter.zipkin.config.zookeeper.ZooKeeperConfig
+import java.net.InetSocketAddress
+
+new ZipkinWebConfig {
+  // Change the hostname below to allow the Zipkin JS code to talk to the Zipkin API Scala code
+  // Suspect this should be marked as a bug really...
+  rootUrl = "http://localhost:" + serverPort + "/"
+
+  def zkConfig = new ZooKeeperConfig {
+    servers = List("localhost:2181")
+  }
+
+}
+

--- a/zipkin-scribe/src/scripts/collector.sh
+++ b/zipkin-scribe/src/scripts/collector.sh
@@ -1,3 +1,3 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VERSION=@VERSION@
-java -cp "$DIR/../libs/*" -jar $DIR/../zipkin-server_2.9.1-$VERSION.jar $*
+java -cp "$DIR/../libs/*" -jar $DIR/../zipkin-scribe_2.9.1-$VERSION.jar $*


### PR DESCRIPTION
Hi,
Just fixed an issue in the collector.sh (referencing the wrong JAR)
Added a config file for Finatra which uses the localhost zookeeper and doesn't override the queryhost
(This means they match the other config within the repo)
