### PR TITLE
Fixed wrong jar filename in collector.sh

### DIFF
--- a/zipkin-scribe/src/scripts/collector.sh
+++ b/zipkin-scribe/src/scripts/collector.sh
@@ -1,3 +1,3 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VERSION=@VERSION@
-java -cp "$DIR/../libs/*" -jar $DIR/../zipkin-server_2.9.1-$VERSION.jar $*
+java -cp "$DIR/../libs/*" -jar $DIR/../zipkin-scribe_2.9.1-$VERSION.jar $*


### PR DESCRIPTION
Fixed the name of the zipkin-scribe jar file in collector.sh
