### PR TITLE
Add complex query support in QueryService 

### DIFF
--- a/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
@@ -81,9 +81,33 @@ enum Order { TIMESTAMP_DESC, TIMESTAMP_ASC, DURATION_ASC, DURATION_DESC, NONE }
  */
 enum Adjust { NOTHING, TIME_SKEW }
 
+struct QueryAnnotation {
+  1: string value
+}
+
+struct QueryRequest {
+  1: string service_name
+  2: optional string span_name
+  3: optional list<QueryAnnotation> annotations
+  4: optional list<zipkinCore.BinaryAnnotation> binary_annotations
+  5: i64 end_ts
+  6: i32 limit
+  7: Order order
+}
+
+struct QueryResponse {
+  1: list<i64> trace_ids
+  2: optional list<i32> annotations_counts
+  3: optional list<i32> binary_annotations_counts
+  4: i64 start_ts
+  5: i64 end_ts
+}
+
 service ZipkinQuery {
 
     //************** Index lookups **************
+
+    QueryResponse getTraceIds(1: QueryRequest request) throws (1: QueryException qe);
 
     /**
      * Fetch trace ids by service and span name.


### PR DESCRIPTION
- Add endpoint `getTraceIds` that allows for queries that specify multiple annotations or binary annotations that must be satisfied. Expected result is the intersection of all traces that satisfy the conditions. This endpoint is intended to eventually replace the `getTraceIdBy*` endpoints.
