### PR TITLE
Add complex query support in QueryService

### DIFF
--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/Constants.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/Constants.scala
@@ -1,0 +1,9 @@
+package com.twitter.zipkin.query
+
+import com.twitter.conversions.time._
+import com.twitter.util.Duration
+
+object Constants {
+  /* Amount of time padding to use when resolving complex query timestamps */
+  val TraceTimestampPadding: Duration = 1.minute
+}

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/Constants.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/Constants.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
 package com.twitter.zipkin.query
 
 import com.twitter.conversions.time._

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
@@ -118,8 +118,10 @@ class QueryService(storage: Storage, index: Index, aggregates: Aggregates, adjus
 
       sliceQueries match {
         case Nil => {
-          /* No queries: return a default empty response */
-          Future.exception(gen.QueryException("Invalid query"))
+          /* No queries: get service level traces */
+          index.getTraceIdsByName(serviceName, None, endTs, limit).map {
+            constructQueryResponse(_, limit, order)
+          }.flatten
         }
         case head :: Nil => {
           /* One query: just run it */

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
@@ -142,7 +142,7 @@ class QueryService(storage: Storage, index: Index, aggregates: Aggregates, adjus
             }.min
           }.map { alignedTimestamp =>
             /* Pad the aligned timestamp by a minute */
-            val ts = alignedTimestamp + 1.minute.inMicroseconds
+            val ts = alignedTimestamp + Constants.TraceTimestampPadding.inMicroseconds
 
             Future.collect {
               queries.map {

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
@@ -102,7 +102,7 @@ class QueryService(storage: Storage, index: Index, aggregates: Aggregates, adjus
         },
         queryRequest.`annotations`.map {
           _.map { a =>
-            AnnotationSliceQuery(serviceName, a.`value`, None, endTs, 1)
+            AnnotationSliceQuery(serviceName, a, None, endTs, 1)
           }
         },
         queryRequest.`binaryAnnotations`.map {

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
@@ -142,7 +142,7 @@ class QueryService(storage: Storage, index: Index, aggregates: Aggregates, adjus
             }.min
           }.map { alignedTimestamp =>
             /* Pad the aligned timestamp by a minute */
-            val ts = alignedTimestamp + Constants.TraceTimestampPadding.inMicroseconds
+            val ts = padTimestamp(alignedTimestamp)
 
             Future.collect {
               queries.map {
@@ -168,6 +168,8 @@ class QueryService(storage: Storage, index: Index, aggregates: Aggregates, adjus
       }
     }
   }
+
+  private[query] def padTimestamp(timestamp: Long): Long = timestamp + Constants.TraceTimestampPadding.inMicroseconds
 
   private[query] def traceIdsIntersect(idSeqs: Seq[Seq[IndexedTraceId]]): Seq[IndexedTraceId] = {
     /* Find the trace IDs present in all the Seqs */

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/QueryService.scala
@@ -82,7 +82,7 @@ class QueryService(storage: Storage, index: Index, aggregates: Aggregates, adjus
         case Nil => (-1L, defaultEndTs)
         case _   => (ts.min, ts.max)
       }
-      gen.QueryResponse(sortedIds, None, None, min, max)
+      gen.QueryResponse(sortedIds, min, max)
     }
   }
 

--- a/zipkin-server/src/main/scala/com/twitter/zipkin/query/SliceQuery.scala
+++ b/zipkin-server/src/main/scala/com/twitter/zipkin/query/SliceQuery.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.twitter.zipkin.query
+
+import com.twitter.util.Future
+import com.twitter.zipkin.storage.{Index, IndexedTraceId}
+import java.nio.ByteBuffer
+
+sealed trait SliceQuery {
+  def execute(index: Index): Future[Seq[IndexedTraceId]]
+}
+case class SpanSliceQuery(serviceName: String, spanName: String, endTs: Long, limit: Int) extends SliceQuery {
+  def execute(index: Index) = {
+    index.getTraceIdsByName(serviceName, Some(spanName), endTs, limit)
+  }
+}
+case class AnnotationSliceQuery(serviceName: String, key: String, value: Option[ByteBuffer], endTs: Long, limit: Int) extends SliceQuery {
+  def execute(index: Index) = {
+    index.getTraceIdsByAnnotation(serviceName, key, value, endTs, limit)
+  }
+}

--- a/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
@@ -81,9 +81,33 @@ enum Order { TIMESTAMP_DESC, TIMESTAMP_ASC, DURATION_ASC, DURATION_DESC, NONE }
  */
 enum Adjust { NOTHING, TIME_SKEW }
 
+struct QueryAnnotation {
+  1: string value
+}
+
+struct QueryRequest {
+  1: string service_name
+  2: optional string span_name
+  3: optional list<QueryAnnotation> annotations
+  4: optional list<zipkinCore.BinaryAnnotation> binary_annotations
+  5: i64 end_ts
+  6: i32 limit
+  7: Order order
+}
+
+struct QueryResponse {
+  1: list<i64> trace_ids
+  2: optional list<i32> annotations_counts
+  3: optional list<i32> binary_annotations_counts
+  4: i64 start_ts
+  5: i64 end_ts
+}
+
 service ZipkinQuery {
 
     //************** Index lookups **************
+
+    QueryResponse getTraceIds(1: QueryRequest request) throws (1: QueryException qe);
 
     /**
      * Fetch trace ids by service and span name.

--- a/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
@@ -93,10 +93,8 @@ struct QueryRequest {
 
 struct QueryResponse {
   1: list<i64> trace_ids
-  2: optional list<i32> annotations_counts
-  3: optional list<i32> binary_annotations_counts
-  4: i64 start_ts
-  5: i64 end_ts
+  2: i64 start_ts
+  3: i64 end_ts
 }
 
 service ZipkinQuery {

--- a/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
@@ -81,14 +81,10 @@ enum Order { TIMESTAMP_DESC, TIMESTAMP_ASC, DURATION_ASC, DURATION_DESC, NONE }
  */
 enum Adjust { NOTHING, TIME_SKEW }
 
-struct QueryAnnotation {
-  1: string value
-}
-
 struct QueryRequest {
   1: string service_name
   2: optional string span_name
-  3: optional list<QueryAnnotation> annotations
+  3: optional list<string> annotations
   4: optional list<zipkinCore.BinaryAnnotation> binary_annotations
   5: i64 end_ts
   6: i32 limit


### PR DESCRIPTION
- Add endpoint `getTraceIds` that allows for queries that specify multiple annotations or binary annotations that must be satisfied. Expected result is the intersection of all traces that satisfy the conditions. This endpoint is intended to eventually replace the `getTraceIdBy*` endpoints.
