### PR TITLE
Default sample rate to 1

### DIFF
--- a/zipkin-collector-core/src/main/scala/com/twitter/zipkin/config/sampler/ZooKeeperAdjustableRateConfig.scala
+++ b/zipkin-collector-core/src/main/scala/com/twitter/zipkin/config/sampler/ZooKeeperAdjustableRateConfig.scala
@@ -32,7 +32,7 @@ object ZooKeeperSampleRateConfig {
 
   val Min     = 0.0
   val Max     = 1.0
-  val Default = 0.01
+  val Default = 1.0
 
   def apply(client: ZkClient, configPath: String, key: String) =
     BoundedZooKeeperAdjustableRateConfig(client, configPath, key, Min, Max, Default)


### PR DESCRIPTION
Setting the default to 100% makes it one less thing new users have to worry about when spinning up a collector.
