### PR TITLE
Cleanup Future[Void] -> Future[Unit] conversion

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregates.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregates.scala
@@ -95,7 +95,7 @@ trait CassandraAggregates extends Aggregates with Cassandra {
     }
     remove transform {
       case Return(r) => {
-        Future.join(Seq(batch.execute()))
+        batch.execute().unit
       }
       case Throw(e) => {
         Future.exception(e)

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraIndex.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraIndex.scala
@@ -277,7 +277,7 @@ trait CassandraIndex extends Index with Cassandra {
     }
     val annFuture = batch.execute()
 
-    Future.join(Seq(annFuture))
+    annFuture.unit
   }
 
   def indexSpanDuration(span: Span): Future[Void] = {

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraStorage.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraStorage.scala
@@ -58,9 +58,7 @@ trait CassandraStorage extends Storage with Cassandra {
     WRITE_REQUEST_COUNTER.incr()
     val traceKey = span.traceId
     val traceCol = Column[String, gen.Span](createSpanColumnName(span), ThriftAdapter(span)).ttl(cassandraConfig.tracesTimeToLive)
-    Future.join {
-      Seq(traces.insert(traceKey, traceCol))
-    }
+    traces.insert(traceKey, traceCol).unit
   }
 
   def setTimeToLive(traceId: Long, ttl: Duration): Future[Unit] = {
@@ -75,8 +73,7 @@ trait CassandraStorage extends Storage with Cassandra {
       batch.insert(traceId, col)
     }
 
-    // convert to Future[Unit]. Sigh.
-    Future.join(Seq(batch.execute()))
+    batch.execute().unit
   }
 
   def getTimeToLive(traceId: Long): Future[Duration] = {


### PR DESCRIPTION
Use the `.unit` method that transforms a `Future[_]` to `Future[Unit]`
