### PR TITLE
hadoop: use UtcDateRangeJob

### DIFF
--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/DependencyTree.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/DependencyTree.scala
@@ -24,7 +24,7 @@ import com.twitter.zipkin.hadoop.sources._
 * Find out how often services call each other throughout the entire system
 */
 
-class DependencyTree(args: Args) extends Job(args) with DefaultDateRangeJob {
+class DependencyTree(args: Args) extends Job(args) with UtcDateRangeJob {
 
   val timeGranularity = TimeGranularity.Day
 

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/ExpensiveEndpoints.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/ExpensiveEndpoints.scala
@@ -17,13 +17,13 @@
 package com.twitter.zipkin.hadoop
 
 import com.twitter.zipkin.gen.{Constants, SpanServiceName, Annotation}
-import com.twitter.scalding.{Tsv, DefaultDateRangeJob, Job, Args}
+import com.twitter.scalding.{Tsv, UtcDateRangeJob, Job, Args}
 import com.twitter.zipkin.hadoop.sources._
 
 /**
  * Per service call (i.e. pair of services), finds the average run time (in microseconds) of that service call
  */
-class ExpensiveEndpoints(args : Args) extends Job(args) with DefaultDateRangeJob {
+class ExpensiveEndpoints(args : Args) extends Job(args) with UtcDateRangeJob {
 
   val timeGranularity = TimeGranularity.Day
 

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/FindDuplicateTraces.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/FindDuplicateTraces.scala
@@ -15,15 +15,18 @@
  */
 package com.twitter.zipkin.hadoop
 
-import com.twitter.scalding.{Tsv, DefaultDateRangeJob, Job, Args}
+import com.twitter.scalding._
 import com.twitter.zipkin.gen.{SpanServiceName, Annotation}
 import com.twitter.zipkin.hadoop.sources.{TimeGranularity, PreprocessedSpanSource}
+import com.twitter.scalding.Tsv
+import sources.PreprocessedSpanSource
+import scala.Some
 
 /**
  * Finds traces with duplicate trace IDs
  */
 
-class FindDuplicateTraces(args: Args) extends Job(args) with DefaultDateRangeJob {
+class FindDuplicateTraces(args: Args) extends Job(args) with UtcDateRangeJob {
 
   val maxDuration = augmentString(args.required("maximum_duration")).toInt
 

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/GrepByAnnotation.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/GrepByAnnotation.scala
@@ -16,10 +16,12 @@
 package com.twitter.zipkin.hadoop
 
 import com.twitter.zipkin.gen.{Annotation, Span}
-import com.twitter.scalding.{Tsv, DefaultDateRangeJob, Job, Args}
+import com.twitter.scalding._
 import com.twitter.zipkin.hadoop.sources.{TimeGranularity, SpanSource}
+import com.twitter.scalding.Tsv
+import sources.SpanSource
 
-class GrepByAnnotation(args: Args) extends Job(args) with DefaultDateRangeJob {
+class GrepByAnnotation(args: Args) extends Job(args) with UtcDateRangeJob {
 
   val grepByWord = args.required("word")
 

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/MemcacheRequest.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/MemcacheRequest.scala
@@ -22,7 +22,7 @@ import com.twitter.zipkin.hadoop.sources.{PreprocessedSpanSource, TimeGranularit
 /**
  * Find out how often each service does memcache accesses
  */
-class MemcacheRequest(args : Args) extends Job(args) with DefaultDateRangeJob {
+class MemcacheRequest(args : Args) extends Job(args) with UtcDateRangeJob {
 
   val preprocessed = PrepNoNamesSpanSource(TimeGranularity.Day)
     .read

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/PopularAnnotations.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/PopularAnnotations.scala
@@ -24,7 +24,7 @@ import com.twitter.zipkin.gen.{SpanServiceName, Annotation}
 /**
  * Per service, find the 100 most common annotations used to annotate spans involving that service
  */
-class PopularAnnotations(args : Args) extends Job(args) with DefaultDateRangeJob {
+class PopularAnnotations(args : Args) extends Job(args) with UtcDateRangeJob {
 
   val preprocessed = PreprocessedSpanSource(TimeGranularity.Day)
     .read

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/PopularKeys.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/PopularKeys.scala
@@ -22,7 +22,7 @@ import com.twitter.zipkin.gen.{SpanServiceName, BinaryAnnotation}
 /**
  * Per service, find the 100 most common keys used to annotate spans involving that service
  */
-class PopularKeys(args : Args) extends Job(args) with DefaultDateRangeJob {
+class PopularKeys(args : Args) extends Job(args) with UtcDateRangeJob {
 
   val preprocessed = PreprocessedSpanSource(TimeGranularity.Day)
     .read

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/ServerResponsetime.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/ServerResponsetime.scala
@@ -26,7 +26,7 @@ import java.net.{Inet4Address, Inet6Address, InetAddress}
  * Let's calculate how long it takes for a server to respond. The idea being
  * that we can find servers that are unusually slow compared to others running the same service.
  */
-class ServerResponsetime(args: Args) extends Job(args) with DefaultDateRangeJob {
+class ServerResponsetime(args: Args) extends Job(args) with UtcDateRangeJob {
 
   val serverAnnotations = Seq(Constants.SERVER_RECV, Constants.SERVER_SEND)
 

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/Timeouts.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/Timeouts.scala
@@ -25,7 +25,7 @@ import com.twitter.zipkin.hadoop.sources._
  * Find which services timeout the most
  */
 
-class Timeouts(args: Args) extends Job(args) with DefaultDateRangeJob {
+class Timeouts(args: Args) extends Job(args) with UtcDateRangeJob {
 
   val timeGranularity = TimeGranularity.Day
   val ERROR_TYPE = List("finagle.timeout", "finagle.retry")

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/WhaleReport.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/WhaleReport.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.zipkin.hadoop
 
-import com.twitter.scalding.{Tsv, DefaultDateRangeJob, Job, Args}
+import com.twitter.scalding.{Tsv, UtcDateRangeJob, Job, Args}
 import com.twitter.zipkin.gen.{BinaryAnnotation, SpanServiceName, Annotation}
 import com.twitter.zipkin.hadoop.sources.{TimeGranularity, PreprocessedSpanSource, Util}
 import java.nio.ByteBuffer
@@ -26,7 +26,7 @@ import java.nio.ByteBuffer
  * Finds traces that have 500 Internal Service Errors and finds the spans in those traces that have retries or timeouts
  */
 
-class WhaleReport(args: Args) extends Job(args) with DefaultDateRangeJob {
+class WhaleReport(args: Args) extends Job(args) with UtcDateRangeJob {
 
   val ERRORS = List("finagle.timeout", "finagle.retry")
 

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/WorstRuntimes.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/WorstRuntimes.scala
@@ -22,7 +22,7 @@ import com.twitter.zipkin.hadoop.sources.{TimeGranularity, PreprocessedSpanSourc
 /**
  * Obtain the IDs and the durations of the one hundred service calls which take the longest per service
  */
-class WorstRuntimes(args: Args) extends Job(args) with DefaultDateRangeJob {
+class WorstRuntimes(args: Args) extends Job(args) with UtcDateRangeJob {
 
   val clientAnnotations = Seq(Constants.CLIENT_RECV, Constants.CLIENT_SEND)
 

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/WorstRuntimesPerTrace.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/WorstRuntimesPerTrace.scala
@@ -22,7 +22,7 @@ import com.twitter.zipkin.gen.{SpanServiceName, Constants, Annotation}
 /**
  * Obtain the IDs and the durations of the one hundred service calls which take the longest per service
  */
-class WorstRuntimesPerTrace(args: Args) extends Job(args) with DefaultDateRangeJob {
+class WorstRuntimesPerTrace(args: Args) extends Job(args) with UtcDateRangeJob {
 
   val clientAnnotations = Seq(Constants.CLIENT_RECV, Constants.CLIENT_SEND)
 

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/sources/FindIDtoName.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/sources/FindIDtoName.scala
@@ -15,13 +15,13 @@
  */
 package com.twitter.zipkin.hadoop.sources
 
-import com.twitter.scalding.{DefaultDateRangeJob, Job, Args}
+import com.twitter.scalding.{UtcDateRangeJob, Job, Args}
 import com.twitter.zipkin.gen.SpanServiceName
 
 /**
  * Finds the mapping from span ID to service name
  */
-class FindIDtoName(args: Args) extends Job(args) with DefaultDateRangeJob {
+class FindIDtoName(args: Args) extends Job(args) with UtcDateRangeJob {
 
   val timeGranularity: TimeGranularity = TimeGranularity.Hour
 

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/sources/FindNames.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/sources/FindNames.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 /**
  * Finds the best client side and service names for each span, if any exist
  */
-class FindNames(args: Args) extends Job(args) with DefaultDateRangeJob {
+class FindNames(args: Args) extends Job(args) with UtcDateRangeJob {
   val timeGranularity: TimeGranularity = TimeGranularity.Hour
 
   val preprocessed = PrepNoNamesSpanSource(timeGranularity)

--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/sources/Preprocessed.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/sources/Preprocessed.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 /**
  * Preprocesses the data by merging different pieces of the same span
  */
-class Preprocessed(args : Args) extends Job(args) with DefaultDateRangeJob {
+class Preprocessed(args : Args) extends Job(args) with UtcDateRangeJob {
   val timeGranularity: TimeGranularity = TimeGranularity.Hour
 
   val preprocessed = SpanSource(timeGranularity)

--- a/zipkin-hadoop/src/scripts/run_job.rb
+++ b/zipkin-hadoop/src/scripts/run_job.rb
@@ -1,4 +1,4 @@
-#!/usr/bash/env ruby
+#!/usr/bin/env ruby
 # Copyright 2012 Twitter Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- Use `UtcDateRangeJob` rather than `DefaultDateRangeJob` (TZ=Pacific)
- Fix `run_jobs.rb` file header
