### PR TITLE
hadoop: Replace TimeGranularity case objects with fields

### DIFF
--- a/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/sources/TimeGranularity.scala
+++ b/zipkin-hadoop/src/main/scala/com/twitter/zipkin/hadoop/sources/TimeGranularity.scala
@@ -18,8 +18,8 @@ package com.twitter.zipkin.hadoop.sources
 import com.twitter.scalding.TimePathedSource
 
 object TimeGranularity {
-  case object Hour extends TimeGranularity("Hour", TimePathedSource.YEAR_MONTH_DAY_HOUR)
-  case object Day extends TimeGranularity("Day", TimePathedSource.YEAR_MONTH_DAY)
+  val Hour = TimeGranularity("Hour", TimePathedSource.YEAR_MONTH_DAY_HOUR)
+  val Day = TimeGranularity("Day", TimePathedSource.YEAR_MONTH_DAY)
 }
 
-abstract class TimeGranularity(val name: String, val timePath: String)
+case class TimeGranularity(name: String, timePath: String)


### PR DESCRIPTION
Hadoop can't seem to create case objects through reflection, so use
a val in TimeGranularity obj instead
