### PR TITLE
finatra: Fix JSON Span serialization

### DIFF
--- a/zipkin-finatra/src/main/scala/com/twitter/zipkin/adapter/JsonAdapter.scala
+++ b/zipkin-finatra/src/main/scala/com/twitter/zipkin/adapter/JsonAdapter.scala
@@ -55,8 +55,8 @@ object JsonAdapter extends Adapter {
       s.id.toString,
       s.parentId.map(_.toString),
       s.serviceNames,
-      s.firstAnnotation.get.timestamp,
-      s.duration.get,
+      s.firstAnnotation.map(_.timestamp) getOrElse -1,
+      s.duration getOrElse 0,
       s.annotations.sortWith((a,b) => a.timestamp < b.timestamp),
       s.binaryAnnotations.map(JsonAdapter(_)))
   }

--- a/zipkin-finatra/src/main/scala/com/twitter/zipkin/adapter/JsonAdapter.scala
+++ b/zipkin-finatra/src/main/scala/com/twitter/zipkin/adapter/JsonAdapter.scala
@@ -55,8 +55,8 @@ object JsonAdapter extends Adapter {
       s.id.toString,
       s.parentId.map(_.toString),
       s.serviceNames,
-      s.firstAnnotation.map(_.timestamp) getOrElse -1,
-      s.duration getOrElse 0,
+      s.firstAnnotation.map(_.timestamp),
+      s.duration,
       s.annotations.sortWith((a,b) => a.timestamp < b.timestamp),
       s.binaryAnnotations.map(JsonAdapter(_)))
   }

--- a/zipkin-finatra/src/main/scala/com/twitter/zipkin/common/json/JsonSpan.scala
+++ b/zipkin-finatra/src/main/scala/com/twitter/zipkin/common/json/JsonSpan.scala
@@ -23,7 +23,7 @@ case class JsonSpan(
   id: String,
   parentId: Option[String],
   services: Set[String],
-  startTimestamp: Long,
-  duration: Long,
+  startTimestamp: Option[Long],
+  duration: Option[Long],
   annotations: List[Annotation],
   binaryAnnotations: Seq[JsonBinaryAnnotation])

--- a/zipkin-finatra/src/test/scala/com/twitter/zipkin/web/JsonSerializationSpec.scala
+++ b/zipkin-finatra/src/test/scala/com/twitter/zipkin/web/JsonSerializationSpec.scala
@@ -1,0 +1,17 @@
+package com.twitter.zipkin.web
+
+import org.specs.Specification
+import com.twitter.zipkin.common.{Endpoint, Annotation}
+import com.codahale.jerkson.Json
+
+class JsonSerializationSpec extends Specification {
+  "Jerkson" should {
+    "serialize" in {
+      "annotation with None duration" in {
+        val a = Annotation(1L, "value", Some(Endpoint.Unknown), None)
+        Json.generate(a)
+      }
+
+    }
+  }
+}

--- a/zipkin-finatra/src/test/scala/com/twitter/zipkin/web/JsonSerializationSpec.scala
+++ b/zipkin-finatra/src/test/scala/com/twitter/zipkin/web/JsonSerializationSpec.scala
@@ -1,17 +1,17 @@
 package com.twitter.zipkin.web
 
-import org.specs.Specification
-import com.twitter.zipkin.common.{Endpoint, Annotation}
+import com.twitter.zipkin.adapter.JsonAdapter
+import com.twitter.zipkin.common.{Annotation, BinaryAnnotation, Span}
 import com.codahale.jerkson.Json
+import org.specs.Specification
 
 class JsonSerializationSpec extends Specification {
   "Jerkson" should {
     "serialize" in {
-      "annotation with None duration" in {
-        val a = Annotation(1L, "value", Some(Endpoint.Unknown), None)
-        Json.generate(a)
+      "span with no annotations" in {
+        val s = Span(1L, "Unknown", 2L, None, List.empty[Annotation], List.empty[BinaryAnnotation], false)
+        Json.generate(JsonAdapter(s)) mustNot throwAnException
       }
-
     }
   }
 }


### PR DESCRIPTION
JsonAdapter incorrectly assumed that a Span has at least one annotation. 
- Let start time of the span be -1 if there are no annotations
- Let the duration of the span be 0 if there are no annotations
