### PR TITLE
respects limit

### DIFF
--- a/zipkin-query-core/src/main/scala/com/twitter/zipkin/query/QueryService.scala
+++ b/zipkin-query-core/src/main/scala/com/twitter/zipkin/query/QueryService.scala
@@ -98,16 +98,16 @@ class QueryService(storage: Storage, index: Index, aggregates: Aggregates, adjus
 
       val sliceQueries = Seq(
         spanName.map { name =>
-          Seq(SpanSliceQuery(serviceName, name, endTs, 1))
+          Seq(SpanSliceQuery(serviceName, name, endTs, limit))
         },
         queryRequest.`annotations`.map {
           _.map { a =>
-            AnnotationSliceQuery(serviceName, a, None, endTs, 1)
+            AnnotationSliceQuery(serviceName, a, None, endTs, limit)
           }
         },
         queryRequest.`binaryAnnotations`.map {
           _.map { b =>
-            AnnotationSliceQuery(serviceName, b.`key`, Some(b.`value`), endTs, 1)
+            AnnotationSliceQuery(serviceName, b.`key`, Some(b.`value`), endTs, limit)
           }
         }
       ).collect {

--- a/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
+++ b/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
@@ -494,9 +494,9 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
         val request = gen.QueryRequest(serviceName, spanName, annotations, binaryAnnotations, endTs, limit, order)
 
         expect {
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, endTs, limit) willReturn Future(Seq(id(1, endTs)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, endTs, limit) willReturn Future(Seq(id(1, endTs)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), endTs, limit) willReturn Future(Seq(id(1, endTs)))
+          one(mockIndex).getTraceIdsByName(serviceName, spanName, endTs, 1) willReturn Future(Seq(id(1, endTs)))
+          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, endTs, 1) willReturn Future(Seq(id(1, endTs)))
+          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), endTs, 1) willReturn Future(Seq(id(1, endTs)))
 
           one(mockIndex).getTraceIdsByName(serviceName, spanName, paddedTs, limit) willReturn Future(Seq(id(1, 1), id(2, 2), id(3, 3)))
           one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, paddedTs, limit) willReturn Future(Seq(id(4, 4), id(1, 5), id(3, 4)))

--- a/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
+++ b/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
@@ -494,9 +494,9 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
         val request = gen.QueryRequest(serviceName, spanName, annotations, binaryAnnotations, endTs, limit, order)
 
         expect {
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, endTs, 1) willReturn Future(Seq(id(1, endTs)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, endTs, 1) willReturn Future(Seq(id(1, endTs)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), endTs, 1) willReturn Future(Seq(id(1, endTs)))
+          one(mockIndex).getTraceIdsByName(serviceName, spanName, endTs, limit) willReturn Future(Seq(id(1, endTs)))
+          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, endTs, limit) willReturn Future(Seq(id(1, endTs)))
+          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), endTs, limit) willReturn Future(Seq(id(1, endTs)))
 
           one(mockIndex).getTraceIdsByName(serviceName, spanName, paddedTs, limit) willReturn Future(Seq(id(1, 1), id(2, 2), id(3, 3)))
           one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, paddedTs, limit) willReturn Future(Seq(id(4, 4), id(1, 5), id(3, 4)))


### PR DESCRIPTION
## motivation

Can't look up traces by span.
## fix

respects the "limit" field.
## testing

changed the spec to expect proper "limit" field.  I don't know why it didn't in the first place.  Seems like the test was incorrect too.
