### PR TITLE
ui: replace static link with url update

### DIFF
--- a/zipkin-finatra/src/main/resources/public/js/application-index.js
+++ b/zipkin-finatra/src/main/resources/public/js/application-index.js
@@ -445,9 +445,9 @@ Zipkin.Application.Index = (function() {
       var queryResults = query.execute();
       queryResultsView = new QueryResultsView({collection: queryResults});
 
-      /* Shove the query string into the static link */
+      /* Update the URL to reflect the search */
       searchQuery = queryResults.url().split("?")[1];
-      $("#static-search-link").attr("href", root_url + "?" + searchQuery).show();
+      history.pushState({}, "Zipkin", root_url + "?" + searchQuery);
 
       return false;
     };
@@ -544,10 +544,6 @@ Zipkin.Application.Index = (function() {
       e.stopPropagation();
       $(e.target).parents(".control-group").remove();
       return false;
-    });
-
-    $(document).on("click", "li.trace", function(e) {
-      history.pushState({}, "Zipkin", root_url + "?" + searchQuery);
     });
 
     Zipkin.Base.initialize();

--- a/zipkin-finatra/src/main/resources/templates/index.mustache
+++ b/zipkin-finatra/src/main/resources/templates/index.mustache
@@ -47,7 +47,6 @@
       <div class="sidebar-block filter-block-contents filter-submit">
         <button class="btn primary" disabled>Find traces</button>
         <a data-toggle="modal" href="#lookup-help-modal" class="btn"><i class="icon-info-sign"></i></a>
-        <a id="static-search-link" class="hide pull-right">link</a>
       </div>
     </form>
 


### PR DESCRIPTION
Rather than displaying a `link` button to the static search page, update the URL so it contains the same info.
