### PR TITLE
Make server address configurable

### DIFF
--- a/zipkin-collector-core/src/main/scala/com/twitter/zipkin/config/ZipkinCollectorConfig.scala
+++ b/zipkin-collector-core/src/main/scala/com/twitter/zipkin/config/ZipkinCollectorConfig.scala
@@ -116,8 +116,6 @@ trait ZipkinCollectorConfig extends ZipkinConfig[ZipkinCollector] {
   def writeQueueConfig: WriteQueueConfig[T]
   lazy val writeQueue: WriteQueue[T] = writeQueueConfig.apply(processor)
 
-  lazy val serverAddr = new InetSocketAddress(InetAddress.getLocalHost, serverPort)
-
   val serverConfig: CollectorServerConfig
 
   def apply(runtime: RuntimeEnvironment): ZipkinCollector = {

--- a/zipkin-collector-scribe/src/main/scala/com/twitter/zipkin/config/ScribeCollectorServerConfig.scala
+++ b/zipkin-collector-scribe/src/main/scala/com/twitter/zipkin/config/ScribeCollectorServerConfig.scala
@@ -23,13 +23,16 @@ import com.twitter.zipkin.collector.ScribeCollectorService
 import com.twitter.zipkin.gen
 import org.apache.thrift.protocol.TBinaryProtocol
 import com.twitter.zipkin.config.collector.CollectorServerConfig
+import java.net.InetSocketAddress
 
 class ScribeCollectorServerConfig(config: ScribeZipkinCollectorConfig) extends CollectorServerConfig {
 
   val log = Logger.get(Logger.getClass)
 
   def apply(): Server = {
-    log.info("Starting collector service on addr " + config.serverAddr)
+    val serverAddress = new InetSocketAddress(config.serverAddress, config.serverPort)
+
+    log.info("Starting collector service on addr " + serverAddress)
 
     /* Start the service */
     val service = new ScribeCollectorService(config, config.writeQueue, config.categories)
@@ -39,7 +42,7 @@ class ScribeCollectorServerConfig(config: ScribeZipkinCollectorConfig) extends C
     /* Start the server */
     ServerBuilder()
       .codec(ThriftServerFramedCodec())
-      .bindTo(config.serverAddr)
+      .bindTo(serverAddress)
       .name("ZipkinCollector")
       .reportTo(config.statsReceiver)
       .build(new gen.ZipkinCollector.FinagledService(service, new TBinaryProtocol.Factory()))

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/config/ZipkinConfig.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/config/ZipkinConfig.scala
@@ -23,8 +23,11 @@ import com.twitter.logging.{ConsoleHandler, LoggerFactory, Logger}
 import com.twitter.util.{JavaTimer, Timer, Config}
 import com.twitter.ostrich.admin._
 import scala.util.matching.Regex
+import java.net.{InetAddress, InetSocketAddress}
 
 trait ZipkinConfig[T <: Service] extends Config[RuntimeEnvironment => T] {
+
+  var serverAddress: InetAddress = InetAddress.getLocalHost
 
   /* The port on which the server runs */
   var serverPort: Int

--- a/zipkin-query-core/src/main/scala/com/twitter/zipkin/query/ZipkinQuery.scala
+++ b/zipkin-query-core/src/main/scala/com/twitter/zipkin/query/ZipkinQuery.scala
@@ -17,16 +17,16 @@ package com.twitter.zipkin.query
  *
  */
 import com.twitter.logging.Logger
-import org.apache.thrift.protocol.TBinaryProtocol
 import com.twitter.zipkin.storage.{Aggregates, Index, Storage}
 import com.twitter.zipkin.gen
 import com.twitter.finagle.thrift.ThriftServerFramedCodec
 import com.twitter.finagle.zookeeper.ZookeeperServerSetCluster
 import com.twitter.finagle.builder.{ServerBuilder, Server}
-import java.net.{InetAddress, InetSocketAddress}
 import com.twitter.ostrich.admin.{ServiceTracker, Service}
 import com.twitter.zipkin.config.ZipkinQueryConfig
 import com.twitter.common.zookeeper.ServerSet
+import java.net.InetSocketAddress
+import org.apache.thrift.protocol.TBinaryProtocol
 
 class ZipkinQuery(
   config: ZipkinQueryConfig, serverSet: ServerSet, storage: Storage, index: Index, aggregates: Aggregates
@@ -35,7 +35,7 @@ class ZipkinQuery(
   val log = Logger.get(getClass.getName)
   var thriftServer: Server = null
 
-  val serverAddr = new InetSocketAddress(InetAddress.getLocalHost, config.serverPort)
+  val serverAddr = new InetSocketAddress(config.serverAddress, config.serverPort)
 
   def start() {
     log.info("Starting query thrift service on addr " + serverAddr)


### PR DESCRIPTION
Users may not want to bind to the default `InetAddress.getLocalHost` if they have multiple network interfaces.
