### PR TITLE
ui: change default query client port to 9411

### DIFF
--- a/zipkin-finatra/config/web-dev.scala
+++ b/zipkin-finatra/config/web-dev.scala
@@ -44,5 +44,5 @@ new ZipkinWebConfig {
     servers = List("localhost:3003")
   }
 
-  override def queryClient = Left(new InetSocketAddress("localhost", 3002))
+  override def queryClient = Left(new InetSocketAddress("localhost", 9411))
 }


### PR DESCRIPTION
Default the query client to use the query service's default port
