### PR TITLE
ui: catch binary annotation conversion errors

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/conversions/json.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/conversions/json.scala
@@ -12,17 +12,21 @@ object json {
   /* BinaryAnnotation */
   class WrappedBinaryAnnotation(b: BinaryAnnotation) {
     lazy val toJson = {
-      val value = b.annotationType match {
-        case AnnotationType(0, _) => if (b.value.get() != 0) true else false  // bool
-        case AnnotationType(1, _) => new String(b.value.array(), b.value.position(), b.value.remaining()) // bytes
-        case AnnotationType(2, _) => b.value.getShort            // i16
-        case AnnotationType(3, _) => b.value.getInt              // i32
-        case AnnotationType(4, _) => b.value.getLong             // i64
-        case AnnotationType(5, _) => b.value.getDouble           // double
-        case AnnotationType(6, _) => new String(b.value.array(), b.value.position(), b.value.remaining()) // string
-        case _ => {
-          throw new Exception("Unsupported annotation type: %s".format(b))
+      val value = try {
+        b.annotationType match {
+          case AnnotationType(0, _) => if (b.value.get() != 0) true else false  // bool
+          case AnnotationType(1, _) => new String(b.value.array(), b.value.position(), b.value.remaining()) // bytes
+          case AnnotationType(2, _) => b.value.getShort            // i16
+          case AnnotationType(3, _) => b.value.getInt              // i32
+          case AnnotationType(4, _) => b.value.getLong             // i64
+          case AnnotationType(5, _) => b.value.getDouble           // double
+          case AnnotationType(6, _) => new String(b.value.array(), b.value.position(), b.value.remaining()) // string
+          case _ => {
+            throw new Exception("Unsupported annotation type: %s".format(b))
+          }
         }
+      } catch {
+        case e: Exception => "Error parsing binary annotation"
       }
       JsonBinaryAnnotation(b.key, value, b.annotationType, b.host)
     }


### PR DESCRIPTION
Converting a malformed binary annotation throws exceptions that break the UI. In this case just catch the exception and say it could not be read.
