### PR TITLE
InetAddress.getLocalHost requires the local hostname to be resolveable.

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/config/ZipkinConfig.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/config/ZipkinConfig.scala
@@ -27,7 +27,7 @@ import java.net.{InetAddress, InetSocketAddress}
 
 trait ZipkinConfig[T <: Service] extends Config[RuntimeEnvironment => T] {
 
-  var serverAddress: InetAddress = InetAddress.getLocalHost
+  var serverAddress: InetAddress = InetAddress.getByName("localhost")
 
   /* The port on which the server runs */
   var serverPort: Int

--- a/zipkin-test/src/main/scala/com/twitter/zipkin/tracegen/Main.scala
+++ b/zipkin-test/src/main/scala/com/twitter/zipkin/tracegen/Main.scala
@@ -31,7 +31,7 @@ object Main {
     val (collectorHost, collectorPort, queryHost, queryPort) =
       if (args.length < 4) {
         // Default to localhost:9410, localhost:9411
-        (InetAddress.getLocalHost.getHostAddress, 9410, InetAddress.getLocalHost.getHostAddress, 9411)
+        ("localhost", 9410, "localhost", 9411)
       } else {
         (args(0), args(1).toInt, args(2), args(3).toInt)
       }

--- a/zipkin-test/src/test/scala/com/twitter/zipkin/ZipkinSpec.scala
+++ b/zipkin-test/src/test/scala/com/twitter/zipkin/ZipkinSpec.scala
@@ -90,13 +90,13 @@ class ZipkinSpec extends Specification with JMocker with ClassMocker {
       query.start()
 
       queryTransport = ClientBuilder()
-        .hosts(InetAddress.getLocalHost.getHostName + ":" + queryPort)
+        .hosts("localhost:" + queryPort)
         .hostConnectionLimit(1)
         .codec(ThriftClientFramedCodec())
         .build()
 
       collectorTransport = ClientBuilder()
-        .hosts(InetAddress.getLocalHost.getHostName + ":" + collectorPort)
+        .hosts("localhost:" + collectorPort)
         .hostConnectionLimit(1)
         .codec(ThriftClientFramedCodec())
         .build()


### PR DESCRIPTION
It is safer to simply resolve "localhost".
