### PR TITLE
Fix util.Duration json serialization

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/common/json/JsonAnnotation.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/common/json/JsonAnnotation.scala
@@ -15,13 +15,10 @@
  */
 package com.twitter.zipkin.common.json
 
-case class JsonSpan(
-  traceId: String,
-  name: String,
-  id: String,
-  parentId: Option[String],
-  services: Set[String],
-  startTimestamp: Option[Long],
-  duration: Option[Long],
-  annotations: List[JsonAnnotation],
-  binaryAnnotations: Seq[JsonBinaryAnnotation])
+import com.twitter.zipkin.common.Endpoint
+
+case class JsonAnnotation(
+  timestamp: String,
+  value: String,
+  host: Option[Endpoint],
+  duration: Option[String]) // Duration in microseconds

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/common/json/JsonAnnotation.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/common/json/JsonAnnotation.scala
@@ -22,3 +22,4 @@ case class JsonAnnotation(
   value: String,
   host: Option[Endpoint],
   duration: Option[String]) // Duration in microseconds
+

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/conversions/json.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/conversions/json.scala
@@ -9,6 +9,14 @@ import com.twitter.zipkin.query._
  */
 object json {
 
+  /* Annotation */
+  class WrappedAnnotation(a: Annotation) {
+    lazy val toJson = {
+      JsonAnnotation(a.timestamp.toString, a.value, a.host, a.duration map { _.inMicroseconds.toString })
+    }
+  }
+  implicit def annotationToJson(a: Annotation) = new WrappedAnnotation(a)
+
   /* BinaryAnnotation */
   class WrappedBinaryAnnotation(b: BinaryAnnotation) {
     lazy val toJson = {
@@ -44,7 +52,7 @@ object json {
         s.serviceNames,
         s.firstAnnotation.map(_.timestamp),
         s.duration,
-        s.annotations.sortWith((a,b) => a.timestamp < b.timestamp),
+        s.annotations.sortWith((a,b) => a.timestamp < b.timestamp).map { _.toJson },
         s.binaryAnnotations.map(_.toJson))
     }
   }


### PR DESCRIPTION
Jackson can't serialize `util.Duration`, so convert `Annotation`s to
`JsonAnnotation`s that have a String duration field in microseconds
