### PR TITLE
web: Fix modal close 'x'

### DIFF
--- a/zipkin-web/src/main/resources/templates/index.mustache
+++ b/zipkin-web/src/main/resources/templates/index.mustache
@@ -98,7 +98,7 @@
 <!-- help panel for different lookup options -->
 <div class="modal hide" id="lookup-help-modal">
   <div class="modal-header">
-    <a class="close" data-dismiss="modal" href="#lookup-help-modal">×</a>
+    <a class="close" data-dismiss="modal" href="#lookup-help-modal">x</a>
     <h3>How to find a trace</h3>
   </div>
   <div class="modal-body">


### PR DESCRIPTION
Unicode character causes problems, so changed it to a text 'x'
