### PR TITLE
Unify storage classes under Store

### DIFF
--- a/doc/redis.md
+++ b/doc/redis.md
@@ -16,27 +16,26 @@ There are a few configuration changes that must be made before you can use zipki
 #### Config Changes
 Go into zipkin/zipkin-collector-service/config/collector-dev.scala, and replace the lines which say:
 ```scala
-  def storageConfig = new CassandraStorageConfig {
-    def cassandraConfig = _cassandraConfig
-  }
-
-  def indexConfig = new CassandraIndexConfig {
-    def cassandraConfig = _cassandraConfig
-  }
+  def storeBuilder = Store.Builder(
+    cassandra.StorageBuilder(keyspaceBuilder),
+    cassandra.IndexBuilder(keyspaceBuilder),
+    cassandra.AggregatesBuilder(keyspaceBuilder)
+  )
 ```
 
 with
 
 ```scala
-  def storageConfig = new RedisStorageConfig {
-    val host = "0.0.0.0"
-    val port = 6379
-  }
-
-  def indexConfig = new RedisIndexConfig {
-    val host = "0.0.0.0"
-    val port = 6379
-  }
+  def storeBuilder = Store.Builder(
+    new RedisStorageConfig {
+      val host = "0.0.0.0"
+      val port = 6379
+    },
+    new RedisIndexConfig {
+      val host = "0.0.0.0"
+      val port = 6379
+    }
+  )
 ```
 Then do the same in zipkin/zipkin-query-service/config/query-dev.scala.  Host and port should be the host and port your redis-server is listening on.
 

--- a/zipkin-collector-core/src/main/scala/com/twitter/zipkin/config/ZipkinCollectorConfig.scala
+++ b/zipkin-collector-core/src/main/scala/com/twitter/zipkin/config/ZipkinCollectorConfig.scala
@@ -15,7 +15,7 @@
  */
 package com.twitter.zipkin.config
 
-import com.twitter.zipkin.storage.{Store, Aggregates, Index, Storage}
+import com.twitter.zipkin.storage.Store
 import com.twitter.zipkin.collector.{WriteQueue, ZipkinCollector}
 import com.twitter.zipkin.collector.filter.{ServiceStatsFilter, SamplerFilter, ClientIndexFilter}
 import com.twitter.zipkin.collector.sampler.{AdaptiveSampler, ZooKeeperGlobalSampler, GlobalSampler}

--- a/zipkin-collector-scribe/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorService.scala
+++ b/zipkin-collector-scribe/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorService.scala
@@ -112,7 +112,7 @@ class ScribeCollectorService(config: ScribeZipkinCollectorConfig, val writeQueue
     log.info("storeDependencies: " + serviceName + "; " + endpoints)
 
     Stats.timeFutureMillis("collector.storeDependencies") {
-      config.aggregates.storeDependencies(serviceName, endpoints)
+      config.store.aggregates.storeDependencies(serviceName, endpoints)
     } rescue {
       case e: Exception =>
         log.error(e, "storeDependencies failed")
@@ -126,7 +126,7 @@ class ScribeCollectorService(config: ScribeZipkinCollectorConfig, val writeQueue
     log.info("storeTopAnnotations: " + serviceName + "; " + annotations)
 
     Stats.timeFutureMillis("collector.storeTopAnnotations") {
-      config.aggregates.storeTopAnnotations(serviceName, annotations)
+      config.store.aggregates.storeTopAnnotations(serviceName, annotations)
     } rescue {
       case e: Exception =>
         log.error(e, "storeTopAnnotations failed")
@@ -140,7 +140,7 @@ class ScribeCollectorService(config: ScribeZipkinCollectorConfig, val writeQueue
     log.info("storeTopKeyValueAnnotations: " + serviceName + ";" + annotations)
 
     Stats.timeFutureMillis("collector.storeTopKeyValueAnnotations") {
-      config.aggregates.storeTopKeyValueAnnotations(serviceName, annotations)
+      config.store.aggregates.storeTopKeyValueAnnotations(serviceName, annotations)
     } rescue {
       case e: Exception =>
         log.error(e, "storeTopKeyValueAnnotations failed")

--- a/zipkin-collector-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
+++ b/zipkin-collector-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
@@ -23,7 +23,7 @@ import com.twitter.zipkin.config.sampler.AdjustableRateConfig
 import com.twitter.zipkin.config.ScribeZipkinCollectorConfig
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.gen
-import com.twitter.zipkin.storage.Aggregates
+import com.twitter.zipkin.storage.{Store, Aggregates}
 import org.specs.Specification
 import org.specs.mock.{ClassMocker, JMocker}
 
@@ -47,14 +47,12 @@ class ScribeCollectorServiceSpec extends Specification with JMocker with ClassMo
   val config = new ScribeZipkinCollectorConfig {
     def writeQueueConfig = null
     def zkConfig = null
-    def indexConfig = null
-    def storageConfig = null
-    def aggregatesConfig = null
     def methodConfig = null
+    def storeBuilder = null
 
     override lazy val writeQueue = queue
     override lazy val sampleRateConfig = zkSampleRateConfig
-    override lazy val aggregates = mockAggregates
+    override lazy val store = Store(null, null, mockAggregates)
   }
 
   def scribeCollectorService = new ScribeCollectorService(config, config.writeQueue, Set(category)) {

--- a/zipkin-collector-service/config/collector-dev.scala
+++ b/zipkin-collector-service/config/collector-dev.scala
@@ -23,6 +23,7 @@ import com.twitter.conversions.time._
 import com.twitter.logging.LoggerFactory
 import com.twitter.logging.config._
 import com.twitter.ostrich.admin.{TimeSeriesCollectorFactory, JsonStatsLoggerFactory, StatsFactory}
+import com.twitter.zipkin.storage.Store
 
 // development mode.
 new ScribeZipkinCollectorConfig {
@@ -45,9 +46,11 @@ new ScribeZipkinCollectorConfig {
 
   val keyspaceBuilder = cassandra.Keyspace.static(nodes = Set("localhost"))
 
-  def storageConfig = cassandra.StorageBuilder(keyspaceBuilder)
-  def indexConfig = cassandra.IndexBuilder(keyspaceBuilder)
-  def aggregatesConfig = cassandra.AggregatesBuilder(keyspaceBuilder)
+  def storeBuilder = Store.Builder(
+    cassandra.StorageBuilder(keyspaceBuilder),
+    cassandra.IndexBuilder(keyspaceBuilder),
+    cassandra.AggregatesBuilder(keyspaceBuilder)
+  )
 
   override def adaptiveSamplerConfig = new NullAdaptiveSamplerConfig {}
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Store.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Store.scala
@@ -3,10 +3,15 @@ package com.twitter.zipkin.storage
 import com.twitter.util.Config
 
 object Store {
+
+  private val nullAggregatesBuilder = new Config[Aggregates] {
+    def apply() = new NullAggregates
+  }
+
   case class Builder(
     storageBuilder: Config[Storage],
     indexBuilder: Config[Index],
-    aggregatesBuilder: Config[Aggregates]
+    aggregatesBuilder: Config[Aggregates] = nullAggregatesBuilder
   ) extends Config[Store] {
     def apply() = Store(storageBuilder.apply(), indexBuilder.apply(), aggregatesBuilder.apply())
   }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Store.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Store.scala
@@ -1,0 +1,18 @@
+package com.twitter.zipkin.storage
+
+import com.twitter.util.Config
+
+object Store {
+  case class Builder(
+    storageBuilder: Config[Storage],
+    indexBuilder: Config[Index],
+    aggregatesBuilder: Config[Aggregates]
+  ) extends Config[Store] {
+    def apply() = Store(storageBuilder.apply(), indexBuilder.apply(), aggregatesBuilder.apply())
+  }
+}
+
+/**
+ * Wrapper class for the necessary store components
+ */
+case class Store(storage: Storage, index: Index, aggregates: Aggregates)

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Store.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Store.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.zipkin.storage
 
 import com.twitter.util.Config

--- a/zipkin-query-core/src/main/scala/com/twitter/zipkin/config/ZipkinQueryConfig.scala
+++ b/zipkin-query-core/src/main/scala/com/twitter/zipkin/config/ZipkinQueryConfig.scala
@@ -17,7 +17,7 @@ package com.twitter.zipkin.config
 
 import com.twitter.zipkin.query.ZipkinQuery
 import com.twitter.zipkin.gen
-import com.twitter.zipkin.storage.{Aggregates, Index, Storage}
+import com.twitter.zipkin.storage.{Store, Aggregates, Index, Storage}
 import com.twitter.common.zookeeper.{ServerSetImpl, ZooKeeperClient}
 import com.twitter.finagle.zipkin.thrift.ZipkinTracer
 import com.twitter.ostrich.admin.RuntimeEnvironment
@@ -37,14 +37,8 @@ trait ZipkinQueryConfig extends ZipkinConfig[ZipkinQuery] {
     gen.Adjust.TimeSkew -> new TimeSkewAdjuster()
   )
 
-  def storageConfig: Config[Storage]
-  lazy val storage: Storage = storageConfig.apply()
-
-  def indexConfig: Config[Index]
-  lazy val index: Index = indexConfig.apply()
-
-  def aggregatesConfig: Config[Aggregates]
-  lazy val aggregates: Aggregates = aggregatesConfig.apply()
+  def storeBuilder: Config[Store]
+  lazy val store: Store = storeBuilder.apply()
 
   def zkConfig: ZooKeeperConfig
 
@@ -59,6 +53,6 @@ trait ZipkinQueryConfig extends ZipkinConfig[ZipkinQuery] {
     ZipkinTracer(statsReceiver = statsReceiver, sampleRate = 1f)
 
   def apply(runtime: RuntimeEnvironment) = {
-    new ZipkinQuery(this, serverSet, storage, index, aggregates)
+    new ZipkinQuery(this, serverSet, store.storage, store.index, store.aggregates)
   }
 }

--- a/zipkin-query-service/config/query-dev.scala
+++ b/zipkin-query-service/config/query-dev.scala
@@ -20,6 +20,7 @@ import com.twitter.zipkin.config.zookeeper.ZooKeeperConfig
 import com.twitter.logging.LoggerFactory
 import com.twitter.logging.config._
 import com.twitter.ostrich.admin.{TimeSeriesCollectorFactory, JsonStatsLoggerFactory, StatsFactory}
+import com.twitter.zipkin.storage.Store
 
 // development mode.
 new ZipkinQueryConfig {
@@ -36,10 +37,7 @@ new ZipkinQueryConfig {
     )
 
   val keyspaceBuilder = cassandra.Keyspace.static()
-
-  def storageConfig = cassandra.StorageBuilder(keyspaceBuilder)
-  def indexConfig = cassandra.IndexBuilder(keyspaceBuilder)
-  def aggregatesConfig = cassandra.AggregatesBuilder(keyspaceBuilder)
+  def storeBuilder = Store.Builder(cassandra.StorageBuilder(keyspaceBuilder), cassandra.IndexBuilder(keyspaceBuilder), cassandra.AggregatesBuilder(keyspaceBuilder))
 
   def zkConfig = new ZooKeeperConfig {
     servers = List("localhost:2181")

--- a/zipkin-test/src/test/scala/com/twitter/zipkin/Configs.scala
+++ b/zipkin-test/src/test/scala/com/twitter/zipkin/Configs.scala
@@ -91,10 +91,7 @@ object Configs {
       )
 
     val keyspaceBuilder = Keyspace.static(port = cassandraPort)
-
-    def storageConfig = StorageBuilder(keyspaceBuilder)
-    def indexConfig = IndexBuilder(keyspaceBuilder)
-    def aggregatesConfig = AggregatesBuilder(keyspaceBuilder)
+    def storeBuilder = Store.Builder(StorageBuilder(keyspaceBuilder), IndexBuilder(keyspaceBuilder), AggregatesBuilder(keyspaceBuilder))
 
     def zkConfig = new ZooKeeperConfig {
       servers = List("localhost:2181")

--- a/zipkin-test/src/test/scala/com/twitter/zipkin/Configs.scala
+++ b/zipkin-test/src/test/scala/com/twitter/zipkin/Configs.scala
@@ -23,6 +23,7 @@ import com.twitter.zipkin.collector.sampler.{EverythingGlobalSampler, GlobalSamp
 import com.twitter.zipkin.config.sampler.NullAdaptiveSamplerConfig
 import com.twitter.zipkin.config.zookeeper.ZooKeeperConfig
 import com.twitter.zipkin.config.{ZipkinQueryConfig, WriteQueueConfig, ScribeZipkinCollectorConfig}
+import com.twitter.zipkin.storage.Store
 
 object Configs {
   def collector(cassandraPort: Int) = new ScribeZipkinCollectorConfig {
@@ -45,9 +46,7 @@ object Configs {
 
     var keyspaceBuilder = Keyspace.static(port = cassandraPort)
 
-    def storageConfig = StorageBuilder(keyspaceBuilder)
-    def indexConfig = IndexBuilder(keyspaceBuilder)
-    def aggregatesConfig = AggregatesBuilder(keyspaceBuilder)
+    def storeBuilder = Store.Builder(StorageBuilder(keyspaceBuilder), IndexBuilder(keyspaceBuilder), AggregatesBuilder(keyspaceBuilder))
 
     override def adaptiveSamplerConfig = new NullAdaptiveSamplerConfig {}
 

--- a/zipkin-test/src/test/scala/com/twitter/zipkin/ZipkinSpec.scala
+++ b/zipkin-test/src/test/scala/com/twitter/zipkin/ZipkinSpec.scala
@@ -75,7 +75,7 @@ class ZipkinSpec extends Specification with JMocker with ClassMocker {
       collector = new ZipkinCollector(collectorConfig)
       collector.start()
 
-      query = new ZipkinQuery(queryConfig, nullServerSetsImpl, queryConfig.storage, queryConfig.index, queryConfig.aggregates)
+      query = new ZipkinQuery(queryConfig, nullServerSetsImpl, queryConfig.store.storage, queryConfig.store.index, queryConfig.store.aggregates)
       query.start()
 
       queryTransport = ClientBuilder()


### PR DESCRIPTION
To make configuration simpler, introduce a Store case class that wraps Storage, Index, and Aggregates. This is a temporary stopgap to get to Builder style configs.
