### PR TITLE
Update path to schema file in install document

### DIFF
--- a/install.html
+++ b/install.html
@@ -44,7 +44,7 @@
 <ol>
 <li>See Cassandra&#39;s <a href="http://cassandra.apache.org/">site</a> for instructions on how to start a cluster.</li>
 <li>Use the Zipkin Cassandra schema attached to this project. You can create the schema with the following command.
-<code>bin/cassandra-cli -host localhost -port 9160 -f zipkin-server/src/schema/cassandra-schema.txt</code></li>
+<code>bin/cassandra-cli -host localhost -port 9160 -f zipkin-cassandra/src/schema/cassandra-schema.txt</code></li>
 </ol>
 
 <h3>ZooKeeper</h3>


### PR DESCRIPTION
It appears that the schema file (in the master branch anyway) is located in `zipkin-cassandra/...` rather than `zipkin-server/...`.
