### PR TITLE
Make it easier to show remote data in a local instance

### DIFF
--- a/zipkin-web/config/web-dev.scala
+++ b/zipkin-web/config/web-dev.scala
@@ -17,7 +17,10 @@ import com.twitter.finagle.zipkin.thrift.ZipkinTracer
 import com.twitter.zipkin.builder.{QueryClient, WebBuilder}
 import java.net.{InetSocketAddress, InetAddress}
 
-val queryClient = QueryClient.static(new InetSocketAddress(InetAddress.getLoopbackAddress(), 9411)) map {
+// We'd rather use InetAddress.getLoopbackAddress than 127.0.0.1 but it's JDK
+// 1.7+. Previously we used InetAddress.getLocalHost, but that doesn't let us
+// do SSH port forwarding.
+val queryClient = QueryClient.static(new InetSocketAddress("127.0.0.1", 9411)) map {
   _.tracer(ZipkinTracer.mk())
 }
 WebBuilder("http://localhost:8080/", queryClient)

--- a/zipkin-web/config/web-dev.scala
+++ b/zipkin-web/config/web-dev.scala
@@ -17,7 +17,7 @@ import com.twitter.finagle.zipkin.thrift.ZipkinTracer
 import com.twitter.zipkin.builder.{QueryClient, WebBuilder}
 import java.net.{InetSocketAddress, InetAddress}
 
-val queryClient = QueryClient.static(new InetSocketAddress(InetAddress.getLocalHost, 9411)) map {
+val queryClient = QueryClient.static(new InetSocketAddress(InetAddress.getLoopbackAddress(), 9411)) map {
   _.tracer(ZipkinTracer.mk())
 }
 WebBuilder("http://localhost:8080/", queryClient)

--- a/zipkin-web/config/web-dev.scala
+++ b/zipkin-web/config/web-dev.scala
@@ -17,9 +17,6 @@ import com.twitter.finagle.zipkin.thrift.ZipkinTracer
 import com.twitter.zipkin.builder.{QueryClient, WebBuilder}
 import java.net.{InetSocketAddress, InetAddress}
 
-// We'd rather use InetAddress.getLoopbackAddress than 127.0.0.1 but it's JDK
-// 1.7+. Previously we used InetAddress.getLocalHost, but that doesn't let us
-// do SSH port forwarding.
 val queryClient = QueryClient.static(new InetSocketAddress("127.0.0.1", 9411)) map {
   _.tracer(ZipkinTracer.mk())
 }


### PR DESCRIPTION
This change allows us to point Zipkin to a remote query source so that it can use live data in a local (testing/dev) setup.
