### PR TITLE
update internal sbt script to match intended versions

### DIFF
--- a/bin/sbt
+++ b/bin/sbt
@@ -9,13 +9,13 @@ sbtjar=sbt-launch.jar
 
 if [ ! -f $sbtjar ]; then
   echo 'downloading '$sbtjar 1>&2
-  curl -O http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.12.1/$sbtjar
+  curl -O http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.12.3/$sbtjar
 fi
 
 test -f $sbtjar || exit 1
 sbtjar_md5=$(openssl md5 < $sbtjar|cut -f2 -d'='|awk '{print $1}')
-if [ "${sbtjar_md5}" != 9d832c4cfdb889103bd37a8bda3faa0e ]; then
-  echo 'bad sbtjar!' 1>&2
+if [ "${sbtjar_md5}" != 124fb91b398542c23cd920360580d2d7 ]; then
+  echo "bad sbtjar!: ${sbtjar_md5}" 1>&2
   exit 1
 fi
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,24 +1,13 @@
-sbtResolver <<= (sbtResolver) { r =>
-  Option(System.getenv("SBT_PROXY_REPO")) map { x =>
-    Resolver.url("proxy repo for sbt", url(x))(Resolver.ivyStylePatterns)
-  } getOrElse r
-}
 
-resolvers <<= (resolvers) { r =>
-  (Option(System.getenv("SBT_PROXY_REPO")) map { url =>
-    Seq("proxy-repo" at url)
-  } getOrElse {
-    r ++ Seq(
-      "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
-      "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/",
-      "twitter.com" at "http://maven.twttr.com/",
-      "scala-tools" at "http://scala-tools.org/repo-releases/",
-      "maven" at "http://repo1.maven.org/maven2/",
-      "freemarker" at "http://freemarker.sourceforge.net/maven2/",
-      Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-    )
-  }) ++ Seq("local" at ("file:" + System.getProperty("user.home") + "/.m2/repository/"))
-}
+resolvers ++= Seq(
+  "travisci-central" at "http://maven.travis-ci.org/nexus/content/repositories/central/",
+  "travisci-sonatype" at "http://maven.travis-ci.org/nexus/content/repositories/sonatype/",
+  "twitter.com" at "http://maven.twttr.com/",
+  "scala-tools" at "http://scala-tools.org/repo-releases/",
+  "maven" at "http://repo1.maven.org/maven2/",
+  "freemarker" at "http://freemarker.sourceforge.net/maven2/",
+  "local" at ("file:" + System.getProperty("user.home") + "/.m2/repository/"))
+
 
 libraryDependencies ++= Seq(
     "com.google.collections" % "google-collections" % "0.8",
@@ -26,6 +15,4 @@ libraryDependencies ++= Seq(
     "org.slf4j"              % "slf4j-api"          % "1.6.1",
     "org.slf4j"              % "slf4j-simple"       % "1.6.1",
     "com.twitter"            % "scrooge-generator"  % "3.1.1")
-
-externalResolvers <<= (resolvers) map identity
 


### PR DESCRIPTION
I don't use this script on my dev machine, it's purely there for convenience for new users.  I had forgotten to update it to sbt 0.12.3 which is what we'd want them to use.  This fixes it.
