### PR TITLE
Update installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ Zipkin itself provides three services:
 If all three of these daemons are running, you should be able to visit
 http://localhost:8080 to view the Zipkin UI.
 
-The next step is to collect trace data to view in Zipkin. For testing and
-development purposes, it is possible to use SSH port forwarding to run a remote
-query daemon behind a local Zipkin instance. In production, interface with the
-collector (e.g. with Scribe) to record trace data.
+The next step is to collect trace data to view in Zipkin. To do this, interface
+with the collector (e.g. by using Scribe) to record trace data. There are
+several libraries to make this easier to do in different environments. Twitter
+uses [Finagle](https://github.com/twitter/finagle/tree/master/finagle-zipkin);
+external libraries (currently for Python, REST, node, and Java) are listed in the
+[wiki](https://github.com/twitter/zipkin/wiki#external-projects-that-use-zipkin);
+and there is also a Ruby gem.
 
 See the [in-depth installation guide](https://github.com/twitter/zipkin/blob/master/doc/install.md) for more information.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ several libraries to make this easier to do in different environments. Twitter
 uses [Finagle](https://github.com/twitter/finagle/tree/master/finagle-zipkin);
 external libraries (currently for Python, REST, node, and Java) are listed in the
 [wiki](https://github.com/twitter/zipkin/wiki#external-projects-that-use-zipkin);
-and there is also a Ruby gem.
+and there is also a [Ruby gem](https://rubygems.org/gems/finagle-thrift) and
+[Ruby Thrift client](https://github.com/twitter/thrift_client).
 
 See the [in-depth installation guide](https://github.com/twitter/zipkin/blob/master/doc/install.md) for more information.
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,29 @@
 See [http://twitter.github.com/zipkin](http://twitter.github.com/zipkin)
 
 ## Quick start
-You'll need Scala 2.9.1
 
-Clone the repo, `git clone git://github.com/twitter/zipkin`, or [download a release](https://github.com/twitter/zipkin/downloads)
+To install Zipkin on a single machine, see the
+[Ubuntu Quickstart](https://github.com/twitter/zipkin/blob/master/doc/ubuntu-quickstart.txt) and
+[Mac Quickstart](https://github.com/twitter/zipkin/blob/master/doc/mac-quickstart.md) guides.
+For more in-depth installation instructions with an explanation of the
+dependencies and related services, see
+[install.md](https://github.com/twitter/zipkin/blob/master/doc/install.md).
 
-To run a collector daemon: `bin/collector`
+Zipkin itself provides three services:
 
-To run a query daemon: `bin/query`
+ - To collect data: `bin/collector`
+ - To extract data: `bin/query`
+ - To display data: `bin/web`
 
-To run a UI daemon: `bin/web`
+If all three of these daemons are running, you should be able to visit
+http://localhost:8080 to view the Zipkin UI.
 
-For a more in-depth installation guide, see: [http://twitter.github.com/zipkin/install.html](http://twitter.github.com/zipkin/install.html)
+The next step is to collect trace data to view in Zipkin. For testing and
+development purposes, it is possible to use SSH port forwarding to run a remote
+query daemon behind a local Zipkin instance. In production, interface with the
+collector (e.g. with Scribe) to record trace data.
+
+See the [in-depth installation guide](https://github.com/twitter/zipkin/blob/master/doc/install.md) for more information.
 
 ## Get involved
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -11,9 +11,10 @@ interacts, and more advanced configuration.
 
 ### Cassandra
 
-Zipkin currently relies on [Cassandra](http://cassandra.apache.org/) for the
-collector's storage, although the storage system is pluggable and we'd like to
-see support for other databases.
+Zipkin is most commonly used with [Cassandra](http://cassandra.apache.org/) for
+the collector's storage. There is also a
+[Redis plugin](https://github.com/twitter/zipkin/blob/master/doc/redis.md) and
+we'd like to see support for other databases.
 
 1. See Cassandra's <a href="http://cassandra.apache.org/">site</a> for instructions on how to start a cluster.
 2. Use the Zipkin Cassandra schema attached to this project. You can create the schema with the following command:
@@ -52,25 +53,9 @@ We're hoping that others might add non-Scribe transports for the tracing data; t
 ### Zipkin servers
 We developed Zipkin with <a href="http://www.scala-lang.org/downloads">Scala 2.9.1</a>, <a href="http://www.scala-sbt.org/download.html">SBT 0.11.2</a>, and JDK7.
 
-TODO: I don't know how much of this is still relevant
-1. `git clone https://github.com/twitter/zipkin.git`
-1. `cd zipkin`
-1. `cp zipkin-collector-service/config/collector-dev.scala zipkin-collector-service/config/collector-prod.scala`
-1. `cp zipkin-query-service/config/query-dev.scala zipkin-query-service/config/query-prod.scala`
-1. Modify the configs above as needed. Pay particular attention to ZooKeeper and Cassandra server entries.
-1. `bin/sbt update package-dist` (This downloads SBT 0.11.2 if it doesn't already exist)
-1. `scp dist/zipkin*.zip [server]`
-1. `ssh [server]`
-1. `unzip zipkin*.zip`
-1. `mkdir -p /var/log/zipkin`
-1. `zipkin-collector-service/src/scripts/collector.sh -f zipkin-collector-service/config/collector-prod.scala`
-1. `zipkin-query-service/src/scripts/query.sh -f zipkin-query-service/config/query-prod.scala`
-
-You can also run the collector and query services through SBT.
-
-To run the Scribe collector service: `bin/sbt 'project zipkin-collector-service' 'run -f zipkin-collector-service/config/collector-dev.scala'` or `bin/collector`
-
-To run the query service: `bin/sbt 'project zipkin-query-service' 'run -f zipkin-query-service/config/query-dev.scala'` or `bin/query`
+The [Ubuntu Quickstart](https://github.com/twitter/zipkin/blob/master/doc/ubuntu-quickstart.txt)
+and [Mac Quickstart](https://github.com/twitter/zipkin/blob/master/doc/mac-quickstart.md)
+guides explain how to set up and run the collector and query services.
 
 ### Zipkin UI
 The UI is a standard Rails 3 app.

--- a/doc/install.md
+++ b/doc/install.md
@@ -1,11 +1,23 @@
 ## Installation
 
+To get going quickly, see the
+[Ubuntu Quickstart](https://github.com/twitter/zipkin/blob/master/doc/ubuntu-quickstart.txt) and
+[Mac Quickstart](https://github.com/twitter/zipkin/blob/master/doc/mac-quickstart.md) guides.
+These will help you get Zipkin running on a single machine so that you can experiment with it.
+
+This document explains the services and dependencies with which Zipkin
+interacts, and more advanced configuration.
+
+
 ### Cassandra
-Zipkin relies on Cassandra for storage. So you will need to bring up a Cassandra cluster.
+
+Zipkin currently relies on [Cassandra](http://cassandra.apache.org/) for the
+collector's storage, although the storage system is pluggable and we'd like to
+see support for other databases.
 
 1. See Cassandra's <a href="http://cassandra.apache.org/">site</a> for instructions on how to start a cluster.
-2. Use the Zipkin Cassandra schema attached to this project. You can create the schema with the following command.
-`bin/cassandra-cli -host localhost -port 9160 -f zipkin-cassandra/src/schema/cassandra-schema.txt`
+2. Use the Zipkin Cassandra schema attached to this project. You can create the schema with the following command:
+`cassandra-cli -host localhost -port 9160 -f zipkin-cassandra/src/schema/cassandra-schema.txt`
 
 ### ZooKeeper
 Zipkin uses ZooKeeper for coordination. That's where we store the server side sample rate and register the servers.
@@ -38,8 +50,9 @@ If you want to get all fancy you can use a modified version of <a href="Scribe">
 We're hoping that others might add non-Scribe transports for the tracing data; there is no reason why Scribe has to be the only one.
 
 ### Zipkin servers
-We've developed Zipkin with <a href="http://www.scala-lang.org/downloads">Scala 2.9.1</a>, <a href="http://www.scala-sbt.org/download.html">SBT 0.11.2</a>, and JDK7.
+We developed Zipkin with <a href="http://www.scala-lang.org/downloads">Scala 2.9.1</a>, <a href="http://www.scala-sbt.org/download.html">SBT 0.11.2</a>, and JDK7.
 
+TODO: I don't know how much of this is still relevant
 1. `git clone https://github.com/twitter/zipkin.git`
 1. `cd zipkin`
 1. `cp zipkin-collector-service/config/collector-dev.scala zipkin-collector-service/config/collector-prod.scala`

--- a/doc/install.md
+++ b/doc/install.md
@@ -21,15 +21,20 @@ we'd like to see support for other databases.
 `cassandra-cli -host localhost -port 9160 -f zipkin-cassandra/src/schema/cassandra-schema.txt`
 
 ### ZooKeeper
-Zipkin uses ZooKeeper for coordination. That's where we store the server side sample rate and register the servers.
+Zipkin can use ZooKeeper for coordination. That's where we store the server side sample rate and register the servers.
 
 1. See ZooKeeper's <a href="http://zookeeper.apache.org/">site</a> for instructions on how to install it.
 
 ### Scribe
-<a href="https://github.com/facebook/scribe">Scribe</a> is the logging framework we use to transport the trace data.
-You need to set up a network store that points to the Zipkin collector daemon. If you are just trying out Zipkin you can skip this step entirely and point the ZipkinTracer directly at the collector.
+<a href="https://github.com/facebook/scribe">Scribe</a> is the logging
+framework we use at Twitter to transport the trace data. There are several other
+ways to tell Zipkin what trace data to collect; in particular, if you are just
+trying out Zipkin you can skip this step entirely and point the ZipkinTracer
+directly at the collector.
 
-A Scribe store for Zipkin might look something like this.
+To use Scribe with Zipkin, you need to set up a network store that points to
+the Zipkin collector daemon. A Scribe store for Zipkin might look something
+like this:
 
     <store>
       category=zipkin
@@ -42,16 +47,24 @@ A Scribe store for Zipkin might look something like this.
       must_succeed=no
     </store>
 
-If you don't want to hardcode the IP address of your collector there are a few options. 
+If you don't want to hardcode the IP address of your collector there are a few
+options. One is to use an internal DNS entry for the collectors so that you only
+have one place to change the addresses when you add or remove collectors.
+Alternatively, if you want to get all fancy you can use a
+[modified version of Scribe](https://github.com/traviscrawford/scribe) that
+picks up the collectors via ZooKeeper. When each collector starts up it adds
+itself to ZooKeeper and when a collector shuts down it is automatically
+removed. The modified Scribe gets notified when the set of collectors change.
+To use this mode you change `remote_host` in the configuration to
+`zk://zookeeper-hostname:2181/scribe/zipkin` or something similar.
 
-You can use an internal DNS entry for the collectors, that way you only have one place to change the addresses when you add or remove collectors. 
-
-If you want to get all fancy you can use a modified version of <a href="Scribe">https://github.com/traviscrawford/scribe</a> that picks up the collectors via ZooKeeper. When each collector starts up it adds itself to ZooKeeper and when a collector shuts down it is automatically removed. The modified Scribe gets notified when the set of collectors change. To use this mode you change remote_host in the configuration to zk://zookeeper-hostname:2181/scribe/zipkin or something similar.
-
-We're hoping that others might add non-Scribe transports for the tracing data; there is no reason why Scribe has to be the only one.
+We're hoping that others might add non-Scribe transports for the tracing data;
+there is no reason why Scribe has to be the only one.
 
 ### Zipkin servers
-We developed Zipkin with <a href="http://www.scala-lang.org/downloads">Scala 2.9.1</a>, <a href="http://www.scala-sbt.org/download.html">SBT 0.11.2</a>, and JDK7.
+We developed Zipkin with
+[Scala 2.9.1](http://www.scala-lang.org/downloads),
+[SBT 0.11.2](http://www.scala-sbt.org/download.html), and JDK7.
 
 The [Ubuntu Quickstart](https://github.com/twitter/zipkin/blob/master/doc/ubuntu-quickstart.txt)
 and [Mac Quickstart](https://github.com/twitter/zipkin/blob/master/doc/mac-quickstart.md)

--- a/doc/mac-quickstart.md
+++ b/doc/mac-quickstart.md
@@ -1,0 +1,61 @@
+This page explains how to set up Zipkin on a single Mac (typically for local
+testing) with Cassandra and Zookeeper, the most common configuration.
+
+Scala 2.9.1 or later is required.
+
+[Install Homebrew](http://mxcl.github.io/homebrew/) if you haven't already. It
+will make your life easier. Then run the following commands to install
+Zipkin's dependencies (you can skip dependencies you already have installed):
+
+    # Cassandra is currently required, though it should be possible to replace it.
+    brew install cassandra
+    # Start Cassandra on login
+    ln -sfv /opt/twitter/opt/cassandra/*.plist ~/Library/LaunchAgents
+    launchctl load ~/Library/LaunchAgents/homebrew.mxcl.cassandra.plist
+    # Python is required for pip, which is required to get CQL
+    brew install python
+    pip install cql
+    # Zookeeper helps Zipkin sample data
+    brew install zookeeper
+    # Scala Build Tool
+    brew install sbt
+    # VCS
+    brew install git
+
+These dependencies are explained in more detail in
+[install.md](https://github.com/twitter/zipkin/blob/master/doc/install.md).
+
+Now we can install Zipkin itself:
+
+    # WORKSPACE is wherever you want your Zipkin folder
+    cd WORKSPACE
+    git clone https://github.com/twitter/zipkin.git
+    cd zipkin
+    # TODO are these next 3 lines necessary?
+    cp zipkin-collector-service/config/collector-dev.scala zipkin-collector-service/config/collector-prod.scala
+    cp zipkin-query-service/config/query-dev.scala zipkin-query-service/config/query-prod.scala
+    bin/sbt update package-dist
+    # Install the Zipkin schema
+    cassandra-cli -host localhost -port 9160 -f zipkin-cassandra/src/schema/cassandra-schema.txt
+    # TODO not sure this is necessary either
+    sudo mkdir -p /var/log/zipkin
+
+Zipkin is installed now. To run it (you'll need to leave these processes
+running, so use separate bash windows if you're doing it that way):
+
+    # Collect data
+    bin/collector
+    # Extract data
+    bin/query
+    # Display data
+    bin/web
+
+Zipkin should now be running and you can access the UI at http://localhost:8080/
+
+The next step is to have your existing services record data to the collector.
+If you are testing or developing Zipkin locally and you already have data being
+recorded in production, you can use SSH port forwarding to run a remote query
+daemon behind a local Zipkin instance. In production, Twitter records data by
+connecting Scribe to the Collector daemon and writing to Scribe from its other
+services as described in
+[install.md](https://github.com/twitter/zipkin/blob/master/doc/install.md).

--- a/doc/mac-quickstart.md
+++ b/doc/mac-quickstart.md
@@ -42,9 +42,6 @@ separate bash windows if you're doing it that way):
 Zipkin should now be running and you can access the UI at http://localhost:8080/
 
 The next step is to have your existing services record data to the collector.
-If you are testing or developing Zipkin locally and you already have data being
-recorded in production, you can use SSH port forwarding to run a remote query
-daemon behind a local Zipkin instance. In production, Twitter records data by
-connecting Scribe to the Collector daemon and writing to Scribe from its other
-services as described in
+The most common way to do this is to connect Scribe to the Collector daemon and
+write to Scribe from your other services as described in
 [install.md](https://github.com/twitter/zipkin/blob/master/doc/install.md).

--- a/doc/mac-quickstart.md
+++ b/doc/mac-quickstart.md
@@ -12,11 +12,6 @@ Zipkin's dependencies (you can skip dependencies you already have installed):
     # Start Cassandra on login
     ln -sfv /opt/twitter/opt/cassandra/*.plist ~/Library/LaunchAgents
     launchctl load ~/Library/LaunchAgents/homebrew.mxcl.cassandra.plist
-    # Python is required for pip, which is required to get CQL
-    brew install python
-    pip install cql
-    # Zookeeper helps Zipkin sample data
-    brew install zookeeper
     # Scala Build Tool
     brew install sbt
     # VCS
@@ -31,17 +26,11 @@ Now we can install Zipkin itself:
     cd WORKSPACE
     git clone https://github.com/twitter/zipkin.git
     cd zipkin
-    # TODO are these next 3 lines necessary?
-    cp zipkin-collector-service/config/collector-dev.scala zipkin-collector-service/config/collector-prod.scala
-    cp zipkin-query-service/config/query-dev.scala zipkin-query-service/config/query-prod.scala
-    bin/sbt update package-dist
     # Install the Zipkin schema
     cassandra-cli -host localhost -port 9160 -f zipkin-cassandra/src/schema/cassandra-schema.txt
-    # TODO not sure this is necessary either
-    sudo mkdir -p /var/log/zipkin
 
-Zipkin is installed now. To run it (you'll need to leave these processes
-running, so use separate bash windows if you're doing it that way):
+Now you can run Zipkin (you'll need to leave these processes running, so use
+separate bash windows if you're doing it that way):
 
     # Collect data
     bin/collector

--- a/doc/mac-quickstart.md
+++ b/doc/mac-quickstart.md
@@ -41,7 +41,13 @@ separate bash windows if you're doing it that way):
 
 Zipkin should now be running and you can access the UI at http://localhost:8080/
 
-The next step is to have your existing services record data to the collector.
-The most common way to do this is to connect Scribe to the Collector daemon and
-write to Scribe from your other services as described in
+The next step is to collect trace data to view in Zipkin. To do this, interface
+with the collector (e.g. by using Scribe) to record trace data. There are
+several libraries to make this easier to do in different environments. Twitter
+uses [Finagle](https://github.com/twitter/finagle/tree/master/finagle-zipkin);
+external libraries (currently for Python, REST, node, and Java) are listed in the
+[wiki](https://github.com/twitter/zipkin/wiki#external-projects-that-use-zipkin);
+and there is also a [Ruby gem](https://rubygems.org/gems/finagle-thrift) and
+[Ruby Thrift client](https://github.com/twitter/thrift_client). Additional
+information is available in
 [install.md](https://github.com/twitter/zipkin/blob/master/doc/install.md).


### PR DESCRIPTION
The current installation documentation didn't get me very far in getting set up, in part because it seems outdated. I added a document with the commands I ran on my MBP to get Zipkin working and cleaned up some of the explanation around it. NOTE: this is not quite ready for merging as there are a few TODOs that need review where I wasn't sure if some steps were still required.

The next step is to update the website (in the gh-pages branch) to reflect these changes; or we might decide that the master branch is the Source of Truth and we should just point the website to /docs for installation instructions.
