### PR TITLE
Added better support for Redis.

### DIFF
--- a/bin/collector-redis
+++ b/bin/collector-redis
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+bin/sbt 'project zipkin-collector-service' 'run -f zipkin-collector-service/config/collector-redis.scala'

--- a/bin/query-redis
+++ b/bin/query-redis
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+bin/sbt 'project zipkin-query-service' 'run -f zipkin-query-service/config/query-redis.scala'

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -65,7 +65,7 @@ object Zipkin extends Build {
     Project(
       id = "zipkin",
       base = file(".")
-    ) aggregate(test, queryCore, queryService, common, scrooge, collectorScribe, web, cassandra, collectorCore, collectorService, kafka) // TODO - add redis back in
+    ) aggregate(test, queryCore, queryService, common, scrooge, collectorScribe, web, cassandra, collectorCore, collectorService, kafka, redis)
 
   lazy val test   = Project(
     id = "zipkin-test",
@@ -201,7 +201,7 @@ object Zipkin extends Build {
       base =>
         (base / "config" +++ base / "src" / "test" / "resources").get
     }
-  ).dependsOn(queryCore, cassandra)
+  ).dependsOn(queryCore, cassandra, redis)
 
   lazy val collectorScribe =
     Project(
@@ -244,7 +244,7 @@ object Zipkin extends Build {
       base =>
         (base / "config" +++ base / "src" / "test" / "resources").get
     }
-  ).dependsOn(collectorCore, collectorScribe, cassandra, kafka)
+  ).dependsOn(collectorCore, collectorScribe, cassandra, kafka, redis)
 
   lazy val web =
     Project(

--- a/zipkin-collector-service/config/collector-redis.scala
+++ b/zipkin-collector-service/config/collector-redis.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.twitter.zipkin.builder.Scribe
+import com.twitter.zipkin.redis
+import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
+import com.twitter.zipkin.storage.Store
+
+
+val redisBuilder = Store.Builder(
+    redis.StorageBuilder("0.0.0.0", 6379),
+    redis.IndexBuilder("0.0.0.0", 6379)
+)
+
+CollectorServiceBuilder(Scribe.Interface(categories = Set("zipkin")))
+  .writeTo(redisBuilder)

--- a/zipkin-query-service/config/query-redis.scala
+++ b/zipkin-query-service/config/query-redis.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.twitter.zipkin.builder.QueryServiceBuilder
+import com.twitter.zipkin.redis
+import com.twitter.zipkin.storage.Store
+
+val storeBuilder = Store.Builder(
+  redis.StorageBuilder("0.0.0.0", 6379),
+  redis.IndexBuilder("0.0.0.0", 6379)
+)
+
+QueryServiceBuilder(storeBuilder)

--- a/zipkin-redis/config/scribe-client.conf
+++ b/zipkin-redis/config/scribe-client.conf
@@ -1,0 +1,22 @@
+# This file configures Scribe to listen for messages on port 7001 and write
+# them to a Zipkin Collector on 0.0.0.0:9410
+#
+# This is an example configuration file for Facebook Scribe to talk to a Zipkin
+# Collector. This file is denoted as being the client config only as an example
+# if you are testing a client/server interaction on the same machine and need
+# to run multiple scribe instances on different ports.
+
+port=7001
+max_msg_per_second=2000000
+check_interval=3
+
+<store>
+  category=zipkin
+  type=network
+  remote_host=0.0.0.0
+  remote_port=9410
+  use_conn_pool=yes
+  default_max_msg_before_reconnect=50000
+  allowable_delta_before_reconnect=12500
+  must_succeed=no
+</store>

--- a/zipkin-redis/config/scribe-server.conf
+++ b/zipkin-redis/config/scribe-server.conf
@@ -1,0 +1,22 @@
+# This file configures Scribe to listen for messages on port 7000 and write
+# them to a Zipkin Collector on 0.0.0.0:9410
+#
+# This is an example configuration file for Facebook Scribe to talk to a Zipkin
+# Collector. This file is denoted as being the server config only as an example
+# if you are testing a client/server interaction on the same machine and need
+# to run multiple scribe instances on different ports.
+
+port=7001
+max_msg_per_second=2000000
+check_interval=1
+
+<store>
+  category=zipkin
+  type=network
+  remote_host=0.0.0.0
+  remote_port=9410
+  use_conn_pool=yes
+  default_max_msg_before_reconnect=50000
+  allowable_delta_before_reconnect=12500
+  must_succeed=no
+</store>

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSortedSetMap.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSortedSetMap.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2012 Tumblr Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,13 +46,17 @@ class RedisSortedSetMap(database: Client, prefix: String, defaultTTL: Option[Dur
 
   /**
    * Gets elements from a sorted set, in reverse order.
+   *
+   * Because this get method always asks for a sorted set from redis, it will never return a Seq[ChannelBuffer]. Thus,
+   * when zRevRangeByScore returns Either[ZRangeResults, Seq[ChannelBuffer], we can simply return Either[ZRangeResults].
+   *
    * @param key specifies which sorted set
    * @param start items must have a score bigger than this
    * @param stop items must have a score smaller than this
    * @param count number of items to return
    */
   def get(key: String, start: Double, stop: Double, count: Long): Future[ZRangeResults] = {
-    database.zRevRangeByScore(preface(key), ZInterval(stop), ZInterval(start), true, Some(Limit(0, count)))
+    database.zRevRangeByScore(preface(key), ZInterval(stop), ZInterval(start), true, Some(Limit(0, count))).map(_.left.get)
   }
 
 }


### PR DESCRIPTION
Fixed a bug in
zipkin-redis:com.twitter.zipkin.storage.redis.RedisSortedSetMap where a
`Either[Future[ZRangeResults], Future[Seq[ChannelBuffer]]]` was being returned instead of
a `Future[ZRangeResults]`. The method in question will always return a
`Future[ZRangeResult]` because it is getting a sorted map, so we simply get the
left item of the Either.

Added bin/collector-redis and bin/query-redis for easier
setup of the collector and querier with redis support.

Added zipkin-redis/config with the scribe configuration files for a
sample client and server. These are simply example files.
