### PR TITLE
HBase Storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ services:
 jdk:
   - openjdk7
   - openjdk6
+script:
+  - "umask 0022"
+  - "sbt ++$TRAVIS_SCALA_VERSION clean test"

--- a/bin/collector
+++ b/bin/collector
@@ -1,2 +1,6 @@
-#!/usr/bin/env sh
-bin/sbt 'project zipkin-collector-service' 'run -f zipkin-collector-service/config/collector-dev.scala'
+#!/usr/bin/env bash
+
+DEFAULT_TYPE=dev
+SERVICE_TYPE=${1:-$DEFAULT_TYPE}
+
+bin/sbt 'project zipkin-collector-service' "run -f zipkin-collector-service/config/collector-${SERVICE_TYPE}.scala"

--- a/bin/query
+++ b/bin/query
@@ -1,2 +1,6 @@
-#!/usr/bin/env sh
-bin/sbt 'project zipkin-query-service' 'run -f zipkin-query-service/config/query-dev.scala'
+#!/usr/bin/env bash
+
+DEFAULT_TYPE=dev
+SERVICE_TYPE=${1:-$DEFAULT_TYPE}
+
+bin/sbt 'project zipkin-query-service' "run -f zipkin-query-service/config/query-${SERVICE_TYPE}.scala"

--- a/bin/sbt
+++ b/bin/sbt
@@ -19,7 +19,6 @@ if [ "${sbtjar_md5}" != 124fb91b398542c23cd920360580d2d7 ]; then
   exit 1
 fi
 
-
 test -f ~/.sbtconfig && . ~/.sbtconfig
 
 java -ea                          \
@@ -37,6 +36,6 @@ java -ea                          \
   -XX:ReservedCodeCacheSize=64m   \
   -Xss8M                          \
   -Xms512M                        \
-  -Xmx1G                          \
+  -Xmx4G                          \
   -server                         \
   -jar $sbtjar "$@"

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+bin/sbt 'project zipkin-test' 'run -f com.twitter.zipkin.tracegen.Main'

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
@@ -229,7 +229,7 @@ case class AnormIndex(db: DB, openCon: Option[Connection] = None) extends Index 
   /**
    * Index a span's duration. This is so we can look up the trace duration.
    */
-  def indexSpanDuration(span: Span): Future[Void] = {
-    Future.Void
+  def indexSpanDuration(span: Span): Future[Unit] = {
+    Future.Unit
   }
 }

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraIndex.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraIndex.scala
@@ -283,7 +283,7 @@ case class CassandraIndex(
     annFuture.unit
   }
 
-  def indexSpanDuration(span: Span): Future[Void] = {
+  def indexSpanDuration(span: Span): Future[Unit] = {
     val first = span.firstAnnotation.map(_.timestamp)
     val last = span.lastAnnotation.map(_.timestamp)
 
@@ -296,6 +296,6 @@ case class CassandraIndex(
       WRITE_REQUEST_COUNTER.incr()
       t => batch.insert(span.traceId, Column[Long, String](t, "").ttl(dataTimeToLive))
     }
-    batch.execute()
+    batch.execute().unit
   }
 }

--- a/zipkin-collector-service/config/collector-hbase.scala
+++ b/zipkin-collector-service/config/collector-hbase.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.twitter.zipkin.builder.Scribe
+import com.twitter.zipkin.hbase
+import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
+import com.twitter.zipkin.storage.Store
+
+val hbaseBuilder = Store.Builder(
+  hbase.StorageBuilder(zkServers = Some("localhost"), zkPort = Some(2181)),
+  hbase.IndexBuilder(zkServers = Some("localhost"), zkPort = Some(2181)),
+  hbase.AggregatesBuilder(zkServers = Some("localhost"), zkPort = Some(2181))
+)
+
+CollectorServiceBuilder(Scribe.Interface(categories = Set("zipkin")))
+  .writeTo(hbaseBuilder)

--- a/zipkin-collector-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
+++ b/zipkin-collector-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
@@ -29,6 +29,7 @@ class ConfigSpec extends Specification {
     "validate collector configs" in {
       val configFiles = Seq(
         "/collector-dev.scala",
+        "/collector-hbase.scala",
         "/collector-cassandra.scala"
       ) map { TempFile.fromResourcePath(_) }
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Index.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Index.scala
@@ -93,5 +93,5 @@ trait Index {
   /**
    * Index a span's duration. This is so we can look up the trace duration.
    */
-  def indexSpanDuration(span: Span): Future[Void]
+  def indexSpanDuration(span: Span): Future[Unit]
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/util/Retry.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/util/Retry.scala
@@ -1,0 +1,31 @@
+package com.twitter.zipkin.storage.util
+
+/**
+ * Retry a given function up to nTries.
+ *
+ * All exceptions will be caught until the retry limit is met.
+ *
+ * No clean up between each invocation is attempted.  It's up to the user to ensue that
+ * supplied function is resilient to this fact.
+ */
+object Retry{
+  def apply[T](n: Int)(f: => T) : T = {
+    var result:Option[T] = None
+    var throwable:Option[Throwable] = None
+
+    for (i <- 0 until n if result.isEmpty) {
+      try {
+        result = Option(f)
+      } catch {
+        case e:Throwable => { throwable = Some(e) }
+      }
+    }
+
+    if (result.isEmpty && throwable.isDefined) {
+      throw new RetriesExhaustedException("%d retries exhausted".format(n), throwable.get)
+    }
+
+    result.get
+  }
+  class RetriesExhaustedException(msg:String, throwable:Throwable) extends RuntimeException(msg,throwable)
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/hbase/AggregatesBuilder.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/hbase/AggregatesBuilder.scala
@@ -1,0 +1,28 @@
+package com.twitter.zipkin.hbase
+
+import com.twitter.zipkin.builder.Builder
+import com.twitter.zipkin.storage.Aggregates
+import com.twitter.zipkin.storage.hbase.HBaseAggregates
+import com.twitter.zipkin.storage.hbase.utils.{ThreadProvider, ConfBuilder, HBaseTable}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.HBaseConfiguration
+
+
+case class AggregatesBuilder(
+  confOption: Option[Configuration] = Some(HBaseConfiguration.create()),
+  zkServers: Option[String] = None,
+  zkPort: Option[Int] = None
+) extends Builder[Aggregates] with ConfBuilder {
+  self =>
+
+  def apply() = {
+
+    // Create the HBaseIndex supplying all of the tables.
+    new HBaseAggregates {
+      val dependenciesTable = new HBaseTable(conf, TableLayouts.dependenciesTableName)
+      val topAnnotationsTable = new HBaseTable(conf, TableLayouts.topAnnotationsTableName)
+      val mappingTable = new HBaseTable(conf, TableLayouts.mappingTableName, mainExecutor = ThreadProvider.mappingTableExecutor)
+      val idGenTable = new HBaseTable(conf, TableLayouts.idGenTableName, mainExecutor = ThreadProvider.idGenTableExecutor)
+    }
+  }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/hbase/IndexBuilder.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/hbase/IndexBuilder.scala
@@ -1,0 +1,32 @@
+package com.twitter.zipkin.hbase
+
+
+import com.twitter.zipkin.builder.Builder
+import com.twitter.zipkin.storage.Index
+import com.twitter.zipkin.storage.hbase.HBaseIndex
+import com.twitter.zipkin.storage.hbase.utils.{ThreadProvider, ConfBuilder, HBaseTable}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.HBaseConfiguration
+
+case class IndexBuilder(
+  confOption: Option[Configuration] = Some(HBaseConfiguration.create()),
+  zkServers: Option[String] = None,
+  zkPort: Option[Int] = None
+) extends Builder[Index] with ConfBuilder {
+  self =>
+
+  def apply() = {
+
+    // Create the HBaseIndex supplying all of the tables.
+    new HBaseIndex {
+      val durationTable = new HBaseTable(conf, TableLayouts.durationTableName)
+      val idxServiceTable = new HBaseTable(conf, TableLayouts.idxServiceTableName, mainExecutor = ThreadProvider.indexServiceExecutor)
+      val idxServiceSpanNameTable = new HBaseTable(conf, TableLayouts.idxServiceSpanNameTableName, mainExecutor = ThreadProvider.indexServiceSpanExecutor)
+      val idxServiceAnnotationTable = new HBaseTable(conf, TableLayouts.idxServiceAnnotationTableName, mainExecutor = ThreadProvider.indexAnnotationExecutor)
+
+      val mappingTable = new HBaseTable(conf, TableLayouts.mappingTableName, mainExecutor = ThreadProvider.mappingTableExecutor)
+      val idGenTable = new HBaseTable(conf, TableLayouts.idGenTableName, mainExecutor = ThreadProvider.idGenTableExecutor)
+    }
+  }
+}
+

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/hbase/StorageBuilder.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/hbase/StorageBuilder.scala
@@ -1,0 +1,22 @@
+package com.twitter.zipkin.hbase
+
+import com.twitter.zipkin.builder.Builder
+import com.twitter.zipkin.storage.Storage
+import com.twitter.zipkin.storage.hbase.HBaseStorage
+import com.twitter.zipkin.storage.hbase.utils.{ThreadProvider, ConfBuilder, HBaseTable}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.HBaseConfiguration
+
+case class StorageBuilder(
+  confOption: Option[Configuration] = Some(HBaseConfiguration.create()),
+  zkServers: Option[String] = None,
+  zkPort: Option[Int] = None
+) extends Builder[Storage] with ConfBuilder {
+  self =>
+
+  def apply() = {
+    new HBaseStorage {
+      val hbaseTable = new HBaseTable(conf, TableLayouts.storageTableName, mainExecutor = ThreadProvider.storageExecutor)
+    }
+  }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/hbase/TableLayouts.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/hbase/TableLayouts.scala
@@ -1,0 +1,111 @@
+package com.twitter.zipkin.hbase
+
+import com.twitter.conversions.time._
+import com.twitter.util.Duration
+import org.apache.hadoop.hbase.client.HBaseAdmin
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding
+import org.apache.hadoop.hbase.io.hfile.Compression
+import org.apache.hadoop.hbase.regionserver.StoreFile.BloomType
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.{HBaseConfiguration, HColumnDescriptor, HTableDescriptor}
+
+/**
+ * This a utility to create all of the needed tables.
+ *
+ * It also contains all of the table names and the column family names.
+ */
+object TableLayouts {
+
+  val storageTableName = "zipkin.traces"
+  val storageFamily = Bytes.toBytes("S")
+  val storageTTL = 14.days
+
+  val durationTableName = "zipkin.duration"
+  val durationDurationFamily = Bytes.toBytes("D")
+  val durationStartTimeFamily = Bytes.toBytes("s")
+
+  val idxServiceTableName = "zipkin.idxService"
+  val idxServiceFamily = Bytes.toBytes("D")
+
+  val idxServiceSpanNameTableName = "zipkin.idxServiceSpanName"
+  val idxServiceSpanNameFamily = Bytes.toBytes("D")
+
+  val idxServiceAnnotationTableName = "zipkin.idxServiceAnnotation"
+  val idxAnnotationFamily = Bytes.toBytes("D")
+
+  val topAnnotationsTableName = "zipkin.topAnnotations"
+  val topAnnotationFamily = Bytes.toBytes("A")
+  val topAnnotationKeyValueFamily = Bytes.toBytes("K")
+
+  val dependenciesTableName = "zipkin.dependencies"
+  val dependenciesFamily = Bytes.toBytes("D")
+
+  val mappingTableName = "zipkin.mappings"
+  val mappingForwardFamily = Bytes.toBytes("F")
+  val mappingBackwardsFamily = Bytes.toBytes("R")
+
+  val idGenTableName = "zipkin.idGen"
+  val idGenFamily = Bytes.toBytes("D")
+
+  val tables = Map(
+    storageTableName -> (Seq(storageFamily), Some(storageTTL)),
+    durationTableName -> (Seq(durationDurationFamily, durationStartTimeFamily), Some(storageTTL)),
+    idxServiceTableName -> (Seq(idxServiceFamily), Some(storageTTL)),
+    idxServiceSpanNameTableName -> (Seq(idxServiceSpanNameFamily), Some(storageTTL)),
+    idxServiceAnnotationTableName -> (Seq(idxAnnotationFamily), Some(storageTTL)),
+    topAnnotationsTableName -> (Seq(topAnnotationFamily, topAnnotationKeyValueFamily), Some(storageTTL)),
+    dependenciesTableName -> (Seq(dependenciesFamily) , Some(storageTTL)),
+
+    // Tables that need to be kept forever.
+    idGenTableName -> (Seq(idGenFamily), None),
+    mappingTableName -> (Seq(mappingForwardFamily, mappingBackwardsFamily), None)
+  )
+
+  def createTables(admin:HBaseAdmin) {
+    createTables(admin, tables.keys.toSeq, None)
+  }
+
+  def createTables(admin:HBaseAdmin, compression:Option[Compression.Algorithm]) {
+    createTables(admin, tables.keys.toSeq, compression)
+  }
+
+  def createTables(admin: HBaseAdmin, tableNames:Seq[String], compression:Option[Compression.Algorithm]) {
+    tableNames.foreach { tableName =>
+      tables.get(tableName).foreach { case (families, ttl) =>
+        if (admin.tableExists(tableName)) {
+          admin.disableTable(tableName)
+          admin.deleteTable(tableName)
+        }
+        admin.createTable(createHTD(tableName, families, ttl, compression))
+      }
+    }
+  }
+
+
+  private[this] def createHTD(tableName: String,
+                              families: Seq[Array[Byte]],
+                              ttlOption: Option[Duration] = None,
+                              compressionOption:Option[Compression.Algorithm]=None): HTableDescriptor = {
+    val htd = new HTableDescriptor(tableName)
+    val hcds = families.map { fam =>
+      val hcd = new HColumnDescriptor(fam)
+      hcd.setBloomFilterType(BloomType.ROW)
+      hcd.setDataBlockEncoding(DataBlockEncoding.FAST_DIFF)
+      ttlOption.foreach { ttl => hcd.setTimeToLive(ttl.inSeconds)     }
+      compressionOption.foreach { algo => hcd.setCompressionType(algo) }
+      hcd
+    }
+
+    hcds.foreach(htd.addFamily)
+    htd
+  }
+
+  def main(args: Array[String]) {
+    val conf = HBaseConfiguration.create()
+    val hbaseAdmin = new HBaseAdmin(conf)
+
+    val compression = args.headOption.map { compString =>  Compression.getCompressionAlgorithmByName(compString) }
+
+    createTables(hbaseAdmin, compression)
+  }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/HBaseAggregates.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/HBaseAggregates.scala
@@ -1,0 +1,117 @@
+package com.twitter.zipkin.storage.hbase
+
+import com.twitter.algebird.Monoid
+import com.twitter.scrooge.BinaryThriftStructSerializer
+import com.twitter.util.{Time, Future}
+import com.twitter.zipkin.common.Dependencies
+import com.twitter.zipkin.conversions.thrift._
+import com.twitter.zipkin.gen
+import com.twitter.zipkin.hbase.TableLayouts
+import com.twitter.zipkin.storage.Aggregates
+import com.twitter.zipkin.storage.hbase.mapping.ServiceMapper
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+import org.apache.hadoop.hbase.client.{Scan, Put}
+import org.apache.hadoop.hbase.util.Bytes
+import scala.collection.JavaConverters._
+
+trait HBaseAggregates extends Aggregates {
+
+  val dependenciesTable: HBaseTable
+  val topAnnotationsTable: HBaseTable
+
+  val mappingTable: HBaseTable
+  val idGenTable: HBaseTable
+  lazy val idGen = new IDGenerator(idGenTable)
+  lazy val serviceMapper = new ServiceMapper(mappingTable, idGen)
+
+  val serializer = new BinaryThriftStructSerializer[gen.Dependencies] {
+    def codec = gen.Dependencies
+  }
+
+  def close() {
+    mappingTable.close()
+    idGenTable.close()
+
+    topAnnotationsTable.close()
+    dependenciesTable.close()
+  }
+
+  def getDependencies(startDate: Option[Time], endDate: Option[Time]=None): Future[Dependencies] = {
+    val scan = new Scan()
+    scan.setStartRow(Bytes.toBytes(Long.MaxValue - startDate.map(_.inMilliseconds).getOrElse(Long.MaxValue)))
+    endDate.foreach { ed => scan.setStopRow(Bytes.toBytes(Long.MaxValue - ed.inMilliseconds))}
+    scan.addColumn(TableLayouts.dependenciesFamily, Bytes.toBytes("\0"))
+    dependenciesTable.scan(scan, 100).map { results =>
+      val depList = results.flatMap { result =>
+        result.list().asScala.headOption.map { kv =>
+          val tDep = serializer.fromBytes(kv.getValue)
+          tDep.toDependencies
+        }
+      }
+      Monoid.sum(depList)
+    }
+  }
+
+  def storeDependencies(dependencies: Dependencies): Future[Unit] = {
+    val rk = Bytes.toBytes(Long.MaxValue - dependencies.startTime.inMilliseconds)
+    val put = new Put(rk)
+    put.add(TableLayouts.dependenciesFamily, Bytes.toBytes("\0"), serializer.toBytes(dependencies.toThrift))
+    dependenciesTable.put(Seq(put))
+  }
+
+  def getTopAnnotations(serviceName: String): Future[Seq[String]] = {
+    getTopAnnotationInternal(serviceName, TableLayouts.topAnnotationFamily)
+  }
+
+  def getTopKeyValueAnnotations(serviceName: String): Future[Seq[String]] = {
+    getTopAnnotationInternal(serviceName, TableLayouts.topAnnotationKeyValueFamily)
+  }
+
+  def storeTopAnnotations(serviceName: String, annotations: Seq[String]): Future[Unit] = {
+    storeTopAnnotationsInternal(serviceName, annotations, TableLayouts.topAnnotationFamily)
+  }
+
+  def storeTopKeyValueAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = {
+    storeTopAnnotationsInternal(serviceName, a, TableLayouts.topAnnotationKeyValueFamily)
+  }
+
+  private def getTopAnnotationInternal(serviceName: String, fam: Array[Byte]): Future[Seq[String]] = {
+    serviceMapper.get(serviceName).map { serviceMapping =>
+      val startRk = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(0L)
+      val scan = new Scan()
+      scan.addFamily(fam)
+      scan.setCaching(1)
+
+      // This is a very small table and there will
+      // be row key skew.  To get away with this the table
+      // needs to stay in memory as much as possible.
+      scan.setCacheBlocks(true)
+
+      scan.setStartRow(startRk)
+      scan
+    }.flatMap { scan =>
+      val results = topAnnotationsTable.scan(scan, 1)
+      results
+    }.map { results =>
+      val resultOption = results.headOption
+      resultOption.map { result =>
+        result.list().asScala.map { kv =>
+          (Bytes.toInt(kv.getQualifier), Bytes.toString(kv.getValue))
+        }.sortBy {_._1}.map {_._2}
+      }.getOrElse(Seq.empty[String])
+    }
+  }
+
+  private def storeTopAnnotationsInternal(serviceName: String, annotations: Seq[String], fam: Array[Byte]): Future[Unit] = {
+    serviceMapper.get(serviceName).map { serviceMapping =>
+      val put = new Put(Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(Long.MaxValue - System.currentTimeMillis()))
+      annotations.zipWithIndex.map { case (anno: String, id: Int)=>
+        put.add(TableLayouts.topAnnotationFamily, Bytes.toBytes(id), Bytes.toBytes(anno))
+      }
+      put
+    }.flatMap { put =>
+      topAnnotationsTable.put(Seq(put))
+    }
+  }
+
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/HBaseIndex.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/HBaseIndex.scala
@@ -1,0 +1,295 @@
+package com.twitter.zipkin.storage.hbase
+
+import com.twitter.logging.Logger
+import com.twitter.util.Future
+import com.twitter.zipkin.Constants
+import com.twitter.zipkin.common.Span
+import com.twitter.zipkin.hbase.TableLayouts
+import com.twitter.zipkin.storage.hbase.mapping.ServiceMapper
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+import com.twitter.zipkin.storage.{IndexedTraceId, TraceIdDuration, Index}
+import java.nio.ByteBuffer
+import org.apache.hadoop.hbase.client.{Get, Result, Scan, Put}
+import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp
+import org.apache.hadoop.hbase.filter.{BinaryComparator, ValueFilter}
+import org.apache.hadoop.hbase.util.Bytes
+import scala.collection.JavaConverters._
+import scala.collection.Set
+import com.twitter.zipkin.util.Util
+
+trait HBaseIndex extends Index {
+  val log = Logger.get(getClass.getName)
+
+  val durationTable: HBaseTable
+  val idxServiceTable: HBaseTable
+  val idxServiceSpanNameTable: HBaseTable
+  val idxServiceAnnotationTable: HBaseTable
+
+  val mappingTable: HBaseTable
+  val idGenTable: HBaseTable
+  lazy val idGen = new IDGenerator(idGenTable)
+  lazy val serviceMapper    = new ServiceMapper(mappingTable, idGen)
+
+  /**
+   * Close the index
+   */
+  def close() {
+    idGenTable.close()
+    mappingTable.close()
+
+    //ttl tables.
+    durationTable.close()
+    idxServiceTable.close()
+    idxServiceAnnotationTable.close()
+    idxServiceSpanNameTable.close()
+  }
+
+
+  /**
+   * Get the trace ids for this particular service and if provided, span name.
+   * Only return maximum of limit trace ids from before the endTs.
+   */
+  def getTraceIdsByName(serviceName: String, spanNameOption: Option[String], endTs: Long, limit: Int): Future[Seq[IndexedTraceId]] = {
+    val resultsFuture = spanNameOption match {
+      case None       => getTraceIdsByNameNoSpanName(serviceName, endTs, limit)
+      case Some(spanName) => getTraceIdsByNameWithSpanName(serviceName, spanName, endTs, limit)
+    }
+
+    resultsFuture.map { results =>
+      results.flatMap { result => indexResultToTraceId(result) }.toSeq.distinct.take(limit)
+    }
+  }
+
+  /**
+   * Get the trace ids for this annotation between the two timestamps. If value is also passed we expect
+   * both the annotation key and value to be present in index for a match to be returned.
+   * Only return maximum of limit trace ids from before the endTs.
+   */
+  def getTraceIdsByAnnotation(serviceName: String, annotation: String, value: Option[ByteBuffer], endTs: Long, limit: Int): Future[Seq[IndexedTraceId]] = {
+    val serviceMappingFuture = serviceMapper.get(serviceName)
+    val annoMappingFuture = serviceMappingFuture.flatMap { serviceMapping =>
+      serviceMapping.annotationMapper.get(annotation)
+    }
+
+    annoMappingFuture.flatMap { annoMapping =>
+      val scan = new Scan()
+      val startRk = Bytes.toBytes(annoMapping.parent.get.id) ++ Bytes.toBytes(annoMapping.id) ++ Bytes.toBytes(0L)
+      val endRk = Bytes.toBytes(annoMapping.parent.get.id) ++ Bytes.toBytes(annoMapping.id) ++ getEndScanTimeStampRowKeyBytes(endTs)
+      scan.setStartRow(startRk)
+      scan.setStopRow(endRk)
+      scan.addFamily(TableLayouts.idxAnnotationFamily)
+      value.foreach { bb => scan.setFilter(new ValueFilter(CompareOp.EQUAL, new BinaryComparator(bb.array()))) }
+      idxServiceAnnotationTable.scan(scan, limit).map { results =>
+        results.flatMap { result => indexResultToTraceId(result)}.toSeq.distinct.take(limit)
+      }
+    }
+  }
+
+  /**
+   * Fetch the duration or an estimate thereof from the traces.
+   * Duration returned in micro seconds.
+   */
+  def getTracesDuration(traceIds: Seq[Long]): Future[Seq[TraceIdDuration]] = {
+    val gets = traceIds.map { traceId =>
+      val get = new Get(Bytes.toBytes(traceId))
+      get.setMaxVersions(1)
+    }
+    // Go to hbase to get all of the durations.
+    durationTable.get(gets).map { results => results.map(durationResultToDuration).toSet.toSeq  }
+  }
+
+  /**
+   * Get all the service names for as far back as the ttl allows.
+   */
+  def getServiceNames: Future[Set[String]] = serviceMapper.getAll.map { f => f.map(_.name) }
+
+  /**
+   * Get all the span names for a particular service, as far back as the ttl allows.
+   */
+  def getSpanNames(service: String): Future[Set[String]] = {
+    // From the service get the spanNameMapper.  Then get all the maps.
+    val spanNameMappingsFuture = serviceMapper.get(service).flatMap { _.spanNameMapper.getAll }
+    // get the names from the mappings.
+    spanNameMappingsFuture.map { maps => maps.map { _.name} }
+  }
+
+  /**
+   * Index a trace id on the service and name of a specific Span
+   */
+  def indexTraceIdByServiceAndName(span: Span): Future[Unit] = {
+    // Get the id of services and span names
+    val serviceMappingsFuture =  Future.collect( span.serviceNames.map { sn =>
+      serviceMapper.get(sn)
+    }.toSeq)
+
+    // Figure out when this happened.
+    val timeBytes = getTimeStampRowKeyBytes(span)
+
+    val traceIdBytes = Bytes.toBytes(span.traceId)
+    val putsFuture = serviceMappingsFuture.flatMap { serviceMappings =>
+      Future.collect(serviceMappings.map { serviceMapping =>
+        val putF: Future[Put] = serviceMapping.spanNameMapper.get(span.name).map { spanNameMapping =>
+          val rk = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(spanNameMapping.id) ++ timeBytes
+          val p = new Put(rk)
+          p.add(TableLayouts.idxServiceSpanNameFamily, traceIdBytes, Bytes.toBytes(true))
+          p
+        }
+        putF
+      })
+    }
+
+    // Put the data into hbase.
+    putsFuture.flatMap { puts => idxServiceSpanNameTable.put(puts) }
+  }
+
+  /**
+   * Index the span by the annotations attached
+   */
+  def indexSpanByAnnotations(span: Span): Future[Unit] = {
+    // Get the normal annotations
+    val annoFutures = span.annotations.filter { a =>
+    // skip core annotations since that query can be done by service name/span name anyway 5
+      !Constants.CoreAnnotations.contains(a.value)
+    }.map { a =>
+      val sf = serviceMapper.get(a.serviceName)
+      sf.flatMap { service => service.annotationMapper.get(a.value)}.map { am => (am, Bytes.toBytes(true))}
+    }
+
+    // Get the binary annotations.
+    val baFutures = span.binaryAnnotations.map { ba =>
+      ba.host match {
+        case Some(host) => Some((ba, host))
+        case None => None
+      }
+    }.flatten.map { case (ba, host) =>
+      val sf = serviceMapper.get(host.serviceName)
+      sf.flatMap { service =>
+        service.annotationMapper.get(ba.key)
+      }.map { am =>
+        val bytes = Util.getArrayFromBuffer(ba.value)
+        (am, bytes)
+      }
+    }
+
+    // Store the sortable time stamp byte array.  This will be used for rk creation.
+    val tsBytes = getTimeStampRowKeyBytes(span)
+    val putsFuture = (baFutures ++ annoFutures).map { annoF =>
+      annoF.map { case (anno, bytes) =>
+        // Pulling out the parent here is safe because the parent must be set to find it here.
+        val rk = Bytes.toBytes(anno.parent.get.id) ++ Bytes.toBytes(anno.id) ++ tsBytes
+        val put = new Put(rk)
+        put.add(TableLayouts.idxAnnotationFamily, Bytes.toBytes(span.traceId), bytes)
+        put
+      }
+    }
+
+    // Now put them into the table.
+    Future.collect(putsFuture).flatMap { puts => idxServiceAnnotationTable.put(puts)  }
+  }
+
+  /**
+   * Store the service name, so that we easily can
+   * find out which services have been called from now and back to the ttl
+   */
+  def indexServiceName(span: Span): Future[Unit] = {
+    val futureMappings = Future.collect(span.serviceNames.map { sn => serviceMapper.get(sn)}.toSeq)
+    val timeBytes = getTimeStampRowKeyBytes(span)
+    val putsFuture = futureMappings.map { mappings =>
+      mappings.map { map =>
+        val rk = Bytes.toBytes(map.id) ++ timeBytes
+        val put = new Put(rk)
+        put.add(TableLayouts.idxServiceFamily, Bytes.toBytes(span.traceId), Bytes.toBytes(true))
+        put
+      }
+    }
+    putsFuture.flatMap { puts => idxServiceTable.put(puts) }
+  }
+
+  /**
+   * Index the span name on the service name. This is so we
+   * can get a list of span names when given a service name.
+   * Mainly for UI purposes
+   */
+  def indexSpanNameByService(span: Span): Future[Unit] = {
+    val serviceMappingsFuture = span.serviceNames.map { sn => serviceMapper.get(sn)}.toSeq
+    Future.collect(serviceMappingsFuture.map { smf =>
+      smf.flatMap {_.spanNameMapper.get(span.name)}
+    }).flatMap {
+      snm => Future.Unit
+    }
+  }
+
+  /**
+   * Index a span's duration. This is so we can look up the trace duration.
+   */
+  def indexSpanDuration(span: Span): Future[Unit] = {
+    val durationOption = span.duration
+    val tsOption = getTimeStamp(span)
+    val putOption = (durationOption, tsOption) match {
+      case (Some(duration), Some(timestamp)) => Option({
+        val put = new Put(Bytes.toBytes(span.traceId))
+        put.add(TableLayouts.durationDurationFamily, Bytes.toBytes(span.id), Bytes.toBytes(duration))
+        put.add(TableLayouts.durationStartTimeFamily, Bytes.toBytes(span.id), Bytes.toBytes(timestamp))
+        put
+      })
+      case _ => None
+    }
+    putOption.map { put => durationTable.put(Seq(put)) }.getOrElse(Future.Unit)
+  }
+
+  //
+  // Internal Helper Methods.
+  //
+
+  private def indexResultToTraceId(result: Result): Seq[IndexedTraceId] = {
+    val rowLen = result.getRow.length
+    val tsBytes = result.getRow.slice(rowLen - Bytes.SIZEOF_LONG, rowLen)
+    val ts = Long.MaxValue - Bytes.toLong(tsBytes)
+    result.list().asScala.map { kv =>
+      IndexedTraceId(Bytes.toLong(kv.getQualifier), ts)
+    }
+  }
+
+  private def getTraceIdsByNameNoSpanName(serviceName: String, endTs: Long, limit: Int): Future[Seq[Result]] = {
+    val serviceMappingFuture = serviceMapper.get(serviceName)
+    serviceMappingFuture.flatMap { serviceMapping =>
+
+      val scan = new Scan()
+      // Ask for more rows because there can be large number of dupes.
+      scan.setCaching(limit * 10)
+
+      val startRk = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(0L)
+      val endRk =  Bytes.toBytes(serviceMapping.id) ++ getEndScanTimeStampRowKeyBytes(endTs)
+      scan.setStartRow(startRk)
+      scan.setStopRow(endRk)
+      // TODO(eclark): make this go back to the region server multiple times with a smart filter.
+      idxServiceTable.scan(scan, limit*10)
+    }
+  }
+
+  private def getTraceIdsByNameWithSpanName(serviceName: String, spanName: String, endTs: Long, limit: Int): Future[Seq[Result]] = {
+    val serviceMappingFuture = serviceMapper.get(serviceName)
+    serviceMappingFuture.flatMap { serviceMapping =>
+      val spanNameMappingFuture = serviceMapping.spanNameMapper.get(spanName)
+      spanNameMappingFuture.flatMap { spanNameMapping =>
+        val scan = new Scan()
+        val startRow = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(spanNameMapping.id) ++ Bytes.toBytes(0L)
+        val stopRow = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(spanNameMapping.id) ++ getEndScanTimeStampRowKeyBytes(endTs)
+        scan.setStartRow(startRow)
+        scan.setStopRow(stopRow)
+        idxServiceSpanNameTable.scan(scan, limit)
+      }
+    }
+  }
+
+  private def durationResultToDuration(result: Result): TraceIdDuration = {
+    val traceId = Bytes.toLong(result.getRow)
+    val durationMap = result.getFamilyMap(TableLayouts.durationDurationFamily).asScala
+    val startMap = result.getFamilyMap(TableLayouts.durationStartTimeFamily).asScala
+
+    val duration = durationMap.map { case (qual, value) => Bytes.toLong(value)}.sum
+    val start = startMap.map { case (qual, value) => Bytes.toLong(value)}.min
+
+    TraceIdDuration(traceId, duration, start)
+  }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/HBaseStorage.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/HBaseStorage.scala
@@ -1,0 +1,143 @@
+package com.twitter.zipkin.storage.hbase
+
+import com.twitter.conversions.time._
+import com.twitter.scrooge.BinaryThriftStructSerializer
+import com.twitter.util.{Duration, Future}
+import com.twitter.zipkin.common.Span
+import com.twitter.zipkin.conversions.thrift._
+import com.twitter.zipkin.gen
+import com.twitter.zipkin.hbase.TableLayouts
+import com.twitter.zipkin.storage.Storage
+import com.twitter.zipkin.storage.hbase.utils.HBaseTable
+import org.apache.hadoop.hbase.KeyValue
+import org.apache.hadoop.hbase.client.{Result, Get, Put}
+import org.apache.hadoop.hbase.filter.KeyOnlyFilter
+import org.apache.hadoop.hbase.util.Bytes
+import scala.collection.JavaConverters._
+
+/**
+ * Storage to store spans into an HBase Table. TTL is handled by HBase.
+ *
+ * The HBase table is laid out as follows:
+ *
+ * RowKey: [ TraceId ]
+ * Column Family: D
+ * Column Qualifier: [ SpanId ][ Hash of Annotations ]
+ * Column Value: Thrift Serialized Span
+ */
+trait HBaseStorage extends Storage {
+
+  val hbaseTable: HBaseTable
+
+  val serializer = new BinaryThriftStructSerializer[gen.Span] {
+    def codec = gen.Span
+  }
+
+  /**
+   * Close the storage
+   */
+  def close() {
+    hbaseTable.close()
+  }
+
+  /**
+   * Store the span in the underlying storage for later retrieval.
+   * @return a future for the operation
+   */
+  def storeSpan(span: Span): Future[Unit] = {
+    val rk = rowKeyFromSpan(span)
+    val p = new Put(rk)
+    val qual =  Bytes.toBytes(span.id) ++ Bytes.toBytes(span.annotations.hashCode())
+    p.add(TableLayouts.storageFamily, qual, serializer.toBytes(span.toThrift))
+    hbaseTable.put(Seq(p))
+  }
+
+  /**
+   * Set the ttl of a trace. Used to store a particular trace longer than the
+   * default. It must be oh so interesting!
+   *
+   * This is a NO-OP for HBase. when the data is initially put into HBase the ttl starts from the
+   * timestamp. See http://hbase.apache.org/book.html#ttl for more information about HBase's TTL Data model.
+   */
+  def setTimeToLive(traceId: Long, ttl: Duration): Future[Unit] = Future.Unit
+
+  /**
+   * Get the time to live for a specific trace.
+   * If there are multiple ttl entries for one trace, pick the lowest one.
+   */
+  def getTimeToLive(traceId: Long): Future[Duration] = Future.value(7.days)
+
+  def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] = {
+    val gets = traceIds.map(createTraceExistsGet)
+    val futures: Future[Seq[Result]] = hbaseTable.get(gets)
+    futures.map { results =>
+      results.map(traceExistsResultToTraceId).toSet
+    }
+  }
+
+  private[this] def createTraceExistsGet(traceId: Long): Get = {
+    val g = new Get(Bytes.toBytes(traceId))
+    g.addFamily(TableLayouts.storageFamily)
+    g.setFilter(new KeyOnlyFilter())
+    g
+  }
+
+  private[this] def traceExistsResultToTraceId(result: Result): Long = {
+    traceIdFromRowKey(result.getRow)
+  }
+
+  /**
+   * Get the available trace information from the storage system.
+   * Spans in trace should be sorted by the first annotation timestamp
+   * in that span. First event should be first in the spans list.
+   */
+  def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = {
+    hbaseTable.get(createTraceGets(traceIds)).map { rl =>
+      rl.map { result =>
+        val spans = resultToSpans(Option(result)).sortBy { span => getTimeStamp(span)}
+        spans
+      }
+    }
+  }
+
+  def getSpansByTraceId(traceId: Long): Future[Seq[Span]] = {
+    val gets = createTraceGets(List(traceId))
+    hbaseTable.get(gets).map { rl =>
+      resultToSpans(rl.headOption).sortBy { span => getTimeStamp(span)}
+    }
+  }
+
+  /**
+   * This creates an HBase Get request for a Seq of traces.
+   * @param traceIds All of the traceId's that are requested.
+   * @return Seq of Get Requests.
+   */
+  private[this] def createTraceGets(traceIds: Seq[Long]): Seq[Get] = {
+    traceIds.map { id =>
+      val g = new Get(Bytes.toBytes(id))
+      g.setMaxVersions(1)
+      g.addFamily(TableLayouts.storageFamily)
+    }
+  }
+
+  private[this] def resultToSpans(option: Option[Result]): Seq[Span] = {
+    val lists: Seq[KeyValue] = option match {
+      case Some(result) => result.list().asScala
+      case None => Seq.empty[KeyValue]
+    }
+
+    val spans: Seq[Span] = lists.map { kv =>
+      serializer.fromBytes(kv.getValue).toSpan
+    }
+    spans
+  }
+
+  /**
+   * How long do we store the data before we delete it? In seconds.
+   */
+  def getDataTimeToLive: Int = TableLayouts.storageTTL.inSeconds
+
+  private[this] def traceIdFromRowKey(bytes: Array[Byte]): Long = Bytes.toLong(bytes)
+
+  private[this] def rowKeyFromSpan(span: Span): Array[Byte] = Bytes.toBytes(span.traceId)
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/AnnotationMapper.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/AnnotationMapper.scala
@@ -1,0 +1,16 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+import org.apache.hadoop.hbase.util.Bytes
+
+case class AnnotationMapper(serviceMapping: ServiceMapping) extends Mapper[AnnotationMapping] {
+  val mappingTable: HBaseTable = serviceMapping.mappingTable
+  val typeBytes = Array[Byte](2)
+  val qualBytes: Array[Byte] = Bytes.toBytes(serviceMapping.id) ++ typeBytes
+  val idGen: IDGenerator = serviceMapping.idGen
+  val parentId: Long = serviceMapping.id
+
+  protected def createInternal(id: Long, value: Array[Byte]): AnnotationMapping = {
+    AnnotationMapping(id, value, Some(serviceMapping))
+  }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/AnnotationMapping.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/AnnotationMapping.scala
@@ -1,0 +1,3 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+case class AnnotationMapping(id: Long, value: Array[Byte], parent: Option[ServiceMapping]) extends Mapping

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/Mapper.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/Mapper.scala
@@ -1,0 +1,190 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+import com.twitter.logging.Logger
+import com.twitter.util._
+import com.twitter.zipkin.hbase.TableLayouts
+import com.twitter.zipkin.storage.hbase.utils._
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentHashMap
+import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase.util.Bytes
+import com.twitter.zipkin.storage.hbase.utils.HBaseTable
+import com.twitter.zipkin.storage.hbase.utils.IDGenerator
+import com.twitter.zipkin.util.Util
+import com.twitter.util.Duration._
+import scala.Some
+import com.twitter.zipkin.storage.hbase.utils.HBaseTable
+import com.twitter.zipkin.storage.hbase.utils.IDGenerator
+import com.twitter.zipkin.storage.util.Retry
+
+trait Mapper[T >: Null <: Mapping] {
+  val log = Logger.get(getClass.getName)
+
+  val mappingTable: HBaseTable
+  val qualBytes: Array[Byte]
+  val idGen: IDGenerator
+  val parentId: Long
+  val typeBytes: Array[Byte]
+
+
+  private lazy val cache = new ConcurrentHashMap[ByteBuffer, T]()
+  private lazy val pool = new ExecutorServiceFuturePool(ThreadProvider.mappingExecutor)
+  private val emptyBytes: Array[Byte] = Array[Byte]()
+
+  /**
+   * All implementations need to provide their own implementation that creates
+   * whichever type of mapping is being generated.
+   *
+   * @param id The id of the mapping.  A positive Long.
+   * @param value The value that is being mapped to an id.
+   * @return New Mapping object to represent id <-> value.
+   */
+  protected def createInternal(id: Long, value: Array[Byte]): T
+
+  /**
+   * Get the mapping for a name.
+   * @param name
+   * @return
+   */
+  def get(name: String): Future[T] = {
+    val normString = name.toLowerCase
+    if (normString.equals("")) {
+      throw new Exception("Can't get empty string")
+    }
+    get(ByteBuffer.wrap(Bytes.toBytes(normString)))
+  }
+
+  def get(value: ByteBuffer): Future[T] = {
+    // Check in the local cache first before using the FuturePool.  Most requests will be served from
+    // cache so no need to incur the ExecutorService overhead.
+    val earlyCacheOption = Option(cache.get(value)).map(Future.value)
+
+    // Once we reach here we are pretty sure that going to HBase will be required.  So we return a wrapping
+    // Future to be run on the FuturePool.  Then inside the future we'll block on all of the different ways that
+    // a mapping can be created.  Blocking until getting a durable result allows us to catch errors in the retry loop
+    // and present a single future to the caller.
+    val result: Future[T] = pool {
+      // Blocking retry loop.
+      Retry(100) {
+        // Try the cache again.  It's possible that some other thread has done all the work for us.
+        val cachedOption: Option[Future[T]] = Option(cache.get(value)).map(Future.value)
+        val mapping: Future[T] = cachedOption.getOrElse {
+          // If the cache doesn't contain a mapping we'll need to get it from or put it into HBase.
+
+          // so get the byte array for the value.
+          val valueBytes: Array[Byte] = Util.getArrayFromBuffer(value)
+          val fromOrToHBase: Future[T] = getFromHBase(valueBytes).flatMap { mo =>
+            mo match {
+              // If there is already a mapping stored in hbase
+              case Some(fromHBaseMapping) => {
+                // put the mapping from hbase into the cache.
+                cacheMapping(fromHBaseMapping)
+                // re-wrap the mapping in a future to keep types sane.
+                Future.value(fromHBaseMapping)
+              }
+              // If there was no mapping on HBase then try and create and store a new mapping.
+              case None => createProposed(valueBytes).flatMap { pm =>
+                store(pm)
+              }
+            }
+          }
+          fromOrToHBase
+        }
+        Await.result(mapping, Duration.fromMilliseconds(500))
+      }
+    }
+    // return the future that best answers the query.
+    earlyCacheOption.getOrElse(result)
+  }
+
+  def getAll: Future[Set[T]] = {
+    val maxToLoad = 100000
+    val scan = new Scan()
+    scan.setMaxVersions(1)
+    scan.setCaching(maxToLoad)
+    scan.addColumn(TableLayouts.mappingForwardFamily, qualBytes)
+    /*
+    Yes turn on caching for a scan.
+
+    GASP!!!
+
+    This should be a small table and it will greatly help with
+    creating more mappings if this is in cache.
+    */
+    scan.setCacheBlocks(true)
+    mappingTable.scan(scan, maxToLoad).map { results =>
+      val mappings = results.map(createFromResult)
+      mappings.foreach { m => cacheMapping(m)}
+      mappings.toSeq.toSet
+    }
+  }
+
+  private def getFromHBase(valueBytes: Array[Byte]): Future[Option[T]] = {
+    val get = new Get(valueBytes)
+    get.addColumn(TableLayouts.mappingForwardFamily, qualBytes)
+    val resultFuture: Future[Seq[Result]] = mappingTable.get(Seq(get))
+    resultFuture.map { results =>
+      results.headOption.map(createFromResult(_))
+    }
+  }
+
+  private def store(proposedMapping: T): Future[T] = {
+    // Forwards : Name to Id
+    // backwards: Id to Name
+
+    val idBytes = Bytes.toBytes(proposedMapping.id)
+    val valBytes = proposedMapping.value
+
+    // Now that we have an id put the id to name mapping in hbase.
+    val backwardPut = new Put(idBytes)
+    backwardPut.add(TableLayouts.mappingBackwardsFamily, qualBytes, valBytes)
+
+    val forwardPut = new Put(valBytes)
+    forwardPut.add(TableLayouts.mappingForwardFamily, qualBytes, idBytes)
+
+    // Probably need to clean up if we fail here but the ui should be fine.
+    // There will be a dangling id -> name reference.  But since in order to ever use it
+    // this whole method must complete, a dangling reference isn't a large deal.
+    val backwardsSuccessFuture = mappingTable.checkAndPut(idBytes, TableLayouts.mappingBackwardsFamily, qualBytes, emptyBytes, backwardPut)
+
+    // Send it to hbase.
+    val forwardsSuccessFuture = backwardsSuccessFuture.flatMap { backwardsSuccess =>
+    // Make sure that the id -> name mapping worked before continuing on.
+    // This should never fail, but better safe than sorry.
+      if (!backwardsSuccess) {
+        throw new Exception("ID(" + Bytes.toLong(idBytes) + ") Already Exists. Retrying")
+      }
+      mappingTable.checkAndPut(valBytes, TableLayouts.mappingForwardFamily, qualBytes, emptyBytes, forwardPut)
+    }
+
+    // The boolean returned should tell us if there was a race creating the forward mapping.
+    val resultingMapping: Future[T] = forwardsSuccessFuture.map { forwardsSuccess =>
+      if (!forwardsSuccess) {
+        throw new Exception("Mapping (" + proposedMapping + ") Already Exists. Retrying")
+      }
+
+      // At this point the mapping is durable.
+      cacheMapping(proposedMapping)
+      proposedMapping
+    }
+
+    resultingMapping
+  }
+
+  private def cacheMapping(mapping:T) {
+    val replaced = cache.put(ByteBuffer.wrap(mapping.value), mapping)
+    assert( replaced == null || replaced.id == mapping.id)
+  }
+
+  private def createProposed(value: Array[Byte]): Future[T] = {
+    idGen.createNewId(parentId, typeBytes.head).map { id =>
+      createInternal(id, value)
+    }
+  }
+
+  private def createFromResult(result: Result): T = {
+    val id = Bytes.toLong(result.getValue(TableLayouts.mappingForwardFamily, qualBytes))
+    createInternal(id, result.getRow)
+  }
+
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/Mapping.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/Mapping.scala
@@ -1,0 +1,7 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+trait Mapping {
+  val id: Long
+  val value: Array[Byte]
+  val parent: Option[Mapping]
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/ServiceMapper.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/ServiceMapper.scala
@@ -1,0 +1,13 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+
+case class ServiceMapper(mappingTable: HBaseTable, idGen: IDGenerator) extends Mapper[ServiceMapping] {
+  val qualBytes: Array[Byte] = Array[Byte](0, 0)
+  val typeBytes = Array[Byte](0)
+  val parentId: Long = 0
+
+  protected def createInternal(id: Long, value: Array[Byte]): ServiceMapping = {
+    ServiceMapping(id, value, mappingTable, idGen)
+  }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/ServiceMapping.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/ServiceMapping.scala
@@ -1,0 +1,12 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+import org.apache.hadoop.hbase.util.Bytes
+
+case class ServiceMapping(id: Long, value: Array[Byte], mappingTable: HBaseTable, idGen: IDGenerator) extends Mapping {
+  val parent: Option[Mapping] = None
+  val annotationMapper = new AnnotationMapper(this)
+  val spanNameMapper = new SpanNameMapper(this)
+  lazy val name = Bytes.toString(value)
+}
+

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/SpanNameMapper.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/SpanNameMapper.scala
@@ -1,0 +1,17 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+import org.apache.hadoop.hbase.util.Bytes
+
+
+case class SpanNameMapper(serviceMapping: ServiceMapping) extends Mapper[SpanNameMapping] {
+  val mappingTable: HBaseTable = serviceMapping.mappingTable
+  val typeBytes = Array[Byte](1)
+  val qualBytes: Array[Byte] = Bytes.toBytes(serviceMapping.id) ++ typeBytes
+  val idGen: IDGenerator = serviceMapping.idGen
+  val parentId: Long = serviceMapping.id
+
+  protected def createInternal(id: Long, value: Array[Byte]): SpanNameMapping = {
+    SpanNameMapping(id, value, Some(serviceMapping))
+  }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/SpanNameMapping.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/mapping/SpanNameMapping.scala
@@ -1,0 +1,8 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+import org.apache.hadoop.hbase.util.Bytes
+
+case class SpanNameMapping(id: Long, value: Array[Byte], parent: Option[ServiceMapping]) extends Mapping {
+  val mappingType: Byte = 1
+  lazy val name = Bytes.toString(value)
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/package.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/package.scala
@@ -1,0 +1,33 @@
+package com.twitter.zipkin.storage
+
+import com.twitter.logging.Logger
+import com.twitter.util.Time
+import com.twitter.zipkin.common.Span
+import org.apache.hadoop.hbase.util.Bytes
+
+package object hbase {
+
+  val log = Logger.get(getClass.getName)
+
+  /**
+   * From a span get the starting timestamp.
+   * @param span
+   * @return
+   */
+  def getTimeStampRowKeyBytes(span: Span): Array[Byte] = {
+    val ts = getTimeStamp(span).getOrElse {
+      log.debug("Could not get timeStamp for %s", span)
+      Time.now.inMicroseconds
+    }
+    timeStampToRowKeyBytes(ts)
+  }
+
+  def getTimeStamp(span: Span): Option[Long] = {
+    val timeStamps = span.annotations.map {_.timestamp}.sortWith(_ < _)
+    timeStamps.headOption
+  }
+
+  def timeStampToRowKeyBytes(timeStamp: Long): Array[Byte] = Bytes.toBytes(Long.MaxValue - timeStamp)
+
+  def getEndScanTimeStampRowKeyBytes(ts: Long) = Bytes.toBytes(scala.math.max(Long.MaxValue - ts, 1L) - 1L)
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/ConfBuilder.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/ConfBuilder.scala
@@ -1,0 +1,28 @@
+package com.twitter.zipkin.storage.hbase.utils
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.{HConstants, HBaseConfiguration}
+
+/**
+ * Trait used to create Hadoop conf from different passed in params.
+ */
+trait ConfBuilder {
+
+  val confOption : Option[Configuration]
+  val zkServers: Option[String]
+  val zkPort: Option[Int]
+
+  /**
+   * If the user didn't pass a conf, instead the passed zk hostname and port
+   * then we need to create a hadoop conf for containing that info
+   * @return
+   */
+  private def createConf() = {
+    val conf = HBaseConfiguration.create()
+    zkServers.foreach { q => conf.set(HConstants.ZOOKEEPER_QUORUM, q ) }
+    zkPort.foreach { p => conf.set(HConstants.ZOOKEEPER_CLIENT_PORT, p.toString) }
+    conf
+  }
+
+  lazy val conf = confOption.getOrElse { createConf() }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/HBaseTable.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/HBaseTable.scala
@@ -1,0 +1,129 @@
+package com.twitter.zipkin.storage.hbase.utils
+
+import com.twitter.util.{FuturePool, ExecutorServiceFuturePool, Future}
+import java.util.concurrent.{Executors, ExecutorService}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase.util.PoolMap.PoolType
+import scala.collection.JavaConverters._
+import com.twitter.logging.Logger
+
+/**
+ * Class to expose non-blocking version of HBase's HTable.
+ *
+ * All operations are non-blocking by using a thread pool.  Any empty results are filtered out before being returned.
+ * @param conf Hadoop conf with HBase variables inside
+ * @param tableName The name of the table to target.
+ * @param mainExecutor The thread pool executor.
+ * @param clientExecutor The thread pool executor.
+ */
+case class HBaseTable(
+  conf: Configuration,
+  tableName:String,
+  mainExecutor: ExecutorService = ThreadProvider.defaultExecutor,
+  clientExecutor: ExecutorService = ThreadProvider.clientExecutor
+) {
+
+  /**
+   * Thread pool for futures.
+   */
+  private val pool: FuturePool = new ExecutorServiceFuturePool(mainExecutor)
+
+  private val htablePool = new HTablePool(conf, 32,
+                                          new HTableFactoryWithExecutor(clientExecutor),
+                                          PoolType.Reusable)
+
+  val log = Logger.get(getClass.getName)
+
+  /**
+   * Execute a Put async and return void when done.
+   * @param puts Seq of HBase puts to send to regionserver.
+   * @return Future[Unit]
+   */
+  def put(puts:Seq[Put]):Future[Unit] = pool {
+    val htable = htablePool.getTable(tableName)
+    try {
+      htable.put(puts.asJava)
+      htable.flushCommits()
+    } catch {
+      case e:Exception => log.debug("Error Putting to HBase")
+    } finally {
+      htable.close()
+    }
+  }
+
+  /**
+   * Perform a given scan.  It will grab the number of results asked for
+   * @param scan Scan to execute against HBase.
+   * @param numRows Number of rows to ask for.
+   * @return
+   */
+  def scan(scan:Scan, numRows:Int):Future[Seq[Result]] = pool {
+    val htable = htablePool.getTable(tableName)
+    var resultScanner:ResultScanner = null
+    try {
+      resultScanner = htable.getScanner(scan)
+      resultScanner.next(numRows).toSeq.filter { _.size > 0}.slice(0,numRows)
+    } finally {
+      if (resultScanner != null) {
+        resultScanner.close()
+      }
+      htable.close()
+    }
+  }
+
+  /**
+   * Execute several gets returning results.
+   * @param gets list of gets to pass to HBase.
+   * @return Results that are returned from HBase.
+   */
+  def get(gets:Seq[Get]):Future[Seq[Result]] = pool {
+    val htable = htablePool.getTable(tableName)
+    try {
+      htable.get(gets.asJava).map { r => Option(r) }.flatten.toSeq.filter { _.size > 0}
+    } finally {
+      htable.close()
+    }
+  }
+
+  def checkAndPut(rk:Array[Byte],
+                  fam:Array[Byte],
+                  qaul:Array[Byte],
+                  value:Array[Byte],
+                  put:Put):Future[Boolean] = pool {
+    val htable = htablePool.getTable(tableName)
+    try {
+
+
+      val result = htable.checkAndPut(rk, fam, qaul, value, put)
+      result
+    } catch {
+      case e:Exception =>
+        log.debug("Error: while check and put., %s", e)
+        throw e
+    } finally {
+      htable.close()
+    }
+  }
+
+  /**
+   * Atomic increment.
+   *
+   * @param incr the increment to execute.
+   * @return result from incrementing.
+   */
+  def atomicIncrement(incr:Increment):Future[Result] = pool {
+    val htable = htablePool.getTable(tableName)
+    try {
+      htable.increment(incr)
+    } finally {
+      htable.close()
+    }
+  }
+
+  def close() {
+    this.synchronized {
+      htablePool.close()
+    }
+  }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/HTableFactoryWithExecutor.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/HTableFactoryWithExecutor.scala
@@ -1,0 +1,12 @@
+package com.twitter.zipkin.storage.hbase.utils
+
+import java.util.concurrent.ExecutorService
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.client.{HTable, HTableInterface, HTableFactory}
+
+case class HTableFactoryWithExecutor(executor: ExecutorService) extends HTableFactory {
+  override def createHTableInterface(config: Configuration, tableName: Array[Byte]): HTableInterface = {
+    new HTable(config, tableName, executor)
+  }
+
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/IDGenerator.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/IDGenerator.scala
@@ -1,0 +1,24 @@
+package com.twitter.zipkin.storage.hbase.utils
+
+import com.twitter.util.Future
+import com.twitter.zipkin.hbase.TableLayouts
+import org.apache.hadoop.hbase.client.Increment
+import org.apache.hadoop.hbase.util.Bytes
+
+case class IDGenerator(idGenTable:HBaseTable) {
+  def createNewId(parent:Long, idType:Byte):Future[Long] = {
+    // Try and get a new ID.
+    val inc = new Increment(Bytes.toBytes(parent))
+    val qual =  new Array[Byte](idType)
+    inc.addColumn(TableLayouts.idGenFamily, qual, 1L)
+    // Failing here is fine.  We just waste an id.
+    val idResult = idGenTable.atomicIncrement(inc)
+    idResult.map { r =>
+      val bytes = r.getValue(TableLayouts.idGenFamily, qual)
+      if (Bytes.toLong(bytes) == Long.MaxValue) {
+        throw new Exception("All ID's are used up.")
+      }
+      Bytes.toLong(bytes)
+    }
+  }
+}

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/ThreadProvider.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/utils/ThreadProvider.scala
@@ -1,0 +1,64 @@
+package com.twitter.zipkin.storage.hbase.utils
+
+import com.twitter.concurrent.NamedPoolThreadFactory
+import java.util.concurrent._
+
+
+/**
+ * Object to provide shared thread pools to the HBase storage system.
+ */
+object ThreadProvider {
+  /**
+   * Default executor used for most operations.
+   */
+  lazy val defaultExecutor = createExecutor(16, "HBase")
+
+  /**
+   * Storage Executor
+   */
+  lazy val storageExecutor = createExecutor(16, "HBase-Storage")
+
+  /**
+   * Index Service Executor
+   */
+  lazy val indexServiceExecutor = createExecutor(16, "HBase-Idx-Service")
+
+  /**
+   * Index Service Span Executor
+   */
+  lazy val indexServiceSpanExecutor = createExecutor(16, "HBase-Idx-Span")
+
+  /**
+   * Index Annotation Executor
+   */
+  lazy val indexAnnotationExecutor = createExecutor(16, "HBase-Idx-Annotation")
+
+  /**
+   * Mapping executor. Used by ServiceMapper et al.
+   */
+  lazy val mappingExecutor = createExecutor(16, "HBase-Mapping")
+
+  /**
+   * Used by the Mapping table
+   */
+  lazy val mappingTableExecutor = createExecutor(16, "HBase-Mapping-Table")
+
+  /**
+   * IDGen thread pool.
+   */
+  lazy val idGenTableExecutor = createExecutor(16, "HBase-IDGen")
+
+  /**
+   * Client executor used to power the insides of org.apache.hadoop.hbase.client.HTable
+   */
+  lazy val clientExecutor = createExecutor(32, "HBase-Client")
+
+  private def createExecutor(numThreads:Int, poolName:String):ExecutorService = {
+    new ThreadPoolExecutor(
+      4,
+      numThreads,
+      60, TimeUnit.SECONDS,
+      new LinkedBlockingQueue[Runnable](),
+      new NamedPoolThreadFactory(poolName, true))
+  }
+}

--- a/zipkin-hbase/src/test/resources/log4j.properties
+++ b/zipkin-hbase/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+hbase.root.logger=FATAL,console
+hbase.security.logger=FATAL,console
+log4j.rootLogger=${hbase.root.logger}
+log4j.threshold=FATAL
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/HBaseAggregatesSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/HBaseAggregatesSpec.scala
@@ -1,0 +1,67 @@
+package com.twitter.zipkin.storage.hbase
+
+import com.twitter.algebird.Moments
+import com.twitter.util.{Await, Time}
+import com.twitter.zipkin.common.{Dependencies, Service, DependencyLink}
+import com.twitter.zipkin.hbase.{TableLayouts, AggregatesBuilder}
+import com.twitter.zipkin.storage.hbase.utils.HBaseTable
+import org.apache.hadoop.hbase.client.{Scan, Get}
+import org.apache.hadoop.hbase.util.Bytes
+
+
+class HBaseAggregatesSpec extends ZipkinHBaseSpecification {
+
+  val tablesNeeded = Seq(
+    TableLayouts.topAnnotationsTableName,
+    TableLayouts.dependenciesTableName,
+    TableLayouts.idGenTableName,
+    TableLayouts.mappingTableName
+  )
+
+  var aggregates: HBaseAggregates = null
+
+  val m1 = Moments(1)
+  val m2 = Moments(2)
+  val d1 = DependencyLink(Service("HBase.Client"), Service("HBase.RegionServer"), m1)
+  val d2 = DependencyLink(Service("HBase.Master"), Service("HBase.RegionServer"), m2)
+  val deps = Dependencies(Time.fromSeconds(2), Time.fromSeconds(1000), List(d1, d2))
+
+  val topAnnos = Seq("key1", "key2", "key3")
+  val annoService = "HBase.RegionServer"
+
+  "HBaseAggregates" should {
+
+    doBefore {
+      aggregates = AggregatesBuilder(confOption = Some(_conf))()
+    }
+
+    "storeDependencies" in {
+      Await.result(aggregates.storeDependencies(deps))
+      val depsTable = new HBaseTable(_conf, TableLayouts.dependenciesTableName)
+      val get = new Get(Bytes.toBytes(Long.MaxValue - Time.fromSeconds(2).inMilliseconds))
+      val result = Await.result(depsTable.get(Seq(get)))
+      result.size must_== 1
+    }
+
+    "getDependencies" in {
+      Await.result(aggregates.storeDependencies(deps))
+      val retrieved = Await.result(aggregates.getDependencies(Some(Time.fromSeconds(100))))
+      retrieved must_== deps
+    }
+
+    "storeTopAnnotations" in {
+      Await.result(aggregates.storeTopAnnotations(annoService, topAnnos))
+      val topAnnoTable = new HBaseTable(_conf, TableLayouts.topAnnotationsTableName)
+      val scan = new Scan().addFamily(TableLayouts.topAnnotationFamily)
+      val results = Await.result(topAnnoTable.scan(scan, 100))
+      results.size must_== 1
+    }
+
+    "getTopAnnotations" in {
+      Await.result(aggregates.storeTopAnnotations(annoService, topAnnos))
+      val retrieved = Await.result(aggregates.getTopAnnotations(annoService))
+      retrieved must_== topAnnos
+    }
+  }
+
+}

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/HBaseIndexSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/HBaseIndexSpec.scala
@@ -1,0 +1,153 @@
+package com.twitter.zipkin.storage.hbase
+
+import com.twitter.util.Await
+import com.twitter.zipkin.Constants
+import com.twitter.zipkin.common.{Endpoint, Span, Annotation}
+import com.twitter.zipkin.hbase.{TableLayouts, IndexBuilder}
+import com.twitter.zipkin.storage.hbase.mapping.ServiceMapper
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+import org.apache.hadoop.hbase.client.Scan
+import org.apache.hadoop.hbase.util.Bytes
+
+class HBaseIndexSpec extends ZipkinHBaseSpecification {
+
+  val tablesNeeded = TableLayouts.tables.keys.toSeq
+
+  var index: HBaseIndex = null
+
+  val traceIdOne = 100
+  val spanOneStart = 90000L
+  val serviceNameOne = "HBase.Client"
+  val endpointOne = new Endpoint(0, 0, serviceNameOne)
+  val annoOneList = List(
+    new Annotation(spanOneStart, Constants.ClientSend, Some(endpointOne)),
+    new Annotation(spanOneStart + 100, Constants.ClientRecv, Some(endpointOne))
+  )
+  val spanOneId: Long = 32003
+  val spanOneName = "startingSpan"
+  val spanOne = new Span(traceIdOne, spanOneName, spanOneId, None, annoOneList, Seq())
+
+  val spanTwoStart = spanOneStart + 100
+  val serviceNameTwo = "HBase.RegionServer"
+  val endPointTwo = new Endpoint(0, 0, serviceNameTwo)
+  val annoTwoList = List(new Annotation(spanTwoStart, Constants.ServerRecv, Some(endPointTwo)))
+  val spanTwo = new Span(traceIdOne, "secondSpan", 45006, Some(spanOneId), annoTwoList, Seq())
+
+  val spanThreeStart = spanTwoStart + 100
+  val annoThreeList = List(new Annotation(spanThreeStart, Constants.ServerRecv, Some(endPointTwo)))
+  val spanThree = new Span(traceIdOne, "spanThree", 45007, Some(spanOneId), annoThreeList, Seq())
+
+  val traceIdFour = 103
+  val spanFourStart = spanThreeStart + 100
+  val annoFourList = List(new Annotation(spanFourStart, Constants.ServerRecv, Some(endPointTwo)))
+  val spanFour = new Span(traceIdFour, "spanThree", 45008, None, annoFourList, Seq())
+
+
+  val spanFiveStart = spanFourStart + 100
+  val annoFiveValue = "CustomANNO"
+  val annoFiveList = List(new Annotation(spanFiveStart, annoFiveValue, Some(endPointTwo)))
+  val spanFive = new Span(traceIdFour, "spanThree", 45009, Some(45006), annoFiveList, Seq())
+  "HBaseIndex" should {
+
+    doBefore {
+      index = IndexBuilder(confOption = Some(_conf))()
+    }
+
+    "indexServiceName" in {
+      val serviceTable = new HBaseTable(_conf, TableLayouts.idxServiceTableName)
+
+      val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
+      val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
+      val idGen = new IDGenerator(idGenTable)
+      val serviceMapper = new ServiceMapper(mappingTable, idGen)
+
+      Await.result(index.indexServiceName(spanOne))
+      val results = Await.result(serviceTable.scan(new Scan(), 100))
+      results.size must_== 1
+
+      val result = results.head
+      result.getRow.size must_== Bytes.SIZEOF_LONG * 2
+
+      val serviceNameFromSpan = spanOne.serviceName.get
+      val serviceMapping = Await.result(serviceMapper.get(serviceNameFromSpan))
+      Bytes.toLong(result.getRow) must_== serviceMapping.id
+      Bytes.toLong(result.getRow.slice(Bytes.SIZEOF_LONG, Bytes.SIZEOF_LONG * 2)) must_== Long.MaxValue - spanOneStart
+    }
+
+    "indexTraceIdByServiceAndName" in {
+      val serviceSpanNameTable = new HBaseTable(_conf, TableLayouts.idxServiceSpanNameTableName)
+      Await.result(index.indexTraceIdByServiceAndName(spanOne))
+      val scan = new Scan()
+      val results = Await.result(serviceSpanNameTable.scan(scan, 100))
+      results.size must_== 1
+
+    }
+
+    "indexSpanByAnnotations" in {
+      val annoTable = new HBaseTable(_conf, TableLayouts.idxServiceAnnotationTableName)
+      Await.result(index.indexSpanByAnnotations(spanFive))
+      val result = Await.result(annoTable.scan(new Scan(), 1000))
+      result.size must_== 1
+    }
+
+    "indexDuration" in {
+      val durationTable = new HBaseTable(_conf, TableLayouts.durationTableName)
+      Await.result(index.indexSpanDuration(spanOne))
+      val result = Await.result(durationTable.scan(new Scan(), 1000))
+      result.size must_== 1
+    }
+
+    "getTracesDuration" in {
+      Await.result(index.indexSpanDuration(spanOne))
+      val durations = Await.result(index.getTracesDuration(Seq(traceIdOne)))
+      durations mustNotBe empty
+      durations.map {_.duration} must contain(100)
+
+      durations.map {_.traceId} must contain(traceIdOne)
+    }
+
+    "getTraceIdsByName" in {
+      Await.result(index.indexServiceName(spanOne))
+      Await.result(index.indexServiceName(spanTwo))
+      Await.result(index.indexServiceName(spanThree))
+      Await.result(index.indexServiceName(spanFour))
+
+      Await.result(index.indexTraceIdByServiceAndName(spanOne))
+      Await.result(index.indexTraceIdByServiceAndName(spanTwo))
+      Await.result(index.indexTraceIdByServiceAndName(spanThree))
+      Await.result(index.indexTraceIdByServiceAndName(spanFour))
+
+      val emptyResult = Await.result(index.getTraceIdsByName(serviceNameOne, None, spanOneStart + 100, 1))
+      emptyResult must beEmpty
+
+      // Try and get the first trace from the first service name
+      val t1 = Await.result(index.getTraceIdsByName(serviceNameOne, None, 0, 1))
+      t1.map {_.traceId} must contain(traceIdOne)
+      t1.map {_.timestamp} must contain(spanOneStart)
+      t1.size must_== 1
+
+      // Try and get the first two traces from the second service name
+      val t2 = Await.result(index.getTraceIdsByName(serviceNameTwo, None, 0, 100))
+      t2.map {_.traceId} must contain(traceIdOne)
+      t2.map {_.traceId} must contain(traceIdFour)
+      t2.map {_.timestamp} must contain(spanTwoStart)
+      t2.map {_.timestamp} must contain(spanThreeStart)
+
+      // Try and get the first trace from the first service name and the first span name
+      val t3 = Await.result(index.getTraceIdsByName(serviceNameOne, Some(spanOne.name), 0, 1))
+      t3.map {_.traceId} must contain(traceIdOne)
+      t3.map {_.timestamp} must contain(spanOneStart)
+      t3.size must_== 1
+    }
+
+    "getTraceIdsByAnnotation" in {
+      Await.result(index.indexSpanByAnnotations(spanFive))
+      val idf = index.getTraceIdsByAnnotation(spanFive.annotations.head.serviceName, spanFive.annotations.head.value, None, 0, 100)
+      val ids = Await.result(idf)
+      ids.size must_== 1
+      ids.map {_.traceId} must contain(spanFive.traceId)
+    }
+
+  }
+
+}

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/HBaseStorageSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/HBaseStorageSpec.scala
@@ -1,0 +1,66 @@
+package com.twitter.zipkin.storage.hbase
+
+import com.twitter.util.Await
+import com.twitter.zipkin.common.Span
+import com.twitter.zipkin.hbase.{TableLayouts, StorageBuilder}
+import org.apache.hadoop.hbase.client.{Get, HTable}
+import org.apache.hadoop.hbase.util.Bytes
+
+/**
+ * This isn't really a great unit test but it's a good starting
+ * point until I have a mock HBaseTable.
+ */
+class HBaseStorageSpec extends ZipkinHBaseSpecification {
+
+  val tablesNeeded = Seq(
+    TableLayouts.storageTableName
+  )
+
+  val traceId = 100L
+  val spanId = 567L
+  val span = Span(traceId, "span.methodCall()", spanId, None, List(), List())
+
+  var hbaseStorage: HBaseStorage = null
+
+  "HBaseStorage" should {
+
+    doBefore {
+      hbaseStorage = StorageBuilder(confOption = Some(_conf))()
+    }
+
+    doAfter {
+      hbaseStorage.close()
+      hbaseStorage = null
+    }
+
+    "storeSpan" in {
+      Await.result(hbaseStorage.storeSpan(span))
+      // The data should be there by now.
+      val htable = new HTable(_conf, TableLayouts.storageTableName)
+      val result = htable.get(new Get(Bytes.toBytes(traceId)))
+      result.size mustEqual 1
+    }
+
+    "tracesExist" in {
+      // Put the span just in case the ordering changes.
+      Await.result(hbaseStorage.storeSpan(span))
+      val idsFound = Await.result(hbaseStorage.tracesExist(Seq(traceId, 3002L)))
+      idsFound must contain(traceId)
+      idsFound.size mustEqual 1
+    }
+
+    "getSpansByTraceId" in {
+      Await.result(hbaseStorage.storeSpan(span))
+      val spansFound = hbaseStorage.getSpansByTraceId(traceId)
+      Await.result(spansFound) must contain(span)
+    }
+
+    "getSpansByTraceIds" in {
+      Await.result(hbaseStorage.storeSpan(span))
+      val spansFoundFuture = hbaseStorage.getSpansByTraceIds(Seq(traceId, 302L))
+      val spansFound = Await.result(spansFoundFuture).flatten
+      spansFound must contain(span)
+      spansFound.size must_== 1
+    }
+  }
+}

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/ZipkinHBaseSpecification.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/ZipkinHBaseSpecification.scala
@@ -1,0 +1,30 @@
+package com.twitter.zipkin.storage.hbase
+
+import com.twitter.zipkin.hbase.TableLayouts
+import org.apache.hadoop.hbase.util.Bytes
+import com.twitter.zipkin.storage.hbase.utils.HBaseSpecification
+
+trait ZipkinHBaseSpecification extends HBaseSpecification {
+  /**
+   * The list of tables that will be avaliable for tests.
+   */
+  val tablesNeeded:Seq[String]
+
+  doBeforeSpec {
+    // Grab a lock on the util to make sure we're the only one making changes
+    HBaseSpecification.sharedUtil.synchronized {
+      TableLayouts.createTables(_util.getHBaseAdmin, tablesNeeded, None)
+    }
+  }
+
+  doBefore {
+    HBaseSpecification.sharedUtil.synchronized {
+      tablesNeeded.foreach { tableName =>
+        _util.truncateTable(Bytes.toBytes(tableName))
+      }
+    }
+  }
+
+  sequential
+}
+

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/mapping/ServiceMapperSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/mapping/ServiceMapperSpec.scala
@@ -1,0 +1,45 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+import com.twitter.util.Await
+import com.twitter.zipkin.hbase.{TableLayouts}
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+import org.apache.hadoop.hbase.util.Bytes
+import java.nio.ByteBuffer
+import com.twitter.zipkin.storage.hbase.ZipkinHBaseSpecification
+
+class ServiceMapperSpec extends ZipkinHBaseSpecification {
+
+  val tablesNeeded = Seq(
+    TableLayouts.idGenTableName,
+    TableLayouts.mappingTableName
+  )
+
+  val namePrefix = "mapping-"
+  val names = (0 to 30) map { i => namePrefix + i}
+
+  "ServiceMapperSpec" should {
+
+    doBefore {
+      _util.truncateTable(Bytes.toBytes(TableLayouts.idGenTableName))
+      _util.truncateTable(Bytes.toBytes(TableLayouts.mappingTableName))
+    }
+
+    "get" in {
+      val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
+      val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
+      val idGen = new IDGenerator(idGenTable)
+      val serviceMapper = new ServiceMapper(mappingTable, idGen)
+      val serviceMapperTwo = new ServiceMapper(mappingTable, idGen)
+
+
+      Await.result(serviceMapper.get("test")).id must_== Await.result(serviceMapperTwo.get("test")).id
+      Await.result(serviceMapper.get("test")).id must_== Await.result(serviceMapper.get("test")).id
+      Await.result(serviceMapperTwo.get("test")).id must_== Await.result(serviceMapperTwo.get("test")).id
+
+      ByteBuffer.wrap(Await.result(serviceMapper.get("test")).value) must_== ByteBuffer.wrap(Await.result(serviceMapperTwo.get("test")).value)
+      ByteBuffer.wrap(Await.result(serviceMapper.get("test")).value) must_== ByteBuffer.wrap(Await.result(serviceMapper.get("test")).value)
+      ByteBuffer.wrap(Await.result(serviceMapperTwo.get("test")).value) must_== ByteBuffer.wrap(Await.result(serviceMapperTwo.get("test")).value)
+    }
+  }
+
+}

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/mapping/SpanNameMapperSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/mapping/SpanNameMapperSpec.scala
@@ -1,0 +1,71 @@
+package com.twitter.zipkin.storage.hbase.mapping
+
+import com.twitter.util.Await
+import com.twitter.zipkin.hbase.{TableLayouts}
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+import com.twitter.zipkin.storage.hbase.ZipkinHBaseSpecification
+
+class SpanNameMapperSpec extends ZipkinHBaseSpecification {
+
+  val tablesNeeded = Seq(
+    TableLayouts.idGenTableName,
+    TableLayouts.mappingTableName
+  )
+
+  "SpanNameMapper" should {
+    "get" in {
+      val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
+      val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
+      val idGen = new IDGenerator(idGenTable)
+      val serviceMapper = new ServiceMapper(mappingTable, idGen)
+
+      val serviceNameOne = "TestService"
+      val spanNameOne = "TestSpanOne"
+
+      val serviceMappingOne = Await.result(serviceMapper.get(serviceNameOne))
+      val spanNameMappingOne = Await.result(serviceMappingOne.spanNameMapper.get(spanNameOne))
+      val spanNameMappingOneAgain = Await.result(serviceMappingOne.spanNameMapper.get(spanNameOne))
+
+      spanNameMappingOne.id must_== spanNameMappingOneAgain.id
+
+      val names = Await.result(serviceMappingOne.spanNameMapper.getAll.map { maps => maps.map(_.name)}).toSeq
+      names must contain(spanNameOne.toLowerCase)
+    }
+
+    "be independent" in {
+      val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
+      val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
+      val idGen = new IDGenerator(idGenTable)
+      val serviceMapper = new ServiceMapper(mappingTable, idGen)
+
+      val serviceNameOne = "TestServiceOne"
+      val serviceNameTwo = "TestServiceTwo"
+
+      val spanNameOne = "spanNameOne"
+      val spanNameTwo = "spanNameOne"
+      val spanNameThree =  serviceNameTwo + ".spanNameThree"
+
+      val serviceMappingOne = Await.result(serviceMapper.get(serviceNameOne))
+      val serviceMappingTwo = Await.result(serviceMapper.get(serviceNameTwo))
+
+      val spanNameMappingOne = Await.result(serviceMappingOne.spanNameMapper.get(spanNameOne))
+      val spanNameMappingTwo = Await.result(serviceMappingTwo.spanNameMapper.get(spanNameTwo))
+      val spanNameMappingThree = Await.result(serviceMappingTwo.spanNameMapper.get(spanNameThree))
+
+      spanNameMappingOne.id must_== 1
+      spanNameMappingTwo.id must_== 1
+      spanNameMappingThree.id must_== 2
+
+      val serviceOneSpanMappings = Await.result(serviceMappingOne.spanNameMapper.getAll)
+      val serviceTwoSpanMappings = Await.result(serviceMappingTwo.spanNameMapper.getAll)
+
+      // Make sure that none of the mappings from service One have a parent that points to service two
+      serviceOneSpanMappings.map {_.parent.get.id} must not contain (serviceMappingTwo.id)
+      // make sure that none of the mappings from service two have a parent that points to service one
+      serviceTwoSpanMappings.map {_.parent.get.id} must not contain (serviceMappingOne.id)
+
+      serviceOneSpanMappings.map { _.name } must not contain (spanNameThree)
+    }
+  }
+
+}

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/HBaseSpecification.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/HBaseSpecification.scala
@@ -1,0 +1,36 @@
+package com.twitter.zipkin.storage.hbase.utils
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.HBaseTestingUtility
+import org.junit.runner.RunWith
+import org.specs.SpecificationWithJUnit
+import org.specs.runner.JUnitSuiteRunner
+
+@RunWith(classOf[JUnitSuiteRunner])
+class HBaseSpecification extends SpecificationWithJUnit {
+  lazy val _util: HBaseTestingUtility = HBaseSpecification.sharedUtil
+  lazy val _conf: Configuration = _util.getConfiguration
+
+  doBeforeSpec {
+    HBaseSpecification.sharedUtil.synchronized {
+      _util.startMiniCluster()
+    }
+  }
+
+  doAfterSpec {
+    HBaseSpecification.sharedUtil.synchronized {
+      _util.shutdownMiniCluster()
+      Thread.sleep(10 * 1000)
+    }
+  }
+
+  sequential
+}
+
+/**
+ * Object to hold single util.
+ */
+object HBaseSpecification {
+  lazy val sharedUtil = new HBaseTestingUtility()
+}
+

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/HBaseTableSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/HBaseTableSpec.scala
@@ -1,0 +1,58 @@
+package com.twitter.zipkin.storage.hbase.utils
+
+import com.twitter.util.Await
+import org.apache.hadoop.hbase.client.{Get, HTable, Put}
+import org.apache.hadoop.hbase.util.Bytes
+
+class HBaseTableSpec extends HBaseSpecification {
+
+  val tableName = "testTable"
+  val family = Bytes.toBytes("D")
+
+  doBeforeSpec {
+    _util.createTable(Bytes.toBytes(tableName), family)
+  }
+
+  "HBaseTable" should {
+    doBefore {
+      _util.truncateTable(Bytes.toBytes(tableName))
+    }
+    "checkAndPut" in {
+      val t1 = new HBaseTable(_conf, tableName)
+      val t2 = new HBaseTable(_conf, tableName)
+
+      val rk = Bytes.toBytes("test")
+      val qual = Bytes.toBytes(0)
+
+      val p = new Put(rk)
+      p.add(family, qual, Bytes.toBytes("TESTING"))
+
+      val t1Result = t1.checkAndPut(rk, family, qual, Array[Byte](), p)
+      val t2Result = t2.checkAndPut(rk, family, qual, Array[Byte](), p)
+
+      !Await.result(t1Result) must_== Await.result(t2Result)
+    }
+    "put" in {
+      val t1 =  new HBaseTable(_conf, tableName)
+      val p = new Put(Bytes.toBytes("hello"))
+      p.add(family, Bytes.toBytes("a"), Bytes.toBytes("world."))
+      Await.result(t1.put(Seq(p)))
+
+      val ht = new HTable(_conf, tableName)
+      val result = ht.get(new Get(Bytes.toBytes("hello")))
+      result.size() must_== 1
+    }
+    "get" in {
+      val ht = new HTable(_conf, tableName)
+      val p = new Put(Bytes.toBytes("hello"))
+      p.add(family, Bytes.toBytes("a"), Bytes.toBytes("world."))
+      ht.put(p)
+
+      val t1 =  new HBaseTable(_conf, tableName)
+      val resultFuture = t1.get(Seq(new Get(Bytes.toBytes("hello"))))
+      val result = Await.result(resultFuture)
+      result.size must_== 1
+    }
+  }
+
+}

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/RetrySpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/RetrySpec.scala
@@ -1,0 +1,39 @@
+package com.twitter.zipkin.storage.hbase.utils
+
+import org.specs.SpecificationWithJUnit
+import java.util.concurrent.atomic.AtomicLong
+import com.twitter.zipkin.storage.util.Retry
+
+class RetrySpec extends SpecificationWithJUnit {
+  "Retry" should {
+    "return if success" in {
+      val counter = new AtomicLong(0)
+      val result = Retry(10) {
+        val innerResult: Long = counter.incrementAndGet()
+        LongWrapper(innerResult)
+      }
+      result must_== LongWrapper(1L)
+    }
+    "throw an error if retries are exhausted" in {
+      {
+        val result = Retry(5) {
+          throw new Exception("No! No! No!")
+          LongWrapper(1)
+        }
+      } must throwAnException
+
+    }
+    "return if fewer than max retries are needed" in {
+      val counter = new AtomicLong(0)
+      val result = Retry(10) {
+        val innerResult: Long = counter.incrementAndGet()
+        if (innerResult < 10) {
+           throw new Exception("No No No")
+        }
+        LongWrapper(innerResult)
+      }
+      result must_== LongWrapper(10L)
+    }
+  }
+  case class LongWrapper(value:Long)
+}

--- a/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
+++ b/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
@@ -111,7 +111,7 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       def indexSpanByAnnotations(span: Span) = null
       def indexServiceName(span: Span) = null
       def indexSpanNameByService(span: Span) = null
-      def indexSpanDuration(span: Span): Future[Void] = null
+      def indexSpanDuration(span: Span): Future[Unit] = null
     }
 
     "find traces in service span name index, fetch from storage" in {

--- a/zipkin-query-service/config/query-hbase.scala
+++ b/zipkin-query-service/config/query-hbase.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.twitter.zipkin.builder.QueryServiceBuilder
+import com.twitter.zipkin.hbase
+import com.twitter.zipkin.storage.Store
+
+val hbaseBuilder = Store.Builder(
+  hbase.StorageBuilder(zkServers = Some("localhost"), zkPort = Some(2181)),
+  hbase.IndexBuilder(zkServers = Some("localhost"), zkPort = Some(2181))
+)
+QueryServiceBuilder(hbaseBuilder)

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisIndex.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisIndex.scala
@@ -179,12 +179,12 @@ trait RedisIndex extends Index {
     else
       Future.Unit
 
-  override def indexSpanDuration(span: Span): Future[Void] = (traceHash.get(span.traceId) map {
+  override def indexSpanDuration(span: Span): Future[Unit] = (traceHash.get(span.traceId) map {
     case None => TimeRange.fromSpan(span) map { timeRange =>
       traceHash.put(span.traceId, timeRange)
     }
     case Some(bytes) => indexNewStartAndEnd(span, bytes)
-  }).voided
+  }).unit
 
   private[this] def indexNewStartAndEnd(span: Span, buf: ChannelBuffer) =
     TimeRange.fromSpan(span) map { timeRange =>

--- a/zipkin-test/src/main/scala/com/twitter/zipkin/tracegen/Requests.scala
+++ b/zipkin-test/src/main/scala/com/twitter/zipkin/tracegen/Requests.scala
@@ -97,6 +97,7 @@ class Requests(collectorHost: String, collectorPort: Int, queryHost: String, que
 
     val traceTimeline = Await.result(client.getTraceTimelinesByIds(ts4, List(gen.Adjust.TimeSkew)))
 
+    println("Timeline:")
     println(traceTimeline.toString)
 
     println("Data ttl: " + Await.result(client.getDataTimeToLive()))


### PR DESCRIPTION
Here's the start of an HBase storage module.  It's still in pretty early form but I wanted to get this up so that reviews could start early.
## Tables
- zipkin.traces
- zipkin.duration
- zipkin.idxService
- zipkin.idxServiceSpanName
- zipkin.idxServiceAnnotation
- zipkin.topAnnotations
- zipkin.dependencies
- zipkin.mappings
- zipkin.idGen
## Internals

I created a non-blocking futures based version of HBase's HTable.  This HBaseTable uses a thread pool to execute the calls to HBase.

Currently it's using HBase 0.94.9 and hadoop 1
## Row Keys Construction

Whenever possible I am using a fixed length row key.  That necessitates a set id for any variable length strings that can be on the row key.  This mapping is created using the mapping table and the id gen table. The idGen table holds the last idGenerated.
- There can be up to Long.MaxValue services
- Each service can have Long.MaxValue spanNames and annotations

The mapping table holds the mapping of Array[Byte] to id and the reverse.
## Still ToDo
- counters, counters, more counters
- Allow this to build against current hbase trunk
