### PR TITLE
Add aggregates support to the Anorm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,15 @@ See [http://twitter.github.com/zipkin](http://twitter.github.com/zipkin)
 
 ## Quick start
 
-To install Zipkin on a single machine, see the
-[Ubuntu Quickstart](https://github.com/twitter/zipkin/blob/master/doc/ubuntu-quickstart.txt) and
-[Mac Quickstart](https://github.com/twitter/zipkin/blob/master/doc/mac-quickstart.md) guides.
-For more in-depth installation instructions with an explanation of the
-dependencies and related services, see
-[install.md](https://github.com/twitter/zipkin/blob/master/doc/install.md).
-
-Zipkin itself provides three services:
+Zipkin provides three services:
 
  - To collect data: `bin/collector`
  - To extract data: `bin/query`
  - To display data: `bin/web`
 
-If all three of these daemons are running, you should be able to visit
-http://localhost:8080 to view the Zipkin UI. There is also a
+You can run these services immediately after downloading Zipkin. Once all three
+daemons are running, you should be able to visit http://localhost:8080 to view
+the Zipkin UI. There is also a
 [browser extension](https://github.com/twitter/zipkin/tree/master/zipkin-browser-extension)
 which shows visualizations of traces of each page as you browse your website.
 
@@ -34,7 +28,8 @@ external libraries (currently for Python, REST, node, and Java) are listed in th
 and there is also a [Ruby gem](https://rubygems.org/gems/finagle-thrift) and
 [Ruby Thrift client](https://github.com/twitter/thrift_client).
 
-See the [in-depth installation guide](https://github.com/twitter/zipkin/blob/master/doc/install.md) for more information.
+See the [in-depth installation guide](https://github.com/twitter/zipkin/blob/master/doc/install.md)
+for more information on larger / more complex Zipkin installations.
 
 ## Get involved
 

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/anormdb/AggregatesBuilder.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/anormdb/AggregatesBuilder.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.zipkin.anormdb
+
+import com.twitter.zipkin.storage.anormdb.{AnormAggregates, DB}
+
+class AggregatesBuilder(db: DB) {
+  def apply() = {
+    AnormAggregates(db)
+  }
+}

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormAggregates.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormAggregates.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.zipkin.storage.anormdb
+
+import com.twitter.util.{Future, Time}
+import com.twitter.conversions.time._
+import com.twitter.zipkin.common.{Service, DependencyLink, Dependencies}
+import com.twitter.zipkin.storage.Aggregates
+import java.sql.Connection
+import anorm._
+import anorm.SqlParser._
+import com.twitter.algebird.Moments
+
+/**
+ * Retrieve and store aggregate dependency information.
+ *
+ * The top annotations methods are stubbed because they're not currently
+ * used anywhere; that feature was never completed.
+ */
+case class AnormAggregates(db: DB, openCon: Option[Connection] = None) extends Aggregates {
+  // Database connection object
+  private implicit val conn = openCon match {
+    case None => db.getConnection()
+    case Some(con) => con
+  }
+
+  /**
+   * Close the index
+   */
+  def close() { conn.close() }
+
+  /**
+   * Get the dependencies in a time range.
+   *
+   * endDate is optional and if not passed defaults to startDate plus one day.
+   */
+  def getDependencies(startDate: Time, endDate: Option[Time]=None): Future[Dependencies] = {
+    val startMs = startDate.inMicroseconds
+    val endMs = endDate.getOrElse(startDate + 1.day).inMicroseconds
+
+    val links: List[DependencyLink] = SQL(
+      """SELECT parent, child, m0, m1, m2, m3, m4
+        |FROM zipkin_dependency_links AS l
+        |LEFT JOIN zipkin_dependencies AS d
+        |  ON l.dlid = d.dlid
+        |WHERE start_ts >= {startTs}
+        |  AND end_ts <= {endTs}
+        |ORDER BY l.dlid DESC
+      """.stripMargin)
+    .on("startTs" -> startMs)
+    .on("endTs" -> endMs)
+    .as((str("parent") ~ str("child") ~ long("m0") ~ get[Double]("m1") ~ get[Double]("m2") ~ get[Double]("m3") ~ get[Double]("m4") map {
+      case parent ~ child ~ m0 ~ m1 ~ m2 ~ m3 ~ m4 => new DependencyLink(
+        new Service(parent),
+        new Service(child),
+        new Moments(m0, m1, m2, m3, m4)
+      )
+    }) *)
+
+    Future {
+      new Dependencies(startDate, Time.fromNanoseconds(endMs*1000), links)
+    }
+  }
+
+  /**
+   * Write dependencies
+   *
+   * Synchronize these so we don't do concurrent writes from the same box
+   */
+  def storeDependencies(dependencies: Dependencies): Future[Unit] = {
+    val dlid = SQL("""INSERT INTO zipkin_dependencies
+          |  (start_ts, end_ts)
+          |VALUES ({startTs}, {endTs})
+        """.stripMargin)
+      .on("startTs" -> dependencies.startTime.inMicroseconds)
+      .on("endTs" -> dependencies.endTime.inMicroseconds)
+    .executeInsert()
+
+    dependencies.links.foreach { link =>
+      SQL("""INSERT INTO zipkin_dependency_links
+            |  (dlid, parent, child, m0, m1, m2, m3, m4)
+            |VALUES ({dlid}, {parent}, {child}, {m0}, {m1}, {m2}, {m3}, {m4})
+          """.stripMargin)
+        .on("dlid" -> dlid)
+        .on("parent" -> link.parent.name)
+        .on("child" -> link.child.name)
+        .on("m0" -> link.durationMoments.m0)
+        .on("m1" -> link.durationMoments.m1)
+        .on("m2" -> link.durationMoments.m2)
+        .on("m3" -> link.durationMoments.m3)
+        .on("m4" -> link.durationMoments.m4)
+      .execute()
+    }
+
+    Future.Unit
+  }
+
+  /**
+   * Get the top annotations for a service name
+   */
+  def getTopAnnotations(serviceName: String): Future[Seq[String]] = {
+    Future.value(Seq[String]())
+  }
+
+  /**
+   * Get the top key value annotation keys for a service name
+   */
+  def getTopKeyValueAnnotations(serviceName: String): Future[Seq[String]] = {
+    Future.value(Seq[String]())
+  }
+
+  /**
+   * Override the top annotations for a service
+   */
+  def storeTopAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = {
+    Future.Unit
+  }
+
+  /**
+   * Override the top key value annotation keys for a service
+   */
+  def storeTopKeyValueAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = {
+    Future.Unit
+  }
+}

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormAggregatesSpec.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormAggregatesSpec.scala
@@ -44,14 +44,6 @@ class AnormAggregatesSpec extends Specification {
       val agg5 = Await.result(aggregates.getDependencies(Time.fromSeconds(1) + 1.millisecond, Some(Time.fromSeconds(2) - 1.millisecond))) // start and end inside the dependency
       val agg6 = Await.result(aggregates.getDependencies(Time.fromSeconds(1) + 1.millisecond, Some(Time.fromSeconds(3)))) // start inside the dependency
 
-      println("[DEBUG] dep1: " + dep1)
-      println("[DEBUG] agg1: " + agg1)
-      println("[DEBUG] agg2: " + agg2)
-      println("[DEBUG] agg3: " + agg3)
-      println("[DEBUG] agg4: " + agg4)
-      println("[DEBUG] agg5: " + agg5)
-      println("[DEBUG] agg6: " + agg6)
-
       agg1.links mustEqual dep1.links
       agg2.links mustEqual dep1.links
       agg3.links mustEqual dep1.links

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormAggregatesSpec.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormAggregatesSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.zipkin.storage.anormdb
+
+import org.specs._
+import com.twitter.zipkin.common.{Service, DependencyLink, Dependencies}
+import com.twitter.algebird.Moments
+import com.twitter.util.Time
+import com.twitter.util.Await
+import com.twitter.conversions.time._
+
+class AnormAggregatesSpec extends Specification {
+  "AnormAggregates" should {
+    "store and get dependencies" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinAggregatesTest1")))
+      val con = db.install()
+      val aggregates = new AnormAggregates(db, Some(con))
+
+      val dl1 = new DependencyLink(new Service("parent1"), new Service("child1"), Moments(18))
+      val dl2 = new DependencyLink(new Service("parent2"), new Service("child2"), Moments(42))
+      val dep1 = new Dependencies(Time.fromSeconds(1), Time.fromSeconds(2), List(dl1, dl2))
+
+      Await.result(aggregates.storeDependencies(dep1))
+
+      val agg1 = Await.result(aggregates.getDependencies(dep1.startTime, Some(dep1.endTime))) // Inclusive, start to end
+      val agg2 = Await.result(aggregates.getDependencies(Time.fromSeconds(0), Some(Time.now))) // All time
+      val agg3 = Await.result(aggregates.getDependencies(Time.fromSeconds(0), None)) // 0 to +1.day
+
+      val agg4 = Await.result(aggregates.getDependencies(Time.fromSeconds(0), Some(Time.fromSeconds(1) + 1.millisecond))) // end inside the dependency
+      val agg5 = Await.result(aggregates.getDependencies(Time.fromSeconds(1) + 1.millisecond, Some(Time.fromSeconds(2) - 1.millisecond))) // start and end inside the dependency
+      val agg6 = Await.result(aggregates.getDependencies(Time.fromSeconds(1) + 1.millisecond, Some(Time.fromSeconds(3)))) // start inside the dependency
+
+      println("[DEBUG] dep1: " + dep1)
+      println("[DEBUG] agg1: " + agg1)
+      println("[DEBUG] agg2: " + agg2)
+      println("[DEBUG] agg3: " + agg3)
+      println("[DEBUG] agg4: " + agg4)
+      println("[DEBUG] agg5: " + agg5)
+      println("[DEBUG] agg6: " + agg6)
+
+      agg1.links mustEqual dep1.links
+      agg2.links mustEqual dep1.links
+      agg3.links mustEqual dep1.links
+
+      agg4.links.isEmpty mustBe true
+      agg5.links.isEmpty mustBe true
+      agg6.links.isEmpty mustBe true
+
+      con.close()
+    }
+  }
+}

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormDBSpec.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormDBSpec.scala
@@ -26,7 +26,7 @@ class AnormDBSpec extends Specification {
   "AnormDB" should {
     "have the correct schema" in {
       implicit val con = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest"))).install()
-      val expectedTables = List("zipkin_annotations", "zipkin_binary_annotations", "zipkin_spans")
+      val expectedTables = List("zipkin_annotations", "zipkin_binary_annotations", "zipkin_spans", "zipkin_dependencies", "zipkin_dependency_links")
       // The right tables are present
       val tables: List[String] = SQL(
         "SELECT name FROM sqlite_master WHERE type='table'"

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregates.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregates.scala
@@ -53,10 +53,10 @@ case class CassandraAggregates(
   def getDependencies(startDate: Time, endDate: Option[Time]) : Future[Dependencies] = {
 
     // floor to nearest day in microseconds
-    val realStart = startDate.floor(1.day).inMicroseconds
-    val realEnd = endDate.getOrElse(startDate).floor(1.day).inMicroseconds
+    val realStart = startDate.inMicroseconds
+    val realEnd = endDate.getOrElse(startDate + 1.day).inMicroseconds
 
-    val rows = new NumericRange.Inclusive[Long](realEnd, realStart, 1.days.inMicroseconds)
+    val rows = new NumericRange.Inclusive[Long](realStart, realEnd, 1.days.inMicroseconds)
 
     val result: Future[Iterable[gen.Dependencies]] =
       dependenciesCF.multigetRows(rows.toSet.asJava, None, None, Order.Normal, Int.MaxValue)

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregatesSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregatesSpec.scala
@@ -87,7 +87,7 @@ class CassandraAggregatesSpec extends SpecificationWithJUnit with JMocker with C
         val col = new Column[Long, gen.Dependencies](0L, deps1.toThrift)
 
         expect {
-          one(mockDependenciesCf).multigetRows(Set(0L).asJava, None, None, Order.Normal, Int.MaxValue) willReturn Future.value(Map(0L -> Map(0L -> col).asJava).asJava)
+          one(mockDependenciesCf).multigetRows(Set(0L, 1.day.inMicroseconds).asJava, None, None, Order.Normal, Int.MaxValue) willReturn Future.value(Map(0L -> Map(0L -> col).asJava).asJava)
         }
 
         val result = Await.result(agg.getDependencies(Time.fromSeconds(0)))

--- a/zipkin-thrift/src/main/resources/thrift/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/resources/thrift/zipkinQuery.thrift
@@ -215,8 +215,8 @@ service ZipkinQuery {
     /**
      * Get an aggregate representation of all services paired with every service they call in to.
      * This includes information on call counts and mean/stdDev/etc of call durations.  The two arguments
-     * specify epoch time in microseconds and describe the an inclusive day range to pull the data from.
-     * For example, requesting the current time will pull all data from today.
+     * specify epoch time in microseconds. The end time is optional and defaults to one day after the
+     * start time.
      */
     zipkinDependencies.Dependencies getDependencies(1: i64 start_time, 2: optional i64 end_time) throws (1: QueryException qe);
 

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/App.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/App.scala
@@ -217,12 +217,13 @@ class App(
    * API: dependencies
    * Returns all services paired with every service they call in to
    *
-   * Required GET params:
-   * - startTime: Date in epoch seconds (this will be rounded to the nearest day)
-   * - endTime: Optional date in epoch seconds (rounded to the nearest day)
+   * Optional GET params:
+   * - startTime: Start date in epoch microseconds. Defaults to 1 day ago
+   * - endTime: End date in epoch microseconds. Defaults to now
    */
   get("/api/dependencies/?:startTime?/?:endTime?") { request =>
-    val startTime = request.routeParams.getOrElse("startTime", Time.now.inSeconds.toString).toLong
+    import com.twitter.conversions.time._
+    val startTime = request.routeParams.getOrElse("startTime", (Time.now - 1.day).inMicroseconds.toString).toLong
     val endTime = request.routeParams.get("endTime").map(_.toLong)
 
     client.getDependencies(startTime, endTime).map { deps =>


### PR DESCRIPTION
A preemptive note about the getDependencies time range -- CassandraAggregates does this:

```
val realStart = startDate.floor(1.day).inMicroseconds
val realEnd = endDate.getOrElse(startDate).floor(1.day).inMicroseconds
```

Whereas AnormAggregates does this:

```
val startMs = startDate.inMicroseconds
val endMs = endDate.getOrElse(startDate + 1.day).inMicroseconds
```

What CassandraAggregates does looks clearly wrong to me, and Franklin confirms that it looks broken. Basically right now it says that if you request a start date but do not pass the optional end date, or if you request a start and end date within the same day, it will search within a single microsecond at the beginning of that day. I would humbly suggest that it is not getDependencies' role to enforce flooring to the day; rather it should return dependencies in the exact time range requested, and the caller should choose whether they want dependencies within a day range or not. In any case, the documentation for floor() indicates that it should not be called for values higher than 1 hour or unexpected results could occur due to time zone differences -- so our current usage of floor has an undefined result.

The places where getDependencies are used confirms that this is broken. Currently it is only called from the CassandraAggregatesSpec test and from the /api/dependencies callback in App.scala. The API endpoint has incorrect documentation (it indicates that the parameters should be in seconds) and nonsensical default behavior (if startTime is undefined it retrieves only dependencies from the first microsecond of the current day). The test passes because it only looks for dependencies in the first microsecond of the specified day.

That's why this pull request attempts to fix those things in addition to implementing Aggregates support in the Anorm module.

Also note, as indicated at the top of AnormAggregates.scala, that the top and KV dependencies methods are stubbed because they are not currently used anywhere (that feature was never completed) so there is no definition of what "working" means for them.
