### PR TITLE
debug timeouts

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
@@ -90,14 +90,15 @@ case class AnormIndex(db: DB, openCon: Option[Connection] = None) extends Index 
   def getTraceIdsByAnnotation(serviceName: String, annotation: String, value: Option[ByteBuffer],
                               endTs: Long, limit: Int): Future[Seq[IndexedTraceId]] = sqlFuturePool[Seq[IndexedTraceId]] {
     // Ignore core annotations. Yay magic names!
-    if (List("cs", "cr", "ss", "sr", "ca", "sa").contains(annotation))
-      return Future.value[Seq[IndexedTraceId]](Seq())
-
-    val result:List[(Long, Long)] = value match {
-      // Binary annotations
-      case Some(bytes) => {
-        SQL(
-          """SELECT zba.trace_id, s.created_ts
+    if (List("cs", "cr", "ss", "sr", "ca", "sa").contains(annotation)) {
+      Seq.empty
+    }
+    else {
+      val result:List[(Long, Long)] = value match {
+        // Binary annotations
+        case Some(bytes) => {
+          SQL(
+            """SELECT zba.trace_id, s.created_ts
             |FROM zipkin_binary_annotations AS zba
             |LEFT JOIN zipkin_spans AS s
             |  ON zba.trace_id = s.trace_id
@@ -110,17 +111,17 @@ case class AnormIndex(db: DB, openCon: Option[Connection] = None) extends Index 
             |ORDER BY s.created_ts DESC
             |LIMIT {limit}
           """.stripMargin)
-          .on("service_name" -> serviceName)
-          .on("annotation" -> annotation)
-          .on("value" -> Util.getArrayFromBuffer(bytes))
-          .on("end_ts" -> endTs)
-          .on("limit" -> limit)
-          .as((long("trace_id") ~ long("created_ts") map flatten) *)
-      }
-      // Normal annotations
-      case None => {
-        SQL(
-          """SELECT trace_id, MAX(a_timestamp)
+            .on("service_name" -> serviceName)
+            .on("annotation" -> annotation)
+            .on("value" -> Util.getArrayFromBuffer(bytes))
+            .on("end_ts" -> endTs)
+            .on("limit" -> limit)
+            .as((long("trace_id") ~ long("created_ts") map flatten) *)
+        }
+        // Normal annotations
+        case None => {
+          SQL(
+            """SELECT trace_id, MAX(a_timestamp)
             |FROM zipkin_annotations
             |WHERE service_name = {service_name}
             |  AND value = {annotation}
@@ -129,15 +130,16 @@ case class AnormIndex(db: DB, openCon: Option[Connection] = None) extends Index 
             |ORDER BY a_timestamp DESC
             |LIMIT {limit}
           """.stripMargin)
-          .on("service_name" -> serviceName)
-          .on("annotation" -> annotation)
-          .on("end_ts" -> endTs)
-          .on("limit" -> limit)
-          .as((long("trace_id") ~ long("MAX(a_timestamp)") map flatten) *)
+            .on("service_name" -> serviceName)
+            .on("annotation" -> annotation)
+            .on("end_ts" -> endTs)
+            .on("limit" -> limit)
+            .as((long("trace_id") ~ long("MAX(a_timestamp)") map flatten) *)
+        }
       }
-    }
-    result map { case (tId, ts) =>
-      IndexedTraceId(traceId = tId, timestamp = ts)
+      result map { case (tId, ts) =>
+          IndexedTraceId(traceId = tId, timestamp = ts)
+      }
     }
   }
 

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
@@ -16,6 +16,7 @@
 
 package com.twitter.zipkin.storage.anormdb
 
+import com.twitter.zipkin.Constants
 import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.storage.{Index, IndexedTraceId, TraceIdDuration}
 import com.twitter.util.{FuturePool, Future}
@@ -89,8 +90,7 @@ case class AnormIndex(db: DB, openCon: Option[Connection] = None) extends Index 
    */
   def getTraceIdsByAnnotation(serviceName: String, annotation: String, value: Option[ByteBuffer],
                               endTs: Long, limit: Int): Future[Seq[IndexedTraceId]] = sqlFuturePool[Seq[IndexedTraceId]] {
-    // Ignore core annotations. Yay magic names!
-    if (List("cs", "cr", "ss", "sr", "ca", "sa").contains(annotation)) {
+    if ((Constants.CoreAnnotations ++ Constants.CoreAddress).contains(annotation)) {
       Seq.empty
     }
     else {

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/Constants.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/Constants.scala
@@ -22,8 +22,12 @@ object Constants {
   val ServerSend: String = "ss"
   val ServerRecv: String = "sr"
 
+  val ClientAddr: String = "ca"
+  val ServerAddr: String = "sa"
+
   val CoreClient: Seq[String] = Seq(ClientSend, ClientRecv)
   val CoreServer: Seq[String] = Seq(ServerRecv, ServerSend)
+  val CoreAddress: Seq[String] = Seq(ClientAddr, ServerAddr)
 
   val CoreAnnotations: Seq[String] = CoreClient ++ CoreServer
 


### PR DESCRIPTION
The way that future pools work is that they return empty promises immediately, but spin off a thread to fulfill the promise.  Instead of trying to fulfil the promise, returning Future.value hopes to short-circuit the promise entirely, but the promise had already been returned.  I actually don't know exactly what the behavior is when you try to drop a stack frame that doesn't exist anymore, but it doesn't sound good!

In general, we should probably avoid having multiple exit points for a given method.  Having multiple exit points makes functions more difficult to reason about.

TL;DR the future never got finished :anguished:

edit: figured out what [happens](http://stackoverflow.com/questions/17754976/scala-return-statements-in-anonymous-functions/17755988#17755988) when you return elsewhere
