### PR TITLE
Fix MySQL reserved keyword error

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
@@ -98,8 +98,8 @@ case class AnormIndex(db: DB, openCon: Option[Connection] = None) extends Index 
             |LEFT JOIN zipkin_spans AS s
             |  ON zba.trace_id = s.trace_id
             |WHERE zba.service_name = {service_name}
-            |  AND zba.a_key = {annotation}
-            |  AND zba.value = {value}
+            |  AND zba.annotation_key = {annotation}
+            |  AND zba.annotation_value = {value}
             |  AND s.created_ts < {end_ts}
             |  AND s.created_ts IS NOT NULL
             |GROUP BY zba.trace_id

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormIndex.scala
@@ -98,7 +98,7 @@ case class AnormIndex(db: DB, openCon: Option[Connection] = None) extends Index 
             |LEFT JOIN zipkin_spans AS s
             |  ON zba.trace_id = s.trace_id
             |WHERE zba.service_name = {service_name}
-            |  AND zba.key = {annotation}
+            |  AND zba.a_key = {annotation}
             |  AND zba.value = {value}
             |  AND s.created_ts < {end_ts}
             |  AND s.created_ts IS NOT NULL

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormStorage.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormStorage.scala
@@ -97,7 +97,7 @@ case class AnormStorage(db: DB, openCon: Option[Connection] = None) extends Stor
     span.binaryAnnotations.foreach(b =>
       SQL(
         """INSERT INTO zipkin_binary_annotations
-          |  (span_id, trace_id, span_name, service_name, key, value,
+          |  (span_id, trace_id, span_name, service_name, a_key, value,
           |    annotation_type_value, ipv4, port)
           |VALUES
           |  ({span_id}, {trace_id}, {span_name}, {service_name}, {key}, {value},
@@ -177,12 +177,12 @@ case class AnormStorage(db: DB, openCon: Option[Connection] = None) extends Stor
           }) *)
     val binAnnos:List[DBBinaryAnnotation] =
       SQL(
-        """SELECT span_id, trace_id, service_name, key, value, annotation_type_value,
+        """SELECT span_id, trace_id, service_name, a_key, value, annotation_type_value,
           |  ipv4, port
           |FROM zipkin_binary_annotations
           |WHERE trace_id IN (%s)
         """.stripMargin.format(traceIdsString))
-        .as((long("span_id") ~ long("trace_id") ~ str("service_name") ~ str("key") ~
+        .as((long("span_id") ~ long("trace_id") ~ str("service_name") ~ str("a_key") ~
           db.bytes("value") ~ int("annotation_type_value") ~
           get[Option[Int]]("ipv4") ~ get[Option[Int]]("port") map {
             case a~b~c~d~e~f~g~h => DBBinaryAnnotation(a, b, c, d, e, f, g, h)

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -87,7 +87,7 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
         |  trace_id BIGINT NOT NULL,
         |  span_name VARCHAR(255) NOT NULL,
         |  service_name VARCHAR(255) NOT NULL,
-        |  key VARCHAR(255) NOT NULL,
+        |  a_key VARCHAR(255) NOT NULL,
         |  value %s,
         |  annotation_type_value INT NOT NULL,
         |  ipv4 INT,

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -87,8 +87,8 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
         |  trace_id BIGINT NOT NULL,
         |  span_name VARCHAR(255) NOT NULL,
         |  service_name VARCHAR(255) NOT NULL,
-        |  a_key VARCHAR(255) NOT NULL,
-        |  value %s,
+        |  annotation_key VARCHAR(255) NOT NULL,
+        |  annotation_value %s,
         |  annotation_type_value INT NOT NULL,
         |  ipv4 INT,
         |  port INT


### PR DESCRIPTION
As reported by Alex Xu on the user list, "key" is a reserved word in MySQL and that is causing errors when the zipkin_binary_annotations schema is installed. This change fixes it.
