### PR TITLE
web: UI improvements for zero-length spans

### DIFF
--- a/zipkin-web/src/main/resources/public/js/zipkin-trace-summary.js
+++ b/zipkin-web/src/main/resources/public/js/zipkin-trace-summary.js
@@ -212,7 +212,7 @@ Zipkin.TraceSummary = (function(Zipkin) {
       }
 
       if (d.getDuration() === 0) {
-        return 0;
+        return x(1);
       }
       if(d.getDuration() > 1) {
         return x(d.getDuration());

--- a/zipkin-web/src/main/resources/public/js/zipkin-trace-summary.js
+++ b/zipkin-web/src/main/resources/public/js/zipkin-trace-summary.js
@@ -273,9 +273,6 @@ Zipkin.TraceSummary = (function(Zipkin) {
       .on("mouseout", Zipkin.Util.bind(this, blurEvent))
       .on("click", Zipkin.Util.bind(this, clickEvent))
       .text(function(d) {
-        if (d.getDuration() === 0) {
-          return "";
-        }
         var text = d.getDuration().toFixed(3);
         if (!d.isFilter || !d.isFilter()) {
           text += " " + d.getName();


### PR DESCRIPTION
Two minor improvements for spans with length zero:
- Draw span bars with small width instead of zero
- Show bar labels even if the span is of length zero
