### PR TITLE
Make configuring hbase client easier

### DIFF
--- a/bin/create-table-hbase
+++ b/bin/create-table-hbase
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+DEFAULT_COMPRESSION=none
+COMPRESSION_TYPE=${1:-$DEFAULT_COMPRESSION}
+
+bin/sbt 'project zipkin-hbase' "run-main com.twitter.zipkin.hbase.TableLayouts ${COMPRESSION_TYPE}"

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -340,11 +340,8 @@ object Zipkin extends Build {
       "com.twitter"           % "util-logging"          % UTIL_VERSION
     ) ++ testDependencies,
 
-    /* Add configs to resource path for ConfigSpec */
-    unmanagedResourceDirectories in Test <<= baseDirectory {
-      base =>
-        (base / "config" +++ base / "src" / "test" / "resources").get
-    }
+    unmanagedClasspath in Runtime <+= baseDirectory map { bd => Attributed.blank(bd / "config") }
+
   ).dependsOn(scrooge)
 }
 

--- a/zipkin-hbase/config/README.md
+++ b/zipkin-hbase/config/README.md
@@ -1,0 +1,3 @@
+## Configuring HBase
+
+Place a copy of your hbase-site.xml into the config config directory.  Then edit the log4j.properties to your specifications.

--- a/zipkin-hbase/config/log4j.properties
+++ b/zipkin-hbase/config/log4j.properties
@@ -1,0 +1,25 @@
+# Define some default values that can be overridden by system properties
+hbase.root.logger=INFO,console
+hbase.security.logger=INFO,console
+hbase.log.dir=.
+hbase.log.file=hbase.log
+
+# Define the root logger to the system property "hbase.root.logger".
+log4j.rootLogger=${hbase.root.logger}
+
+# Logging Threshold
+log4j.threshold=ALL
+
+#
+# console
+# Add "console" to rootlogger above if you want to use this 
+#
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n
+
+log4j.logger.org.apache.zookeeper=INFO
+log4j.logger.org.apache.hadoop.hbase=DEBUG
+log4j.logger.org.apache.hadoop.hbase.zookeeper.ZKUtil=INFO
+log4j.logger.org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher=INFO

--- a/zipkin-hbase/src/test/resources/log4j.properties
+++ b/zipkin-hbase/src/test/resources/log4j.properties
@@ -1,9 +1,0 @@
-hbase.root.logger=FATAL,console
-hbase.security.logger=FATAL,console
-log4j.rootLogger=${hbase.root.logger}
-log4j.threshold=FATAL
-
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/ZipkinHBaseSpecification.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/ZipkinHBaseSpecification.scala
@@ -26,5 +26,12 @@ trait ZipkinHBaseSpecification extends HBaseSpecification {
   }
 
   sequential
+
+  org.apache.log4j.Logger.getLogger("org.apache.zookeeper").setLevel(org.apache.log4j.Level.ERROR);
+  org.apache.log4j.Logger.getLogger("org.apache.hadoop").setLevel(org.apache.log4j.Level.ERROR);
+  org.apache.log4j.Logger.getLogger("org.apache.hadoop.hbase").setLevel(org.apache.log4j.Level.ERROR);
+  org.apache.log4j.Logger.getLogger("org.apache.hbase").setLevel(org.apache.log4j.Level.ERROR);
+  org.apache.log4j.Logger.getLogger("org.mortbay").setLevel(org.apache.log4j.Level.ERROR);
+  org.apache.log4j.Logger.getLogger("org").setLevel(org.apache.log4j.Level.ERROR);
 }
 


### PR DESCRIPTION
This make configuring hbase easier.  It also adds some docs about how to
configure hbase using hbase-site.xml

This also creates a script that helps automate creating hbase tables.
