### PR TITLE
anormdb: fix span merging

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormStorage.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormStorage.scala
@@ -166,33 +166,33 @@ case class AnormStorage(db: DB, openCon: Option[Connection] = None) extends Stor
           }) *)
     val annos:List[DBAnnotation] =
       SQL(
-        """SELECT span_id, trace_id, service_name, value, ipv4, port, a_timestamp, duration
+        """SELECT span_id, trace_id, span_name, service_name, value, ipv4, port, a_timestamp, duration
           |FROM zipkin_annotations
           |WHERE trace_id IN (%s)
         """.stripMargin.format(traceIdsString))
-        .as((long("span_id") ~ long("trace_id") ~ str("service_name") ~ str("value") ~
+        .as((long("span_id") ~ long("trace_id") ~ str("span_name") ~ str("service_name") ~ str("value") ~
           get[Option[Int]]("ipv4") ~ get[Option[Int]]("port") ~
           long("a_timestamp") ~ get[Option[Long]]("duration") map {
-            case a~b~c~d~e~f~g~h => DBAnnotation(a, b, c, d, e, f, g, h)
+            case a~b~c~d~e~f~g~h~i => DBAnnotation(a, b, c, d, e, f, g, h, i)
           }) *)
     val binAnnos:List[DBBinaryAnnotation] =
       SQL(
-        """SELECT span_id, trace_id, service_name, annotation_key,
+        """SELECT span_id, trace_id, span_name, service_name, annotation_key,
           |  annotation_value, annotation_type_value, ipv4, port
           |FROM zipkin_binary_annotations
           |WHERE trace_id IN (%s)
         """.stripMargin.format(traceIdsString))
-        .as((long("span_id") ~ long("trace_id") ~ str("service_name") ~
+        .as((long("span_id") ~ long("trace_id") ~ str("span_name") ~ str("service_name") ~
           str("annotation_key") ~ db.bytes("annotation_value") ~
           int("annotation_type_value") ~ get[Option[Int]]("ipv4") ~
           get[Option[Int]]("port") map {
-            case a~b~c~d~e~f~g~h => DBBinaryAnnotation(a, b, c, d, e, f, g, h)
+            case a~b~c~d~e~f~g~h~i => DBBinaryAnnotation(a, b, c, d, e, f, g, h, i)
           }) *)
 
     val results: Seq[Seq[Span]] = traceIds.map { traceId =>
       spans.filter(_.traceId == traceId).map { span =>
         val spanAnnos = annos.filter { a =>
-            a.traceId == span.traceId && a.spanId == span.spanId
+            a.traceId == span.traceId && a.spanId == span.spanId && a.spanName == span.spanName
           }
           .map { anno =>
             val host:Option[Endpoint] = (anno.ipv4, anno.port) match {
@@ -206,7 +206,7 @@ case class AnormStorage(db: DB, openCon: Option[Connection] = None) extends Stor
             Annotation(anno.timestamp, anno.value, host, duration)
           }
         val spanBinAnnos = binAnnos.filter { a =>
-            a.traceId == span.traceId && a.spanId == span.spanId
+            a.traceId == span.traceId && a.spanId == span.spanId && a.spanName == span.spanName
           }
           .map { binAnno =>
             val host:Option[Endpoint] = (binAnno.ipv4, binAnno.port) match {
@@ -236,6 +236,6 @@ case class AnormStorage(db: DB, openCon: Option[Connection] = None) extends Stor
   }
 
   case class DBSpan(spanId: Long, parentId: Option[Long], traceId: Long, spanName: String, debug: Boolean)
-  case class DBAnnotation(spanId: Long, traceId: Long, serviceName: String, value: String, ipv4: Option[Int], port: Option[Int], timestamp: Long, duration: Option[Long])
-  case class DBBinaryAnnotation(spanId: Long, traceId: Long, serviceName: String, key: String, value: Array[Byte], annotationTypeValue: Int, ipv4: Option[Int], port: Option[Int])
+  case class DBAnnotation(spanId: Long, traceId: Long, spanName: String, serviceName: String, value: String, ipv4: Option[Int], port: Option[Int], timestamp: Long, duration: Option[Long])
+  case class DBBinaryAnnotation(spanId: Long, traceId: Long, spanName: String, serviceName: String, key: String, value: Array[Byte], annotationTypeValue: Int, ipv4: Option[Int], port: Option[Int])
 }

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormStorageSpec.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormStorageSpec.scala
@@ -42,11 +42,15 @@ class AnormStorageSpec extends Specification {
   val ann1 = Annotation(1, "cs", Some(ep))
   val ann2 = Annotation(2, "sr", None)
   val ann3 = Annotation(2, "custom", Some(ep))
+  val ann4 = Annotation(3, "ss", None)
 
   val span1 = Span(123, "methodcall", spanId, None, List(ann1, ann3),
     List(binaryAnnotation("BAH", "BEH")))
   val span2 = Span(667, "methodcall2", spanId, None, List(ann2),
     List(binaryAnnotation("BAH2", "BEH2")))
+  val span3 = Span(667, "methodcall3", spanId, None, List(ann4), List(binaryAnnotation("KEY", "VALUE")))
+
+  val span2and3 = span2 mergeSpan span3
 
   "AnormStorage" should {
     "tracesExist" in {
@@ -91,6 +95,7 @@ class AnormStorageSpec extends Specification {
 
       Await.result(storage.storeSpan(span1))
       Await.result(storage.storeSpan(span2))
+      Await.result(storage.storeSpan(span3))
 
       val emptySpans = Await.result(storage.getSpansByTraceIds(List(traceIdDNE)))
       emptySpans.isEmpty mustEqual true
@@ -108,7 +113,9 @@ class AnormStorageSpec extends Specification {
       trace2a.spans.isEmpty mustEqual false
       trace2a.spans(0) mustEqual span1
       trace2b.spans.isEmpty mustEqual false
-      trace2b.spans(0) mustEqual span2
+      trace2b.spans.length mustEqual 1
+
+      trace2b.spans(0) mustEqual span2and3
 
       con.close()
     }


### PR DESCRIPTION
Annotations and binary annotations were not joined with spans
predicated on span names. This caused for duplicate annotations to show
up in the UI.
