### PR TITLE
highlight server duration on trace summary page

### DIFF
--- a/zipkin-web/src/main/resources/public/css/application.css
+++ b/zipkin-web/src/main/resources/public/css/application.css
@@ -624,6 +624,18 @@ ul.traces li:hover .timestamp .label {
 .bars.depth5 { fill: #08306B;}
 .bars.selected { fill: #00A8C6; }
 
+/**
+ * Same as .bars, but shifted by 1
+ */
+.server-bars.filtered { fill: #F9F2E7; }
+.server-bars.depth0 { fill: #9ECAE1; }
+.server-bars.depth1 { fill: #4292C6; }
+.server-bars.depth2 { fill: #2171B5;}
+.server-bars.depth3 { fill: #08519C;}
+.server-bars.depth4 { fill: #08306B;}
+.server-bars.depth5 { fill: #C6DBEF; }
+.server-bars.selected { fill: #00A8C6; }
+
 /** Span text */
 .bar-text {
   fill: #000000;

--- a/zipkin-web/src/main/resources/public/js/application-show.js
+++ b/zipkin-web/src/main/resources/public/js/application-show.js
@@ -82,6 +82,22 @@ Zipkin.Application.Show = (function() {
         $.each(data.trace.spans, function(i, span) {
           span.startTime = span.startTimestamp - traceStartTime;
           span.endTime = span.endTimestamp - traceStartTime;
+          var hasClient, serverStartTime, serverEndTime;
+          $.each(span.annotations, function(i, a) {
+              if (a.value === "sr") {
+                  serverStartTime = a.timestamp - traceStartTime;
+              } else if (a.value === "ss") {
+                  serverEndTime = a.timestamp - traceStartTime;
+              } else if (a.value === "cr" || a.value === "cs") {
+                  hasClient = true;
+              }
+          });
+          // Only include detailed server timing if this span has client timing as well.
+          if (hasClient) {
+              span.serverStartTime = serverStartTime;
+              span.serverEndTime = serverEndTime;
+              span.serverDuration = serverEndTime - serverStartTime;
+          }
 
           var s = Zipkin.fromRawSpan(span);
           spanMap[s.id] = s;

--- a/zipkin-web/src/main/resources/public/js/zipkin-span.js
+++ b/zipkin-web/src/main/resources/public/js/zipkin-span.js
@@ -26,6 +26,10 @@ Zipkin.Span = (function(superClass) {
     this.services      = config.services || [];
     this.annotations   = config.annotations || [];
     this.kvAnnotations = config.kvAnnotations || [];
+
+    this.serverStartTime = config.serverStartTime
+    this.serverEndTime   = config.serverEndTime
+    this.serverDuration  = config.serverDuration
   };
 
   jQuery.extend(Span.prototype, superClass.prototype);
@@ -37,6 +41,10 @@ Zipkin.Span = (function(superClass) {
   Span.prototype.getServices      = function() { return this.services; };
   Span.prototype.getAnnotations   = function() { return Zipkin.Util.shallowCopy(this.annotations); };
   Span.prototype.getKvAnnotations = function() { return Zipkin.Util.shallowCopy(this.kvAnnotations); };
+
+  Span.prototype.getServerStartTime = function() { return this.serverStartTime; };
+  Span.prototype.getServerEndTime   = function() { return this.serverEndTime; };
+  Span.prototype.getServerDuration  = function() { return this.serverDuration; };
 
   Span.prototype.setTraceId       = function(id)   { this.traceId = id; };
   Span.prototype.setStartTime     = function(s)    { this.startTime = s; };
@@ -67,7 +75,11 @@ Zipkin.Span = (function(superClass) {
         duration      : this.getDuration(),
         services      : this.getServices(),
         annotations   : this.getAnnotations(),
-        kvAnnotations : this.getKvAnnotations()
+        kvAnnotations : this.getKvAnnotations(),
+
+        serverStartTime : this.getServerStartTime(),
+        serverEndTime   : this.getServerEndTime(),
+        serverDuration  : this.getServerDuration()
       }
     );
   };
@@ -89,6 +101,10 @@ Zipkin.fromRawSpan = function(rawSpan) {
     services      : rawSpan.services,
     annotations   : [],
     kvAnnotations : [],
+
+    serverStartTime : rawSpan.serverStartTime,
+    serverEndTime   : rawSpan.serverEndTime,
+    serverDuration  : rawSpan.serverDuration,
   });
   var annotations = $.map(rawSpan.annotations, function(a) {
     var ann = Zipkin.fromRawAnnotation(a);


### PR DESCRIPTION
It is helpful to tell at a glance how network latency affected a trace.
This change shows a highlight at the bottom of each span that contains
both client and server timings. The highlight shows what duration of the
span was spent in the server.

I arrived on this highlight style after a few other attempts. It keeps the
span text readable and uses the color for the next depth (which
hopefully makes it more intuitive).

Related to issue #196, but probably not everything envisioned.

![example](http://f.cl.ly/items/1L3R0F2z0m2o3a1H0w1r/zipkin-server-highlight-2.png)
