### PR TITLE
ZooKeeperClient/Scribe fixes

### DIFF
--- a/zipkin-receiver-scribe/src/main/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiver.scala
+++ b/zipkin-receiver-scribe/src/main/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiver.scala
@@ -64,8 +64,7 @@ trait ScribeSpanReceiverFactory { self: App with ZooKeeperClientFactory =>
     val zkNode: Option[Closable] = scribeZkPath.get.map { path =>
       val addr = InetSocketAddressUtil.toPublic(scribeAddr()).asInstanceOf[InetSocketAddress]
       val nodeName = "%s:%d".format(addr.getHostName, addr.getPort)
-      val fullPath = path + "/" + nodeName
-      zkClient.createEphemeral(path, nodeName.getBytes)
+      zkClient.createEphemeral(path + "/" + nodeName, nodeName.getBytes)
     }
 
     val service = Thrift.serveIface(


### PR DESCRIPTION
ZK: Allow for optional credentials
ZK: Check for the existance of a node before attempting to create it
Scribe: annouce the proper path (use addr as the node name)
