### PR TITLE
Fix validator and in-memory sort ordering

### DIFF
--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassieSpanStoreTest.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassieSpanStoreTest.scala
@@ -37,6 +37,7 @@ class CassieSpanStoreTest extends FunSuite {
   }
 
   test("validate") {
-    new SpanStoreValidator(newSpanStore).validate
+    // FakeCassandra doesn't honor sort order
+    new SpanStoreValidator(newSpanStore, true).validate
   }
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
@@ -182,7 +182,7 @@ class InMemorySpanStore extends SpanStore {
         spans
     }) filter { span =>
       span.lastAnnotation match {
-        case Some(ann) => ann.timestamp >= endTs
+        case Some(ann) => ann.timestamp <= endTs
         case None => false
       }
     } filter(shouldIndex) take(limit) map { span =>

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ThriftQueryServiceTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ThriftQueryServiceTest.scala
@@ -80,10 +80,10 @@ class ThriftQueryServiceTest extends FunSuite {
 
     // exception on null serviceName
     intercept[thrift.QueryException] {
-      Await.result(svc.getTraceIdsBySpanName(null, "span", 0, 100, thrift.Order.DurationDesc))
+      Await.result(svc.getTraceIdsBySpanName(null, "span", 100, 100, thrift.Order.DurationDesc))
     }
 
-    val actual = Await.result(svc.getTraceIdsBySpanName("service2", "methodcall", 0, 50, thrift.Order.DurationDesc))
+    val actual = Await.result(svc.getTraceIdsBySpanName("service2", "methodcall", 1000, 50, thrift.Order.DurationDesc))
     assert(actual === Seq(2, 2, 2))
   }
 
@@ -91,15 +91,15 @@ class ThriftQueryServiceTest extends FunSuite {
     val svc = newLoadedService()
 
     // desc
-    val actualDesc = Await.result(svc.getTraceIdsByServiceName("service3", 0, 50, thrift.Order.DurationDesc))
+    val actualDesc = Await.result(svc.getTraceIdsByServiceName("service3", 1000, 50, thrift.Order.DurationDesc))
     assert(actualDesc === Seq(3, 5))
 
     // asc
-    val actualAsc = Await.result(svc.getTraceIdsByServiceName("service3", 0, 50, thrift.Order.DurationAsc))
+    val actualAsc = Await.result(svc.getTraceIdsByServiceName("service3", 1000, 50, thrift.Order.DurationAsc))
     assert(actualAsc === Seq(5, 3))
 
     // none
-    val actualNone = Await.result(svc.getTraceIdsByServiceName("service3", 0, 50, thrift.Order.None))
+    val actualNone = Await.result(svc.getTraceIdsByServiceName("service3", 1000, 50, thrift.Order.None))
     assert(actualNone === Seq(3, 5))
   }
 
@@ -123,7 +123,7 @@ class ThriftQueryServiceTest extends FunSuite {
 
   test("find trace ids by service name") {
     val svc = newLoadedService()
-    val actual = Await.result(svc.getTraceIdsByServiceName("service3", 0, 50, thrift.Order.DurationDesc))
+    val actual = Await.result(svc.getTraceIdsByServiceName("service3", 1000, 50, thrift.Order.DurationDesc))
     assert(actual === Seq(3, 5))
   }
 


### PR DESCRIPTION
FakeCassandra doesn't honor sort order so any operations that require a
sort then scan will fail. I tried, in vain, to get cassandra running
in-process for the tests. Unfortunately, cassie depends on libthrift
0.5.0 while cassandra requires libthrift 0.9.1. The two are not binary
compatible.

Cassie has been mostly abandoned. It may behove us to implement
zipkin-cassandra directly on top of scrooge generated thrift bindings to
cassandra. That's a larger change for a different time.
