### PR TITLE
Summingbird: serializer, injections and configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.9.2	
+  - 2.9.3
 services:
   - redis-server
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -2,5 +2,5 @@ name := "zipkin"
 
 organization := "com.twitter"
 
-scalaVersion := "2.9.2"
+scalaVersion := "2.9.3"
 

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -83,7 +83,7 @@ object Zipkin extends Build {
   def zipkinSettings = Seq(
     organization := "com.twitter",
     version := zipkinVersion,
-    crossScalaVersions := Seq("2.9.2"),
+    crossScalaVersions := Seq("2.9.3"),
     scalaVersion := "2.9.3",
     crossPaths := false,            /* Removes Scala version from artifact name */
     fork := true, // forking prevents runaway thread pollution of sbt

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -40,10 +40,12 @@ object Zipkin extends Build {
   val twitterServerVersion = "1.4.0"
   val algebirdVersion  = "0.4.0"
   val hbaseVersion = "0.94.10"
+  val summingbirdVersion = "0.3.2"
 
-  def finagle(name: String) = "com.twitter" %% ("finagle-" + name) % finagleVersion
-  def util(name: String) = "com.twitter" %% ("util-" + name) % utilVersion
-  def scroogeDep(name: String) = "com.twitter" %% ("scrooge-" + name) % scroogeVersion
+  def finagle(name: String) = "com.twitter" % ("finagle-" + name + "_2.9.2") % finagleVersion
+  def util(name: String) = "com.twitter" % ("util-" + name + "_2.9.2") % utilVersion
+  def scroogeDep(name: String) = "com.twitter" % ("scrooge-" + name + "_2.9.2") % scroogeVersion
+  def algebird(name: String) = "com.twitter" %% ("algebird-" + name) % algebirdVersion
   def zk(name: String) = "com.twitter.common.zookeeper" % name % zookeeperVersions(name)
 
   // cassie brings in old versions of finagle and util. we need to exclude here and bring in exclusive versions
@@ -82,7 +84,7 @@ object Zipkin extends Build {
     organization := "com.twitter",
     version := zipkinVersion,
     crossScalaVersions := Seq("2.9.2"),
-    scalaVersion := "2.9.2",
+    scalaVersion := "2.9.3",
     crossPaths := false,            /* Removes Scala version from artifact name */
     fork := true, // forking prevents runaway thread pollution of sbt
     baseDirectory in run := file(cwd), // necessary for forking
@@ -158,8 +160,8 @@ object Zipkin extends Build {
         finagle("exception"),
         util("core"),
         zk("client"),
-        "com.twitter" %% "ostrich" % ostrichVersion,
-        "com.twitter" % "algebird-core_2.9.3" % algebirdVersion
+        algebird("core"),
+        "com.twitter" % "ostrich_2.9.2" % ostrichVersion
       ) ++ testDependencies ++ scalaTestDeps
     )
 
@@ -200,8 +202,8 @@ object Zipkin extends Build {
         util("core"),
         scroogeDep("core"),
         scroogeDep("serializer"),
-        "com.twitter" %% "ostrich" % ostrichVersion,
-        "com.twitter" % "algebird-core_2.9.3" % algebirdVersion
+        algebird("core"),
+        "com.twitter" % "ostrich_2.9.2" % ostrichVersion
       ) ++ testDependencies
     ).dependsOn(common)
 
@@ -234,9 +236,9 @@ object Zipkin extends Build {
       util("zk-common"),
       zk("candidate"),
       zk("group"),
-      "com.twitter" %% "ostrich" % ostrichVersion,
-      "com.twitter" % "algebird-core_2.9.3" % algebirdVersion,
-      "com.twitter" %% "twitter-server" % twitterServerVersion
+      algebird("core"),
+      "com.twitter" % "ostrich_2.9.2" % ostrichVersion,
+      "com.twitter" % "twitter-server_2.9.2" % twitterServerVersion
     ) ++ testDependencies
   ).dependsOn(common, scrooge)
 
@@ -268,7 +270,7 @@ object Zipkin extends Build {
     settings = defaultSettings
   ).settings(
     libraryDependencies ++= Seq(
-      "play" %% "anorm" % "2.1-09142012",
+      "play" % "anorm_2.9.2" % "2.1-09142012",
       anormDriverDependencies("sqlite-persistent")
     ) ++ testDependencies ++ scalaTestDeps,
 
@@ -309,8 +311,8 @@ object Zipkin extends Build {
         util("zk-common"),
         zk("candidate"),
         zk("group"),
-        "com.twitter" %% "ostrich" % ostrichVersion,
-        "com.twitter" % "algebird-core_2.9.3" % algebirdVersion
+        algebird("core"),
+        "com.twitter" % "ostrich_2.9.2" % ostrichVersion
       ) ++ testDependencies
     ).dependsOn(common, query, scrooge)
 
@@ -351,7 +353,7 @@ object Zipkin extends Build {
     libraryDependencies ++= Seq(
       finagle("core"),
       util("core"),
-      "com.twitter" %% "twitter-server" % twitterServerVersion
+      "com.twitter" % "twitter-server_2.9.2" % twitterServerVersion
     ) ++ scalaTestDeps
   ).dependsOn(common, scrooge)
 
@@ -374,7 +376,7 @@ object Zipkin extends Build {
       settings = defaultSettings
     ).settings(
       libraryDependencies ++= Seq(
-        "com.twitter"      %% "kafka"    % "0.7.0",
+        "com.twitter"      % "kafka_2.9.2"    % "0.7.0",
         scroogeDep("serializer")
       ) ++ testDependencies,
       resolvers ++= (proxyRepo match {
@@ -414,9 +416,9 @@ object Zipkin extends Build {
         finagle("serversets"),
         finagle("zipkin"),
         zk("server-set"),
-        "com.twitter" %% "twitter-server" % twitterServerVersion,
-        "com.github.spullara.mustache.java" % "compiler" % "0.8.13",
-        "com.twitter" % "algebird-core_2.9.3" % algebirdVersion
+        algebird("core"),
+        "com.twitter" % "twitter-server_2.9.2" % twitterServerVersion,
+        "com.github.spullara.mustache.java" % "compiler" % "0.8.13"
       ) ++ scalaTestDeps,
 
       PackageDist.packageDistZipName := "zipkin-web.zip",
@@ -487,11 +489,16 @@ object Zipkin extends Build {
     libraryDependencies ++= Seq(
       util("logging"),
       scroogeDep("serializer"),
-      "storm"                 % "storm"                 % "0.9.0.1" % "provided",
-      "storm"                 % "storm-kafka"           % "0.9.0-wip16a-scala292",
       "commons-logging"       % "commons-logging"       % "1.1.1",
       "commons-configuration" % "commons-configuration" % "1.6",
-      "com.twitter"           %% "kafka"                % "0.7.0"
+      "com.twitter"           %% "bijection-core"       % "0.6.0",
+      "com.twitter"           %% "bijection-scrooge"    % "0.6.0",
+      "com.twitter"           %% "storehaus-memcache"   % "0.8.0",
+      "com.twitter"           %% "summingbird-core"     % summingbirdVersion,
+      "com.twitter"           %% "summingbird-batch"    % summingbirdVersion,
+      "com.twitter"           %% "tormenta-kafka"       % "0.6.1" exclude("org.slf4j", "log4j-over-slf4j") exclude("ch.qos.logback", "logback-classic"),
+      "storm"                 % "storm"                 % "0.9.0.1" % "provided",
+      "storm"                 % "storm-kafka"           % "0.9.0-wip16a-scala292"
     ) ++ scalaTestDeps,
 
     publishArtifact in packageDoc := false,
@@ -506,12 +513,20 @@ object Zipkin extends Build {
         (base / "config" +++ base / "src" / "test" / "resources").get
     },
 
+    excludedJars in assembly <<= (fullClasspath in assembly) map { cp =>
+      cp filter {_.data.getName == "netty-3.2.3.Final.jar"}
+    },
+
     mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
       {
+        case PathList("com", "esotericsoftware", xs @ _*) => MergeStrategy.last
+        case PathList("com", "fasterxml", xs @ _*) => MergeStrategy.last
+        case PathList("com", "twitter", xs @ _*) => MergeStrategy.last
         case PathList("javax", "servlet", xs @ _*) => MergeStrategy.last
         case PathList("org", "apache", xs @ _*) => MergeStrategy.last
-        case PathList("com", "twitter", xs @ _*) => MergeStrategy.last
-        case PathList("project.clj") => MergeStrategy.last
+        case PathList("org", "objectweb", xs @ _*) => MergeStrategy.last
+        case PathList("org", "slf4j", xs @ _*) => MergeStrategy.last
+        case "project.clj" => MergeStrategy.last
         case x => old(x)
       }
     }

--- a/zipkin-storm/src/main/scala/com/twitter/zipkin/Serialization.scala
+++ b/zipkin-storm/src/main/scala/com/twitter/zipkin/Serialization.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.zipkin.storm
 
-import com.twitter.bijection.{ AbstractBijection, Bufferable, Injection }
+import com.twitter.bijection._
 import com.twitter.bijection.Codec
 import com.twitter.summingbird.batch.BatchID
 import com.twitter.bijection.scrooge.BinaryScalaCodec
@@ -31,9 +31,9 @@ object Serialization {
     def apply(span: Span) = span.toThrift
   }
   val bytes2genspan = BinaryScalaCodec(gen.Span)
-  implicit val bijection: Injection[Span, Array[Byte]] = bytes2genspan compose gen2span
+  implicit val bytes2spanInj: Injection[Span, Array[Byte]] = bytes2genspan compose gen2span
 
-  implicit def kInjection[T: Codec]: Injection[(T, BatchID), Array[Byte]] = {
+  implicit def kInj[T: Codec]: Injection[(T, BatchID), Array[Byte]] = {
     implicit val buf =
       Bufferable.viaInjection[(T, BatchID), (Array[Byte], Array[Byte])]
     Bufferable.injectionOf[(T, BatchID)]
@@ -42,12 +42,18 @@ object Serialization {
   implicit def vInj[V: Codec]: Injection[(BatchID, V), Array[Byte]] =
     Injection.connect[(BatchID, V), (V, BatchID), Array[Byte]]
 
-  implicit val spanMonoid: Monoid[Span] = new Monoid[Span] {
-    def plus(l: Span, r: Span) = {
-      new Span(l.traceId, l.name, l.id, l.parentId,
-        l.annotations, l.binaryAnnotations, l.debug)
-    }
+  implicit val mapInj: Injection[Map[String, Long], Array[Byte]] =
+    Bufferable.injectionOf[Map[String, Long]]
 
-    val zero = Span(0L, "", 0L, None, List.empty, Seq.empty, false)
+  implicit val spanMonoid: Monoid[Span] = new Monoid[Span] {
+    val zero = Span(0, "zero", 0, None, Nil, Nil, true)
+    val invalid = Span(0, "invalid", 0, None, Nil, Nil, true)
+
+    def plus(l: Span, r: Span) = {
+      if (l == zero || r == invalid)  r
+      else if (r == zero || l == invalid) l
+      else if (l.id == r.id) l.mergeSpan(r)
+      else invalid
+    }
   }
 }

--- a/zipkin-storm/src/main/scala/com/twitter/zipkin/Serialization.scala
+++ b/zipkin-storm/src/main/scala/com/twitter/zipkin/Serialization.scala
@@ -1,0 +1,53 @@
+/*
+ Copyright 2013 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.zipkin.storm
+
+import com.twitter.bijection.{ AbstractBijection, Bufferable, Injection }
+import com.twitter.bijection.Codec
+import com.twitter.summingbird.batch.BatchID
+import com.twitter.bijection.scrooge.BinaryScalaCodec
+import com.twitter.zipkin.common.{Annotation, BinaryAnnotation, Span}
+import com.twitter.zipkin.conversions.thrift._
+import com.twitter.zipkin.gen
+import com.twitter.algebird.Monoid
+
+object Serialization {
+  val gen2span = new AbstractBijection[Span, gen.Span] {
+    override def invert(g: gen.Span) = g.toSpan
+    def apply(span: Span) = span.toThrift
+  }
+  val bytes2genspan = BinaryScalaCodec(gen.Span)
+  implicit val bijection: Injection[Span, Array[Byte]] = bytes2genspan compose gen2span
+
+  implicit def kInjection[T: Codec]: Injection[(T, BatchID), Array[Byte]] = {
+    implicit val buf =
+      Bufferable.viaInjection[(T, BatchID), (Array[Byte], Array[Byte])]
+    Bufferable.injectionOf[(T, BatchID)]
+  }
+
+  implicit def vInj[V: Codec]: Injection[(BatchID, V), Array[Byte]] =
+    Injection.connect[(BatchID, V), (V, BatchID), Array[Byte]]
+
+  implicit val spanMonoid: Monoid[Span] = new Monoid[Span] {
+    def plus(l: Span, r: Span) = {
+      new Span(l.traceId, l.name, l.id, l.parentId,
+        l.annotations, l.binaryAnnotations, l.debug)
+    }
+
+    val zero = Span(0L, "", 0L, None, List.empty, Seq.empty, false)
+  }
+}

--- a/zipkin-storm/src/main/scala/com/twitter/zipkin/spout/ZipkinSpout.scala
+++ b/zipkin-storm/src/main/scala/com/twitter/zipkin/spout/ZipkinSpout.scala
@@ -17,6 +17,7 @@
 package com.twitter.zipkin.storm
 
 import backtype.storm.spout.MultiScheme
+import com.twitter.tormenta.spout._
 import storm.kafka.KafkaConfig
 import storm.kafka.trident.{OpaqueTridentKafkaSpout, TridentKafkaConfig}
 
@@ -24,7 +25,8 @@ import storm.kafka.trident.{OpaqueTridentKafkaSpout, TridentKafkaConfig}
  * Storm spout to read spans from Kafka
  */
 object ZipkinSpout {
-  def getSpanSpout(
+  import Serialization._
+  def getTridentSpanSpout(
       zkBroker: String,
       zkPath: String,
       kafkaTopic: String,
@@ -38,4 +40,22 @@ object ZipkinSpout {
     kafkaConf.scheme = scheme
     new OpaqueTridentKafkaSpout(kafkaConf)
   }
+
+  def getTormentaSpanSpout(
+      zkHost: String,
+      brokerZkPath: String,
+      topic: String,
+      appID: String,
+      zkRoot: String,
+      timeOffset: Int = -1) = {
+    new KafkaSpout(
+      new SpanInjectionScheme(),
+      zkHost,
+      brokerZkPath,
+      topic,
+      appID,
+      zkRoot,
+      timeOffset)
+  }
+
 }

--- a/zipkin-storm/src/test/scala/com/twitter/zipkin/SerializationTest.scala
+++ b/zipkin-storm/src/test/scala/com/twitter/zipkin/SerializationTest.scala
@@ -19,19 +19,45 @@ import org.scalatest._
 import com.twitter.zipkin.common.{Endpoint, Annotation, Span}
 
 class SerializationTest extends FunSuite {
-  val annotation1 = Annotation(1, "cs", Some(Endpoint(1, 2, "service")))
-  val annotation2 = Annotation(2, "cr", Some(Endpoint(3, 4, "Service")))
-  val annotation3 = Annotation(3, "cr", Some(Endpoint(5, 6, "Service")))
-  val span = Span(12345, "methodcall", 666, None,
-    List(annotation1, annotation2), Nil)
-  val span2 = Span(6789, "methodcall2", 000, None,
+  val annotation1 = Annotation(1, "cs", Some(Endpoint(1, 2, "service1")))
+  val annotation2 = Annotation(2, "cr", Some(Endpoint(3, 4, "Service2")))
+  val annotation3 = Annotation(3, "cr", Some(Endpoint(5, 6, "Service3")))
+  val spanParent = Span(12345, "methodcall", 666, Some(777),
+    List(annotation1), Nil)
+  val spanParentDup = Span(12345, "methodcall", 666, Some(777),
+    List(annotation2), Nil)
+  val spanChild = Span(12345, "methodcall", 888, Some(666),
     List(annotation3), Nil)
-  //val spanScheme = new Serialization()
 
-  test("spanMonoid plus") {
-    val expectedSpan = Span(12345, "methodcall", 666, None,
+  val zero = Span(0, "zero", 0, None, Nil, Nil, true)
+  val invalid = Span(0, "invalid", 0, None, Nil, Nil, true)
+
+  test("spanMonoid plus should merge dup span") {
+    val expectedSpan = Span(12345, "methodcall", 666, Some(777),
       List(annotation1, annotation2), Nil)
-    val spanAfterPlus = Serialization.spanMonoid.plus(span, span2)
+    val spanAfterPlus = Serialization.spanMonoid.plus(spanParent, spanParentDup)
     assert(expectedSpan === spanAfterPlus)
+  }
+
+  test("spanMonoid plus parent and child span should be invalid") {
+    val spanAfterPlus = Serialization.spanMonoid.plus(spanParent, spanChild)
+    assert(invalid === spanAfterPlus)
+  }
+
+  test("spanMonoid plus zero and span should be span") {
+    val spanAfterPlus = Serialization.spanMonoid.plus(spanParent, zero)
+    assert(spanAfterPlus === spanAfterPlus)
+  }
+
+  test("spanMonoid plus invalid and span should be invalid") {
+    val spanAfterPlus = Serialization.spanMonoid.plus(invalid, spanParent)
+    assert(invalid === spanAfterPlus)
+  }
+
+  test("map injection") {
+    val mInj = Serialization.mapInj
+    val map = Map("str1" -> 1L, "str2" -> 2L)
+    val value = mInj.invert(mInj(map)).get
+    assert(map === value)
   }
 }

--- a/zipkin-storm/src/test/scala/com/twitter/zipkin/SerializationTest.scala
+++ b/zipkin-storm/src/test/scala/com/twitter/zipkin/SerializationTest.scala
@@ -16,27 +16,22 @@
 package com.twitter.zipkin.storm
 
 import org.scalatest._
-import com.twitter.zipkin.gen.{Annotation, Endpoint, Span}
-import scala.collection.JavaConversions._
+import com.twitter.zipkin.common.{Endpoint, Annotation, Span}
 
-class SpanSchemeSpec extends FunSuite {
-
+class SerializationTest extends FunSuite {
   val annotation1 = Annotation(1, "cs", Some(Endpoint(1, 2, "service")))
   val annotation2 = Annotation(2, "cr", Some(Endpoint(3, 4, "Service")))
+  val annotation3 = Annotation(3, "cr", Some(Endpoint(5, 6, "Service")))
   val span = Span(12345, "methodcall", 666, None,
     List(annotation1, annotation2), Nil)
+  val span2 = Span(6789, "methodcall2", 000, None,
+    List(annotation3), Nil)
+  //val spanScheme = new Serialization()
 
-  val spanScheme = new SpanScheme()
-  val bytes = spanScheme.deserializer.toBytes(span)
-
-  test("SpanScheme deserializes bytes to span" ) {
-    val spanRecovered = spanScheme.deserializer.fromBytes(bytes)
-    assert(spanRecovered === span)
-  }
-
-  test("SpanScheme return correct values of the fields") {
-    val expectedValues = Seq(12345, 666, "methodcall", "service", true)
-    val values = spanScheme.deserialize(bytes).toList
-    assert(expectedValues === values)
+  test("spanMonoid plus") {
+    val expectedSpan = Span(12345, "methodcall", 666, None,
+      List(annotation1, annotation2), Nil)
+    val spanAfterPlus = Serialization.spanMonoid.plus(span, span2)
+    assert(expectedSpan === spanAfterPlus)
   }
 }

--- a/zipkin-storm/src/test/scala/com/twitter/zipkin/SpanSchemeTest.scala
+++ b/zipkin-storm/src/test/scala/com/twitter/zipkin/SpanSchemeTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.zipkin.storm
+
+import org.scalatest._
+import com.twitter.zipkin.gen.{Annotation, Endpoint, Span}
+import scala.collection.JavaConversions._
+
+class SpanSchemeSpec extends FunSuite {
+  val annotation1 = Annotation(1, "cs", Some(Endpoint(1, 2, "service")))
+  val annotation2 = Annotation(2, "cr", Some(Endpoint(3, 4, "Service")))
+  val span = Span(12345, "methodcall", 666, None,
+    List(annotation1, annotation2), Nil)
+
+  val spanScheme = new SpanScheme()
+  val bytes = spanScheme.deserializer.toBytes(span)
+
+  test("SpanScheme deserializes bytes to span" ) {
+    val spanRecovered = spanScheme.deserializer.fromBytes(bytes)
+    assert(spanRecovered === span)
+  }
+
+  test("SpanScheme return correct values of the fields") {
+    val expectedValues = Seq(12345, 666, "methodcall", "service", true)
+    val values = spanScheme.deserialize(bytes).toList
+    assert(expectedValues === values)
+  }
+}


### PR DESCRIPTION
This PR provides additional components needed for summingbird jobs:
1) serialization for span and a monoid used by summingbird sumByKey()
2) injection scheme for span
3) config changes: the scala version is bumped to 2.9.3. 
