### PR TITLE
Add injection of Map[String, List[Long]] for span duration aggregation

### DIFF
--- a/zipkin-storm/src/main/scala/com/twitter/zipkin/Serialization.scala
+++ b/zipkin-storm/src/main/scala/com/twitter/zipkin/Serialization.scala
@@ -42,8 +42,11 @@ object Serialization {
   implicit def vInj[V: Codec]: Injection[(BatchID, V), Array[Byte]] =
     Injection.connect[(BatchID, V), (V, BatchID), Array[Byte]]
 
-  implicit val mapInj: Injection[Map[String, Long], Array[Byte]] =
+  implicit val mapStrLongInj: Injection[Map[String, Long], Array[Byte]] =
     Bufferable.injectionOf[Map[String, Long]]
+
+  implicit val mapStrListInj: Injection[Map[String, List[Long]], Array[Byte]] =
+    Bufferable.injectionOf[Map[String, List[Long]]]
 
   implicit val spanMonoid: Monoid[Span] = new Monoid[Span] {
     val zero = Span(0, "zero", 0, None, Nil, Nil, true)

--- a/zipkin-storm/src/test/scala/com/twitter/zipkin/SerializationTest.scala
+++ b/zipkin-storm/src/test/scala/com/twitter/zipkin/SerializationTest.scala
@@ -54,9 +54,16 @@ class SerializationTest extends FunSuite {
     assert(invalid === spanAfterPlus)
   }
 
-  test("map injection") {
-    val mInj = Serialization.mapInj
+  test("map[string, long] injection") {
+    val mInj = Serialization.mapStrLongInj
     val map = Map("str1" -> 1L, "str2" -> 2L)
+    val value = mInj.invert(mInj(map)).get
+    assert(map === value)
+  }
+
+  test("map[string, list[long]] injection") {
+    val mInj = Serialization.mapStrListInj
+    val map = Map("str1" -> List(1L), "str2" -> List(2L))
     val value = mInj.invert(mInj(map)).get
     assert(map === value)
   }


### PR DESCRIPTION
In order to support span duration in the summingbird job, an injection of Map[String, List[Long]] is added. Summingbird job can aggregate the duration of the spans(List[Long]) and come up with stats such as avg, p99 etc
