### PR TITLE
move default adjusters to constants package

### DIFF
--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/Constants.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/Constants.scala
@@ -18,8 +18,15 @@ package com.twitter.zipkin.query
 
 import com.twitter.conversions.time._
 import com.twitter.util.Duration
+import com.twitter.zipkin.gen.Adjust
+import com.twitter.zipkin.query.adjusters._
 
 package object constants {
   /* Amount of time padding to use when resolving complex query timestamps */
   val TraceTimestampPadding: Duration = 1.minute
+
+  val DefaultAdjusters = Map[Adjust, Adjuster](
+    Adjust.Nothing -> NullAdjuster,
+    Adjust.TimeSkew -> new TimeSkewAdjuster()
+  )
 }

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServerFactory.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServerFactory.scala
@@ -29,15 +29,10 @@ trait ZipkinQueryServerFactory { self: App =>
   val queryServicePort = flag("zipkin.queryService.port", ":9411", "port for the query service to listen on")
   val queryServiceDurationBatchSize = flag("zipkin.queryService.durationBatchSize", 500, "max number of durations to pull per batch")
 
-  val defaultAdjusterMap: Map[Adjust, Adjuster] = Map(
-    Adjust.Nothing -> NullAdjuster,
-    Adjust.TimeSkew -> new TimeSkewAdjuster()
-  )
-
   def newQueryServer(
     spanStore: SpanStore,
     aggregatesStore: Aggregates = new NullAggregates,
-    adjusters: Map[Adjust, Adjuster] = defaultAdjusterMap,
+    adjusters: Map[Adjust, Adjuster] = constants.DefaultAdjusters,
     stats: StatsReceiver = DefaultStatsReceiver.scope("QueryService"),
     log: Logger = Logger.get("QueryService")
   ): ListeningServer = {


### PR DESCRIPTION
Move the default adjusters to the constants package. This will make it much easier to use them in cases where we want to implement a query service outside of the server factory.
