### PR TITLE
de-duplicate span records in anormdb

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -205,7 +205,7 @@ class AnormSpanStore(
   def getSpansByTraceIds(ids: Seq[Long]): Future[Seq[Seq[Span]]] = {
     val spans = pool {
       spansSql(ids).as(spansResults *)
-    } map { _.groupBy(_.traceId) }
+    } map { _.distinct.groupBy(_.traceId) }
 
     val anns = pool {
       annsSql(ids).as(annsResults *)


### PR DESCRIPTION
The AnormDB data model is a bit wrong. Spans don't get stored as unique records. Because of this a span from the server and a span from the server get saved to the span table as two different records. Reading them out then causes duplicate data to be displayed in the UI. 
