### PR TITLE
re-write Endpoint.toString in terms of the cheaper getHostAddress

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Endpoint.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Endpoint.scala
@@ -35,9 +35,8 @@ object Endpoint {
 case class Endpoint(ipv4: Int, port: Short, serviceName: String)
   extends Ordered[Endpoint] {
 
-  override def toString: String = {
-    this.getInetSocketAddress.toString() + "(" + serviceName + ")"
-  }
+  override def toString: String =
+    "%s:%d(%s)".format(getHostAddress, port, serviceName)
 
   /**
    * Return the java.net.InetSocketAddress which contains host/port


### PR DESCRIPTION
Using toString from InetSocketAddress will cause a DNS lookup to resolve the IP to a hostname. An endpoint is defined as an IP, port, and service name, it's unnecessary for it to resolve the hostname when printing its string representation. A user should explicitly request the hostname via getInetSocketAddress if they are interested.
