### PR TITLE
Scrooge updated to match plugin version

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -25,9 +25,9 @@ import AssemblyKeys._
 object Zipkin extends Build {
   val zipkinVersion = "1.2.0-SNAPSHOT"
 
-  val finagleVersion = "6.12.2"
-  val utilVersion = "6.12.1"
-  val scroogeVersion = "3.12.2"
+  val finagleVersion = "6.13.1"
+  val utilVersion = "6.13.2"
+  val scroogeVersion = "3.13.0"
   val cassieVersion = "0.25.3"
   val zookeeperVersions = Map(
     "candidate" -> "0.0.41",
@@ -47,7 +47,7 @@ object Zipkin extends Build {
   def algebird(name: String) = "com.twitter" %% ("algebird-" + name) % algebirdVersion
   def zk(name: String) = "com.twitter.common.zookeeper" % name % zookeeperVersions(name)
 
-  val twitterServer = "com.twitter" % "twitter-server_2.9.2" % "1.4.0"
+  val twitterServer = "com.twitter" % "twitter-server_2.9.2" % "1.6.1"
 
   // cassie brings in old versions of finagle and util. we need to exclude here and bring in exclusive versions
   def cassie(name: String) =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,6 @@ libraryDependencies ++= Seq(
     "org.slf4j"              % "slf4j-api"          % "1.6.1",
     "org.slf4j"              % "slf4j-simple"       % "1.6.1")
 
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.12.3")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.13.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.9.2")


### PR DESCRIPTION
When I tried running scrooge I got to an error:

```
[error] (zipkin-scrooge/*:update) sbt.ResolveException: download failed: com.twitter#scrooge-runtime_2.9.2;3.12.2!scrooge-runtime_2.9.2.jar(doc)
[error] download failed: com.twitter#scrooge-runtime_2.9.2;3.12.2!scrooge-runtime_2.9.2.pom
[error] download failed: com.twitter#scrooge-runtime_2.9.2;3.12.2!scrooge-runtime_2.9.2.jar(src)
```

Updating scrooge dependency version to 3.12.3, so that it matches scrooge-plugin version, resolved the issue.
