### PR TITLE
Fixing tests for zipkin-hbase

### DIFF
--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/HBaseIndex.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/HBaseIndex.scala
@@ -73,8 +73,8 @@ trait HBaseIndex extends Index {
 
     annoMappingFuture.flatMap { annoMapping =>
       val scan = new Scan()
-      val startRk = Bytes.toBytes(annoMapping.parent.get.id) ++ Bytes.toBytes(annoMapping.id) ++ Bytes.toBytes(0L)
-      val endRk = Bytes.toBytes(annoMapping.parent.get.id) ++ Bytes.toBytes(annoMapping.id) ++ getEndScanTimeStampRowKeyBytes(endTs)
+      val startRk = Bytes.toBytes(annoMapping.parent.get.id) ++ Bytes.toBytes(annoMapping.id) ++ getEndScanTimeStampRowKeyBytes(endTs)
+      val endRk = Bytes.toBytes(annoMapping.parent.get.id) ++ Bytes.toBytes(annoMapping.id) ++ Bytes.toBytes(Long.MaxValue)
       scan.setStartRow(startRk)
       scan.setStopRow(endRk)
       scan.addFamily(TableLayouts.idxAnnotationFamily)
@@ -258,8 +258,8 @@ trait HBaseIndex extends Index {
       // Ask for more rows because there can be large number of dupes.
       scan.setCaching(limit * 10)
 
-      val startRk = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(0L)
-      val endRk =  Bytes.toBytes(serviceMapping.id) ++ getEndScanTimeStampRowKeyBytes(endTs)
+      val startRk = Bytes.toBytes(serviceMapping.id) ++ getEndScanTimeStampRowKeyBytes(endTs)
+      val endRk =  Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(Long.MaxValue)
       scan.setStartRow(startRk)
       scan.setStopRow(endRk)
       // TODO(eclark): make this go back to the region server multiple times with a smart filter.
@@ -273,8 +273,8 @@ trait HBaseIndex extends Index {
       val spanNameMappingFuture = serviceMapping.spanNameMapper.get(spanName)
       spanNameMappingFuture.flatMap { spanNameMapping =>
         val scan = new Scan()
-        val startRow = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(spanNameMapping.id) ++ Bytes.toBytes(0L)
-        val stopRow = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(spanNameMapping.id) ++ getEndScanTimeStampRowKeyBytes(endTs)
+        val startRow = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(spanNameMapping.id) ++ getEndScanTimeStampRowKeyBytes(endTs)
+        val stopRow = Bytes.toBytes(serviceMapping.id) ++ Bytes.toBytes(spanNameMapping.id) ++ Bytes.toBytes(Long.MaxValue)
         scan.setStartRow(startRow)
         scan.setStopRow(stopRow)
         idxServiceSpanNameTable.scan(scan, limit)

--- a/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/package.scala
+++ b/zipkin-hbase/src/main/scala/com/twitter/zipkin/storage/hbase/package.scala
@@ -29,5 +29,5 @@ package object hbase {
 
   def timeStampToRowKeyBytes(timeStamp: Long): Array[Byte] = Bytes.toBytes(Long.MaxValue - timeStamp)
 
-  def getEndScanTimeStampRowKeyBytes(ts: Long) = Bytes.toBytes(scala.math.max(Long.MaxValue - ts, 1L) - 1L)
+  def getEndScanTimeStampRowKeyBytes(ts: Long) = Bytes.toBytes(scala.math.max(Long.MaxValue - ts, 0L))
 }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
@@ -40,7 +40,6 @@ object QueryExtractor {
     /* Pull out the annotations */
     val annotations = extractParams(request, "annotations[%d]") match {
       case Nil     => None
-      case Seq("") => None
       case seq @ _ => Some(seq)
     }
 

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
@@ -40,6 +40,7 @@ object QueryExtractor {
     /* Pull out the annotations */
     val annotations = extractParams(request, "annotations[%d]") match {
       case Nil     => None
+      case Seq("") => None
       case seq @ _ => Some(seq)
     }
 


### PR DESCRIPTION
The tests were written for the backwards-scanning behavior, and so they needed updating
with the changes in 3691ce2.
