### PR TITLE
account for timezone change

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
@@ -24,7 +24,7 @@ import java.text.SimpleDateFormat
 import java.util.{Calendar, Date}
 
 object QueryExtractor {
-  val fmt = new SimpleDateFormat("MM-dd-yyyy HH:mm:ss")
+  val fmt = new SimpleDateFormat("MM-dd-yyyy'T'HH:mm:ss.SSSZ")
 
   private[this] val dateFormat = new SimpleDateFormat("MM-dd-yyyy")
   private[this] val timeFormat = new SimpleDateFormat("HH:mm:ss")


### PR DESCRIPTION
If the data was saved in a different timezone than the one it's being viewed, it will not display correct results.
This change will use the ISO 8601 format, which the timeago jquery library knows how to handle.
