### PR TITLE
Improve WriteQueueWorkers' pushback

### DIFF
--- a/zipkin-collector-core/src/main/scala/com/twitter/zipkin/collector/WriteQueueWorker.scala
+++ b/zipkin-collector-core/src/main/scala/com/twitter/zipkin/collector/WriteQueueWorker.scala
@@ -19,6 +19,7 @@ package com.twitter.zipkin.collector
 import com.twitter.finagle.Service
 import com.twitter.ostrich.admin.BackgroundProcess
 import java.util.concurrent.{TimeUnit, BlockingQueue}
+import com.twitter.util.Await
 
 class WriteQueueWorker[T](queue: BlockingQueue[T],
                        service: Service[T, _]) extends BackgroundProcess("WriteQueueWorker", false) {
@@ -31,6 +32,6 @@ class WriteQueueWorker[T](queue: BlockingQueue[T],
   }
 
   private[collector] def process(t: T) {
-    service(t)
+    Await.ready(service(t))
   }
 }


### PR DESCRIPTION
For storage engines that do most of their work under the returned future (such as hbase),
having the WriteQueueWorker return immediately means that the write queue is not an
accurate representation of the amount of outstanding work.
