### PR TITLE
Change thrift source folder

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -193,6 +193,8 @@ object Zipkin extends Build {
       base = file("zipkin-scrooge"),
       settings = defaultSettings ++ ScroogeSBT.newSettings
     ).settings(
+        ScroogeSBT.scroogeThriftSourceFolder in Compile <<= (baseDirectory in ThisBuild)
+          (_ / "zipkin-thrift" / "src" / "main" / "resources" / "thrift"),
         libraryDependencies ++= Seq(
         finagle("ostrich4"),
         finagle("thrift"),


### PR DESCRIPTION
Set Scrooge settings so they point to the IDL
files in zipkin-thrift. Then we can compile IDLs without
relying on symlinks (which doesn't play well cross-platform)

The symlinks should be deleted, but I'm not familiar with Pants so I'm not sure what to do with the BUILD file...
