### PR TITLE
Keep sort order in hidden input

### DIFF
--- a/zipkin-web/src/main/resources/app/js/component_ui/sortOrder.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/sortOrder.js
@@ -1,0 +1,21 @@
+'use strict';
+
+define(
+  [
+    'flight/lib/component'
+  ],
+
+  function (defineComponent) {
+
+    return defineComponent(sortOrder);
+
+    function sortOrder() {
+      this.updateSortOrder = function(ev, data) {
+        this.$node.val(data.order);
+      };
+      this.after('initialize', function () {
+        this.on(document, 'uiUpdateTraceSortOrder', this.updateSortOrder);
+      });
+    }
+  }
+);

--- a/zipkin-web/src/main/resources/app/js/page/default.js
+++ b/zipkin-web/src/main/resources/app/js/page/default.js
@@ -9,7 +9,8 @@ define(
     'component_ui/infoButton',
     'component_ui/traceFilters',
     'component_ui/traces',
-    'component_ui/timeStamp'
+    'component_ui/timeStamp',
+    'component_ui/sortOrder'
   ],
 
   function (
@@ -20,7 +21,8 @@ define(
     InfoButtonUI,
     TraceFiltersUI,
     TracesUI,
-    TimeStampUI
+    TimeStampUI,
+    SortOrderUI
   ) {
 
     return initialize;
@@ -34,6 +36,7 @@ define(
       TraceFiltersUI.attachTo('#trace-filters');
       TracesUI.attachTo('#traces');
       TimeStampUI.attachTo('#time-stamp');
+      SortOrderUI.attachTo('#sort-order');
 
       $('.timeago').timeago();
     }

--- a/zipkin-web/src/main/resources/templates/v2/index.mustache
+++ b/zipkin-web/src/main/resources/templates/v2/index.mustache
@@ -35,6 +35,8 @@
       <span class="glyphicon glyphicon-question-sign"></span>
     </button>
 
+    <input id="sort-order" name="order" type="hidden" value="{{order}}">
+
     <div class="clearfix"></div>
     <input type="text" class="form-control input-sm" id="annotationQuery" name="annotationQuery" value="{{annotationQuery}}" style="width: 100%" placeholder='Annotations Query (e.g. "finagle.timeout", "http.uri=/foo/bar/ and cluster=foo and cache.miss")'>
   </form>
@@ -49,10 +51,9 @@
     <div class="pull-right">
       <span class="selector">Sort:
         <select class="sort-order js-sort-order">
-          <option selected value="duration-desc">Longest First</i></span>
-          <option value="duration-asc">Shortest First</span>
-          <option value="timestamp-desc">Newest First</span>
-          <option value="timestamp-asc">Oldest First</span>
+        {{#orders}}
+          <option value="{{value}}" {{selected}}>{{name}}</option>
+        {{/orders}}
         </select>
       </span>
     </div>

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -84,7 +84,8 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache) {
 
         case ids =>
           val adjusters = getAdjusters(request)
-          client.getTraceSummariesByIds(ids, adjusters) map { _.map { _.toTraceSummary } }
+          val order = SortOrders.getSortFunction(request.params.get("order"))
+          client.getTraceSummariesByIds(ids, adjusters) map { _.map { _.toTraceSummary } } map {_.sortWith(order)}
       }
     }
   }
@@ -253,7 +254,7 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache) {
         t.serviceCounts.toSeq map { case (n, c) => MustacheServiceCount(n, c) },
         ((duration.toFloat / maxDuration) * 100).toInt
       )
-    } sortBy(_.duration) reverse
+    }
 
     Map(
       ("traces" -> traces),
@@ -264,6 +265,7 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache) {
     Service.mk[Request, Renderer] { req =>
       val serviceName = req.params.get("serviceName")
       val spanName = req.params.get("spanName")
+      val order = req.params.get("order")
 
       val qr = QueryExtractor(req)
       val qResults = qr map { query(client, _, req) } getOrElse { EmptyTraces }
@@ -272,6 +274,10 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache) {
       for (services <- getServices(client); results <- qResults; spans <- spanResults) yield {
         val svcList = services map { svc => Map("name" -> svc, "selected" -> (if (Some(svc) == serviceName) "selected" else "")) }
         val spanList = spans map { span => Map("name" -> span, "selected" -> (if (Some(span) == spanName) "selected" else "")) }
+        val orderList = SortOrders.getOrderNames() map {
+          case (orderKey, name) =>
+            Map("name" -> name, "value" -> orderKey, "selected" -> (if (Some(orderKey) == order) "selected" else ""))
+        }
 
         var data = Map[String, Object](
           ("pageTitle" -> "Index"),
@@ -279,7 +285,9 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache) {
           ("annotationQuery" -> req.params.get("annotationQuery").getOrElse("")),
           ("services" -> svcList),
           ("spans" -> spanList),
-          ("limit" -> req.params.get("limit").getOrElse("100")))
+          ("limit" -> req.params.get("limit").getOrElse("100")),
+          ("order" -> order.getOrElse("")),
+          ("orders" -> orderList))
 
         qr foreach { qReq =>
           val binAnn = qReq.binaryAnnotations map { _.map { b =>

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/SortOrders.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/SortOrders.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.zipkin.web
+
+import com.twitter.zipkin.query.TraceSummary
+
+object SortOrders {
+
+  private val OrderByDurationDesc = {
+    (a: TraceSummary, b: TraceSummary) => a.durationMicro > b.durationMicro
+  }
+  private val OrderByDurationAsc = {
+    (a: TraceSummary, b: TraceSummary) => a.durationMicro < b.durationMicro
+  }
+  private val OrderByTimestampDesc = {
+    (a: TraceSummary, b: TraceSummary) => a.startTimestamp > b.startTimestamp
+  }
+  private val OrderByTimestampAsc = {
+    (a: TraceSummary, b: TraceSummary) => a.startTimestamp < b.startTimestamp
+  }
+
+  private[this] val orders = Map(
+    "duration-desc" ->("Longest First", OrderByDurationDesc),
+    "duration-asc" ->("Shortest First", OrderByDurationAsc),
+    "timestamp-desc" ->("Newest First", OrderByTimestampDesc),
+    "timestamp-asc" ->("Oldest First", OrderByTimestampAsc)
+  )
+
+  def getOrderNames(): Map[String, String] = orders.mapValues(_._1)
+
+  def getSortFunction(order: Option[String]): (TraceSummary, TraceSummary) => Boolean = {
+    order.flatMap(orders.get).map(_._2).getOrElse(OrderByDurationDesc)
+  }
+
+}


### PR DESCRIPTION
This patch enables zipkin-web keep sort order in hidden input. Without this patch you have to set sort order every submit.
