### PR TITLE
Add support for sbt-assembly to zipkin-{web,{query,collector}-service}

### DIFF
--- a/bin/prezi_build.sh
+++ b/bin/prezi_build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+releaseid=$(git rev-parse HEAD)
+if [ -z "$releaseid" ]; then
+    echo "git rev-parse HEAD did not give back anything useful, aborting" >&2
+    exit 1
+fi
+
+$(dirname $0)/sbt zipkin-{web,collector-service,query-service}/assembly zipkin-web/package-dist
+
+temp=$(mktemp -d)
+trap "cd $(pwd); rm -rf ${temp}" EXIT
+
+cp -v zipkin-{web,collector-service,query-service}/target/*-assembly-*-SNAPSHOT.jar $temp/
+cp -v zipkin-web/dist/zipkin-web.zip $temp/
+
+cd $temp/
+for f in *; do
+    sha256sum -b $f | cut -d' ' -f1 > $f.sha256
+done
+
+aws s3 cp --acl public-read --recursive . s3://prezireleases/zipkin/$releaseid/

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -7,7 +7,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
+ *  Unless requsred by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
@@ -440,18 +440,19 @@ object Zipkin extends Build {
     }
   ).dependsOn(collectorCore, collectorScribe, receiverKafka, cassandra, kafka, redis, anormDB, hbase)
 
+  lazy val webAssemblySettings = mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
+    {
+      case PathList("com", "twitter", "common", "args", "apt", "cmdline.arg.info.txt.1") => MergeStrategy.first
+      case x => old(x)
+    }
+  }
+
   lazy val web =
     Project(
       id = "zipkin-web",
       base = file("zipkin-web"),
-      settings = defaultSettings ++ assemblySettings ++
-Seq(mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
-        {
-          case PathList("com", "twitter", "common", "args", "apt", "cmdline.arg.info.txt.1") => MergeStrategy.first
-          case x => old(x)
-        }
-      }
-    )).settings(
+      settings = defaultSettings ++ assemblySettings ++ webAssemblySettings
+    ).settings(
       libraryDependencies ++= Seq(
         finagle("exception"),
         finagle("thriftmux"),

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -274,7 +274,8 @@ object Zipkin extends Build {
   ).settings(
     libraryDependencies ++= Seq(
       "play" % "anorm_2.9.2" % "2.1-09142012",
-      anormDriverDependencies("sqlite-persistent")
+      anormDriverDependencies("sqlite-persistent"),
+      anormDriverDependencies("mysql")
     ) ++ testDependencies ++ scalaTestDeps,
 
     /* Add configs to resource path for ConfigSpec */

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -319,10 +319,20 @@ object Zipkin extends Build {
       ) ++ testDependencies
     ).dependsOn(common, query, scrooge)
 
+  lazy val queryServiceAssemblySettings = mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
+    {
+      case PathList("org", "slf4j", "impl", _*) => MergeStrategy.first
+      case PathList("org", "apache", "commons", _*) => MergeStrategy.first
+      case PathList("com", "twitter", "zipkin", "query", "adjusters", _*) => MergeStrategy.first
+      case PathList("com", "twitter", "common", "args", "apt", "cmdline.arg.info.txt.1") => MergeStrategy.first
+      case x => old(x)
+    }
+  }
+
   lazy val queryService = Project(
     id = "zipkin-query-service",
     base = file("zipkin-query-service"),
-    settings = defaultSettings
+    settings = defaultSettings ++ assemblySettings ++ Seq(queryServiceAssemblySettings)
   ).settings(
     libraryDependencies ++= testDependencies,
 
@@ -405,8 +415,8 @@ object Zipkin extends Build {
 
   lazy val collectorServiceAssemblySettings = mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
     {
-      case PathList("org", "slf4j", "impl", ps @ _*) => MergeStrategy.first
-      case PathList("org", "apache", "commons", ps @ _*) => MergeStrategy.first
+      case PathList("org", "slf4j", "impl", _*) => MergeStrategy.first
+      case PathList("org", "apache", "commons", _*) => MergeStrategy.first
       case PathList("com", "twitter", "common", "args", "apt", "cmdline.arg.info.txt.1") => MergeStrategy.first
       case x => old(x)
     }


### PR DESCRIPTION
Since the assembly plugin is already included, I assume this is not very far from the intended purpose. The code is longer than strictly necessary and has some repetition to make sure the change has only minimal impact. This can of course be changed by just adding everything to `defaultSettings`.

The conflicts for which I added the `first` merge strategy:
- `com/twitter/zipkin/query/adjusters/*.class` built for `zipkin-query` and `zipkin-query-core` differed
- `com/twitter/common/args/apt/cmdline.arg.info.txt.1` differs between `com.twitter.common.zookeeper/server-set/jars/server-set-1.0.72.jar` and `com.twitter.common/args/jars/args-0.2.6.jar`
- `commons-beanutils-core` has both versions `1.7.0` and `1.8.0` somewhere in the dependency tree; I didn't track down where exactly.
