### PR TITLE
Show exact time of each annotations at SpanPanel

### DIFF
--- a/zipkin-web/src/main/resources/app/js/component_ui/spanPanel.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/spanPanel.js
@@ -29,6 +29,12 @@ define(
           $annoBody.append($row);
         });
 
+        $annoBody.find(".local-datetime").each(function() {
+          var $this = $(this);
+          var timestamp = $this.text();
+          $this.text((new Date(parseInt(timestamp) / 1000)).toLocaleString());
+        });
+
         var $binAnnoBody = this.$node.find('#binaryAnnotations tbody').text('');
         $.each(span.binaryAnnotations, function(i, anno) {
           var $row = self.$binaryAnnotationTemplate.clone();

--- a/zipkin-web/src/main/resources/templates/v2/trace.mustache
+++ b/zipkin-web/src/main/resources/templates/v2/trace.mustache
@@ -101,6 +101,7 @@
       <div class='modal-body'>
         <table id='annotations' class='table table-striped'>
           <thead><tr>
+            <th>Date Time</th>
             <th>Relative Time</th>
             <th>Duration</th>
             <th>Service</th>
@@ -109,6 +110,7 @@
           </tr></thead>
           <tbody>
             <tr>
+              <td data-key='timestamp' class="local-datetime"></td>
               <td data-key='relativeTime'></td>
               <td data-key='duration'></td>
               <td data-key='serviceName'></td>


### PR DESCRIPTION
For investigation purpose, we often want to know not only duration but also the exact time of each spans. This patch shows their local date time at Span Panel. This is useful to investigate the cause of  irregularly long span by collating its time with server log file.
