### PR TITLE
Include web resource root in packaged web.sh

### DIFF
--- a/zipkin-web/src/scripts/web.sh
+++ b/zipkin-web/src/scripts/web.sh
@@ -2,4 +2,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VERSION=@VERSION@
 
-java -cp "$DIR/../libs/*" -jar $DIR/../zipkin-web-$VERSION.jar $@
+java -cp "$DIR/../libs/*" -jar $DIR/../zipkin-web-$VERSION.jar -zipkin.web.resourcesRoot=$DIR/../resources/ $@


### PR DESCRIPTION
When running zipkin-web/scripts/web.sh from a built distribution (i.e. `${zipkin}/bin/sbt zipkin-web/package-dist`), attempting to access `http://<host>:8080/` currently results in an empty response. This change adds the proper resource root to the web.sh start script per `doc/install.md` and resolves this issue.
