### PR TITLE
Bump sbt version for packaging purpose

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.7


### PR DESCRIPTION
For packaging purpose, i'd like to

```
set every version = "1.2.0~$date+$commitid"
```

which is buggy on 0.13.6 yet fixed in 0.13.7

see: https://github.com/sbt/sbt/issues/1430

Signed-off-by: Arthur Gautier baloo@gandi.net
