### PR TITLE
Bump zipkin-tracer gem minor version to 0.2.0

### DIFF
--- a/zipkin-gems/zipkin-tracer/Rakefile
+++ b/zipkin-gems/zipkin-tracer/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2012 Twitter Inc.
+# Copyright 2015 Twitter Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer.rb
@@ -1,4 +1,4 @@
-# Copyright 2012 Twitter Inc.
+# Copyright 2015 Twitter Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/careless_scribe.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/careless_scribe.rb
@@ -1,11 +1,11 @@
-# Copyright 2012 Twitter Inc.
-# 
+# Copyright 2015 Twitter Inc.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/version.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2012 Twitter Inc.
+# Copyright 2015 Twitter Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/version.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end
 

--- a/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
+++ b/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-# Copyright 2012 Twitter Inc.
+# Copyright 2015 Twitter Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Since `VERSION` hasn't been updated since 2012.

Also: the [version of the gem hosted on Rubygems](https://rubygems.org/gems/zipkin-tracer) is 0.0.1, which was the initial release of the gem. I see that @franklinhu is currently the only maintainer of it—it'd be great to see it updated.
