### PR TITLE
Addition of Redis SpanStore + Factory to enable Cake pattern usage

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -485,7 +485,7 @@ object Zipkin extends Build {
       base =>
         (base / "config" +++ base / "src" / "test" / "resources").get
     }
-  ).dependsOn(scrooge)
+  ).dependsOn(common, scrooge)
 
   lazy val hbaseTestGuavaHack = Project(
     id = "zipkin-hbase-test-guava-hack",
@@ -546,6 +546,21 @@ object Zipkin extends Build {
     tracegen, web, anormDB, query,
     receiverScribe, zookeeper
   )
+
+  lazy val redisExample = Project(
+    id = "zipkin-redis-example",
+    base = file("zipkin-redis-example"),
+    settings = defaultSettings
+  ).settings(
+      libraryDependencies ++= Seq(
+        finagle("zipkin"),
+        finagle("stats"),
+        twitterServer
+      )
+    ).dependsOn(
+      web, redis, query,
+      receiverScribe, zookeeper
+    )
 
   lazy val zipkinDoc = Project(
     id = "zipkin-doc",

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -478,7 +478,7 @@ object Zipkin extends Build {
       util("logging"),
       scroogeDep("serializer"),
       "org.slf4j" % "slf4j-log4j12" % "1.6.4" % "runtime"
-    ) ++ testDependencies,
+    ) ++ testDependencies ++ scalaTestDeps,
 
     /* Add configs to resource path for ConfigSpec */
     unmanagedResourceDirectories in Test <<= baseDirectory {

--- a/zipkin-redis-example/src/main/scala/com/twitter/zipkin/example/Main.scala
+++ b/zipkin-redis-example/src/main/scala/com/twitter/zipkin/example/Main.scala
@@ -1,0 +1,39 @@
+package com.twitter.mycollector
+
+import com.twitter.zipkin.conversions.thrift._
+import com.twitter.finagle.Http
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.server.{Closer, TwitterServer}
+import com.twitter.util.{Await, Closable, Future}
+import com.twitter.zipkin.redis.RedisSpanStoreFactory
+import com.twitter.zipkin.collector.SpanReceiver
+import com.twitter.zipkin.common.Span
+import com.twitter.zipkin.{thriftscala => thrift}
+import com.twitter.zipkin.receiver.scribe.ScribeSpanReceiverFactory
+import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
+import com.twitter.zipkin.web.ZipkinWebFactory
+import com.twitter.zipkin.query.ThriftQueryService
+import com.twitter.zipkin.query.constants.DefaultAdjusters
+
+object Main extends TwitterServer with Closer
+  with ZooKeeperClientFactory
+  with ScribeSpanReceiverFactory
+  with ZipkinWebFactory
+  with RedisSpanStoreFactory
+{
+  def main() {
+    val store = newRedisSpanStore()
+
+    val convert: Seq[thrift.Span] => Seq[Span] = { _.map(_.toSpan) }
+    val receiver = newScribeSpanReceiver(convert andThen store, statsReceiver.scope("scribeSpanReceiver"))
+    val query = new ThriftQueryService(store, adjusters = DefaultAdjusters)
+    val webService = newWebServer(query, statsReceiver.scope("web"))
+    val web = Http.serve(webServerPort(), webService)
+
+    val closer = Closable.sequence(web, receiver, store)
+    closeOnExit(closer)
+
+    println("running and ready")
+    Await.all(web, receiver, store)
+  }
+}

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
@@ -13,7 +13,7 @@ trait RedisSpanStoreFactory { self: App =>
   val redisPort = flag("zipkin.storage.redis.port", 6379, "Port for Redis")
   val redisTtl = flag("zipkin.storage.redis.ttl", 168, "Redis data TTL in hours")
 
-  def newRedisSpanStore(): SpanStore = {
+  def newRedisSpanStore(): RedisSpanStore = {
     val storage = StorageBuilder(redisHost(), redisPort(), redisTtl().hours)
     val index = IndexBuilder(redisHost(), redisPort(), redisTtl().hours)
     new RedisSpanStore(index.apply(), storage.apply())

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
@@ -1,0 +1,21 @@
+package com.twitter.zipkin.redis
+
+import com.twitter.app.App
+import com.twitter.conversions.time._
+import com.twitter.zipkin.storage.redis.RedisSpanStore
+import com.twitter.zipkin.storage.SpanStore
+
+/**
+ * Created by caporp01 on 19/03/2015.
+ */
+trait RedisSpanStoreFactory { self: App =>
+  val redisHost = flag("zipkin.storage.redis.host", "0.0.0.0", "Host for Redis")
+  val redisPort = flag("zipkin.storage.redis.port", 6379, "Port for Redis")
+  val redisTtl = flag("zipkin.storage.redis.ttl", 168, "Redis data TTL in hours")
+
+  def newRedisSpanStore(): SpanStore = {
+    val storage = StorageBuilder(redisHost(), redisPort(), redisTtl().hours)
+    val index = IndexBuilder(redisHost(), redisPort(), redisTtl().hours)
+    new RedisSpanStore(index.apply(), storage.apply())
+  }
+}

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
@@ -3,7 +3,6 @@ package com.twitter.zipkin.redis
 import com.twitter.app.App
 import com.twitter.conversions.time._
 import com.twitter.zipkin.storage.redis.RedisSpanStore
-import com.twitter.zipkin.storage.SpanStore
 
 /**
  * Created by caporp01 on 19/03/2015.

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -1,0 +1,87 @@
+package com.twitter.zipkin.storage.redis
+
+import com.twitter.zipkin.storage._
+
+import com.twitter.util.{Time, Future, Duration}
+import java.nio.ByteBuffer
+import com.twitter.conversions.time._
+import com.twitter.finagle.{Filter => FFilter, Service}
+import com.twitter.util.{Closable, CloseAwaitably, Duration, Future, Time}
+import com.twitter.zipkin.Constants
+import com.twitter.zipkin.common.Span
+import java.nio.ByteBuffer
+import scala.collection.mutable
+
+import com.twitter.util.{Closable, CloseAwaitably, Duration, Future, Time}
+
+/**
+ * Created by caporp01 on 19/03/2015.
+ */
+class RedisSpanStore ( index : RedisIndex, storage : RedisStorage ) extends SpanStore {
+
+  private[this] def call[T](f: => T): Future[T] = synchronized { Future(f) }
+
+  def close(deadline: Time): Future[Unit] = closeAwaitably {
+      call { storage.close() }.unit
+    }
+
+    def apply(newSpans: Seq[Span]): Future[Unit] = call {
+      newSpans foreach {
+        span =>
+          storage.storeSpan(span)
+          index.indexServiceName(span)
+          index.indexSpanNameByService(span)
+          index.indexTraceIdByServiceAndName(span)
+          index.indexSpanByAnnotations(span)
+          index.indexSpanDuration(span)
+      }
+    }.unit
+
+    // Used for pinning
+    def setTimeToLive(traceId: Long, ttl: Duration): Future[Unit] = {
+      storage.setTimeToLive(traceId, ttl)
+    }
+
+    def getTimeToLive(traceId: Long): Future[Duration] = {
+      storage.getTimeToLive(traceId)
+    }
+
+    def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] = {
+      storage.tracesExist(traceIds)
+    }
+
+    def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = {
+      storage.getSpansByTraceIds(traceIds)
+    }
+
+    def getSpansByTraceId(traceId: Long): Future[Seq[Span]] = {
+      storage.getSpansByTraceId(traceId)
+    }
+
+    def getTraceIdsByName(
+                           serviceName: String,
+                           spanName: Option[String],
+                           endTs: Long,
+                           limit: Int
+                           ): Future[Seq[IndexedTraceId]] = {
+      index.getTraceIdsByName(serviceName, spanName, endTs, limit)
+    }
+
+    def getTraceIdsByAnnotation(serviceName: String,
+                                 annotation: String,
+                                 value: Option[ByteBuffer],
+                                 endTs: Long,
+                                 limit: Int
+                                 ): Future[Seq[IndexedTraceId]] = {
+      index.getTraceIdsByAnnotation(serviceName, annotation, value, endTs, limit)
+    }
+
+    def getTracesDuration(traceIds: Seq[Long]): Future[Seq[TraceIdDuration]] = index.getTracesDuration(traceIds)
+
+    def getAllServiceNames: Future[Set[String]] = {
+      println("Getting service names")
+      index.getServiceNames
+    }
+
+    def getSpanNames(serviceName: String): Future[Set[String]] = index.getSpanNames(serviceName)
+}

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -1,18 +1,10 @@
 package com.twitter.zipkin.storage.redis
 
 import com.twitter.zipkin.storage._
-
-import com.twitter.util.{Time, Future, Duration}
-import java.nio.ByteBuffer
-import com.twitter.conversions.time._
-import com.twitter.finagle.{Filter => FFilter, Service}
-import com.twitter.util.{Closable, CloseAwaitably, Duration, Future, Time}
-import com.twitter.zipkin.Constants
 import com.twitter.zipkin.common.Span
 import java.nio.ByteBuffer
-import scala.collection.mutable
 
-import com.twitter.util.{Closable, CloseAwaitably, Duration, Future, Time}
+import com.twitter.util.{Duration, Future, Time}
 
 /**
  * Created by caporp01 on 19/03/2015.

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreTest.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreTest.scala
@@ -1,8 +1,45 @@
+/*
+ * Copyright 2014 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.zipkin.storage.redis
 
-/**
- * Created by caporp01 on 20/03/2015.
- */
-class RedisSpanStoreTest {
+import com.twitter.app.App
+import com.twitter.zipkin.redis.RedisSpanStoreFactory
+import com.twitter.zipkin.storage.util.SpanStoreValidator
+import org.junit.runner.RunWith
+import com.twitter.util.Await
+import com.twitter.app.App
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
+class RedisSpanStoreTest extends FunSuite {
+
+  object RedisStore extends App with RedisSpanStoreFactory
+  RedisStore.main(Array(
+    "-zipkin.storage.redis.host", "127.0.0.1",
+    "-zipkin.storage.redis.port", "6379"))
+
+  def newSpanStore = {
+    val spanStore = RedisStore.newRedisSpanStore()
+    Await.result(spanStore.storage.database.flushDB())
+    spanStore
+  }
+
+  test("validate") {
+    new SpanStoreValidator(newSpanStore).validate
+  }
 }

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreTest.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreTest.scala
@@ -15,10 +15,8 @@
  */
 package com.twitter.zipkin.storage.redis
 
-import com.twitter.app.App
 import com.twitter.zipkin.redis.RedisSpanStoreFactory
 import com.twitter.zipkin.storage.util.SpanStoreValidator
-import org.junit.runner.RunWith
 import com.twitter.util.Await
 import com.twitter.app.App
 import org.junit.runner.RunWith

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreTest.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreTest.scala
@@ -1,0 +1,8 @@
+package com.twitter.zipkin.storage.redis
+
+/**
+ * Created by caporp01 on 20/03/2015.
+ */
+class RedisSpanStoreTest {
+
+}


### PR DESCRIPTION
Hi,
I wanted to try out the Redis storage and couldn't find a SpanStore or SpanStoreFactory for it in the codebase. I have added one, including using the SpanStoreValidator tests. Also found a some minor inconsistencies in RedisIndex class when using the SpanStoreValidator to test
- It threw an exception if there were no annotations in the span
- It indexed core annotations which was inconsistent with the Cassandra/AnormDB implementations

Apologies the pull also includes a sample redis-example project based on your zipkin-example I was using to test with which is included in the Project.scala
