### PR TITLE
Use SBT shortcuts to define local repositories

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -83,7 +83,7 @@ object Zipkin extends Build {
     crossPaths := false,            /* Removes Scala version from artifact name */
     fork := true, // forking prevents runaway thread pollution of sbt
     baseDirectory in run := file(cwd), // necessary for forking
-    publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath + "/.ivy2/local")))
+    publishTo := Some(Resolver.defaultLocal)
   )
 
   // settings from inlined plugins

--- a/project/ZipkinResolver.scala
+++ b/project/ZipkinResolver.scala
@@ -37,7 +37,7 @@ object ZipkinResolver extends Plugin {
       "conjars.org" at "http://conjars.org/repo"
     ),
 
-    localRepo := file(System.getProperty("user.home") + "/.m2/repository"),
+    localRepo := file(Resolver.mavenLocal.root),
 
     // configure resolvers for the build
     resolvers <<= (resolvers, defaultResolvers, localRepo)
@@ -49,7 +49,7 @@ object ZipkinResolver extends Plugin {
       }) ++ Seq(
         // the local repo has to be in here twice, because sbt won't push to a "file:"
         // repo, but it won't read artifacts from a "Resolver.file" repo. (head -> desk)
-        "local-lookup" at ("file:" + localRepo.getAbsolutePath),
+        "local-lookup" at Resolver.file(localRepo.getAbsolutePath),
         Resolver.file("local", localRepo)(Resolver.mavenStylePatterns)
       )
     },

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers ++= Seq(
   "twitter.com" at "http://maven.twttr.com/",
   "maven" at "http://repo1.maven.org/maven2/",
   "freemarker" at "http://freemarker.sourceforge.net/maven2/",
-  "local" at ("file:" + System.getProperty("user.home") + "/.m2/repository/"))
+  Resolver.mavenLocal)
 
 libraryDependencies ++= Seq(
     "com.google.collections" % "google-collections" % "0.8",


### PR DESCRIPTION
This fixes an issue where using SBT on Windows would consistently yield the error :

`[error]         URI is not hierarchical`
