### PR TITLE
Constrains Travis to working configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: scala
 
-sudo: false
-
 scala:
   - 2.10.5
 
@@ -10,7 +8,12 @@ services:
 
 jdk:
   - oraclejdk7
-  - openjdk7
+
+# These directories are cached to S3 at the end of the build
+cache:
+  directories:
+   - $HOME/.ivy2/cache
+   - $HOME/.sbt/boot/scala-$TRAVIS_SCALA_VERSION
 
 before_script:
   # default $SBT_OPTS is irrelevant to sbt lancher


### PR DESCRIPTION
The openjdk7 build doesn't work and #423 broke the one that worked. This constrains Travis to what can pass, allowing contributors to make use of it as opposed to be constantly distracted by a half-broke build.

In the future, we'll want to fixup the current build and re-add openjdk.
