### PR TITLE
Reduce default query limit from 100 to 10

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Constants.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Constants.scala
@@ -16,5 +16,5 @@
 package com.twitter.zipkin.web
 
 object Constants {
-  val DefaultQueryLimit: Int = 100
+  val DefaultQueryLimit: Int = 10
 }


### PR DESCRIPTION
We've found that the default of 100 trace results is somewhat excessive, and 10 is more reasonable (and potentially substantially better performing) in most cases. This pull request reduces the default query limit from 100 to 10. One notable downside to this change is that when two or more annotations are specified, the probability of a matching intersection being found can be decreased.
