### PR TITLE
MySQL performance and connectivity improvements

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -271,6 +271,7 @@ object Zipkin extends Build {
   ).settings(
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "anorm" % "2.3.7",
+      "org.apache.commons" % "commons-dbcp2" % "2.1",
       anormDriverDependencies("sqlite-persistent")
     ) ++ scalaTestDeps,
 

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DBPool.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DBPool.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.zipkin.storage.anormdb
+
+import com.twitter.ostrich.stats.Stats
+import java.sql.Connection
+
+/**
+ * Common database connection code.
+ */
+trait DBPool {
+
+  val db: DB
+
+  // If an open database connection is supplied, it supersedes usage of the connection pool.
+  val openCon: Option[Connection]
+
+  /**
+   * Closes all database connections.
+   */
+  def close() {
+    if (!openCon.isEmpty) {
+      openCon.get.close()
+    }
+    db.closeConnectionPool()
+  }
+
+  /**
+   * Borrow a connection from the connection pool.
+   *
+   * @return a tuple containing the connection and a timestamp for stats tracking
+   */
+  def borrowConn(): (Connection, Long) = {
+    val borrowTime = System.currentTimeMillis()
+    if (openCon.isEmpty) {
+      (db.getPooledConnection(), borrowTime)
+    } else {
+      (openCon.get, borrowTime)
+    }
+  }
+
+  /**
+   * Return a borrowed connection to the connection pool.
+   */
+  def returnConn(con: Connection, borrowTime: Long, method: String) = {
+    if (openCon.isEmpty) {
+      con.close()
+    }
+    Stats.addMetric(method + "_msec", (System.currentTimeMillis() - borrowTime).toInt)
+  }
+}

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
@@ -101,7 +101,8 @@ case class DBConfig(name: String = "sqlite-persistent",
       description = "MySQL",
       driver = "com.mysql.jdbc.Driver",
       location = { dbp: DBParams =>
-        "jdbc:mysql://" + dbp.host + dbp.getPort + "/" + dbp.dbName + "?user=" + dbp.username + "&password=" + dbp.password
+        // We need to enable auto-reconnect to recover from dropped connections
+        "jdbc:mysql://" + dbp.host + dbp.getPort + "/" + dbp.dbName + "?user=" + dbp.username + "&password=" + dbp.password + "&autoReconnect=true"
       }
     )
   )

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/DBSpec.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/DBSpec.scala
@@ -1,0 +1,137 @@
+package com.twitter.zipkin.storage.anormdb
+
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+import org.specs._
+import java.sql.{Connection, SQLRecoverableException, SQLNonTransientException}
+
+class DBSpec extends Specification {
+
+  "DB" should {
+    "retry if SQLRecoverableException is thrown" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest")))
+      var attempt = 0
+      db.withRecoverableRetry({
+        attempt += 1
+        throwsRecoverableUnlessSuccess(attempt == 2)
+      }).apply() mustEqual true
+      attempt mustEqual 2
+    }
+
+    "retry only once if SQLRecoverableException is thrown again" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest")))
+      var attempt = 0
+      db.withRecoverableRetry({
+        attempt += 1
+        throwsRecoverable
+      }).apply() must throwA[SQLRecoverableException]
+      attempt mustEqual 2
+    }
+
+    "not retry if unrecoverable SQLException is thrown" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest")))
+      var attempt = 0
+      db.withRecoverableRetry({
+        attempt += 1
+        throwsUnrecoverable
+      }).apply() must throwA[SQLNonTransientException]
+      attempt mustEqual 1
+    }
+
+    "[withTransaction] retry if SQLRecoverableException is thrown" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest")))
+      implicit val conn: Connection = db.getConnection()
+      var attempt = 0
+      db.withRecoverableTransaction(conn, { implicit conn: Connection =>
+        attempt += 1
+        throwsRecoverableUnlessSuccess(attempt == 2)
+      }).apply() mustEqual true
+      attempt mustEqual 2
+      conn.close()
+    }
+
+    "[withTransaction] retry only once if SQLRecoverableException is thrown again" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest")))
+      implicit val conn: Connection = db.getConnection()
+      var attempt = 0
+      db.withRecoverableTransaction(conn, { implicit conn: Connection =>
+        attempt += 1
+        throwsRecoverable
+      }).apply() must throwA[SQLRecoverableException]
+      attempt mustEqual 2
+      conn.close()
+    }
+
+    "[withTransaction] not retry if unrecoverable SQLException is thrown" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest")))
+      implicit val conn: Connection = db.getConnection()
+      var attempt = 0
+      db.withRecoverableTransaction(conn, { implicit conn: Connection =>
+        attempt += 1
+        throwsUnrecoverable
+      }).apply() must throwA[SQLNonTransientException]
+      attempt mustEqual 1
+      conn.close()
+    }
+
+    "[inNewThread] retry if SQLRecoverableException is thrown" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest")))
+      var attempt = 0
+      db.inNewThreadWithRecoverableRetry({
+        attempt += 1
+        throwsRecoverableUnlessSuccess(attempt == 2)
+      }).apply() mustEqual true
+      attempt mustEqual 2
+    }
+
+    "[inNewThread] retry only once if SQLRecoverableException is thrown again" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest")))
+      var attempt = 0
+      db.inNewThreadWithRecoverableRetry({
+        attempt += 1
+        throwsRecoverable
+      }).apply() must throwA[SQLRecoverableException]
+      attempt mustEqual 2
+    }
+
+    "[inNewThread] not retry if unrecoverable SQLException is thrown" in {
+      val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest")))
+      var attempt = 0
+      db.inNewThreadWithRecoverableRetry({
+        attempt += 1
+        throwsUnrecoverable
+      }).apply() must throwA[SQLNonTransientException]
+      attempt mustEqual 1
+    }
+
+    def throwsRecoverableUnlessSuccess(success: Boolean) : Boolean = {
+      if (!success) {
+         throwsRecoverable
+      }
+      success
+    }
+
+    def throwsRecoverable() : Boolean = {
+      throw new SQLRecoverableException()
+    }
+
+    def throwsUnrecoverable() : Boolean = {
+      throw new SQLNonTransientException()
+    }
+  }
+}

--- a/zipkin-collector-core/src/main/scala/com/twitter/zipkin/collector/filter/ServiceStatsFilter.scala
+++ b/zipkin-collector-core/src/main/scala/com/twitter/zipkin/collector/filter/ServiceStatsFilter.scala
@@ -26,7 +26,8 @@ import com.twitter.zipkin.common.Span
  */
 class ServiceStatsFilter extends Filter[Span, Unit, Span, Unit] {
   def apply(span: Span, service: Service[Span, Unit]): Future[Unit] = {
+    val result = service(span)
     span.serviceNames.foreach { name => Stats.incr("process_" + name) }
-    service(span)
+    result
   }
 }


### PR DESCRIPTION
We have identified several improvements for Zipkin deployments that using a MySQL database for storage,
- Automatic reconnect for dropped connections so that the collector and query services do not need to be restarted
- Automatic retry for transient/recoverable exceptions so that web app users and clients sending traces to the collector service are not affected if seamless recovery is possible
- Proper back-pressure for maintaining stability under heavy load conditions instead of unbounded resource (Java heap, native threads) growth
- Database connection pooling for significantly improved collector service performance under heavy load conditions
- Prevent constraint violation errors if duplicate traces are sent
- Document recommended indexes for optimal performance for MySQL deployments
- Query service performance improved significantly for getServiceNames, getSpanNames, getTraceIdsByName, and getTraceIdsByAnnotation - includes both updated SQL and table schema additions
- Add timers for all SQL executions that can be viewed using the admin API
