### PR TITLE
Switch database connection pool from DBCP2 to HikariCP

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -271,7 +271,7 @@ object Zipkin extends Build {
   ).settings(
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "anorm" % "2.3.7",
-      "org.apache.commons" % "commons-dbcp2" % "2.1",
+      "com.zaxxer" % "HikariCP-java6" % "2.3.8",
       anormDriverDependencies("sqlite-persistent")
     ) ++ testDependencies ++ scalaTestDeps,
 

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -21,7 +21,7 @@ import anorm.SqlParser._
 import java.sql.{Blob, Connection, DriverManager, SQLException, SQLRecoverableException, PreparedStatement}
 import com.twitter.util.{Try, Return, Throw, Future}
 import AnormThreads.inNewThread
-import org.apache.commons.dbcp2.BasicDataSource
+import com.zaxxer.hikari.HikariDataSource
 
 /**
  * Provides SQL database access via Anorm from the Play framework.
@@ -38,10 +38,10 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
   if (dbconfig.install) this.install().close()
 
   // Initialize connection pool
-  private val connpool = new BasicDataSource()
+  private val connpool = new HikariDataSource()
   connpool.setDriverClassName(dbconfig.driver)
-  connpool.setUrl(dbconfig.location)
-  connpool.setMaxTotal(32)
+  connpool.setJdbcUrl(dbconfig.location)
+  connpool.setMaximumPoolSize(32)
 
   /**
    * Gets a dedicated java.sql.Connection to the SQL database. Note that auto-commit is


### PR DESCRIPTION
Switches database connection pool from [Apache Commons DBCP](https://commons.apache.org/proper/commons-dbcp/) to [HikariCP](https://github.com/brettwooldridge/HikariCP).

Collector performance testing results can be found [here](https://github.com/twitter/zipkin/pull/444#issuecomment-118163389). DBCP and HikariCP performed approximately the same under heavy load. However in addition to its comparable performance HikariCP has some significant technical advantages that are described in [this recent pull request comment](https://github.com/twitter/zipkin/pull/444#issuecomment-118304025).
