### PR TITLE
Use SSL for maven.twttr.com repository

### DIFF
--- a/doc/examples/collector/build.sbt
+++ b/doc/examples/collector/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "com.twitter" %% "twitter-server" % "1.4.1")
 
 resolvers ++= Seq(
-  "twitter.com" at "http://maven.twttr.com/",
+  "twitter.com" at "https://maven.twttr.com/",
   "maven" at "http://repo1.maven.org/maven2/",
   "freemarker" at "http://freemarker.sourceforge.net/maven2/",
   "local" at ("file:" + System.getProperty("user.home") + "/.m2/repository/"))

--- a/project/ZipkinResolver.scala
+++ b/project/ZipkinResolver.scala
@@ -24,7 +24,7 @@ object ZipkinResolver extends Plugin {
       // standard resolvers
       "typesafe" at "http://repo.typesafe.com/typesafe/releases",
       "ibiblio" at "http://mirrors.ibiblio.org/pub/mirrors/maven2/",
-      "twitter.com" at "http://maven.twttr.com/",
+      "twitter.com" at "https://maven.twttr.com/",
       "powermock-api" at "http://powermock.googlecode.com/svn/repo/",
       "scala-tools" at "https://oss.sonatype.org/content/groups/scala-tools/", //replaced scala-tools.org
       "oauth.net" at "http://oauth.googlecode.com/svn/code/maven",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 
 resolvers ++= Seq(
-  "twitter.com" at "http://maven.twttr.com/",
+  "twitter.com" at "https://maven.twttr.com/",
   "maven" at "http://repo1.maven.org/maven2/",
   "freemarker" at "http://freemarker.sourceforge.net/maven2/",
   "local" at ("file:" + System.getProperty("user.home") + "/.m2/repository/"))


### PR DESCRIPTION
We [turned on SSL](https://finagle.github.io/blog/2015/07/16/ssl-now-supported-for-maven-twttr-com/) for this repository this week, and unsecured access will no longer be available after September 30.
