### PR TITLE
Removes -Djava.net.preferIPv4Stack=true to dodge a buffer overflow

### DIFF
--- a/bin/sbt
+++ b/bin/sbt
@@ -24,7 +24,6 @@ test -f ~/.sbtconfig && . ~/.sbtconfig
 java -ea                          \
   $SBT_OPTS                       \
   $JAVA_OPTS                      \
-  -Djava.net.preferIPv4Stack=true \
   -XX:+AggressiveOpts             \
   -XX:+UseParNewGC                \
   -XX:+UseConcMarkSweepGC         \


### PR DESCRIPTION
Via @travisbrown, we learned that travis can buffer overflow if we call
`getHostName` in tests. We do that, so pre-emptively cutting the
`-Djava.net.preferIPv4Stack=true` flag to dodge a potential buffer
overflow.

See https://github.com/travis-ci/travis-ci/issues/3120
