### PR TITLE
Caches .m2 for travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jdk:
 # These directories are cached to S3 at the end of the build
 cache:
   directories:
+   - $HOME/.m2
    - $HOME/.ivy2/cache
    - $HOME/.sbt/boot/scala-$TRAVIS_SCALA_VERSION
 


### PR DESCRIPTION
We've had builds fail downloading things from maven central. There's an
approach noted in https://github.com/travis-ci/travis-ci/issues/1441
that suggests caching `.m2`. Seems worth a shot.
