### PR TITLE
Revert "Use newer container-based builders in Travis and test JDK8 too"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: scala
-sudo: false
 
 scala:
   - 2.10.5
@@ -10,7 +9,6 @@ services:
 
 jdk:
   - oraclejdk7
-  - oraclejdk8
 
 # These directories are cached to S3 at the end of the build
 cache:


### PR DESCRIPTION
This reverts commit 88a800dd10e7cf82216956481c8223acb5d47752.

Rationale is that the build is too hosed and the rationale for using the newer containers is speed. Once we get anything passing, we can look at the optimization of using container builds. In the mean time, it is arduous and time consuming to troubleshoot this.
