### PR TITLE
Major refactor of Project.scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,2 @@
+defaultSettings
+Unidoc.settings

--- a/doc/build.sbt
+++ b/doc/build.sbt
@@ -1,0 +1,29 @@
+import Tests._
+import com.typesafe.sbt.site.SphinxSupport.Sphinx
+
+defaultSettings
+Project.defaultSettings
+site.settings
+site.sphinxSupport()
+
+scalacOptions in doc <++= (version).map(v => Seq("-doc-title", "Zipkin", "-doc-version", v))
+
+includeFilter in Sphinx := ("*.html" | "*.jpg" | "*.png" | "*.svg" | "*.js" | "*.css" | "*.gif" | "*.txt")
+
+// A dummy partitioning scheme for tests
+def partitionTests(tests: Seq[TestDefinition]) = {
+  Seq(new Group("inProcess", tests, InProcess))
+}
+// Workaround for sbt bug: Without a testGrouping for all test configs,
+// the wrong tests are run
+testGrouping <<= definedTests in Test map partitionTests
+testGrouping in DocTest <<= definedTests in DocTest map partitionTests
+
+/* Test Configuration for running tests on doc sources */
+lazy val DocTest = config("doctest") extend(Test)
+configs(DocTest)
+inConfig(DocTest)(Defaults.testSettings)
+unmanagedSourceDirectories in DocTest <+= baseDirectory { _ / "src/sphinx/code" }
+//resourceDirectory in DocTest <<= baseDirectory { _ / "src/test/resources" }
+// Make the "test" command run both, test and doctest:test
+test <<= Seq(test in Test, test in DocTest).dependOn

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -16,17 +16,22 @@
  */
 import com.twitter.sbt.{BuildProperties,PackageDist,GitProject}
 import sbt._
-import com.twitter.scrooge.ScroogeSBT
-import sbt.Keys._
 import Keys._
-import Tests._
-import sbtassembly.Plugin._
-import AssemblyKeys._
-import com.typesafe.sbt.SbtSite.site
-import com.typesafe.sbt.site.SphinxSupport.Sphinx
 
 object Zipkin extends Build {
   val zipkinVersion = "1.2.0-SNAPSHOT"
+
+  ///////////////////////
+  // Build environment //
+  ///////////////////////
+
+  val proxyRepo = Option(System.getenv("SBT_PROXY_REPO"))
+  val travisCi = Option(System.getenv("SBT_TRAVIS_CI")) // for adding travis ci maven repos before others
+  val cwd = System.getProperty("user.dir")
+
+  ////////////////////////////////
+  // Commonly used dependencies //
+  ////////////////////////////////
 
   def finagle(name: String) = "com.twitter" %% ("finagle-" + name) % "6.26.0"
   def util(name: String) = "com.twitter" %% ("util-" + name) % "6.25.0"
@@ -37,6 +42,7 @@ object Zipkin extends Build {
   def hadoop(name: String) = "org.apache.hadoop" % ("hadoop-" + name) % "2.4.0"
   def hadoopTest(name: String) = hadoop(name) classifier("tests") classifier("")
 
+  // Instead of Seq(util("foo"), util("bar"), ...) we can now write many(util, "foo", "bar", ...)
   def many(gen: (String => ModuleID), names: String*) = names map gen
 
   val twitterZookeeperVersions = Map(
@@ -51,11 +57,6 @@ object Zipkin extends Build {
   val junit = "junit" % "junit" % "4.12" % "test"
   val slf4jLog4j12 = "org.slf4j" % "slf4j-log4j12" % "1.6.4" % "runtime"
   val ostrich = "com.twitter" %% "ostrich" % "9.9.0"
-
-  val proxyRepo = Option(System.getenv("SBT_PROXY_REPO"))
-  val travisCi = Option(System.getenv("SBT_TRAVIS_CI")) // for adding travis ci maven repos before others
-  val cwd = System.getProperty("user.dir")
-
 
   lazy val scalaTestDeps = Seq(
     "org.scalatest" %% "scalatest" % "2.2.4" % "test",
@@ -75,6 +76,10 @@ object Zipkin extends Build {
     },
     junit
   )
+
+  /////////////////////
+  // Common settings //
+  /////////////////////
 
   def zipkinSettings = Seq(
     organization := "com.twitter",
@@ -112,450 +117,123 @@ object Zipkin extends Build {
     ZipkinResolver.newSettings
   ).flatten
 
-  // Database drivers
-  val anormDriverDependencies = Map(
-    "sqlite-memory"     -> "org.xerial"     % "sqlite-jdbc"          % "3.7.2",
-    "sqlite-persistent" -> "org.xerial"     % "sqlite-jdbc"          % "3.7.2",
-    "h2-memory"         -> "com.h2database" % "h2"                   % "1.3.172",
-    "h2-persistent"     -> "com.h2database" % "h2"                   % "1.3.172",
-    "postgresql"        -> "postgresql"     % "postgresql"           % "8.4-702.jdbc4", // or "9.1-901.jdbc4",
-    "mysql"             -> "mysql"          % "mysql-connector-java" % "5.1.25"
+  ///////////////////////////
+  // Misc helper functions //
+  ///////////////////////////
+
+  def resolversIfNoProxyRepo(resolvers: sbt.Resolver*) =
+    if (proxyRepo.isEmpty) Seq.empty else resolvers
+
+  def subproject(name: String, deps: ClasspathDep[ProjectReference]*) = {
+    val id = "zipkin-" + name
+    Project(
+      id = id,
+      base = file(id)
+    ).dependsOn(deps:_*)
+  }
+
+  def addConfigsToResourcePathForConfigSpec() =
+    unmanagedResourceDirectories in Test <<= baseDirectory {
+      base =>
+        (base / "config" +++ base / "src" / "test" / "resources").get
+    }
+
+  ///////////////////////////////////////////////////////////////////////////////////////////
+  // Projects with outputs that are useful on their own: documentation, examples, services //
+  ///////////////////////////////////////////////////////////////////////////////////////////
+  // These are usually the projects you want to `sbt package`
+
+  // The Project
+  lazy val zipkin = project.in(file(".")) aggregate(
+    tracegen, common, scrooge, zookeeper,
+    query, queryCore, queryService, web, zipkinAggregate,
+    collectorScribe, collectorCore, collectorService,
+    sampler, receiverScribe, receiverKafka, collector,
+    cassandra, anormDB, kafka, redis, hbase, mongodb
+    )
+
+
+  lazy val zipkinDoc = Project(
+    id = "zipkin-doc",
+    base = file("doc"))//.dependsOn(finagleCore, finagleHttp)
+
+  lazy val example = subproject(
+      "example",
+      tracegen, web, anormDB, query,
+      receiverScribe, zookeeper
+    )
+
+  lazy val redisExample = subproject(
+    "redis-example",
+    web, redis, query,
+    receiverScribe, zookeeper
   )
 
-  lazy val zipkin =
-    Project(
-      id = "zipkin",
-      base = file("."),
-      settings = Project.defaultSettings ++
-        defaultSettings ++
-        Unidoc.settings
-    ) aggregate(
-      tracegen, common, scrooge, zookeeper,
-      query, queryCore, queryService, web, zipkinAggregate,
-      collectorScribe, collectorCore, collectorService,
-      sampler, receiverScribe, receiverKafka, collector,
-      cassandra, anormDB, kafka, redis, hbase, mongodb
-    )
+  lazy val collectorService = subproject(
+    "collector-service",
+    collectorCore, collectorScribe, receiverKafka,
+    cassandra, kafka, redis, anormDB, hbase, mongodb)
 
-  lazy val tracegen = Project(
-    id = "zipkin-tracegen",
-    base = file("zipkin-tracegen"),
-    settings = defaultSettings
-  ).dependsOn(queryService, collectorService)
+  lazy val queryService = subproject(
+    "query-service",
+    queryCore, cassandra, redis, anormDB, hbase, mongodb)
 
-  lazy val common =
-    Project(
-      id = "zipkin-common",
-      base = file("zipkin-common"),
-      settings = defaultSettings
-    ).settings(
-      libraryDependencies ++= Seq(
-        util("core"),
-        zk("client"),
-        algebird("core"),
-        ostrich
-      ) ++ scalaTestDeps
-        ++ many(finagle, "ostrich4", "thrift", "zipkin", "exception")
-    )
+  lazy val web = subproject("web", common, scrooge)
 
-  lazy val thriftidl =
-    Project(
-      id = "zipkin-thrift",
-      base = file("zipkin-thrift"),
-      settings = defaultSettings
-    ).settings(
-      // this is a hack to get -idl artifacts for thrift.  Better would be to
-      // define a whole new artifact that gets included in the scrooge publish task
-      (artifactClassifier in packageSrc) := Some("idl")
-    )
+  lazy val zipkinAggregate = subproject("aggregate", cassandra, common)
 
-  lazy val sampler =
-    Project(
-      id = "zipkin-sampler",
-      base = file("zipkin-sampler"),
-      settings = defaultSettings
-    ).settings(
-      libraryDependencies ++= many(finagle, "core", "http")
-          ++ many(util, "core", "zk")
-          ++ scalaTestDeps
+  /////////////////////////////////////
+  // Collector, and Collector inputs //
+  /////////////////////////////////////
 
-    ).dependsOn(common, zookeeper)
+  lazy val collector = subproject("collector", common, scrooge)
+  lazy val collectorCore = subproject("collector-core", common, scrooge)
+  lazy val collectorScribe = subproject("collector-scribe", collectorCore, scrooge)
 
-  lazy val scrooge =
-    Project(
-      id = "zipkin-scrooge",
-      base = file("zipkin-scrooge"),
-      settings = defaultSettings ++ ScroogeSBT.newSettings
-    ).settings(
-        ScroogeSBT.scroogeThriftSourceFolder in Compile <<= (baseDirectory in ThisBuild)
-          (_ / "zipkin-thrift" / "src" / "main" / "thrift" / "com" / "twitter" / "zipkin" ),
-        libraryDependencies ++= Seq(
-            util("core"),
-            algebird("core"),
-            ostrich
-        ) ++ many(finagle, "ostrich4", "thrift", "zipkin")
-          ++ many(scroogeDep, "core", "serializer")
-          ++ scalaTestDeps
-    ).dependsOn(common)
+  ///////////////
+  // Receivers //
+  ///////////////
 
-  lazy val zookeeper = Project(
-    id = "zipkin-zookeeper",
-    base = file("zipkin-zookeeper"),
-    settings = defaultSettings
-  ).settings(
-    libraryDependencies ++= Seq(finagle("core"))
-      ++ many(util, "core", "zk")
-      ++ many(zk, "candidate", "group")
-  )
+  lazy val receiverScribe = subproject("receiver-scribe", collector, zookeeper, scrooge)
+  lazy val receiverKafka = subproject("receiver-kafka", common, collector, zookeeper, scrooge)
 
-  lazy val collectorCore = Project(
-    id = "zipkin-collector-core",
-    base = file("zipkin-collector-core"),
-    settings = defaultSettings
-  ).settings(
-    libraryDependencies ++= Seq(
-      algebird("core"),
-      twitterServer,
-      ostrich
-    ) ++ many(finagle, "ostrich4", "serversets", "thrift", "zipkin")
-      ++ many(util, "core", "zk", "zk-common")
-      ++ many(zk, "candidate", "group")
-      ++ testDependencies
-  ).dependsOn(common, scrooge)
+  /////////////////
+  // Query logic //
+  /////////////////
 
-  lazy val cassandra = Project(
-    id = "zipkin-cassandra",
-    base = file("zipkin-cassandra"),
-    settings = defaultSettings
-  ).settings(
-    libraryDependencies ++= Seq(
-      "commons-codec" % "commons-codec" % "1.6",
-      finagle("serversets"),
-      scroogeDep("serializer"),
-      "org.iq80.snappy" % "snappy" % "0.1",
-      "org.mockito" % "mockito-all" % "1.9.5" % "test",
-      "com.twitter" %% "scalding-core" % "0.11.2",
-      hadoop("client")
-    ) ++ many(util, "logging", "app")
-      ++ testDependencies ++ scalaTestDeps,
+  lazy val query = subproject("query", common, scrooge)
+  lazy val queryCore = subproject("query-core", common, query, scrooge)
 
-    /* Add configs to resource path for ConfigSpec */
-    unmanagedResourceDirectories in Test <<= baseDirectory {
-      base =>
-        (base / "config" +++ base / "src" / "test" / "resources").get
-    }
-  ).dependsOn(scrooge)
+  /////////////////////////////////////////////////////
+  // Libraries wrapping clients to external services //
+  /////////////////////////////////////////////////////
 
-  lazy val anormDB = Project(
-    id = "zipkin-anormdb",
-    base = file("zipkin-anormdb"),
-    settings = defaultSettings
-  ).settings(
-    libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "anorm" % "2.3.7",
-      "com.zaxxer" % "HikariCP-java6" % "2.3.8",
-      anormDriverDependencies("sqlite-persistent")
-    ) ++ testDependencies ++ scalaTestDeps,
-
-    /* Add configs to resource path for ConfigSpec */
-    unmanagedResourceDirectories in Test <<= baseDirectory {
-      base =>
-        (base / "config" +++ base / "src" / "test" / "resources").get
-    }
-  ).dependsOn(common, scrooge)
-
-  lazy val query =
-    Project(
-      id = "zipkin-query",
-      base = file("zipkin-query"),
-      settings = defaultSettings
-    ).settings(
-      libraryDependencies ++= many(finagle, "thriftmux", "zipkin")
-        ++ many(util, "app", "core")
-        ++ scalaTestDeps
-    ).dependsOn(common, scrooge)
-
-  lazy val queryCore =
-    Project(
-      id = "zipkin-query-core",
-      base = file("zipkin-query-core"),
-      settings = defaultSettings
-    ).settings(
-      libraryDependencies ++= Seq(
-        algebird("core"),
-        ostrich
-      ) ++ many(finagle, "ostrich4", "serversets", "thrift", "zipkin")
-        ++ many(util, "core", "zk", "zk-common")
-        ++ many(zk, "candidate", "group")
-        ++ testDependencies
-    ).dependsOn(common, query, scrooge)
-
-  lazy val queryService = Project(
-    id = "zipkin-query-service",
-    base = file("zipkin-query-service"),
-    settings = defaultSettings
-  ).settings(
-    libraryDependencies ++= testDependencies,
-
-    PackageDist.packageDistZipName := "zipkin-query-service.zip",
-    BuildProperties.buildPropertiesPackage := "com.twitter.zipkin",
-    resourceGenerators in Compile <+= BuildProperties.buildPropertiesWrite,
-
-    /* Add configs to resource path for ConfigSpec */
-    unmanagedResourceDirectories in Test <<= baseDirectory {
-      base =>
-        (base / "config" +++ base / "src" / "test" / "resources").get
-    }
-  ).dependsOn(queryCore, cassandra, redis, anormDB, hbase, mongodb)
-
-  lazy val collectorScribe =
-    Project(
-      id = "zipkin-collector-scribe",
-      base = file("zipkin-collector-scribe"),
-      settings = defaultSettings
-    ).settings(
-      libraryDependencies ++= Seq(
-        scroogeDep("serializer")
-      ) ++ testDependencies
-    ).dependsOn(collectorCore, scrooge)
-
-  lazy val collector = Project(
-    id = "zipkin-collector",
-    base = file("zipkin-collector"),
-    settings = defaultSettings
-  ).settings(
-    libraryDependencies ++= Seq(
-      finagle("core"),
-      util("core"),
-      twitterServer
-    ) ++ scalaTestDeps
-  ).dependsOn(common, scrooge)
-
-  lazy val receiverScribe =
-    Project(
-      id = "zipkin-receiver-scribe",
-      base = file("zipkin-receiver-scribe"),
-      settings = defaultSettings
-    ).settings(
-      libraryDependencies ++= Seq(
-        finagle("thriftmux"),
-        util("zk"),
-        slf4jLog4j12
-      ) ++ scalaTestDeps
-    ).dependsOn(collector, zookeeper, scrooge)
-
-  lazy val receiverKafka =
-    Project(
-      id = "zipkin-receiver-kafka",
-      base = file("zipkin-receiver-kafka"),
-      settings = defaultSettings
-    ).settings(
-      libraryDependencies ++= Seq(
-        twitterServer,
-        "org.apache.kafka" %% "kafka" % "0.8.1.1",
-        "org.apache.commons" % "commons-io" % "1.3.2",
-        scroogeDep("serializer")
-      ) ++ scalaTestDeps
-    ).dependsOn(common, collector, zookeeper, scrooge)
-
-  lazy val kafka =
-    Project(
-      id = "zipkin-kafka",
-      base = file("zipkin-kafka"),
-      settings = defaultSettings
-    ).settings(
-      libraryDependencies ++= Seq(
-        "com.twitter" %% "tormenta-kafka" % "0.8.0",
-        scroogeDep("serializer")
-      ) ++ testDependencies,
-      resolvers ++= (proxyRepo match {
-        case None => Seq(
-          "clojars" at "http://clojars.org/repo")
-        case Some(pr) => Seq() // if proxy is set we assume that it has the artifacts we would get from the above repo
-      })
-    ).dependsOn(collectorCore, scrooge)
-
-  lazy val collectorService = Project(
-    id = "zipkin-collector-service",
-    base = file("zipkin-collector-service"),
-    settings = defaultSettings
-  ).settings(
-    libraryDependencies ++= testDependencies,
-
-    PackageDist.packageDistZipName := "zipkin-collector-service.zip",
-    BuildProperties.buildPropertiesPackage := "com.twitter.zipkin",
-    resourceGenerators in Compile <+= BuildProperties.buildPropertiesWrite,
-
-    /* Add configs to resource path for ConfigSpec */
-    unmanagedResourceDirectories in Test <<= baseDirectory {
-      base =>
-        (base / "config" +++ base / "src" / "test" / "resources").get
-    }
-  ).dependsOn(collectorCore, collectorScribe, receiverKafka, cassandra, kafka, redis, anormDB, hbase, mongodb)
-
-  lazy val zipkinAggregate =
-    Project(
-      id = "zipkin-aggregate",
-      base = file("zipkin-aggregate"),
-      settings = defaultSettings ++ assemblySettings
-    ).settings(
-      mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
-        {
-          case PathList("org", xs @ _*) => MergeStrategy.first
-          case PathList("com", xs @ _*) => MergeStrategy.first
-          case "BUILD" => MergeStrategy.first
-          case PathList(ps @_*) if ps.last == "package-info.class" => MergeStrategy.discard
-          case x => old(x)
-        }
-      },
-      BuildProperties.buildPropertiesPackage := "com.twitter.zipkin",
-      resourceGenerators in Compile <+= BuildProperties.buildPropertiesWrite
-  ).dependsOn(cassandra, common)
-
-
-
-  lazy val web =
-    Project(
-      id = "zipkin-web",
-      base = file("zipkin-web"),
-      settings = defaultSettings
-    ).settings(
-      libraryDependencies ++= Seq(
-        zk("server-set"),
-        algebird("core"),
-        twitterServer,
-        "com.github.spullara.mustache.java" % "compiler" % "0.8.13",
-        "com.twitter.common" % "stats-util" % "0.0.42"
-      ) ++ many(finagle, "exception", "thriftmux", "serversets", "zipkin")
-        ++ scalaTestDeps,
-
-      PackageDist.packageDistZipName := "zipkin-web.zip",
-      BuildProperties.buildPropertiesPackage := "com.twitter.zipkin",
-      resourceGenerators in Compile <+= BuildProperties.buildPropertiesWrite,
-
-      /* Add configs to resource path for ConfigSpec */
-      unmanagedResourceDirectories in Test <<= baseDirectory {
-        base =>
-          (base / "config" +++ base / "src" / "test" / "resources").get
-      }
-  ).dependsOn(common, scrooge)
-
-  lazy val redis = Project(
-    id = "zipkin-redis",
-    base = file("zipkin-redis"),
-    settings = defaultSettings
-  ).settings(
-    parallelExecution in Test := false,
-    libraryDependencies ++= Seq(
-      finagle("redis"),
-      util("logging"),
-      scroogeDep("serializer"),
-      slf4jLog4j12
-    ) ++ testDependencies ++ scalaTestDeps,
-
-    /* Add configs to resource path for ConfigSpec */
-    unmanagedResourceDirectories in Test <<= baseDirectory {
-      base =>
-        (base / "config" +++ base / "src" / "test" / "resources").get
-    }
-  ).dependsOn(common, scrooge)
+  lazy val zookeeper = subproject("zookeeper")
+  lazy val cassandra = subproject("cassandra", scrooge)
+  lazy val anormDB = subproject("anormdb", common, scrooge)
+  lazy val kafka = subproject("kafka", collectorCore, scrooge)
+  lazy val redis = subproject("redis", common, scrooge)
+  lazy val mongodb = subproject("mongodb", common, scrooge)
 
   lazy val hbaseTestGuavaHack = Project(
     id = "zipkin-hbase-test-guava-hack",
     base = file("zipkin-hbase/src/test/guava-hack"),
     settings = defaultSettings
   )
-  lazy val hbase = Project(
-    id = "zipkin-hbase",
-    base = file("zipkin-hbase"),
-    settings = defaultSettings
-  ).settings(
-    parallelExecution in Test := false,
-    libraryDependencies ++= Seq(
-      hadoop("common"),
-      "com.google.guava"      % "guava"                             % "11.0.2" % "test", //Hadoop needs a deprecated class
-      "com.google.guava"      % "guava-io"                          % "r03" % "test", //Hadoop needs a deprecated class
-      "com.google.protobuf"   % "protobuf-java"                     % "2.4.1",
-      "commons-logging"       % "commons-logging"                   % "1.1.1",
-      "commons-configuration" % "commons-configuration"             % "1.6",
-      "org.apache.zookeeper"  % "zookeeper"                         % "3.4.6" % "runtime" notTransitive(),
-      slf4jLog4j12,
-      util("logging"),
-      scroogeDep("serializer")
-    ) ++ many(hbaseDep, "", "common", "client")
-      ++ many(hbaseTest, "common", "client", "server", "hadoop-compat", "hadoop2-compat")
-      ++ many(hadoopTest, "mapreduce-client-jobclient", "common", "hdfs" )
-      ++ testDependencies ++ scalaTestDeps,
+  lazy val hbase = subproject("hbase", scrooge, hbaseTestGuavaHack % "test->compile")
 
-    resolvers ~= {rs => Seq(DefaultMavenRepository) ++ rs},
+  ////////////
+  // Thrift //
+  ////////////
 
-    /* Add configs to resource path for ConfigSpec */
-    unmanagedResourceDirectories in Test <<= baseDirectory {
-      base =>
-        (base / "config" +++ base / "src" / "test" / "resources").get
-    }
-  ).dependsOn(scrooge, hbaseTestGuavaHack % "test->compile")
+  lazy val thriftidl = subproject("thrift")
+  lazy val scrooge = subproject("scrooge", common)
 
-  lazy val mongodb = Project(
-    id = "zipkin-mongodb",
-    base = file("zipkin-mongodb"),
-    settings = defaultSettings
-  ).settings(
-    parallelExecution in Test := false,
-    libraryDependencies ++= Seq(
-      "org.mongodb" %% "casbah"        % "2.8.1",
-      slf4jLog4j12,
-      util("logging")
-    ) ++ testDependencies ++ scalaTestDeps
-  ).dependsOn(common, scrooge)
+  //////////
+  // Misc //
+  //////////
 
-  lazy val example = Project(
-    id = "zipkin-example",
-    base = file("zipkin-example"),
-    settings = defaultSettings
-  ).settings(
-    libraryDependencies ++= Seq(twitterServer) ++ many(finagle, "zipkin", "stats")
-  ).dependsOn(
-    tracegen, web, anormDB, query,
-    receiverScribe, zookeeper
-  )
-
-  lazy val redisExample = Project(
-    id = "zipkin-redis-example",
-    base = file("zipkin-redis-example"),
-    settings = defaultSettings
-  ).settings(
-      libraryDependencies ++= Seq(twitterServer) ++ many(finagle, "zipkin", "stats")
-    ).dependsOn(
-      web, redis, query,
-      receiverScribe, zookeeper
-    )
-
-  lazy val zipkinDoc = Project(
-    id = "zipkin-doc",
-    base = file("doc"),
-    settings = Project.defaultSettings ++ site.settings ++ site.sphinxSupport() ++ defaultSettings ++ Seq(
-      scalacOptions in doc <++= (version).map(v => Seq("-doc-title", "Zipkin", "-doc-version", v)),
-      includeFilter in Sphinx := ("*.html" | "*.jpg" | "*.png" | "*.svg" | "*.js" | "*.css" | "*.gif" | "*.txt"),
-
-      // Workaround for sbt bug: Without a testGrouping for all test configs,
-      // the wrong tests are run
-      testGrouping <<= definedTests in Test map partitionTests,
-      testGrouping in DocTest <<= definedTests in DocTest map partitionTests
-
-    )).configs(DocTest).settings(inConfig(DocTest)(Defaults.testSettings): _*).settings(
-      unmanagedSourceDirectories in DocTest <+= baseDirectory { _ / "src/sphinx/code" },
-      //resourceDirectory in DocTest <<= baseDirectory { _ / "src/test/resources" }
-
-      // Make the "test" command run both, test and doctest:test
-      test <<= Seq(test in Test, test in DocTest).dependOn
-    )//.dependsOn(finagleCore, finagleHttp)
-
-  /* Test Configuration for running tests on doc sources */
-  lazy val DocTest = config("doctest") extend(Test)
-
-  // A dummy partitioning scheme for tests
-  def partitionTests(tests: Seq[TestDefinition]) = {
-    Seq(new Group("inProcess", tests, InProcess))
-  }
+  lazy val tracegen = subproject("tracegen", queryService, collectorService)
+  lazy val common = subproject("common")
+  lazy val sampler = subproject("sampler", common, zookeeper)
 }

--- a/zipkin-aggregate/build.sbt
+++ b/zipkin-aggregate/build.sbt
@@ -1,0 +1,18 @@
+import AssemblyKeys._
+import com.twitter.sbt._
+
+defaultSettings ++ assemblySettings
+
+mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
+  {
+    case PathList("org", xs @ _*) => MergeStrategy.first
+    case PathList("com", xs @ _*) => MergeStrategy.first
+    case "BUILD" => MergeStrategy.first
+    case PathList(ps @_*) if ps.last == "package-info.class" => MergeStrategy.discard
+    case x => old(x)
+  }
+}
+
+BuildProperties.buildPropertiesPackage := "com.twitter.zipkin"
+
+resourceGenerators in Compile <+= BuildProperties.buildPropertiesWrite

--- a/zipkin-anormdb/build.sbt
+++ b/zipkin-anormdb/build.sbt
@@ -1,0 +1,24 @@
+// Change this to one of the keys in anormDriverDependencies
+// to use another database engine
+val dbEngine =  "sqlite-persistent"
+
+defaultSettings
+
+// Database drivers
+val anormDriverDependencies = Map(
+  "sqlite-memory"     -> "org.xerial"     % "sqlite-jdbc"          % "3.7.2",
+  "sqlite-persistent" -> "org.xerial"     % "sqlite-jdbc"          % "3.7.2",
+  "h2-memory"         -> "com.h2database" % "h2"                   % "1.3.172",
+  "h2-persistent"     -> "com.h2database" % "h2"                   % "1.3.172",
+  "postgresql"        -> "postgresql"     % "postgresql"           % "8.4-702.jdbc4", // or "9.1-901.jdbc4",
+  "mysql"             -> "mysql"          % "mysql-connector-java" % "5.1.25"
+)
+
+libraryDependencies ++= Seq(
+  "com.typesafe.play" %% "anorm" % "2.3.7",
+  "com.zaxxer" % "HikariCP-java6" % "2.3.8",
+  anormDriverDependencies(dbEngine)
+) ++ testDependencies ++ scalaTestDeps
+
+addConfigsToResourcePathForConfigSpec()
+

--- a/zipkin-cassandra/build.sbt
+++ b/zipkin-cassandra/build.sbt
@@ -1,0 +1,14 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  "commons-codec" % "commons-codec" % "1.6",
+  finagle("serversets"),
+  scroogeDep("serializer"),
+  "org.iq80.snappy" % "snappy" % "0.1",
+  "org.mockito" % "mockito-all" % "1.9.5" % "test",
+  "com.twitter" %% "scalding-core" % "0.11.2",
+  hadoop("client")
+) ++ many(util, "logging", "app") ++ testDependencies ++ scalaTestDeps
+
+addConfigsToResourcePathForConfigSpec()
+

--- a/zipkin-collector-core/build.sbt
+++ b/zipkin-collector-core/build.sbt
@@ -1,0 +1,9 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  Seq(algebird("core"), twitterServer, ostrich),
+  many(finagle, "ostrich4", "serversets", "thrift", "zipkin"),
+  many(util, "core", "zk", "zk-common"),
+  many(zk, "candidate", "group"),
+  testDependencies
+).flatten

--- a/zipkin-collector-scribe/build.sbt
+++ b/zipkin-collector-scribe/build.sbt
@@ -1,0 +1,3 @@
+defaultSettings
+
+libraryDependencies ++= Seq(scroogeDep("serializer")) ++ testDependencies

--- a/zipkin-collector-service/build.sbt
+++ b/zipkin-collector-service/build.sbt
@@ -1,0 +1,12 @@
+import com.twitter.sbt._
+
+defaultSettings
+
+libraryDependencies ++= testDependencies
+
+PackageDist.packageDistZipName := "zipkin-collector-service.zip"
+BuildProperties.buildPropertiesPackage := "com.twitter.zipkin"
+resourceGenerators in Compile <+= BuildProperties.buildPropertiesWrite
+
+addConfigsToResourcePathForConfigSpec()
+

--- a/zipkin-collector/build.sbt
+++ b/zipkin-collector/build.sbt
@@ -1,0 +1,7 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  finagle("core"),
+  util("core"),
+  twitterServer
+) ++ scalaTestDeps

--- a/zipkin-common/build.sbt
+++ b/zipkin-common/build.sbt
@@ -1,0 +1,8 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  Seq(util("core"), zk("client"), algebird("core"), ostrich),
+  many(finagle, "ostrich4", "thrift", "zipkin", "exception"),
+  scalaTestDeps
+).flatten
+

--- a/zipkin-example/build.sbt
+++ b/zipkin-example/build.sbt
@@ -1,0 +1,3 @@
+defaultSettings
+
+libraryDependencies ++= Seq(twitterServer) ++ many(finagle, "zipkin", "stats")

--- a/zipkin-hbase/build.sbt
+++ b/zipkin-hbase/build.sbt
@@ -1,0 +1,27 @@
+defaultSettings
+
+parallelExecution in Test := false
+
+libraryDependencies ++= Seq(
+  Seq(
+    hadoop("common"),
+    "com.google.guava"      % "guava"                 % "11.0.2" % "test", //Hadoop needs a deprecated class
+    "com.google.guava"      % "guava-io"              % "r03" % "test", //Hadoop needs a deprecated class
+    "com.google.protobuf"   % "protobuf-java"         % "2.4.1",
+    "commons-logging"       % "commons-logging"       % "1.1.1",
+    "commons-configuration" % "commons-configuration" % "1.6",
+    "org.apache.zookeeper"  % "zookeeper"             % "3.4.6" % "runtime" notTransitive(),
+    slf4jLog4j12,
+    util("logging"),
+    scroogeDep("serializer")
+  ),
+  many(hbaseDep, "", "common", "client"),
+  many(hbaseTest, "common", "client", "server", "hadoop-compat", "hadoop2-compat"),
+  many(hadoopTest, "mapreduce-client-jobclient", "common", "hdfs" ),
+  testDependencies, scalaTestDeps
+).flatten
+
+resolvers ~= {rs => Seq(DefaultMavenRepository) ++ rs}
+
+addConfigsToResourcePathForConfigSpec()
+

--- a/zipkin-kafka/build.sbt
+++ b/zipkin-kafka/build.sbt
@@ -1,0 +1,9 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  "com.twitter" %% "tormenta-kafka" % "0.8.0",
+  scroogeDep("serializer")
+) ++ testDependencies
+
+resolvers ++= resolversIfNoProxyRepo("clojars" at "http://clojars.org/repo")
+

--- a/zipkin-mongodb/build.sbt
+++ b/zipkin-mongodb/build.sbt
@@ -1,0 +1,9 @@
+defaultSettings
+
+parallelExecution in Test := false
+
+libraryDependencies ++= Seq(
+  "org.mongodb" %% "casbah" % "2.8.1",
+  slf4jLog4j12,
+  util("logging")
+) ++ testDependencies ++ scalaTestDeps

--- a/zipkin-query-core/build.sbt
+++ b/zipkin-query-core/build.sbt
@@ -1,0 +1,9 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  Seq(algebird("core"), ostrich),
+  many(finagle, "ostrich4", "serversets", "thrift", "zipkin"),
+  many(util, "core", "zk", "zk-common"),
+  many(zk, "candidate", "group"),
+  testDependencies
+).flatten

--- a/zipkin-query-service/build.sbt
+++ b/zipkin-query-service/build.sbt
@@ -1,0 +1,12 @@
+import com.twitter.sbt._
+
+defaultSettings
+
+libraryDependencies ++= testDependencies
+
+PackageDist.packageDistZipName := "zipkin-query-service.zip"
+BuildProperties.buildPropertiesPackage := "com.twitter.zipkin"
+resourceGenerators in Compile <+= BuildProperties.buildPropertiesWrite
+
+addConfigsToResourcePathForConfigSpec()
+

--- a/zipkin-query/build.sbt
+++ b/zipkin-query/build.sbt
@@ -1,0 +1,7 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  many(finagle, "thriftmux", "zipkin"),
+  many(util, "app", "core"),
+  scalaTestDeps
+).flatten

--- a/zipkin-receiver-kafka/build.sbt
+++ b/zipkin-receiver-kafka/build.sbt
@@ -1,0 +1,8 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  twitterServer,
+  "org.apache.kafka" %% "kafka" % "0.8.1.1",
+  "org.apache.commons" % "commons-io" % "1.3.2",
+  scroogeDep("serializer")
+) ++ scalaTestDeps

--- a/zipkin-receiver-scribe/build.sbt
+++ b/zipkin-receiver-scribe/build.sbt
@@ -1,0 +1,7 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  finagle("thriftmux"),
+  util("zk"),
+  slf4jLog4j12
+) ++ scalaTestDeps

--- a/zipkin-redis-example/build.sbt
+++ b/zipkin-redis-example/build.sbt
@@ -1,0 +1,3 @@
+defaultSettings
+
+libraryDependencies ++= Seq(twitterServer) ++ many(finagle, "zipkin", "stats")

--- a/zipkin-redis/build.sbt
+++ b/zipkin-redis/build.sbt
@@ -1,0 +1,12 @@
+defaultSettings
+
+parallelExecution in Test := false
+
+libraryDependencies ++= Seq(
+  finagle("redis"),
+  util("logging"),
+  scroogeDep("serializer"),
+  slf4jLog4j12
+) ++ testDependencies ++ scalaTestDeps
+
+addConfigsToResourcePathForConfigSpec()

--- a/zipkin-sampler/build.sbt
+++ b/zipkin-sampler/build.sbt
@@ -1,0 +1,7 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  many(finagle, "core", "http"),
+  many(util, "core", "zk"),
+  scalaTestDeps
+).flatten

--- a/zipkin-scrooge/build.sbt
+++ b/zipkin-scrooge/build.sbt
@@ -1,0 +1,15 @@
+import com.twitter.scrooge.ScroogeSBT
+
+defaultSettings ++ ScroogeSBT.newSettings
+
+ScroogeSBT.scroogeThriftSourceFolder in Compile <<= (
+  (baseDirectory in ThisBuild)
+  (_ / "zipkin-thrift" / "src" / "main" / "thrift" / "com" / "twitter" / "zipkin" )
+)
+
+libraryDependencies ++= Seq(
+  Seq(util("core"), algebird("core"), ostrich),
+  many(finagle, "ostrich4", "thrift", "zipkin"),
+  many(scroogeDep, "core", "serializer"),
+  scalaTestDeps
+).flatten

--- a/zipkin-thrift/build.sbt
+++ b/zipkin-thrift/build.sbt
@@ -1,0 +1,5 @@
+defaultSettings
+
+// this is a hack to get -idl artifacts for thrift.  Better would be to
+// define a whole new artifact that gets included in the scrooge publish task
+(artifactClassifier in packageSrc) := Some("idl")

--- a/zipkin-tracegen/build.sbt
+++ b/zipkin-tracegen/build.sbt
@@ -1,0 +1,1 @@
+defaultSettings

--- a/zipkin-web/build.sbt
+++ b/zipkin-web/build.sbt
@@ -1,0 +1,21 @@
+import com.twitter.sbt._
+
+defaultSettings
+
+libraryDependencies ++= Seq(
+  Seq(
+    zk("server-set"),
+    algebird("core"),
+    twitterServer,
+    "com.github.spullara.mustache.java" % "compiler" % "0.8.13",
+    "com.twitter.common" % "stats-util" % "0.0.42"
+  ),
+  many(finagle, "exception", "thriftmux", "serversets", "zipkin"),
+  scalaTestDeps
+).flatten
+
+PackageDist.packageDistZipName := "zipkin-web.zip"
+BuildProperties.buildPropertiesPackage := "com.twitter.zipkin"
+resourceGenerators in Compile <+= BuildProperties.buildPropertiesWrite
+
+addConfigsToResourcePathForConfigSpec()

--- a/zipkin-zookeeper/build.sbt
+++ b/zipkin-zookeeper/build.sbt
@@ -1,0 +1,7 @@
+defaultSettings
+
+libraryDependencies ++= Seq(
+  Seq(finagle("core")),
+  many(util, "core", "zk"),
+   many(zk, "candidate", "group")
+).flatten


### PR DESCRIPTION
**Note**: this depends on #475 
### What, why

`Project.scala` was over 600 lines of boilerplate-heavy, hard-to-read code. This PR aims to improve the situation by moving what can be moved to `build.sbt` files under each project, and leaving clean, readable, DRY glue-code in `Project.scala`.
### Result

To my eyes, `Project.scala` is now much easier to read. Common code, dependencies and settings are collected and clearly separated from project definitions. The project declarations and the definition of inter-project dependencies are now clearly separated from the configuration of individual projects. The longest `build.sbt` is 29 lines of code, making the build configuration of each project quite approachable and easy to grasp, modify.

I expect this change to make the maintenance of the SBT-based build system much easier, and also to vastly simplify any attempts around migrating to Gradle.
### Testing

To test the changes, I ran `clean`, `compile` and `package` (where applicable) for each project, and compared the log before and after the changes. Also did a full `sbt test` in the end. All this may still mean that some things are broken by the refactor. I'm specifically unclear on how to test, and so unsure of the correctness, of:
- `addConfigsToResourcePathForConfigSpec`, wrt/ evaluation time (I expect it's re-evaluated in the context of each specific project)
- the `DocTest` configuration in the `doc/build.sbt`

I'd highly appreciate a close look at these specifically, and of course at the whole change generally. I did everything that came to mind around testing what I broke, but you know the saying about the number of bugs. Problem classes that may or may not be introduced by this change:
- an artifact is not build
- an artifact doesn't contain what it should / contains stuff it shouldn't
- some tests are not even started
- incomplete / missing generated documentation
