### PR TITLE
Fix Windows issue in ZipkinResolver

### DIFF
--- a/project/ZipkinResolver.scala
+++ b/project/ZipkinResolver.scala
@@ -49,7 +49,7 @@ object ZipkinResolver extends Plugin {
       }) ++ Seq(
         // the local repo has to be in here twice, because sbt won't push to a "file:"
         // repo, but it won't read artifacts from a "Resolver.file" repo. (head -> desk)
-        "local-lookup" at ("file:" + localRepo.getAbsolutePath),
+        "local-lookup" at localRepo.getAbsoluteFile.toURI.toString,
         Resolver.file("local", localRepo)(Resolver.mavenStylePatterns)
       )
     },


### PR DESCRIPTION
Problem:
The current resolver setup configured
a resolver URL that wasn't valid on Windows, leading
to build failures.

Solution:
Replace the resolver with one that is
cross-platform, using Java's APIs that are supposed
to work across platforms.

PS: I added som println statements to debug; **can anybody
on a Unix box please run "sbt" and see what pops up?**
It's important that it should say that the original resolver
and the cross-platform resolver point to the same URL
on a Unix box!!!!!
I will remove the println statements afterwards.
