### PR TITLE
Reduces heap to below travis limits

### DIFF
--- a/bin/sbt
+++ b/bin/sbt
@@ -35,6 +35,6 @@ java -ea                          \
   -XX:ReservedCodeCacheSize=64m   \
   -Xss8M                          \
   -Xms512M                        \
-  -Xmx4G                          \
+  -Xmx2G                          \
   -server                         \
   -jar $sbtjar "$@"


### PR DESCRIPTION
Travis legacy infrastructure has 3GB mem, while containers have 4. Our
build needs to stay under that limit or risk being killed. This changes
the heap size down to 2GB, knowing that other args may still run over 3.
