### PR TITLE
Test split travis build with env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,24 @@ before_script:
   # default $SBT_OPTS is irrelevant to sbt lancher
   - unset SBT_OPTS
 
+env:
+  - PROJECT="zipkin-aggregate"
+  - PROJECT="zipkin-anormdb"
+  - PROJECT="zipkin-cassandra"
+  - PROJECT="zipkin-example"
+  - PROJECT="zipkin-hbase"
+  - PROJECT="zipkin-kafka"
+  - PROJECT="zipkin-mongodb"
+  - PROJECT="zipkin-receiver-kafka"
+  - PROJECT="zipkin-receiver-scribe"
+  - PROJECT="zipkin-redis"
+  - PROJECT="zipkin-sampler"
+  - PROJECT="zipkin-tracegen"
+  - PROJECT="zipkin-web"
+  - PROJECT="zipkin-zookeeper"
+
 script:
-  - "./bin/sbt ++$TRAVIS_SCALA_VERSION clean test"
+  - "./bin/sbt "project $PROJECT" ++$TRAVIS_SCALA_VERSION clean test"
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
   - PROJECT="zipkin-zookeeper"
 
 script:
-  - "./bin/sbt "project $PROJECT" ++$TRAVIS_SCALA_VERSION clean test"
+  - "./bin/sbt 'project $PROJECT' ++$TRAVIS_SCALA_VERSION clean test"
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
   - PROJECT="zipkin-zookeeper"
 
 script:
-  - "./bin/sbt 'project $PROJECT' ++$TRAVIS_SCALA_VERSION clean test"
+  - "./bin/sbt \"project $PROJECT\" ++$TRAVIS_SCALA_VERSION clean test"
 
 
 notifications:


### PR DESCRIPTION
If you look at the Travis build, this is one way to go. Splitting up the build into smaller pieces allows us to isolate failure, and work around the problem of resource usage.
The flip side is that we use more resources, since we have to bootstrap sbt and download dependencies for every submodule.

PS: do not merge
