### PR TITLE
Ports specs/jmock tests to scalatest/mockito and cleanup

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -58,22 +58,10 @@ object Zipkin extends Build {
   val slf4jLog4j12 = "org.slf4j" % "slf4j-log4j12" % "1.6.4" % "runtime"
   val ostrich = "com.twitter" %% "ostrich" % "9.9.0"
 
-  lazy val scalaTestDeps = Seq(
-    "org.scalatest" %% "scalatest" % "2.2.5" % "test",
-    junit
-  )
-
   lazy val testDependencies = Seq(
     junit,
-    "org.scala-tools.testing" %% "specs"        % "1.6.9" % "test" cross CrossVersion.binaryMapped {
-      case "2.10.5" => "2.10"
-      case x => x
-    },
-    "org.jmock"               %  "jmock"        % "2.4.0" % "test",
-        // jmock tests mock classes and require additional dependencies.
-        "cglib"                   %  "cglib"        % "2.2.2" % "test",
-        "asm"                     %  "asm"          % "1.5.3" % "test",
-        "org.objenesis"           %  "objenesis"    % "1.1"   % "test"
+    "org.mockito"              % "mockito-all" % "1.10.19" % "test",
+    "org.scalatest"           %% "scalatest"   % "2.2.5"   % "test"
   )
 
   /////////////////////

--- a/zipkin-anormdb/build.sbt
+++ b/zipkin-anormdb/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "anorm" % "2.3.7",
   "com.zaxxer" % "HikariCP-java6" % "2.3.8",
   anormDriverDependencies(dbEngine)
-) ++ testDependencies ++ scalaTestDeps
+) ++ testDependencies
 
 addConfigsToResourcePathForConfigSpec()
 

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormAggregatesTest.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormAggregatesTest.scala
@@ -16,16 +16,12 @@
 
 package com.twitter.zipkin.storage.anormdb
 
-import com.twitter.zipkin.common.{Service, DependencyLink, Dependencies}
 import com.twitter.algebird.Moments
-import com.twitter.util.Time
-import com.twitter.util.Await
 import com.twitter.conversions.time._
-import org.junit.runner.RunWith
+import com.twitter.util.{Await, Time}
+import com.twitter.zipkin.common.{Dependencies, DependencyLink, Service}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class AnormAggregatesTest extends FunSuite {
   test("store and get dependencies") {
     val db = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinAggregatesTest1")))

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormDBTest.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormDBTest.scala
@@ -17,13 +17,10 @@ package com.twitter.zipkin.storage.anormdb
  *
  */
 
-import anorm._
 import anorm.SqlParser._
-import org.junit.runner.RunWith
+import anorm._
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class AnormDBTest extends FunSuite {
   test("have the correct schema") {
     implicit val con = new DB(new DBConfig("sqlite-memory", new DBParams(dbName = "zipkinTest"))).install()

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormIndexTest.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormIndexTest.scala
@@ -17,14 +17,12 @@ package com.twitter.zipkin.storage.anormdb
  *
  */
 
-import com.twitter.zipkin.common._
 import java.nio.ByteBuffer
-import com.twitter.util.Await
-import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+import com.twitter.util.Await
+import com.twitter.zipkin.common._
+import org.scalatest.FunSuite
+
 class AnormIndexTest extends FunSuite {
 
   /*

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStoreTest.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStoreTest.scala
@@ -18,11 +18,8 @@ package com.twitter.zipkin.storage.anormdb
 import com.twitter.app.App
 import com.twitter.zipkin.anormdb.AnormDBSpanStoreFactory
 import com.twitter.zipkin.storage.util.SpanStoreValidator
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class AnormSpanStoreTest extends FunSuite {
   object AnormStore extends App with AnormDBSpanStoreFactory
   AnormStore.main(Array(

--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormStorageTest.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormStorageTest.scala
@@ -17,15 +17,13 @@ package com.twitter.zipkin.storage.anormdb
  *
  */
 
-import com.twitter.zipkin.common._
 import java.nio.ByteBuffer
-import com.twitter.util.Await
-import com.twitter.zipkin.query.Trace
-import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+import com.twitter.util.Await
+import com.twitter.zipkin.common._
+import com.twitter.zipkin.query.Trace
+import org.scalatest.FunSuite
+
 class AnormStorageTest extends FunSuite {
 
   /*

--- a/zipkin-cassandra/build.sbt
+++ b/zipkin-cassandra/build.sbt
@@ -5,10 +5,9 @@ libraryDependencies ++= Seq(
   finagle("serversets"),
   scroogeDep("serializer"),
   "org.iq80.snappy" % "snappy" % "0.3",
-  "org.mockito" % "mockito-all" % "1.10.9" % "test",
   "com.twitter" %% "scalding-core" % "0.15.0",
   hadoop("client")
-) ++ many(util, "logging", "app") ++ testDependencies ++ scalaTestDeps
+) ++ many(util, "logging", "app") ++ testDependencies
 
 addConfigsToResourcePathForConfigSpec()
 

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/BucketedColumnFamilyTest.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/BucketedColumnFamilyTest.scala
@@ -15,18 +15,17 @@
  */
 package com.twitter.zipkin.storage.cassandra
 
-import com.twitter.cassie.{Order, Column, ColumnFamily}
-import com.twitter.util.Future
 import java.nio.ByteBuffer
-import org.junit.runner.RunWith
+
+import com.twitter.cassie.{Column, ColumnFamily, Order}
+import com.twitter.util.Future
 import org.mockito.Matchers._
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
+
 import scala.collection.JavaConverters._
 
-@RunWith(classOf[JUnitRunner])
 class BucketedColumnFamilyTest extends FunSuite with MockitoSugar {
   val numBuckets = 10
 

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregatesTest.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraAggregatesTest.scala
@@ -15,25 +15,22 @@
  */
 package com.twitter.zipkin.storage.cassandra
 
+import java.nio.ByteBuffer
+
 import com.twitter.algebird.Moments
 import com.twitter.cassie._
 import com.twitter.cassie.tests.util.FakeCassandra
 import com.twitter.conversions.time._
 import com.twitter.util.{Await, Future, Time}
 import com.twitter.zipkin.cassandra.{AggregatesBuilder, Keyspace}
-import com.twitter.zipkin.common.{Dependencies, Service, DependencyLink}
-import com.twitter.zipkin.conversions.thrift._
+import com.twitter.zipkin.common.{Dependencies, DependencyLink, Service}
 import com.twitter.zipkin.thriftscala
-import java.nio.ByteBuffer
-import org.junit.runner.RunWith
-import org.mockito.Matchers._
-import org.mockito.Mockito.{times, verify, when}
-import org.scalatest.{BeforeAndAfter, FunSuite}
-import org.scalatest.junit.JUnitRunner
+import org.mockito.Mockito.when
 import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
 import scala.collection.JavaConverters._
 
-@RunWith(classOf[JUnitRunner])
 class CassandraAggregatesTest extends FunSuite with MockitoSugar with BeforeAndAfter {
 
   val mockKeyspace = mock[Keyspace]

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraIndexTest.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraIndexTest.scala
@@ -16,22 +16,21 @@ package com.twitter.zipkin.storage.cassandra
  *  limitations under the License.
  *
  */
+import java.nio.ByteBuffer
+import java.util.{Set => JSet}
+
 import com.twitter.cassie._
 import com.twitter.cassie.tests.util.FakeCassandra
 import com.twitter.util.Future
 import com.twitter.zipkin.cassandra.{IndexBuilder, Keyspace}
 import com.twitter.zipkin.common._
-import java.nio.ByteBuffer
-import java.util.{Set => JSet}
-import org.junit.runner.RunWith
 import org.mockito.Matchers._
 import org.mockito.Mockito.{atLeastOnce, times, verify, when}
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSuite}
+
 import scala.collection.JavaConverters._
 
-@RunWith(classOf[JUnitRunner])
 class CassandraIndexTest extends FunSuite with BeforeAndAfter with MockitoSugar {
   object FakeServer extends FakeCassandra
 

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraStorageTest.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraStorageTest.scala
@@ -15,18 +15,16 @@
  */
 package com.twitter.zipkin.storage.cassandra
 
+import java.nio.ByteBuffer
+
 import com.twitter.cassie.tests.util.FakeCassandra
 import com.twitter.conversions.time._
 import com.twitter.util.Await
 import com.twitter.zipkin.cassandra.{Keyspace, StorageBuilder}
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.query.Trace
-import java.nio.ByteBuffer
-import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfter, FunSuite}
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class CassandraStorageTest extends FunSuite with BeforeAndAfter {
   object FakeServer extends FakeCassandra
 

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassieSpanStoreTest.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassieSpanStoreTest.scala
@@ -17,13 +17,10 @@ package com.twitter.zipkin.storage.cassandra
 
 import com.twitter.app.App
 import com.twitter.cassie.tests.util.FakeCassandra
-import com.twitter.zipkin.storage.util.SpanStoreValidator
 import com.twitter.zipkin.cassandra.CassieSpanStoreFactory
-import org.junit.runner.RunWith
+import com.twitter.zipkin.storage.util.SpanStoreValidator
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class CassieSpanStoreTest extends FunSuite {
   object FakeServer extends FakeCassandra
   FakeServer.start()

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/SnappyCodecTest.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/SnappyCodecTest.scala
@@ -15,15 +15,13 @@
  */
 package com.twitter.zipkin.storage.cassandra
 
-import com.twitter.zipkin.thriftscala
-import com.twitter.zipkin.common.{Span, Endpoint, Annotation}
+import com.twitter.zipkin.common.{Annotation, Endpoint, Span}
 import com.twitter.zipkin.conversions.thrift._
-import collection.mutable.ArrayBuffer
-import org.junit.runner.RunWith
+import com.twitter.zipkin.thriftscala
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+import scala.collection.mutable.ArrayBuffer
+
 class SnappyCodecTest extends FunSuite {
 
   val thriftCodec = new ScroogeThriftCodec[thriftscala.Span](thriftscala.Span)

--- a/zipkin-collector-core/build.sbt
+++ b/zipkin-collector-core/build.sbt
@@ -4,6 +4,5 @@ libraryDependencies ++= Seq(
   Seq(algebird("core"), twitterServer, ostrich),
   many(finagle, "ostrich4", "serversets", "thrift", "zipkin"),
   many(util, "core", "zk", "zk-common"),
-  many(zk, "candidate", "group"),
-  testDependencies
-).flatten
+  many(zk, "candidate", "group")
+).flatten ++ testDependencies

--- a/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/filter/ClientIndexFilterSpec.scala
+++ b/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/filter/ClientIndexFilterSpec.scala
@@ -16,37 +16,35 @@
  */
 package com.twitter.zipkin.collector.filter
 
-import com.twitter.zipkin.common.{Endpoint, Annotation, Span}
+import com.twitter.zipkin.common.{Annotation, Endpoint, Span}
 import com.twitter.zipkin.thriftscala
-import org.specs.Specification
+import org.scalatest.{FunSuite, Matchers}
 
-class ClientIndexFilterSpec extends Specification {
+class ClientIndexFilterSpec extends FunSuite with Matchers {
 
   val filter = new ClientIndexFilter
 
-  "ClientIndexFilter" should {
-    "not index span" in {
-      // server side, with default name
-      val spanCs = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.CLIENT_SEND, Some(Endpoint(1,1,"client")))), Nil)
-      filter.shouldIndex(spanCs) mustEqual false
-      val spanCr = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.CLIENT_RECV, Some(Endpoint(1,1,"client")))), Nil)
-      filter.shouldIndex(spanCr) mustEqual false
-    }
+  test("not index span") {
+    // server side, with default name
+    val spanCs = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.CLIENT_SEND, Some(Endpoint(1,1,"client")))), Nil)
+    filter.shouldIndex(spanCs) should be (false)
+    val spanCr = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.CLIENT_RECV, Some(Endpoint(1,1,"client")))), Nil)
+    filter.shouldIndex(spanCr) should be (false)
+  }
 
-    "index span" in {
-      // server side, so index
-      val spanSr = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.SERVER_RECV, Some(Endpoint(1,1,"s")))), Nil)
-      filter.shouldIndex(spanSr) mustEqual true
-      val spanSs = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.SERVER_SEND, Some(Endpoint(1,1,"s")))), Nil)
-      filter.shouldIndex(spanSs) mustEqual true
-      // client side, but not with default name
-      val spanCs = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.CLIENT_SEND, Some(Endpoint(1,1,"s")))), Nil)
-      filter.shouldIndex(spanCs) mustEqual true
-      val spanCr = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.CLIENT_RECV, Some(Endpoint(1,1,"s")))), Nil)
-      filter.shouldIndex(spanCr) mustEqual true
-      // the unusual case of having a server with the name "client"
-      val spanClientServer = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.SERVER_SEND, Some(Endpoint(1,1,"client")))), Nil)
-      filter.shouldIndex(spanClientServer) mustEqual true
-    }
+  test("index span") {
+    // server side, so index
+    val spanSr = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.SERVER_RECV, Some(Endpoint(1,1,"s")))), Nil)
+    filter.shouldIndex(spanSr) should be (true)
+    val spanSs = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.SERVER_SEND, Some(Endpoint(1,1,"s")))), Nil)
+    filter.shouldIndex(spanSs) should be (true)
+    // client side, but not with default name
+    val spanCs = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.CLIENT_SEND, Some(Endpoint(1,1,"s")))), Nil)
+    filter.shouldIndex(spanCs) should be (true)
+    val spanCr = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.CLIENT_RECV, Some(Endpoint(1,1,"s")))), Nil)
+    filter.shouldIndex(spanCr) should be (true)
+    // the unusual case of having a server with the name "client"
+    val spanClientServer = Span(1, "n", 2, None, List(Annotation(1, thriftscala.Constants.SERVER_SEND, Some(Endpoint(1,1,"client")))), Nil)
+    filter.shouldIndex(spanClientServer) should be (true)
   }
 }

--- a/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/filter/SamplerFilterSpec.scala
+++ b/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/filter/SamplerFilterSpec.scala
@@ -16,46 +16,41 @@ package com.twitter.zipkin.collector.filter
  *  limitations under the License.
  *
  */
+
 import com.twitter.finagle.Service
-import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.collector.sampler.{EverythingGlobalSampler, NullGlobalSampler}
-import org.specs.Specification
-import org.specs.mock.{JMocker, ClassMocker}
+import com.twitter.zipkin.common.Span
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FunSuite, Matchers}
 
-class SamplerFilterSpec extends Specification with JMocker with ClassMocker {
+class SamplerFilterSpec extends FunSuite with Matchers with MockitoSugar {
+  val service = mock[Service[Span, Unit]]
 
-  "SamplerFilter" should {
-    val mockService = mock[Service[Span, Unit]]
+  test("let the span pass if debug flag is set") {
+    val span = Span(12345, "methodcall", 666, None, List(), Nil, true)
+    val samplerProcessor = new SamplerFilter(NullGlobalSampler)
 
-    "let the span pass if debug flag is set" in {
-      val span = Span(12345, "methodcall", 666, None, List(), Nil, true)
-      val samplerProcessor = new SamplerFilter(NullGlobalSampler)
+    samplerProcessor(span, service)
 
-      expect {
-        one(mockService).apply(span)
-      }
+    verify(service).apply(span)
+  }
 
-      samplerProcessor(span, mockService)
-    }
+  test("let the span pass if debug flag false and sampler says yes") {
+    val span = Span(12345, "methodcall", 666, None, List(), Nil, false)
+    val samplerProcessor = new SamplerFilter(EverythingGlobalSampler)
 
-    "let the span pass if debug flag false and sampler says yes" in {
-      val span = Span(12345, "methodcall", 666, None, List(), Nil, false)
-      val samplerProcessor = new SamplerFilter(EverythingGlobalSampler)
+    samplerProcessor(span, service)
 
-      expect {
-        one(mockService).apply(span)
-      }
+    verify(service).apply(span)
+  }
 
-      samplerProcessor(span, mockService)
-    }
+  test("not let the span pass if debug flag false and sampler says no") {
+    val span = Span(12345, "methodcall", 666, None, List(), Nil, false)
+    val samplerProcessor = new SamplerFilter(NullGlobalSampler)
 
-    "don't let the span pass if debug flag false and sampler says no" in {
-      val span = Span(12345, "methodcall", 666, None, List(), Nil, false)
-      val samplerProcessor = new SamplerFilter(NullGlobalSampler)
+    samplerProcessor(span, service)
 
-      expect {}
-
-      samplerProcessor(span, mockService)
-    }
+    verifyZeroInteractions(service)
   }
 }

--- a/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/processor/FanoutServiceSpec.scala
+++ b/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/processor/FanoutServiceSpec.scala
@@ -17,24 +17,25 @@
 package com.twitter.zipkin.collector.processor
 
 import com.twitter.finagle.Service
-import org.specs.Specification
-import org.specs.mock.{JMocker, ClassMocker}
+import com.twitter.util.Future
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FunSuite, Matchers}
 
-class FanoutServiceSpec extends Specification with JMocker with ClassMocker {
-  "FanoutService" should {
-    "fanout" in {
-      val serv1 = mock[Service[Int, Unit]]
-      val serv2 = mock[Service[Int, Unit]]
+class FanoutServiceSpec extends FunSuite with Matchers with MockitoSugar {
+  test("fanout") {
+    val serv1 = mock[Service[Int, Unit]]
+    val serv2 = mock[Service[Int, Unit]]
 
-      val fanout = new FanoutService[Int](Seq(serv1, serv2))
-      val item = 1
+    val fanout = new FanoutService[Int](Seq(serv1, serv2))
+    val item = 1
 
-      expect {
-        one(serv1).apply(item)
-        one(serv2).apply(item)
-      }
+    when(serv1.apply(item)) thenReturn Future.Done
+    when(serv2.apply(item)) thenReturn Future.Done
 
-      fanout.apply(item)
-    }
+    fanout.apply(item)
+
+    verify(serv1).apply(item)
+    verify(serv2).apply(item)
   }
 }

--- a/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/processor/OstrichServiceSpec.scala
+++ b/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/processor/OstrichServiceSpec.scala
@@ -16,48 +16,50 @@ package com.twitter.zipkin.collector.processor
  *  limitations under the License.
  *
  */
-import com.twitter.zipkin.thriftscala
-import com.twitter.zipkin.common.{Span, Endpoint, Annotation}
-import com.twitter.ostrich.stats.{Histogram, Distribution, Stats}
-import org.specs.Specification
 
-class OstrichServiceSpec extends Specification {
+import com.twitter.ostrich.stats.{Distribution, Histogram, Stats}
+import com.twitter.zipkin.common.{Annotation, Endpoint, Span}
+import com.twitter.zipkin.thriftscala
+import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
+
+class OstrichServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
   val histogram = Histogram()
   histogram.add(10)
   val distribution = new Distribution(histogram)
 
   val prefix = "agg."
 
-  "OstrichService" should {
-    "add two metrics if server span" in {
-      val agg = new OstrichService(prefix)
+  before {
+    Stats.clearAll()
+  }
 
-      val annotation1 = Annotation(10, thriftscala.Constants.SERVER_RECV, Some(Endpoint(1, 2, "service")))
-      val annotation2 = Annotation(20, thriftscala.Constants.SERVER_SEND, Some(Endpoint(3, 4, "service")))
-      val annotation3 = Annotation(30, "value3", Some(Endpoint(5, 6, "service")))
+  test("add two metrics if server span") {
+    val agg = new OstrichService(prefix)
 
-      val span = Span(12345, "methodcall", 666, None, List(annotation1, annotation2, annotation3), Nil)
+    val annotation1 = Annotation(10, thriftscala.Constants.SERVER_RECV, Some(Endpoint(1, 2, "service")))
+    val annotation2 = Annotation(20, thriftscala.Constants.SERVER_SEND, Some(Endpoint(3, 4, "service")))
+    val annotation3 = Annotation(30, "value3", Some(Endpoint(5, 6, "service")))
 
-      agg.apply(span)
+    val span = Span(12345, "methodcall", 666, None, List(annotation1, annotation2, annotation3), Nil)
 
+    agg.apply(span)
 
-      Stats.getMetrics()(prefix + "service") mustEqual distribution
-      Stats.getMetrics()(prefix + "service.methodcall") mustEqual distribution
-    }
+    Stats.getMetrics()(prefix + "service") should be(distribution)
+    Stats.getMetrics()(prefix + "service.methodcall") should be(distribution)
+  }
 
-    "add no metrics since not server span" in {
-      val agg = new OstrichService(prefix)
+  test("add no metrics since not server span") {
+    val agg = new OstrichService(prefix)
 
-      val annotation1 = Annotation(10, thriftscala.Constants.CLIENT_SEND, Some(Endpoint(1, 2, "service")))
-      val annotation2 = Annotation(20, thriftscala.Constants.CLIENT_RECV, Some(Endpoint(3, 4, "service")))
-      val annotation3 = Annotation(30, "value3", Some(Endpoint(5, 6, "service")))
+    val annotation1 = Annotation(10, thriftscala.Constants.CLIENT_SEND, Some(Endpoint(1, 2, "service")))
+    val annotation2 = Annotation(20, thriftscala.Constants.CLIENT_RECV, Some(Endpoint(3, 4, "service")))
+    val annotation3 = Annotation(30, "value3", Some(Endpoint(5, 6, "service")))
 
-      val span = Span(12345, "methodcall", 666, None, List(annotation1, annotation2, annotation3), Nil)
+    val span = Span(12345, "methodcall", 666, None, List(annotation1, annotation2, annotation3), Nil)
 
-      agg.apply(span)
+    agg.apply(span)
 
-      Stats.getMetrics()(prefix + "service") mustNotBe distribution
-      Stats.getMetrics()(prefix + "service.methodcall") mustNotBe distribution
-    }
+    Stats.getMetrics() should not contain key(prefix + "service")
+    Stats.getMetrics() should not contain key(prefix + "service.methodcall")
   }
 }

--- a/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/sampler/adaptive/ZooKeeperAdaptiveReporterSpec.scala
+++ b/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/sampler/adaptive/ZooKeeperAdaptiveReporterSpec.scala
@@ -16,91 +16,89 @@
 package com.twitter.zipkin.collector.sampler.adaptive
 
 import com.twitter.common.zookeeper.{Group, ZooKeeperClient}
-import com.twitter.zipkin.config.sampler.adaptive.ZooKeeperAdaptiveSamplerConfig
-import com.twitter.zipkin.config.sampler.AdjustableRateConfig
 import com.twitter.conversions.time._
 import com.twitter.ostrich.stats.Counter
 import com.twitter.util.Timer
-import org.apache.zookeeper.{CreateMode, ZooKeeper}
+import com.twitter.zipkin.config.sampler.AdjustableRateConfig
+import com.twitter.zipkin.config.sampler.adaptive.ZooKeeperAdaptiveSamplerConfig
 import org.apache.zookeeper.ZooDefs.Ids
 import org.apache.zookeeper.data.Stat
-import org.specs.mock.{ClassMocker, JMocker}
-import org.specs.Specification
+import org.apache.zookeeper.{CreateMode, ZooKeeper}
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FunSuite, Matchers}
 
-class ZooKeeperAdaptiveReporterSpec extends Specification with JMocker with ClassMocker {
+class ZooKeeperAdaptiveReporterSpec extends FunSuite with Matchers with MockitoSugar {
 
   val samplerTimer = mock[Timer]
 
-  "ZooKeeperAdaptiveReporter" should {
-    val zk = mock[ZooKeeper]
-    val _zkClient = mock[ZooKeeperClient]
-    val _gm = mock[Group.Membership]
-    val _path = ""
-    val _updateInterval = 5.seconds
-    val _reportInterval = 30.seconds
-    val _reportWindow = 1.minute
+  val zk = mock[ZooKeeper]
+  val _zkClient = mock[ZooKeeperClient]
+  val _gm = mock[Group.Membership]
+  val _path = ""
+  val _updateInterval = 5.seconds
+  val _reportInterval = 30.seconds
+  val _reportWindow = 1.minute
 
-    val _config = new ZooKeeperAdaptiveSamplerConfig {
-      var client = _zkClient
-      var sampleRate: AdjustableRateConfig = null
-      var storageRequestRate: AdjustableRateConfig = null
-      var taskTimer = samplerTimer
+  val _config = new ZooKeeperAdaptiveSamplerConfig {
+    var client = _zkClient
+    var sampleRate: AdjustableRateConfig = null
+    var storageRequestRate: AdjustableRateConfig = null
+    var taskTimer = samplerTimer
 
-      reportPath = _path
-    }
+    reportPath = _path
+  }
 
-    val _counter = mock[Counter]
+  val _counter = mock[Counter]
 
-    val stat = mock[Stat]
-    val nullStat: Stat = null
+  val stat = mock[Stat]
+  val nullStat: Stat = null
 
-    val _memberId = "1"
-    val fullPath = _path + "/" + _memberId
+  val _memberId = "1"
+  val fullPath = _path + "/" + _memberId
 
-    def adaptiveReporter = new ZooKeeperAdaptiveReporter {
-      val config         = _config
-      val gm             = _gm
-      val counter        = _counter
-      val updateInterval = _updateInterval
-      val reportInterval = _reportInterval
-      val reportWindow   = _reportWindow
+  def adaptiveReporter = new ZooKeeperAdaptiveReporter {
+    val config         = _config
+    val gm             = _gm
+    val counter        = _counter
+    val updateInterval = _updateInterval
+    val reportInterval = _reportInterval
+    val reportWindow   = _reportWindow
 
-      memberId = _memberId
-    }
+    memberId = _memberId
+  }
 
-    "create ephemeral node" in {
-      val reporter = adaptiveReporter
+  test("create ephemeral node") {
+    val reporter = adaptiveReporter
 
-      expect {
-        one(_gm).getMemberId willReturn _memberId
-        one(_zkClient).get willReturn zk
-        one(zk).exists(fullPath, false) willReturn nullStat
-        one(zk).create(fullPath, "0".getBytes, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL)
-      }
+    when(_gm.getMemberId) thenReturn _memberId
+    when(_zkClient.get) thenReturn zk
+    when(zk.exists(fullPath, false)) thenReturn nullStat
 
-      reporter.report()
-    }
+    reporter.report()
 
-    "report" in {
-      val reporter = adaptiveReporter
+    verify(zk).create(fullPath, "0".getBytes, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL)
+  }
 
-      expect {
-        2.of(_gm).getMemberId willReturn _memberId
-        2.of(_zkClient).get willReturn zk
-        2.of(zk).exists(fullPath, false) willReturn stat
+  test("report") {
+    val reporter = adaptiveReporter
 
-        1.of(_counter).apply() willReturn 0
-        1.of(_counter).apply() willReturn 5
+    when(_gm.getMemberId) thenReturn _memberId
+    when(_zkClient.get) thenReturn zk
+    when(zk.exists(fullPath, false)) thenReturn stat
 
-        1.of(zk).setData(fullPath, "0.0".getBytes, -1)
-        1.of(zk).setData(fullPath, "5.0".getBytes, -1)
-      }
+    when(_counter.apply()) thenReturn 0
 
-      reporter.update()
-      reporter.report()
+    reporter.update()
+    reporter.report()
 
-      reporter.update()
-      reporter.report()
-    }
+    verify(zk).setData(fullPath, "0.0".getBytes, -1)
+
+    when(_counter.apply()) thenReturn 5
+
+    reporter.update()
+    reporter.report()
+
+    verify(zk).setData(fullPath, "5.0".getBytes, -1)
   }
 }

--- a/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/sampler/adaptive/policy/LeaderPolicySpec.scala
+++ b/zipkin-collector-core/src/test/scala/com/twitter/zipkin/collector/sampler/adaptive/policy/LeaderPolicySpec.scala
@@ -18,30 +18,27 @@ package com.twitter.zipkin.collector.sampler.adaptive.policy
 import com.twitter.zipkin.collector.sampler.adaptive.BoundedBuffer
 import com.twitter.zipkin.config.sampler.AdjustableRateConfig
 import com.twitter.zipkin.config.sampler.adaptive.ZooKeeperAdaptiveSamplerConfig
-import org.specs.mock.{JMocker, ClassMocker}
-import org.specs.Specification
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FunSuite, Matchers}
 
-class LeaderPolicySpec extends Specification with JMocker with ClassMocker {
+class LeaderPolicySpec extends FunSuite with Matchers with MockitoSugar {
 
   val _config = mock[ZooKeeperAdaptiveSamplerConfig]
   val _sampleRate = mock[AdjustableRateConfig]
   val _storageRequestRate = mock[AdjustableRateConfig]
 
-  "LeaderPolicy" should {
-    "compose with filter" in {
-      val default = 0.25
-      val filter = new ValidLatestValueFilter
-      val policy = new PassLeaderPolicy[BoundedBuffer](default)
-      val buf = new BoundedBuffer { val maxLength = 5 }
-      val composed: LeaderPolicy[BoundedBuffer] = filter andThen policy
+  test("compose with filter") {
+    val default = 0.25
+    val filter = new ValidLatestValueFilter
+    val policy = new PassLeaderPolicy[BoundedBuffer](default)
+    val buf = new BoundedBuffer { val maxLength = 5 }
+    val composed: LeaderPolicy[BoundedBuffer] = filter andThen policy
 
 
-      composed(buf) mustEqual None // buf empty, so invalid value
-      buf.update(-1)
-      composed(buf) mustEqual None // invalid value
-      buf.update(1)
-      composed(buf) mustEqual Some(default)
-
-    }
+    composed(buf) should be (None) // buf empty, so invalid value
+    buf.update(-1)
+    composed(buf) should be (None) // invalid value
+    buf.update(1)
+    composed(buf) should be (Some(default))
   }
 }

--- a/zipkin-collector-core/src/test/scala/com/twitter/zipkin/config/ConfigRequestHandlerSpec.scala
+++ b/zipkin-collector-core/src/test/scala/com/twitter/zipkin/config/ConfigRequestHandlerSpec.scala
@@ -2,46 +2,41 @@ package com.twitter.zipkin.config
 
 import com.sun.net.httpserver.HttpExchange
 import com.twitter.ostrich.admin.CustomHttpHandler
-import org.specs.Specification
-import org.specs.mock.{JMocker, ClassMocker}
 import com.twitter.zipkin.config.sampler.AdjustableRateConfig
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FunSuite, Matchers}
 
 /**
  * Test endpoints for getting and setting configurations for sample rate and storage request rate
  */
-class ConfigRequestHandlerSpec extends Specification with JMocker with ClassMocker {
-  "ConfigRequestHandler" should {
+class ConfigRequestHandlerSpec extends FunSuite with Matchers with MockitoSugar {
 
-    val sampleRateConfig = mock[AdjustableRateConfig]
-    val exchange = mock[HttpExchange]
-    val customHttpHandler = mock[CustomHttpHandler]
+  val sampleRateConfig = mock[AdjustableRateConfig]
+  val exchange = mock[HttpExchange]
+  val customHttpHandler = mock[CustomHttpHandler]
 
-    val handler = new ConfigRequestHandler(sampleRateConfig) {
-      override def render(body: String, exchange: HttpExchange, code: Int) {
-        customHttpHandler.render(body, exchange, code)
-      }
+  val handler = new ConfigRequestHandler(sampleRateConfig) {
+    override def render(body: String, exchange: HttpExchange, code: Int) {
+      customHttpHandler.render(body, exchange, code)
     }
+  }
 
-    "sampleRate" in {
-      "get" in {
-        expect {
-          one(exchange).getRequestMethod willReturn "GET"
-          one(sampleRateConfig).get willReturn 0.5
-          one(customHttpHandler).render("0.5", exchange, 200)
-        }
+  test("sampleRate get") {
+    when(exchange.getRequestMethod) thenReturn "GET"
+    when(sampleRateConfig.get) thenReturn 0.5
 
-        handler.handle(exchange, List("config", "sampleRate"), List.empty[(String, String)])
-      }
+    handler.handle(exchange, List("config", "sampleRate"), List.empty[(String, String)])
 
-      "set" in {
-        expect {
-          one(exchange).getRequestMethod willReturn "POST"
-          one(sampleRateConfig).set(0.3)
-          one(customHttpHandler).render("success", exchange, 200)
-        }
+    verify(customHttpHandler).render("0.5", exchange, 200)
+  }
 
-        handler.handle(exchange, List("config", "sampleRate"), List(("value", "0.3")))
-      }
-    }
+  test("sampleRate set") {
+    when(exchange.getRequestMethod) thenReturn "POST"
+
+    handler.handle(exchange, List("config", "sampleRate"), List(("value", "0.3")))
+
+    verify(sampleRateConfig).set(0.3)
+    verify(customHttpHandler).render("success", exchange, 200)
   }
 }

--- a/zipkin-collector-core/src/test/scala/com/twitter/zipkin/config/sampler/AdjustableRateConfigSpec.scala
+++ b/zipkin-collector-core/src/test/scala/com/twitter/zipkin/config/sampler/AdjustableRateConfigSpec.scala
@@ -15,25 +15,26 @@
  */
 package com.twitter.zipkin.config.sampler
 
-import org.specs.Specification
-import org.specs.mock.{ClassMocker, JMocker}
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FunSuite, Matchers}
 
-class AdjustableRateConfigSpec extends Specification with JMocker with ClassMocker {
+class AdjustableRateConfigSpec extends FunSuite with Matchers with MockitoSugar {
 
-  "ReadOnlyAdjustableRateConfig" should {
-    val sampleRateConfig = mock[AdjustableRateConfig]
-    val sr = 0.3
+  val sampleRateConfig = mock[AdjustableRateConfig]
+  val sr = 0.3
 
-    "not issue zk calls on set" in {
-      expect {}
-      val config = new ReadOnlyAdjustableRateConfig(sampleRateConfig)
-      config.set(sr)
-    }
+  test("not issue zk calls on set") {
+    val config = new ReadOnlyAdjustableRateConfig(sampleRateConfig)
+    config.set(sr)
 
-    "not issue zk calls on setIfNotExists" in {
-      expect {}
-      val config = new ReadOnlyAdjustableRateConfig(sampleRateConfig)
-      config.set(sr)
-    }
+    verifyZeroInteractions(sampleRateConfig)
+  }
+
+  test("not issue zk calls on setIfNotExists") {
+    val config = new ReadOnlyAdjustableRateConfig(sampleRateConfig)
+    config.set(sr)
+
+    verifyZeroInteractions(sampleRateConfig)
   }
 }

--- a/zipkin-collector-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
+++ b/zipkin-collector-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
@@ -16,28 +16,27 @@
  */
 package com.twitter.zipkin.collector
 
+import com.twitter.algebird.Moments
+import com.twitter.conversions.time._
 import com.twitter.scrooge.BinaryThriftStructSerializer
-import com.twitter.zipkin.common._
+import com.twitter.util.{Await, Future, Time}
+import com.twitter.zipkin.common.{Annotation, Service, _}
 import com.twitter.zipkin.config.sampler.AdjustableRateConfig
 import com.twitter.zipkin.conversions.thrift._
+import com.twitter.zipkin.storage.{Aggregates, Store}
 import com.twitter.zipkin.thriftscala
-import com.twitter.zipkin.storage.{Store, Aggregates}
-import org.specs.SpecificationWithJUnit
-import org.specs.mock.{ClassMocker, JMocker}
-import com.twitter.util.{Time, Await}
-import com.twitter.conversions.time._
-import org.junit.runner.RunWith
-import org.specs.runner.JUnitSuiteRunner
-import com.twitter.algebird.Moments
-import com.twitter.zipkin.common.Service
-import com.twitter.zipkin.common.Annotation
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FunSuite, Matchers, OneInstancePerTest}
 
-@RunWith(classOf[JUnitSuiteRunner])
-class ScribeCollectorServiceSpec extends SpecificationWithJUnit with JMocker with ClassMocker {
+class ScribeCollectorServiceSpec extends FunSuite with OneInstancePerTest with Matchers with MockitoSugar {
   val serializer = new BinaryThriftStructSerializer[thriftscala.Span] {
     def codec = thriftscala.Span
   }
   val category = "zipkin"
+  val serviceName = "mockingbird"
+  val annotations = Seq("a" , "b", "c")
 
   val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)), Nil)
   val validList = List(thriftscala.LogEntry(category, serializer.toString(validSpan.toThrift)))
@@ -50,79 +49,55 @@ class ScribeCollectorServiceSpec extends SpecificationWithJUnit with JMocker wit
   val zkSampleRateConfig = mock[AdjustableRateConfig]
   val mockAggregates = mock[Aggregates]
 
-  def scribeCollectorService = new ScribeCollectorService(queue, Seq(Store(null, null, mockAggregates)), Set(category)) {
+  def cs = new ScribeCollectorService(queue, Seq(Store(null, null, mockAggregates)), Set(category)) {
     running = true
   }
 
-  "ScribeCollectorService" should {
-    "add to queue" in {
-      val cs = scribeCollectorService
+  test("add to queue") {
+    when(queue.add(List(base64))) thenReturn true
 
-      expect {
-        one(queue).add(List(base64)) willReturn(true)
-      }
+    Await.result(cs.log(validList)) should be (thriftscala.ResultCode.Ok)
+  }
 
-      thriftscala.ResultCode.Ok mustEqual Await.result(cs.log(validList))
-    }
+  test("push back") {
+    when(queue.add(List(base64))) thenReturn false
 
-    "push back" in {
-      val cs = scribeCollectorService
+    Await.result(cs.log(validList)) should be (thriftscala.ResultCode.TryLater)
+  }
 
-      expect {
-        one(queue).add(List(base64)) willReturn(false)
-      }
+  test("ignore wrong category") {
+    Await.result(cs.log(wrongCatList)) should be (thriftscala.ResultCode.Ok)
 
-      thriftscala.ResultCode.TryLater mustEqual Await.result(cs.log(validList))
-    }
+    verify(queue, never()).add(anyObject())
+  }
 
-    "ignore wrong category" in {
-      val cs = scribeCollectorService
+  test("store dependencies") {
+    val m1 = Moments(2)
+    val m2 = Moments(4)
+    val dl1 = DependencyLink(Service("tfe"), Service("mobileweb"), m1)
+    val dl3 = DependencyLink(Service("Gizmoduck"), Service("tflock"), m2)
+    val deps1 = Dependencies(Time.fromSeconds(0), Time.fromSeconds(0)+1.hour, List(dl1, dl3))
 
-      expect {
-        never(queue).add(any)
-      }
+    when(mockAggregates.storeDependencies(deps1)) thenReturn Future.Done
 
-      thriftscala.ResultCode.Ok mustEqual Await.result(cs.log(wrongCatList))
-    }
+    cs.storeDependencies(deps1.toThrift)
 
-    "store dependencies" in {
-      val cs = scribeCollectorService
-      val m1 = Moments(2)
-      val m2 = Moments(4)
-      val dl1 = DependencyLink(Service("tfe"), Service("mobileweb"), m1)
-      val dl3 = DependencyLink(Service("Gizmoduck"), Service("tflock"), m2)
-      val deps1 = Dependencies(Time.fromSeconds(0), Time.fromSeconds(0)+1.hour, List(dl1, dl3))
+    verify(mockAggregates).storeDependencies(deps1)
+  }
 
-      expect {
-        one(mockAggregates).storeDependencies(deps1)
-      }
+  test("store top annotations") {
+    when(mockAggregates.storeTopAnnotations(serviceName, annotations)) thenReturn Future.Done
 
-      cs.storeDependencies(deps1.toThrift)
-    }
+    cs.storeTopAnnotations(serviceName, annotations)
 
-    "store aggregates" in {
-      val serviceName = "mockingbird"
-      val annotations = Seq("a" , "b", "c")
+    verify(mockAggregates).storeTopAnnotations(serviceName, annotations)
+  }
 
-      "store top annotations" in {
-        val cs = scribeCollectorService
+  test("store top key value annotations") {
+    when(mockAggregates.storeTopKeyValueAnnotations(serviceName, annotations)) thenReturn Future.Done
 
-        expect {
-          one(mockAggregates).storeTopAnnotations(serviceName, annotations)
-        }
+    cs.storeTopKeyValueAnnotations(serviceName, annotations)
 
-        cs.storeTopAnnotations(serviceName, annotations)
-      }
-
-      "store top key value annotations" in {
-        val cs = scribeCollectorService
-
-        expect {
-          one(mockAggregates).storeTopKeyValueAnnotations(serviceName, annotations)
-        }
-
-        cs.storeTopKeyValueAnnotations(serviceName, annotations)
-      }
-    }
+    verify(mockAggregates).storeTopKeyValueAnnotations(serviceName, annotations)
   }
 }

--- a/zipkin-collector-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
+++ b/zipkin-collector-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
@@ -20,26 +20,24 @@ import com.twitter.ostrich.admin.RuntimeEnvironment
 import com.twitter.util.Eval
 import com.twitter.zipkin.builder.Builder
 import com.twitter.zipkin.collector.ZipkinCollector
-import org.specs.Specification
+import org.scalatest.{FunSuite, Matchers}
 
-class ConfigSpec extends Specification {
-  "/config" should {
-    val eval = new Eval
+class ConfigSpec extends FunSuite with Matchers {
+  val eval = new Eval
 
-    "validate collector configs" in {
-      val configFiles = Seq(
-        "/collector-dev.scala",
-        "/collector-hbase.scala",
-        "/collector-cassandra.scala"
-      ) map { TempFile.fromResourcePath(_) }
+  test("validate collector configs") {
+    val configFiles = Seq(
+      "/collector-dev.scala",
+      "/collector-hbase.scala",
+      "/collector-cassandra.scala"
+    ) map {
+      TempFile.fromResourcePath(_)
+    }
 
-      for (file <- configFiles) {
-        file.getName() in {
-          val config = eval[Builder[RuntimeEnvironment => ZipkinCollector]](file)
-          config must notBeNull
-          config.apply()
-        }
-      }
+    for (file <- configFiles) {
+      val config = eval[Builder[RuntimeEnvironment => ZipkinCollector]](file)
+      config should not be(Nil)
+      config.apply()
     }
   }
 }

--- a/zipkin-collector/build.sbt
+++ b/zipkin-collector/build.sbt
@@ -4,4 +4,4 @@ libraryDependencies ++= Seq(
   finagle("core"),
   util("core"),
   twitterServer
-) ++ scalaTestDeps
+) ++ testDependencies

--- a/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/ItemQueueTest.scala
+++ b/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/ItemQueueTest.scala
@@ -15,13 +15,11 @@
  */
 package com.twitter.zipkin.collector
 
-import com.twitter.util.{Await, Future}
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+import com.twitter.util.{Await, Future}
+import org.scalatest.FunSuite
+
 class ItemQueueTest extends FunSuite {
   val Item = ()
 

--- a/zipkin-common/build.sbt
+++ b/zipkin-common/build.sbt
@@ -2,6 +2,5 @@ defaultSettings
 
 libraryDependencies ++= Seq(
   Seq(util("core"), zk("client"), algebird("core"), ostrich),
-  many(finagle, "ostrich4", "thrift", "zipkin", "exception"),
-  scalaTestDeps
-).flatten
+  many(finagle, "ostrich4", "thrift", "zipkin", "exception")
+).flatten ++ testDependencies

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/AnnotationTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/AnnotationTest.scala
@@ -17,11 +17,8 @@
 package com.twitter.zipkin.common
 
 import com.twitter.conversions.time._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class AnnotationTest extends FunSuite {
   test("get min of two annotations") {
     val ann1 = Annotation(1, "one", None)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/DependenciesTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/DependenciesTest.scala
@@ -16,14 +16,11 @@
  */
 package com.twitter.zipkin.common
 
-import com.twitter.algebird.{Semigroup, Moments, Monoid}
-import com.twitter.util.Time
+import com.twitter.algebird.{Moments, Monoid, Semigroup}
 import com.twitter.conversions.time._
-import org.junit.runner.RunWith
+import com.twitter.util.Time
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class DependenciesTest extends FunSuite {
   test("services compare correctly") {
     val s1 = Service("foo")

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/EndpointTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/EndpointTest.scala
@@ -17,11 +17,9 @@
 package com.twitter.zipkin.common
 
 import java.net.InetSocketAddress
-import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+import org.scalatest.FunSuite
+
 class EndpointTest extends FunSuite {
   val google  = Endpoint(  134744072, -80, "google")
   val example = Endpoint(-1073730806,  21, "example")

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
@@ -16,14 +16,11 @@
  */
 package com.twitter.zipkin.common
 
-import com.twitter.zipkin.Constants
 import java.nio.ByteBuffer
-import javax.net.ssl.HostnameVerifier
-import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+import com.twitter.zipkin.Constants
+import org.scalatest.FunSuite
+
 class SpanTest extends FunSuite {
 
   val annotationValue = "NONSENSE"

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceTest.scala
@@ -16,15 +16,14 @@
  */
 package com.twitter.zipkin.common
 
-import collection.mutable
-import com.twitter.zipkin.Constants
-import com.twitter.zipkin.query.{Timespan, Trace, TraceSummary, SpanTreeEntry}
 import java.nio.ByteBuffer
-import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+import com.twitter.zipkin.Constants
+import com.twitter.zipkin.query.{SpanTreeEntry, Timespan, Trace, TraceSummary}
+import org.scalatest.FunSuite
+
+import scala.collection.mutable
+
 class TraceTest extends FunSuite {
 
   // TODO these don't actually make any sense

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/InMemorySpanStoreTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/InMemorySpanStoreTest.scala
@@ -16,11 +16,8 @@
 package com.twitter.zipkin.storage
 
 import com.twitter.zipkin.storage.util.SpanStoreValidator
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class InMemorySpanStoreTest extends FunSuite {
   def newSpanStore = new InMemorySpanStore
   test("validate") { new SpanStoreValidator(newSpanStore).validate }

--- a/zipkin-hbase/build.sbt
+++ b/zipkin-hbase/build.sbt
@@ -17,9 +17,8 @@ libraryDependencies ++= Seq(
   ),
   many(hbaseDep, "", "common", "client"),
   many(hbaseTest, "common", "client", "server", "hadoop-compat", "hadoop2-compat"),
-  many(hadoopTest, "mapreduce-client-jobclient", "common", "hdfs" ),
-  testDependencies, scalaTestDeps
-).flatten
+  many(hadoopTest, "mapreduce-client-jobclient", "common", "hdfs" )
+).flatten ++ testDependencies
 
 addConfigsToResourcePathForConfigSpec()
 

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/HBaseAggregatesSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/HBaseAggregatesSpec.scala
@@ -2,12 +2,11 @@ package com.twitter.zipkin.storage.hbase
 
 import com.twitter.algebird.Moments
 import com.twitter.util.{Await, Time}
-import com.twitter.zipkin.common.{Dependencies, Service, DependencyLink}
-import com.twitter.zipkin.hbase.{TableLayouts, AggregatesBuilder}
+import com.twitter.zipkin.common.{Dependencies, DependencyLink, Service}
+import com.twitter.zipkin.hbase.{AggregatesBuilder, TableLayouts}
 import com.twitter.zipkin.storage.hbase.utils.HBaseTable
-import org.apache.hadoop.hbase.client.{Scan, Get}
+import org.apache.hadoop.hbase.client.{Get, Scan}
 import org.apache.hadoop.hbase.util.Bytes
-
 
 class HBaseAggregatesSpec extends ZipkinHBaseSpecification {
 
@@ -18,7 +17,7 @@ class HBaseAggregatesSpec extends ZipkinHBaseSpecification {
     TableLayouts.mappingTableName
   )
 
-  var aggregates: HBaseAggregates = null
+  val aggregates: HBaseAggregates = AggregatesBuilder(confOption = Some(_conf))()
 
   val m1 = Moments(1)
   val m2 = Moments(2)
@@ -29,39 +28,31 @@ class HBaseAggregatesSpec extends ZipkinHBaseSpecification {
   val topAnnos = Seq("key1", "key2", "key3")
   val annoService = "HBase.RegionServer"
 
-  "HBaseAggregates" should {
-
-    doBefore {
-      aggregates = AggregatesBuilder(confOption = Some(_conf))()
-    }
-
-    "storeDependencies" in {
-      Await.result(aggregates.storeDependencies(deps))
-      val depsTable = new HBaseTable(_conf, TableLayouts.dependenciesTableName)
-      val get = new Get(Bytes.toBytes(Long.MaxValue - Time.fromSeconds(2).inMilliseconds))
-      val result = Await.result(depsTable.get(Seq(get)))
-      result.size must_== 1
-    }
-
-    "getDependencies" in {
-      Await.result(aggregates.storeDependencies(deps))
-      val retrieved = Await.result(aggregates.getDependencies(Some(Time.fromSeconds(100))))
-      retrieved must_== deps
-    }
-
-    "storeTopAnnotations" in {
-      Await.result(aggregates.storeTopAnnotations(annoService, topAnnos))
-      val topAnnoTable = new HBaseTable(_conf, TableLayouts.topAnnotationsTableName)
-      val scan = new Scan().addFamily(TableLayouts.topAnnotationFamily)
-      val results = Await.result(topAnnoTable.scan(scan, 100))
-      results.size must_== 1
-    }
-
-    "getTopAnnotations" in {
-      Await.result(aggregates.storeTopAnnotations(annoService, topAnnos))
-      val retrieved = Await.result(aggregates.getTopAnnotations(annoService))
-      retrieved must_== topAnnos
-    }
+  test("storeDependencies") {
+    Await.result(aggregates.storeDependencies(deps))
+    val depsTable = new HBaseTable(_conf, TableLayouts.dependenciesTableName)
+    val get = new Get(Bytes.toBytes(Long.MaxValue - Time.fromSeconds(2).inMilliseconds))
+    val result = Await.result(depsTable.get(Seq(get)))
+    result.size should be (1)
   }
 
+  test("getDependencies") {
+    Await.result(aggregates.storeDependencies(deps))
+    val retrieved = Await.result(aggregates.getDependencies(Some(Time.fromSeconds(100))))
+    retrieved should be (deps)
+  }
+
+  test("storeTopAnnotations") {
+    Await.result(aggregates.storeTopAnnotations(annoService, topAnnos))
+    val topAnnoTable = new HBaseTable(_conf, TableLayouts.topAnnotationsTableName)
+    val scan = new Scan().addFamily(TableLayouts.topAnnotationFamily)
+    val results = Await.result(topAnnoTable.scan(scan, 100))
+    results.size should be (1)
+  }
+
+  test("getTopAnnotations") {
+    Await.result(aggregates.storeTopAnnotations(annoService, topAnnos))
+    val retrieved = Await.result(aggregates.getTopAnnotations(annoService))
+    retrieved should be (topAnnos)
+  }
 }

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/ZipkinHBaseSpecification.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/ZipkinHBaseSpecification.scala
@@ -3,28 +3,28 @@ package com.twitter.zipkin.storage.hbase
 import com.twitter.zipkin.hbase.TableLayouts
 import org.apache.hadoop.hbase.util.Bytes
 import com.twitter.zipkin.storage.hbase.utils.HBaseSpecification
+import org.scalatest.{BeforeAndAfter, ConfigMap}
 
-trait ZipkinHBaseSpecification extends HBaseSpecification {
+trait ZipkinHBaseSpecification extends HBaseSpecification with BeforeAndAfter {
   /**
    * The list of tables that will be avaliable for tests.
    */
   val tablesNeeded:Seq[String]
 
-  doBeforeSpec {
+  override def beforeAll(configMap: ConfigMap) {
+    super.beforeAll(configMap)
     // Grab a lock on the util to make sure we're the only one making changes
     HBaseSpecification.sharedUtil.synchronized {
       TableLayouts.createTables(_util.getHBaseAdmin, tablesNeeded, None)
     }
   }
 
-  doBefore {
+  def before {
     HBaseSpecification.sharedUtil.synchronized {
       tablesNeeded.foreach { tableName =>
         _util.truncateTable(Bytes.toBytes(tableName))
       }
     }
   }
-
-  sequential
 }
 

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/mapping/ServiceMapperSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/mapping/ServiceMapperSpec.scala
@@ -1,11 +1,11 @@
 package com.twitter.zipkin.storage.hbase.mapping
 
-import com.twitter.util.Await
-import com.twitter.zipkin.hbase.{TableLayouts}
-import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
-import org.apache.hadoop.hbase.util.Bytes
 import java.nio.ByteBuffer
+
+import com.twitter.util.Await
+import com.twitter.zipkin.hbase.TableLayouts
 import com.twitter.zipkin.storage.hbase.ZipkinHBaseSpecification
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
 
 class ServiceMapperSpec extends ZipkinHBaseSpecification {
 
@@ -17,29 +17,20 @@ class ServiceMapperSpec extends ZipkinHBaseSpecification {
   val namePrefix = "mapping-"
   val names = (0 to 30) map { i => namePrefix + i}
 
-  "ServiceMapperSpec" should {
-
-    doBefore {
-      _util.truncateTable(Bytes.toBytes(TableLayouts.idGenTableName))
-      _util.truncateTable(Bytes.toBytes(TableLayouts.mappingTableName))
-    }
-
-    "get" in {
-      val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
-      val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
-      val idGen = new IDGenerator(idGenTable)
-      val serviceMapper = new ServiceMapper(mappingTable, idGen)
-      val serviceMapperTwo = new ServiceMapper(mappingTable, idGen)
+  test("get") {
+    val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
+    val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
+    val idGen = new IDGenerator(idGenTable)
+    val serviceMapper = new ServiceMapper(mappingTable, idGen)
+    val serviceMapperTwo = new ServiceMapper(mappingTable, idGen)
 
 
-      Await.result(serviceMapper.get("test")).id must_== Await.result(serviceMapperTwo.get("test")).id
-      Await.result(serviceMapper.get("test")).id must_== Await.result(serviceMapper.get("test")).id
-      Await.result(serviceMapperTwo.get("test")).id must_== Await.result(serviceMapperTwo.get("test")).id
+    Await.result(serviceMapper.get("test")).id should be (Await.result(serviceMapperTwo.get("test")).id)
+    Await.result(serviceMapper.get("test")).id should be (Await.result(serviceMapper.get("test")).id)
+    Await.result(serviceMapperTwo.get("test")).id should be (Await.result(serviceMapperTwo.get("test")).id)
 
-      ByteBuffer.wrap(Await.result(serviceMapper.get("test")).value) must_== ByteBuffer.wrap(Await.result(serviceMapperTwo.get("test")).value)
-      ByteBuffer.wrap(Await.result(serviceMapper.get("test")).value) must_== ByteBuffer.wrap(Await.result(serviceMapper.get("test")).value)
-      ByteBuffer.wrap(Await.result(serviceMapperTwo.get("test")).value) must_== ByteBuffer.wrap(Await.result(serviceMapperTwo.get("test")).value)
-    }
+    ByteBuffer.wrap(Await.result(serviceMapper.get("test")).value) should be (ByteBuffer.wrap(Await.result(serviceMapperTwo.get("test")).value))
+    ByteBuffer.wrap(Await.result(serviceMapper.get("test")).value) should be (ByteBuffer.wrap(Await.result(serviceMapper.get("test")).value))
+    ByteBuffer.wrap(Await.result(serviceMapperTwo.get("test")).value) should be (ByteBuffer.wrap(Await.result(serviceMapperTwo.get("test")).value))
   }
-
 }

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/mapping/SpanNameMapperSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/mapping/SpanNameMapperSpec.scala
@@ -1,9 +1,9 @@
 package com.twitter.zipkin.storage.hbase.mapping
 
 import com.twitter.util.Await
-import com.twitter.zipkin.hbase.{TableLayouts}
-import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
+import com.twitter.zipkin.hbase.TableLayouts
 import com.twitter.zipkin.storage.hbase.ZipkinHBaseSpecification
+import com.twitter.zipkin.storage.hbase.utils.{HBaseTable, IDGenerator}
 
 class SpanNameMapperSpec extends ZipkinHBaseSpecification {
 
@@ -12,60 +12,57 @@ class SpanNameMapperSpec extends ZipkinHBaseSpecification {
     TableLayouts.mappingTableName
   )
 
-  "SpanNameMapper" should {
-    "get" in {
-      val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
-      val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
-      val idGen = new IDGenerator(idGenTable)
-      val serviceMapper = new ServiceMapper(mappingTable, idGen)
+  test("get") {
+    val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
+    val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
+    val idGen = new IDGenerator(idGenTable)
+    val serviceMapper = new ServiceMapper(mappingTable, idGen)
 
-      val serviceNameOne = "TestService"
-      val spanNameOne = "TestSpanOne"
+    val serviceNameOne = "TestService"
+    val spanNameOne = "TestSpanOne"
 
-      val serviceMappingOne = Await.result(serviceMapper.get(serviceNameOne))
-      val spanNameMappingOne = Await.result(serviceMappingOne.spanNameMapper.get(spanNameOne))
-      val spanNameMappingOneAgain = Await.result(serviceMappingOne.spanNameMapper.get(spanNameOne))
+    val serviceMappingOne = Await.result(serviceMapper.get(serviceNameOne))
+    val spanNameMappingOne = Await.result(serviceMappingOne.spanNameMapper.get(spanNameOne))
+    val spanNameMappingOneAgain = Await.result(serviceMappingOne.spanNameMapper.get(spanNameOne))
 
-      spanNameMappingOne.id must_== spanNameMappingOneAgain.id
+    spanNameMappingOne.id should be (spanNameMappingOneAgain.id)
 
-      val names = Await.result(serviceMappingOne.spanNameMapper.getAll.map { maps => maps.map(_.name)}).toSeq
-      names must contain(spanNameOne.toLowerCase)
-    }
-
-    "be independent" in {
-      val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
-      val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
-      val idGen = new IDGenerator(idGenTable)
-      val serviceMapper = new ServiceMapper(mappingTable, idGen)
-
-      val serviceNameOne = "TestServiceOne"
-      val serviceNameTwo = "TestServiceTwo"
-
-      val spanNameOne = "spanNameOne"
-      val spanNameTwo = "spanNameOne"
-      val spanNameThree =  serviceNameTwo + ".spanNameThree"
-
-      val serviceMappingOne = Await.result(serviceMapper.get(serviceNameOne))
-      val serviceMappingTwo = Await.result(serviceMapper.get(serviceNameTwo))
-
-      val spanNameMappingOne = Await.result(serviceMappingOne.spanNameMapper.get(spanNameOne))
-      val spanNameMappingTwo = Await.result(serviceMappingTwo.spanNameMapper.get(spanNameTwo))
-      val spanNameMappingThree = Await.result(serviceMappingTwo.spanNameMapper.get(spanNameThree))
-
-      spanNameMappingOne.id must_== 1
-      spanNameMappingTwo.id must_== 1
-      spanNameMappingThree.id must_== 2
-
-      val serviceOneSpanMappings = Await.result(serviceMappingOne.spanNameMapper.getAll)
-      val serviceTwoSpanMappings = Await.result(serviceMappingTwo.spanNameMapper.getAll)
-
-      // Make sure that none of the mappings from service One have a parent that points to service two
-      serviceOneSpanMappings.map {_.parent.get.id} must not contain (serviceMappingTwo.id)
-      // make sure that none of the mappings from service two have a parent that points to service one
-      serviceTwoSpanMappings.map {_.parent.get.id} must not contain (serviceMappingOne.id)
-
-      serviceOneSpanMappings.map { _.name } must not contain (spanNameThree)
-    }
+    val names = Await.result(serviceMappingOne.spanNameMapper.getAll.map { maps => maps.map(_.name)}).toSeq
+    names should contain(spanNameOne.toLowerCase)
   }
 
+  test("be independent") {
+    val mappingTable = new HBaseTable(_conf, TableLayouts.mappingTableName)
+    val idGenTable = new HBaseTable(_conf, TableLayouts.idGenTableName)
+    val idGen = new IDGenerator(idGenTable)
+    val serviceMapper = new ServiceMapper(mappingTable, idGen)
+
+    val serviceNameOne = "TestServiceOne"
+    val serviceNameTwo = "TestServiceTwo"
+
+    val spanNameOne = "spanNameOne"
+    val spanNameTwo = "spanNameOne"
+    val spanNameThree =  serviceNameTwo + ".spanNameThree"
+
+    val serviceMappingOne = Await.result(serviceMapper.get(serviceNameOne))
+    val serviceMappingTwo = Await.result(serviceMapper.get(serviceNameTwo))
+
+    val spanNameMappingOne = Await.result(serviceMappingOne.spanNameMapper.get(spanNameOne))
+    val spanNameMappingTwo = Await.result(serviceMappingTwo.spanNameMapper.get(spanNameTwo))
+    val spanNameMappingThree = Await.result(serviceMappingTwo.spanNameMapper.get(spanNameThree))
+
+    spanNameMappingOne.id should be (1)
+    spanNameMappingTwo.id should be (1)
+    spanNameMappingThree.id should be (2)
+
+    val serviceOneSpanMappings = Await.result(serviceMappingOne.spanNameMapper.getAll)
+    val serviceTwoSpanMappings = Await.result(serviceMappingTwo.spanNameMapper.getAll)
+
+    // Make sure that none of the mappings from service One have a parent that points to service two
+    serviceOneSpanMappings.map {_.parent.get.id} should not contain (serviceMappingTwo.id)
+    // make sure that none of the mappings from service two have a parent that points to service one
+    serviceTwoSpanMappings.map {_.parent.get.id} should not contain (serviceMappingOne.id)
+
+    serviceOneSpanMappings.map { _.name } should not contain (spanNameThree)
+  }
 }

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/HBaseSpecification.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/HBaseSpecification.scala
@@ -2,29 +2,24 @@ package com.twitter.zipkin.storage.hbase.utils
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hbase.HBaseTestingUtility
-import org.junit.runner.RunWith
-import org.specs.SpecificationWithJUnit
-import org.specs.runner.JUnitSuiteRunner
+import org.scalatest._
 
-@RunWith(classOf[JUnitSuiteRunner])
-class HBaseSpecification extends SpecificationWithJUnit {
+class HBaseSpecification extends FunSuite with Matchers with BeforeAndAfterAll {
   lazy val _util: HBaseTestingUtility = HBaseSpecification.sharedUtil
   lazy val _conf: Configuration = _util.getConfiguration
 
-  doBeforeSpec {
+  override def beforeAll(configMap: ConfigMap) {
     HBaseSpecification.sharedUtil.synchronized {
       _util.startMiniCluster()
     }
   }
 
-  doAfterSpec {
+  override def afterAll(configMap: ConfigMap) {
     HBaseSpecification.sharedUtil.synchronized {
       _util.shutdownMiniCluster()
       Thread.sleep(10 * 1000)
     }
   }
-
-  sequential
 }
 
 /**

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/HBaseTableSpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/HBaseTableSpec.scala
@@ -3,56 +3,58 @@ package com.twitter.zipkin.storage.hbase.utils
 import com.twitter.util.Await
 import org.apache.hadoop.hbase.client.{Get, HTable, Put}
 import org.apache.hadoop.hbase.util.Bytes
+import org.scalatest.{BeforeAndAfter, ConfigMap}
 
-class HBaseTableSpec extends HBaseSpecification {
+class HBaseTableSpec extends HBaseSpecification with BeforeAndAfter {
 
   val tableName = "testTable"
   val family = Bytes.toBytes("D")
 
-  doBeforeSpec {
+  override def beforeAll(configMap: ConfigMap) {
+    super.beforeAll(configMap)
     _util.createTable(Bytes.toBytes(tableName), family)
   }
 
-  "HBaseTable" should {
-    doBefore {
-      _util.truncateTable(Bytes.toBytes(tableName))
-    }
-    "checkAndPut" in {
-      val t1 = new HBaseTable(_conf, tableName)
-      val t2 = new HBaseTable(_conf, tableName)
-
-      val rk = Bytes.toBytes("test")
-      val qual = Bytes.toBytes(0)
-
-      val p = new Put(rk)
-      p.add(family, qual, Bytes.toBytes("TESTING"))
-
-      val t1Result = t1.checkAndPut(rk, family, qual, Array[Byte](), p)
-      val t2Result = t2.checkAndPut(rk, family, qual, Array[Byte](), p)
-
-      !Await.result(t1Result) must_== Await.result(t2Result)
-    }
-    "put" in {
-      val t1 =  new HBaseTable(_conf, tableName)
-      val p = new Put(Bytes.toBytes("hello"))
-      p.add(family, Bytes.toBytes("a"), Bytes.toBytes("world."))
-      Await.result(t1.put(Seq(p)))
-
-      val ht = new HTable(_conf, tableName)
-      val result = ht.get(new Get(Bytes.toBytes("hello")))
-      result.size() must_== 1
-    }
-    "get" in {
-      val ht = new HTable(_conf, tableName)
-      val p = new Put(Bytes.toBytes("hello"))
-      p.add(family, Bytes.toBytes("a"), Bytes.toBytes("world."))
-      ht.put(p)
-
-      val t1 =  new HBaseTable(_conf, tableName)
-      val resultFuture = t1.get(Seq(new Get(Bytes.toBytes("hello"))))
-      val result = Await.result(resultFuture)
-      result.size must_== 1
-    }
+  before {
+    _util.truncateTable(Bytes.toBytes(tableName))
   }
 
+  test("checkAndPut") {
+    val t1 = new HBaseTable(_conf, tableName)
+    val t2 = new HBaseTable(_conf, tableName)
+
+    val rk = Bytes.toBytes("test")
+    val qual = Bytes.toBytes(0)
+
+    val p = new Put(rk)
+    p.add(family, qual, Bytes.toBytes("TESTING"))
+
+    val t1Result = t1.checkAndPut(rk, family, qual, Array[Byte](), p)
+    val t2Result = t2.checkAndPut(rk, family, qual, Array[Byte](), p)
+
+    !Await.result(t1Result) should be (Await.result(t2Result))
+  }
+
+  test("put") {
+    val t1 =  new HBaseTable(_conf, tableName)
+    val p = new Put(Bytes.toBytes("hello"))
+    p.add(family, Bytes.toBytes("a"), Bytes.toBytes("world."))
+    Await.result(t1.put(Seq(p)))
+
+    val ht = new HTable(_conf, tableName)
+    val result = ht.get(new Get(Bytes.toBytes("hello")))
+    result.size should be (1)
+  }
+
+  test("get") {
+    val ht = new HTable(_conf, tableName)
+    val p = new Put(Bytes.toBytes("hello"))
+    p.add(family, Bytes.toBytes("a"), Bytes.toBytes("world."))
+    ht.put(p)
+
+    val t1 =  new HBaseTable(_conf, tableName)
+    val resultFuture = t1.get(Seq(new Get(Bytes.toBytes("hello"))))
+    val result = Await.result(resultFuture)
+    result.size should be (1)
+  }
 }

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/RetryTest.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/RetryTest.scala
@@ -1,42 +1,39 @@
 package com.twitter.zipkin.storage.hbase.utils
 
-import org.junit.runner.RunWith
-import org.scalatest.{WordSpec, MustMatchers}
-import org.scalatest.junit.JUnitRunner
 import java.util.concurrent.atomic.AtomicLong
+
 import com.twitter.zipkin.storage.util.Retry
+import org.scalatest.{FunSuite, Matchers}
 
-@RunWith(classOf[JUnitRunner])
-class RetryTest extends WordSpec with MustMatchers {
-  "Retry" should {
-    "return if success" in {
-      val counter = new AtomicLong(0)
-      val result = Retry(10) {
-        val innerResult: Long = counter.incrementAndGet()
-        LongWrapper(innerResult)
-      }
-      result mustEqual LongWrapper(1L)
+class RetryTest extends FunSuite with Matchers {
+  test("return if success") {
+    val counter = new AtomicLong(0)
+    val result = Retry(10) {
+      val innerResult: Long = counter.incrementAndGet()
+      LongWrapper(innerResult)
     }
-    "throw an error if retries are exhausted" in {
-      intercept[Retry.RetriesExhaustedException]{
-        val result = Retry(5) {
-          throw new Exception("No! No! No!")
-          LongWrapper(1)
-        }
-      }
+    result should be(LongWrapper(1L))
+  }
 
-    }
-    "return if fewer than max retries are needed" in {
-      val counter = new AtomicLong(0)
-      val result = Retry(10) {
-        val innerResult: Long = counter.incrementAndGet()
-        if (innerResult < 10) {
-           throw new Exception("No No No")
-        }
-        LongWrapper(innerResult)
+  test("throw an error if retries are exhausted") {
+    intercept[Retry.RetriesExhaustedException]{
+      val result = Retry(5) {
+        throw new Exception("No! No! No!")
+        LongWrapper(1)
       }
-      result mustEqual LongWrapper(10L)
     }
+  }
+
+  test("return if fewer than max retries are needed") {
+    val counter = new AtomicLong(0)
+    val result = Retry(10) {
+      val innerResult: Long = counter.incrementAndGet()
+      if (innerResult < 10) {
+         throw new Exception("No No No")
+      }
+      LongWrapper(innerResult)
+    }
+    result should be (LongWrapper(10L))
   }
   case class LongWrapper(value:Long)
 }

--- a/zipkin-mongodb/build.sbt
+++ b/zipkin-mongodb/build.sbt
@@ -6,4 +6,4 @@ libraryDependencies ++= Seq(
   "org.mongodb" %% "casbah" % "2.8.1",
   slf4jLog4j12,
   util("logging")
-) ++ testDependencies ++ scalaTestDeps
+) ++ testDependencies

--- a/zipkin-mongodb/src/test/scala/com/twitter/zipkin/storage/mongodb/MongoDBSpanStoreTest.scala
+++ b/zipkin-mongodb/src/test/scala/com/twitter/zipkin/storage/mongodb/MongoDBSpanStoreTest.scala
@@ -6,13 +6,10 @@ import com.mongodb.casbah.Imports._
 import com.twitter.app.App
 import com.twitter.util.TimeConversions._
 import com.twitter.zipkin.mongodb.MongoDBSpanStoreFactory
-import com.twitter.zipkin.storage.{IndexedTraceId, SpanStore}
 import com.twitter.zipkin.storage.util.SpanStoreValidator
-import org.junit.runner.RunWith
+import com.twitter.zipkin.storage.{IndexedTraceId, SpanStore}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class MongoDBSpanStoreTest extends FunSuite {
 
   test("timestamps in MongoDBSpanStoreUtils") {

--- a/zipkin-query-core/build.sbt
+++ b/zipkin-query-core/build.sbt
@@ -4,6 +4,5 @@ libraryDependencies ++= Seq(
   Seq(algebird("core"), ostrich),
   many(finagle, "ostrich4", "serversets", "thrift", "zipkin"),
   many(util, "core", "zk", "zk-common"),
-  many(zk, "candidate", "group"),
-  testDependencies
-).flatten
+  many(zk, "candidate", "group")
+).flatten ++ testDependencies

--- a/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
+++ b/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/QueryServiceSpec.scala
@@ -16,17 +16,19 @@
  */
 package com.twitter.zipkin.query
 
+import java.nio.ByteBuffer
+
 import com.twitter.util.{Await, Future}
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.conversions.thrift._
-import com.twitter.zipkin.thriftscala
-import com.twitter.zipkin.query.adjusters.{TimeSkewAdjuster, NullAdjuster}
+import com.twitter.zipkin.query.adjusters.{NullAdjuster, TimeSkewAdjuster}
 import com.twitter.zipkin.storage._
-import java.nio.ByteBuffer
-import org.specs.Specification
-import org.specs.mock.{ClassMocker, JMocker}
+import com.twitter.zipkin.thriftscala
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
 
-class QueryServiceSpec extends Specification with JMocker with ClassMocker {
+class QueryServiceSpec extends WordSpec with Matchers with MockitoSugar {
   val ep1 = Endpoint(123, 123, "service1")
   val ep2 = Endpoint(234, 234, "service2")
   val ep3 = Endpoint(345, 345, "service3")
@@ -64,19 +66,25 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
     "thriftscala.rate exception in getTraceIdsByName if service name is null" in {
       val qs = new QueryService(null, null, null, null)
       qs.start
-      Await.result(qs.getTraceIdsBySpanName(null, "span", 101, 100, thriftscala.Order.DurationDesc)) must throwA[thriftscala.QueryException]
+      intercept[thriftscala.QueryException] {
+        Await.result(qs.getTraceIdsBySpanName(null, "span", 101, 100, thriftscala.Order.DurationDesc))
+      }
     }
 
     "throw exception in getTraceIdsByServiceName if service name is null" in {
       val qs = new QueryService(null, null, null, null)
       qs.start
-      Await.result(qs.getTraceIdsByServiceName(null, 101, 100, thriftscala.Order.DurationDesc)) must throwA[thriftscala.QueryException]
+      intercept[thriftscala.QueryException] {
+        Await.result(qs.getTraceIdsByServiceName(null, 101, 100, thriftscala.Order.DurationDesc))
+      }
     }
 
     "throw exception in getTraceIdsByAnnotation if annotation is null" in {
       val qs = new QueryService(null, null, null, null)
       qs.start
-      Await.result(qs.getTraceIdsByAnnotation(null, null, null, 101, 100, thriftscala.Order.DurationDesc)) must throwA[thriftscala.QueryException]
+      intercept[thriftscala.QueryException] {
+        Await.result(qs.getTraceIdsByAnnotation(null, null, null, 101, 100, thriftscala.Order.DurationDesc))
+      }
     }
 
     class MockIndex extends Index {
@@ -87,21 +95,21 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       def close() = null
       def getTraceIdsByName(serviceName: String, spanName: Option[String],
                             endTs: Long, limit: Int): Future[Seq[IndexedTraceId]] = {
-        serviceName mustEqual "service"
-        spanName mustEqual mockSpanName
-        endTs mustEqual 100L
+        serviceName should be ("service")
+        spanName should be (mockSpanName)
+        endTs should be (100L)
         Future(ids)
       }
       def getTraceIdsByAnnotation(service: String, annotation: String, value: Option[ByteBuffer], endTs: Long,
                                   limit: Int): Future[Seq[IndexedTraceId]] = {
-        service mustEqual "service"
-        annotation mustEqual "annotation"
-        value mustEqual mockValue
-        endTs mustEqual 100L
+        service should be ("service")
+        annotation should be ("annotation")
+        value should be (mockValue)
+        endTs should be (100L)
         Future(ids)
       }
       def getTracesDuration(traceIds: Seq[Long]): Future[Seq[TraceIdDuration]] = {
-        traceIds mustEqual Seq(1, 2, 3)
+        traceIds should be (Seq(1, 2, 3))
         Future(Seq(TraceIdDuration(1, 50, 100), TraceIdDuration(2, 401, 101),
           TraceIdDuration(3, 100, 99)))
       }
@@ -121,10 +129,8 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val qs = new QueryService(storage, index, null, Map())
       qs.start()
 
-      val expected = List(2, 3, 1)
-
-      val actual = Await.result(qs.getTraceIdsBySpanName("service", "methodcall", 100, 50, thriftscala.Order.DurationDesc))
-      actual mustEqual expected
+      val result = Await.result(qs.getTraceIdsBySpanName("service", "methodcall", 100, 50, thriftscala.Order.DurationDesc))
+      result should be (List(2, 3, 1))
     }
 
     "find traces in service span name index, order by duration desc" in {
@@ -134,10 +140,8 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val qs = new QueryService(storage, index, null, Map())
       qs.start()
 
-      val expected = List(2, 3, 1)
-
-      val actual = Await.result(qs.getTraceIdsBySpanName("service", "methodcall", 100, 50, thriftscala.Order.DurationDesc))
-      actual mustEqual expected
+      val result = Await.result(qs.getTraceIdsBySpanName("service", "methodcall", 100, 50, thriftscala.Order.DurationDesc))
+      result should be (List(2, 3, 1))
     }
 
     "find traces in service span name index, order by nothing" in {
@@ -147,10 +151,8 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val qs = new QueryService(storage, index, null, Map())
       qs.start()
 
-      val expected = List(1, 2, 3)
-
-      val actual = Await.result(qs.getTraceIdsBySpanName("service", "methodcall", 100, 50, thriftscala.Order.None))
-      actual mustEqual expected
+      val result = Await.result(qs.getTraceIdsBySpanName("service", "methodcall", 100, 50, thriftscala.Order.None))
+      result should be (List(1, 2, 3))
     }
 
     "successfully return the trace summary for a trace id" in {
@@ -161,12 +163,10 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
 
       val traceId = 123L
 
-      expect {
-        one(storage).getSpansByTraceIds(List(traceId)) willReturn Future(List(spans1))
-      }
+      when(storage.getSpansByTraceIds(List(traceId))) thenReturn Future(List(spans1))
 
-      val ts = List(TraceSummary(1, 100, 150, 50, List(SpanTimestamp("service1", 100, 150)), List(ep1)).toThrift)
-      ts mustEqual Await.result(qs.getTraceSummariesByIds(List(traceId), List()))
+      val result = List(TraceSummary(1, 100, 150, 50, List(SpanTimestamp("service1", 100, 150)), List(ep1)).toThrift)
+      result should be (Await.result(qs.getTraceSummariesByIds(List(traceId), List())))
     }
 
     "successfully return the trace combo for a trace id" in {
@@ -177,14 +177,14 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
 
       val traceId = 123L
 
-      expect {
-        one(storage).getSpansByTraceIds(List(traceId)) willReturn Future(List(spans1))
-      }
+      when(storage.getSpansByTraceIds(List(traceId))) thenReturn Future(List(spans1))
+
       val trace = trace1.toThrift
       val summary = TraceSummary(1, 100, 150, 50, List(SpanTimestamp("service1", 100, 150)), List(ep1)).toThrift
       val timeline = TraceTimeline(trace1) map { _.toThrift }
-      val combo = thriftscala.TraceCombo(trace, Some(summary), timeline, Some(Map(666L -> 1)))
-      Seq(combo) mustEqual Await.result(qs.getTraceCombosByIds(List(traceId), List()))
+
+      val result = Await.result(qs.getTraceCombosByIds(List(traceId), List()))
+      result should be (Seq(thriftscala.TraceCombo(trace, Some(summary), timeline, Some(Map(666L -> 1)))))
     }
 
     "find traces in service name index, fetch from storage" in {
@@ -195,10 +195,8 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val qs = new QueryService(storage, index, null, Map())
       qs.start()
 
-      val expected = List(2, 3, 1)
-
-      val actual = Await.result(qs.getTraceIdsByServiceName("service", 100, 50, thriftscala.Order.DurationDesc))
-      expected mustEqual actual
+      val result = Await.result(qs.getTraceIdsByServiceName("service", 100, 50, thriftscala.Order.DurationDesc))
+      result should be (List(2, 3, 1))
     }
 
     "find traces in annotation index by timestamp annotation, fetch from storage" in {
@@ -207,9 +205,8 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val qs = new QueryService(storage, index, null, Map())
       qs.start()
 
-      val expected = List(2, 3, 1)
-
-      expected mustEqual Await.result(qs.getTraceIdsByAnnotation("service", "annotation", null, 100, 50, thriftscala.Order.DurationDesc))
+      val result = Await.result(qs.getTraceIdsByAnnotation("service", "annotation", null, 100, 50, thriftscala.Order.DurationDesc))
+      result should be (List(2, 3, 1))
     }
 
     "find traces in annotation index by kv annotation, fetch from storage" in {
@@ -220,10 +217,8 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val qs = new QueryService(storage, index, null, Map())
       qs.start()
 
-      val expected = List(2, 3, 1)
-      val actual = Await.result(qs.getTraceIdsByAnnotation("service", "annotation", ByteBuffer.wrap("value".getBytes), 100, 50, thriftscala.Order.DurationDesc))
-
-      expected mustEqual actual
+      val result = Await.result(qs.getTraceIdsByAnnotation("service", "annotation", ByteBuffer.wrap("value".getBytes), 100, 50, thriftscala.Order.DurationDesc))
+      result should be (List(2, 3, 1))
     }
 
     "fetch traces from storage" in {
@@ -232,13 +227,9 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val qs = new QueryService(storage, index, null, Map())
       qs.start()
 
-      expect {
-        1.of(storage).getSpansByTraceIds(List(1L)) willReturn Future(List(spans1))
-      }
+      when(storage.getSpansByTraceIds(List(1L))) thenReturn Future(List(spans1))
 
-      val expected = List(trace1.toThrift)
-      val actual = Await.result(qs.getTracesByIds(List(1L), List()))
-      expected mustEqual actual
+      Await.result(qs.getTracesByIds(List(1L), List())) should be (List(trace1.toThrift))
     }
 
     "fetch timeline from storage" in {
@@ -248,9 +239,7 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
         Map(thriftscala.Adjust.Nothing -> NullAdjuster, thriftscala.Adjust.TimeSkew -> new TimeSkewAdjuster()))
       qs.start()
 
-      expect {
-        1.of(storage).getSpansByTraceIds(List(1L)) willReturn Future(List(spans4))
-      }
+      when(storage.getSpansByTraceIds(List(1L))) thenReturn Future(List(spans4))
 
       val ann1 = thriftscala.TimelineAnnotation(100, thriftscala.Constants.CLIENT_SEND,
         ep1.toThrift, 666, None, "service1", "methodcall")
@@ -261,9 +250,8 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val ann4 = thriftscala.TimelineAnnotation(140, thriftscala.Constants.SERVER_SEND,
         ep2.toThrift, 666, None, "service2", "methodcall")
 
-      val expected = List(thriftscala.TraceTimeline(1L, 666, List(ann1, ann3, ann4, ann2), List()))
-      val actual = Await.result(qs.getTraceTimelinesByIds(List(1L), List(thriftscala.Adjust.Nothing, thriftscala.Adjust.TimeSkew)))
-      expected mustEqual actual
+      val result = Await.result(qs.getTraceTimelinesByIds(List(1L), List(thriftscala.Adjust.Nothing, thriftscala.Adjust.TimeSkew)))
+      result should be (List(thriftscala.TraceTimeline(1L, 666, List(ann1, ann3, ann4, ann2), List())))
     }
 
     "fetch timeline with clock skew from storage, fix skew" in {
@@ -296,13 +284,11 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val realSpans = List(rs1, rs2)
       val realTrace = Trace(realSpans)
 
-      expect {
-        1.of(storage).getSpansByTraceIds(List(4488677265848750007L)) willReturn Future(List(realSpans))
-      }
+      when(storage.getSpansByTraceIds(List(4488677265848750007L))) thenReturn Future(List(realSpans))
 
-      val actual = Await.result(qs.getTraceTimelinesByIds(List(4488677265848750007L), List(thriftscala.Adjust.TimeSkew)))
-      actual.size mustEqual 1
-      val tla = actual(0).`annotations`
+      val result = Await.result(qs.getTraceTimelinesByIds(List(4488677265848750007L), List(thriftscala.Adjust.TimeSkew)))
+      result.size should be (1)
+      val tla = result(0).`annotations`
       /*
         we expect the following order of annotations back
         this is the order of the evens as they happened
@@ -315,18 +301,18 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       */
 
       // we ignore the timestamps for now, order is what we care about
-      tla(0).`value` mustEqual "cs"
-      tla(0).`host` mustEqual epKoalabirdT
-      tla(1).`value` mustEqual "sr"
-      tla(1).`host` mustEqual epCuckooT
-      tla(2).`value` mustEqual "cs"
-      tla(2).`host` mustEqual epCuckooCassieT
-      tla(3).`value` mustEqual "cr"
-      tla(3).`host` mustEqual epCuckooCassieT
-      tla(4).`value` mustEqual "ss"
-      tla(4).`host` mustEqual epCuckooT
-      tla(5).`value` mustEqual "cr"
-      tla(5).`host` mustEqual epKoalabirdT
+      tla(0).`value` should be ("cs")
+      tla(0).`host` should be (epKoalabirdT)
+      tla(1).`value` should be ("sr")
+      tla(1).`host` should be (epCuckooT)
+      tla(2).`value` should be ("cs")
+      tla(2).`host` should be (epCuckooCassieT)
+      tla(3).`value` should be ("cr")
+      tla(3).`host` should be (epCuckooCassieT)
+      tla(4).`value` should be ("ss")
+      tla(4).`host` should be (epCuckooT)
+      tla(5).`value` should be ("cr")
+      tla(5).`host` should be (epKoalabirdT)
     }
 
     "fetch timeline with clock skew from storage, fix skew - the sequel" in {
@@ -359,13 +345,11 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val realSpans = List(rs1, rs2)
       val realTrace = Trace(realSpans)
 
-      expect {
-        1.of(storage).getSpansByTraceIds(List(-6120267009876080004L)) willReturn Future(List(realSpans))
-      }
+      when(storage.getSpansByTraceIds(List(-6120267009876080004L))) thenReturn Future(List(realSpans))
 
-      val actual = Await.result(qs.getTraceTimelinesByIds(List(-6120267009876080004L), List(thriftscala.Adjust.TimeSkew)))
-      actual.size mustEqual 1
-      val tla = actual(0).`annotations`
+      val result = Await.result(qs.getTraceTimelinesByIds(List(-6120267009876080004L), List(thriftscala.Adjust.TimeSkew)))
+      result.size should be (1)
+      val tla = result(0).`annotations`
       /*
         we expect the following order of annotations back
         this is the order of the evens as they happened
@@ -389,18 +373,18 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       */
 
       // we ignore the timestamps for now, order is what we care about
-      tla(0).`value` mustEqual "cs"
-      tla(0).`host` mustEqual epKoalabirdT
-      tla(1).`value` mustEqual "sr"
-      tla(1).`host` mustEqual epCuckooT
-      tla(2).`value` mustEqual "cs"
-      tla(2).`host` mustEqual epCuckooCassieT
-      tla(3).`value` mustEqual "cr"
-      tla(3).`host` mustEqual epCuckooCassieT
-      tla(4).`value` mustEqual "ss"
-      tla(4).`host` mustEqual epCuckooT
-      tla(5).`value` mustEqual "cr"
-      tla(5).`host` mustEqual epKoalabirdT
+      tla(0).`value` should be ("cs")
+      tla(0).`host` should be (epKoalabirdT)
+      tla(1).`value` should be ("sr")
+      tla(1).`host` should be (epCuckooT)
+      tla(2).`value` should be ("cs")
+      tla(2).`host` should be (epCuckooCassieT)
+      tla(3).`value` should be ("cr")
+      tla(3).`host` should be (epCuckooCassieT)
+      tla(4).`value` should be ("ss")
+      tla(4).`host` should be (epCuckooT)
+      tla(5).`value` should be ("cr")
+      tla(5).`host` should be (epKoalabirdT)
     }
 
     "fail to find traces by name in index, return empty" in {
@@ -412,7 +396,8 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val qs = new QueryService(storage, index, null, Map())
       qs.start()
 
-      List() mustEqual Await.result(qs.getTraceIdsBySpanName("service", "methodcall", 100, 50, thriftscala.Order.DurationDesc))
+      val result = Await.result(qs.getTraceIdsBySpanName("service", "methodcall", 100, 50, thriftscala.Order.DurationDesc))
+      result should be (List())
     }
 
     "fail to find traces by annotation in index, return empty" in {
@@ -424,7 +409,8 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       val qs = new QueryService(storage, index, null, Map())
       qs.start()
 
-      List() mustEqual Await.result(qs.getTraceIdsByAnnotation("service", "annotation", null, 100, 50, thriftscala.Order.DurationDesc))
+      val result = Await.result(qs.getTraceIdsByAnnotation("service", "annotation", null, 100, 50, thriftscala.Order.DurationDesc))
+      result should be (List())
     }
 
     "return the correct ttl" in {
@@ -434,14 +420,12 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
       qs.start()
       val ttl = 123
 
-      expect {
-        one(storage).getDataTimeToLive willReturn ttl
-      }
+      when(storage.getDataTimeToLive) thenReturn ttl
 
-      ttl mustEqual Await.result(qs.getDataTimeToLive())
+      Await.result(qs.getDataTimeToLive()) should be (ttl)
     }
 
-    "retrieve aggregates" in {
+    "retrieve aggregates" should {
       val aggregates = mock[Aggregates]
       val serviceName = "mockingbird"
       val annotations = Seq("a", "b", "c")
@@ -450,26 +434,22 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
         val qs = new QueryService(null, null, aggregates, Map())
         qs.start()
 
-        expect {
-          one(aggregates).getTopAnnotations(serviceName) willReturn Future.value(annotations)
-        }
+        when(aggregates.getTopAnnotations(serviceName)) thenReturn Future.value(annotations)
 
-        Await.result(qs.getTopAnnotations(serviceName)) mustEqual annotations
+        Await.result(qs.getTopAnnotations(serviceName)) should be (annotations)
       }
 
       "retrieve top key value annotations" in {
         val qs = new QueryService(null, null, aggregates, Map())
         qs.start()
 
-        expect {
-          one(aggregates).getTopKeyValueAnnotations(serviceName) willReturn Future.value(annotations)
-        }
+        when(aggregates.getTopKeyValueAnnotations(serviceName)) thenReturn Future.value(annotations)
 
-        Await.result(qs.getTopKeyValueAnnotations(serviceName)) mustEqual annotations
+        Await.result(qs.getTopKeyValueAnnotations(serviceName)) should be (annotations)
       }
     }
 
-    "getTraceIds" in {
+    "getTraceIds" should {
       val mockIndex = mock[Index]
       val qs = new QueryService(null, mockIndex, null, null)
       qs.start()
@@ -486,93 +466,34 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
 
       def id(id: Long, time: Long) = IndexedTraceId(id, time)
 
-      val request = thriftscala.QueryRequest(serviceName, spanName, annotations, binaryAnnotations, endTs, limit, order)
-
       "get intersection of different filters" in {
-        expect {
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, endTs, 1) willReturn Future(Seq(id(1, endTs)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, endTs, 1) willReturn Future(Seq(id(1, endTs)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), endTs, 1) willReturn Future(Seq(id(1, endTs)))
+        val request = thriftscala.QueryRequest(serviceName, spanName, annotations, binaryAnnotations, endTs, limit, order)
 
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, paddedTs, limit) willReturn Future(Seq(id(1, 1), id(2, 2), id(3, 3)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, paddedTs, limit) willReturn Future(Seq(id(4, 4), id(1, 5), id(3, 4)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), paddedTs, limit) willReturn Future(Seq(id(2, 3), id(4, 9), id(1, 9)))
+        when(mockIndex.getTraceIdsByName(serviceName, spanName, endTs, 1)) thenReturn Future(Seq(id(1, endTs)))
+        when(mockIndex.getTraceIdsByAnnotation(serviceName, "ann1", None, endTs, 1)) thenReturn Future(Seq(id(1, endTs)))
+        when(mockIndex.getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), endTs, 1)) thenReturn Future(Seq(id(1, endTs)))
 
-          one(mockIndex).getTracesDuration(Seq(1)) willReturn Future(Seq(TraceIdDuration(1, 100, 1)))
-        }
+        when(mockIndex.getTraceIdsByName(serviceName, spanName, paddedTs, limit)) thenReturn Future(Seq(id(1, 1), id(2, 2), id(3, 3)))
+        when(mockIndex.getTraceIdsByAnnotation(serviceName, "ann1", None, paddedTs, limit)) thenReturn Future(Seq(id(4, 4), id(1, 5), id(3, 4)))
+        when(mockIndex.getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), paddedTs, limit)) thenReturn Future(Seq(id(2, 3), id(4, 9), id(1, 9)))
 
-        val response = Await.result(qs.getTraceIds(request))
-        response.`traceIds`.length mustEqual 1
-        response.`traceIds`(0) mustEqual 1
-
-        response.`endTs` mustEqual 9
-        response.`startTs` mustEqual 9
-      }
-
-      "empty intersection of empty filters" in {
-        expect {
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, endTs, 1) willReturn Future(Seq(id(1, endTs)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, endTs, 1) willReturn Future(Nil)
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), endTs, 1) willReturn Future(Nil)
-
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, paddedTs, limit) willReturn Future(Seq(id(1, 1), id(2, 2), id(3, 3)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, paddedTs, limit) willReturn Future(Nil)
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), paddedTs, limit) willReturn Future(Nil)
-        }
+        when(mockIndex.getTracesDuration(Seq(1))) thenReturn Future(Seq(TraceIdDuration(1, 100, 1)))
 
         val response = Await.result(qs.getTraceIds(request))
-        response.`traceIds`.length mustEqual 0
+        response.`traceIds`.length should be (1)
+        response.`traceIds`(0) should be (1)
+
+        response.`endTs` should be (9)
+        response.`startTs` should be (9)
       }
 
-      "empty response" in {
-        expect {
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, endTs, 1) willReturn Future(Nil)
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, endTs, 1) willReturn Future(Nil)
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), endTs, 1) willReturn Future(Nil)
-
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, -1, limit) willReturn Future(Nil)
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, -1, limit) willReturn Future(Nil)
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), -1, limit) willReturn Future(Nil)
-        }
-
-        val response = Await.result(qs.getTraceIds(request))
-        response.`traceIds`.length mustEqual 0
-      }
-
-      "empty intersection of different filters" in {
-        expect {
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, endTs, 1) willReturn Future(Seq(id(1, endTs)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, endTs, 1) willReturn Future(Seq(id(2, endTs)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), endTs, 1) willReturn Future(Seq(id(3, endTs)))
-
-          one(mockIndex).getTraceIdsByName(serviceName, spanName, paddedTs, limit) willReturn Future(Seq(id(5, 5)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "ann1", None, paddedTs, limit) willReturn Future(Seq(id(6, 6)))
-          one(mockIndex).getTraceIdsByAnnotation(serviceName, "key", Some(ByteBuffer.wrap("value".getBytes)), paddedTs, limit) willReturn Future(Seq(id(7, 7)))
-        }
-
-        val response = Await.result(qs.getTraceIds(request))
-        response.`traceIds`.length mustEqual 0
-      }
-
-      "find intersection" in {
-        "no ids" in {
-          qs.traceIdsIntersect(Seq(List())) mustEqual Nil
-        }
-
-        "no common ids" in {
-          val ids = Seq(
-            Seq(IndexedTraceId(1, 100), IndexedTraceId(2, 200)),
-            Seq(IndexedTraceId(3, 300))
-          )
-          qs.traceIdsIntersect(ids) mustEqual Nil
-        }
-
+      "find intersection" should {
         "one id" in {
           val ids = Seq(
             Seq(IndexedTraceId(1, 100), IndexedTraceId(2, 140)),
             Seq(IndexedTraceId(1, 100))
           )
-          qs.traceIdsIntersect(ids) mustEqual Seq(IndexedTraceId(1, 100))
+          qs.traceIdsIntersect(ids) should be (Seq(IndexedTraceId(1, 100)))
         }
 
         "multiple ids" in {
@@ -580,10 +501,7 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
             Seq(IndexedTraceId(1, 100), IndexedTraceId(2, 200), IndexedTraceId(3, 300)),
             Seq(IndexedTraceId(2, 200), IndexedTraceId(4, 200), IndexedTraceId(7, 300), IndexedTraceId(3, 300))
           )
-          val actual = qs.traceIdsIntersect(ids)
-          actual.length mustEqual 2
-          actual mustContain IndexedTraceId(2, 200)
-          actual mustContain IndexedTraceId(3, 300)
+          qs.traceIdsIntersect(ids) should be (Seq(IndexedTraceId(2, 200), IndexedTraceId(3, 300)))
         }
 
         "take max time for each id" in {
@@ -591,10 +509,7 @@ class QueryServiceSpec extends Specification with JMocker with ClassMocker {
             Seq(IndexedTraceId(1, 100), IndexedTraceId(2, 200), IndexedTraceId(3, 300)),
             Seq(IndexedTraceId(1, 101), IndexedTraceId(2, 202))
           )
-          val actual = qs.traceIdsIntersect(ids)
-          actual.length mustEqual 2
-          actual mustContain IndexedTraceId(1, 101)
-          actual mustContain IndexedTraceId(2, 202)
+          qs.traceIdsIntersect(ids) should be (Seq(IndexedTraceId(2, 202), IndexedTraceId(1, 101)))
         }
       }
     }

--- a/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/conversions/TraceTimelineSpec.scala
+++ b/zipkin-query-core/src/test/scala/com/twitter/zipkin/query/conversions/TraceTimelineSpec.scala
@@ -15,15 +15,14 @@
  */
 package com.twitter.zipkin.query.conversions
 
-import com.twitter.zipkin.common._
-import com.twitter.zipkin.thriftscala
-import com.twitter.zipkin.query.{Trace, TimelineAnnotation, TraceTimeline}
-import org.specs.Specification
-import org.specs.mock.{ClassMocker, JMocker}
 import java.nio.ByteBuffer
 
-class TraceTimelineSpec extends Specification with JMocker with ClassMocker {
+import com.twitter.zipkin.common._
+import com.twitter.zipkin.query.{TimelineAnnotation, Trace, TraceTimeline}
+import com.twitter.zipkin.thriftscala
+import org.scalatest.{FunSuite, Matchers}
 
+class TraceTimelineSpec extends FunSuite with Matchers {
 
 //T = 0	 koalabird-cuckoo	 ValuesFromSource	 Server receive	 10.34.238.111 ():9149
 //T + 1	 client	 multiget_slice	 Client send	 10.34.238.111 ():54147
@@ -100,16 +99,13 @@ class TraceTimelineSpec extends Specification with JMocker with ClassMocker {
   val expectedTimeline = TraceTimeline(1, 2209720933601260005L, List(tAnn3, tAnn1, tAnn2,
     tAnn5, tAnn4, tAnn6), List(ba1))
 
-  "TraceTimelineSpec" should {
-    "convert to timeline with correct annotations ordering" in {
-      val actualTimeline = TraceTimeline(trace)
-      Some(expectedTimeline) mustEqual actualTimeline
-    }
-
-    "return none if empty trace" in {
-      val actualTimeline = TraceTimeline(new Trace(List()))
-      None mustEqual actualTimeline
-    }
+  test("convert to timeline with correct annotations ordering") {
+    val actualTimeline = TraceTimeline(trace)
+    actualTimeline should be (Some(expectedTimeline))
   }
 
+  test("return none if empty trace") {
+    val actualTimeline = TraceTimeline(new Trace(List()))
+    actualTimeline should be (None)
+  }
 }

--- a/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
+++ b/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
@@ -20,25 +20,22 @@ import com.twitter.ostrich.admin.RuntimeEnvironment
 import com.twitter.util.Eval
 import com.twitter.zipkin.builder.Builder
 import com.twitter.zipkin.query.ZipkinQuery
-import org.specs.Specification
+import org.scalatest.{FunSuite, Matchers}
 
-class ConfigSpec extends Specification {
-  "/config" should {
-    val eval = new Eval
+class ConfigSpec extends FunSuite with Matchers {
 
-    "validate query configs" in {
-      val queryConfigFiles = Seq(
-        "/query-dev.scala",
-        "/query-cassandra.scala"
-      ) map { TempFile.fromResourcePath(_) }
+  val eval = new Eval
 
-      for (file <- queryConfigFiles) {
-        file.getName() in {
-          val config = eval[Builder[RuntimeEnvironment => ZipkinQuery]](file)
-          config must notBeNull
-          config.apply()
-        }
-      }
+  test("validate query configs") {
+    val queryConfigFiles = Seq(
+      "/query-dev.scala",
+      "/query-cassandra.scala"
+    ) map { TempFile.fromResourcePath(_) }
+
+    for (file <- queryConfigFiles) {
+      val config = eval[Builder[RuntimeEnvironment => ZipkinQuery]](file)
+      config should not be(Nil)
+      config.apply()
     }
   }
 }

--- a/zipkin-query/build.sbt
+++ b/zipkin-query/build.sbt
@@ -2,6 +2,5 @@ defaultSettings
 
 libraryDependencies ++= Seq(
   many(finagle, "thriftmux", "zipkin"),
-  many(util, "app", "core"),
-  scalaTestDeps
-).flatten
+  many(util, "app", "core")
+).flatten ++ testDependencies

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ThriftQueryServiceTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ThriftQueryServiceTest.scala
@@ -16,17 +16,15 @@
  */
 package com.twitter.zipkin.query
 
-import com.twitter.util.{Await, Future}
+import java.nio.ByteBuffer
+
+import com.twitter.util.Await
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.storage.InMemorySpanStore
 import com.twitter.zipkin.thriftscala
-import java.nio.ByteBuffer
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ThriftQueryServiceTest extends FunSuite {
   val ep1 = Endpoint(123, 123, "service1")
   val ep2 = Endpoint(234, 234, "service2")

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjusterSpec.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjusterSpec.scala
@@ -16,15 +16,13 @@
  */
 package com.twitter.zipkin.query.adjusters
 
-import com.twitter.zipkin.common.{Endpoint, Annotation, Span}
-import com.twitter.zipkin.thriftscala
+import com.twitter.zipkin.common.{Annotation, Endpoint, Span}
 import com.twitter.zipkin.query.Trace
-import org.junit.runner.RunWith
+import com.twitter.zipkin.thriftscala
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
+
 import scala.collection._
 
-@RunWith(classOf[JUnitRunner])
 class TimeSkewAdjusterTest extends FunSuite {
   val endpoint1 = Some(Endpoint(123, 123, "service"))
   val endpoint2 = Some(Endpoint(321, 321, "service"))

--- a/zipkin-receiver-kafka/build.sbt
+++ b/zipkin-receiver-kafka/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-io" % "1.3.2",
   "com.github.charithe" % "kafka-junit" % "1.4" % "test",
   scroogeDep("serializer")
-) ++ scalaTestDeps
+) ++ testDependencies
 
 dependencyOverrides ++= Set(
   // Twitter's build is pinned to 4.10, but we need 4.11+ to use rules in Scala.

--- a/zipkin-receiver-scribe/build.sbt
+++ b/zipkin-receiver-scribe/build.sbt
@@ -4,4 +4,4 @@ libraryDependencies ++= Seq(
   finagle("thriftmux"),
   util("zk"),
   slf4jLog4j12
-) ++ scalaTestDeps
+) ++ testDependencies

--- a/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
+++ b/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
@@ -20,11 +20,8 @@ import com.twitter.util.{Await, Future}
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.thriftscala.{LogEntry, ResultCode, Span => ThriftSpan}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ScribeSpanReceiverTest extends FunSuite {
   val serializer = new BinaryThriftStructSerializer[ThriftSpan] {
     def codec = ThriftSpan

--- a/zipkin-redis/build.sbt
+++ b/zipkin-redis/build.sbt
@@ -7,6 +7,6 @@ libraryDependencies ++= Seq(
   util("logging"),
   scroogeDep("serializer"),
   slf4jLog4j12
-) ++ testDependencies ++ scalaTestDeps
+) ++ testDependencies
 
 addConfigsToResourcePathForConfigSpec()

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisConversionsSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisConversionsSpec.scala
@@ -17,42 +17,41 @@
 package com.twitter.zipkin.storage.redis
 
 import com.twitter.zipkin.common.Span
-import org.specs.Specification
+import org.scalatest.{FunSuite, Matchers}
+
 import scala.util.Random
 
-class RedisConversionsSpec extends Specification {
-  "RedisConversions" should {
-    val rand = new Random
+class RedisConversionsSpec extends FunSuite with Matchers {
+  val rand = new Random
 
-    "convert from a TraceLog and back" in {
-      val value = ExpiringValue(rand.nextLong(), rand.nextLong())
-      chanBuf2ExpiringValue[Long](expiringValue2ChanBuf[Long](value)) mustEqual value
-    }
+  test("convert from a TraceLog and back") {
+    val value = ExpiringValue(rand.nextLong(), rand.nextLong())
+    chanBuf2ExpiringValue[Long](expiringValue2ChanBuf[Long](value)) should be (value)
+  }
 
-    "convert from TimeRange and back" in {
-      val range = TimeRange(rand.nextLong(), rand.nextLong())
-      decodeStartEnd(encodeStartEnd(range)) mustEqual range
-    }
+  test("convert from TimeRange and back") {
+    val range = TimeRange(rand.nextLong(), rand.nextLong())
+    decodeStartEnd(encodeStartEnd(range)) should be (range)
+  }
 
-    "convert from long and back" in {
-      val long = rand.nextLong()
-      chanBuf2Long(long2ChanBuf(long)) mustEqual long
-    }
+  test("convert from long and back") {
+    val long = rand.nextLong()
+    chanBuf2Long(long2ChanBuf(long)) should be (long)
+  }
 
-    "convert from double and back" in {
-      val double = rand.nextDouble()
-      chanBuf2Double(double2ChanBuf(double)) mustEqual double
-    }
+  test("convert from double and back") {
+    val double = rand.nextDouble()
+    chanBuf2Double(double2ChanBuf(double)) should be (double)
+  }
 
-    "convert from string and back" in {
-      val string = ((0 until (rand.nextInt(10) + 5)) map (_ => rand.nextPrintableChar())).mkString
-      chanBuf2String(string2ChanBuf(string)) mustEqual string
-    }
+  test("convert from string and back") {
+    val string = ((0 until (rand.nextInt(10) + 5)) map (_ => rand.nextPrintableChar())).mkString
+    chanBuf2String(string2ChanBuf(string)) should be (string)
+  }
 
-    "convert from span and back" in {
-      val span = Span(rand.nextLong(), rand.nextString(8), rand.nextLong(),
-        Some(rand.nextLong()), List(), List())
-      deserializeSpan(serializeSpan(span)) mustEqual span
-    }
+  test("convert from span and back") {
+    val span = Span(rand.nextLong(), rand.nextString(8), rand.nextLong(),
+      Some(rand.nextLong()), List(), List())
+    deserializeSpan(serializeSpan(span)) should be (span)
   }
 }

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisHashSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisHashSpec.scala
@@ -19,59 +19,52 @@ package com.twitter.zipkin.storage.redis
 import org.jboss.netty.buffer.ChannelBuffers
 
 class RedisHashSpec extends RedisSpecification {
-  "RedisHash" should {
-    var hash: RedisHash = null
-    val key1 = ChannelBuffers.copiedBuffer("key1")
-    val key2 = ChannelBuffers.copiedBuffer("key2")
-    val key3 = ChannelBuffers.copiedBuffer("key3")
-    val buf1 = ChannelBuffers.copiedBuffer("buf1")
-    val buf2 = ChannelBuffers.copiedBuffer("buf2")
-    val buf3 = ChannelBuffers.copiedBuffer("buf3")
+  val hash = new RedisHash(_client, "prefix")
+  val key1 = ChannelBuffers.copiedBuffer("key1")
+  val key2 = ChannelBuffers.copiedBuffer("key2")
+  val key3 = ChannelBuffers.copiedBuffer("key3")
+  val buf1 = ChannelBuffers.copiedBuffer("buf1")
+  val buf2 = ChannelBuffers.copiedBuffer("buf2")
+  val buf3 = ChannelBuffers.copiedBuffer("buf3")
 
-    val buf4 = ChannelBuffers.buffer(8)
-    buf4.writeLong(100L)
+  val buf4 = ChannelBuffers.buffer(8)
+  buf4.writeLong(100L)
 
-    doBefore {
-      _client.flushDB()
-      hash = new RedisHash(_client, "prefix")
-    }
+  test("place a new item and get it out") {
+    hash.put(key1, buf1)() should be (1)
+    hash.get(key1)() should be (Some(buf1))
+  }
 
-    "place a new item and get it out" in {
-      hash.put(key1, buf1)() mustEqual 1
-      hash.get(key1)() mustEqual Some(buf1)
-    }
+  test("place a new item and update it") {
+    hash.put(key1, buf1)() should be (1)
+    hash.put(key1, buf2)() should be (0)
+    hash.get(key1)() should be (Some(buf2))
+  }
 
-    "place a new item and update it" in {
-      hash.put(key1, buf1)() mustEqual 1
-      hash.put(key1, buf2)() mustEqual 0
-      hash.get(key1)() mustEqual Some(buf2)
-    }
+  test("place a few items and get them out") {
+    hash.put(key1, buf1)() should be (1)
+    hash.put(key2, buf2)() should be (1)
+    hash.put(key3, buf3)() should be (1)
+    hash.get(key1)() should be (Some(buf1))
+    hash.get(key2)() should be (Some(buf2))
+    hash.get(key3)() should be (Some(buf3))
+  }
 
-    "place a few items and get them out" in {
-      hash.put(key1, buf1)() mustEqual 1
-      hash.put(key2, buf2)() mustEqual 1
-      hash.put(key3, buf3)() mustEqual 1
-      hash.get(key1)() mustEqual Some(buf1)
-      hash.get(key2)() mustEqual Some(buf2)
-      hash.get(key3)() mustEqual Some(buf3)
-    }
+  test("place a few items and remove some") {
+    hash.put(key1, buf1)() should be (1)
+    hash.put(key2, buf2)() should be (1)
+    hash.put(key3, buf3)() should be (1)
+    hash.remove(Seq(key1, key2))() should be (2)
+    hash.get(key1)() should be (None)
+    hash.get(key2)() should be (None)
+    hash.get(key3)() should be (Some(buf3))
+  }
 
-    "place a few items and remove some" in {
-      hash.put(key1, buf1)() mustEqual 1
-      hash.put(key2, buf2)() mustEqual 1
-      hash.put(key3, buf3)() mustEqual 1
-      hash.remove(Seq(key1, key2))() mustEqual 2
-      hash.get(key1)() mustEqual None
-      hash.get(key2)() mustEqual None
-      hash.get(key3)() mustEqual Some(buf3)
-    }
-
-    "place an item and incr it" in {
-      val buf5 = ChannelBuffers.buffer(8)
-      buf5.writeLong(101L)
-      hash.put(key1, buf4)() mustEqual 1
-      hash.incrBy(key1, 1)() mustEqual 101
-      hash.get(key1)() mustEqual Some(buf5)
-    }
+  test("place an item and incr it") {
+    val buf5 = ChannelBuffers.buffer(8)
+    buf5.writeLong(101L)
+    hash.put(key1, buf4)() should be (1)
+    hash.incrBy(key1, 1)() should be (101)
+    hash.get(key1)() should be (Some(buf5))
   }
 }

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSetMapSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSetMapSpec.scala
@@ -19,28 +19,20 @@ package com.twitter.zipkin.storage.redis
 import org.jboss.netty.buffer.ChannelBuffers
 
 class RedisSetMapSpec extends RedisSpecification {
-  "RedisSetMap" should {
-    var setMap: RedisSetMap = null
+  val setMap = new RedisSetMap(_client, "prefix", None)
+  val buf1 = ChannelBuffers.copiedBuffer("val1")
+  val buf2 = ChannelBuffers.copiedBuffer("val2")
+  val buf3 = ChannelBuffers.copiedBuffer("val3")
 
-    doBefore {
-      _client.flushDB()
-      setMap = new RedisSetMap(_client, "prefix", None)
-    }
+  test("add an item then get it out") {
+    setMap.add("key", buf1)()
+    setMap.get("key")() should be (Set(buf1))
+  }
 
-    val buf1 = ChannelBuffers.copiedBuffer("val1")
-    val buf2 = ChannelBuffers.copiedBuffer("val2")
-    val buf3 = ChannelBuffers.copiedBuffer("val3")
-
-    "add an item then get it out" in {
-      setMap.add("key", buf1)()
-      setMap.get("key")() mustEqual(Set(buf1))
-    }
-
-    "add many items and then get them out" in {
-      setMap.add("key", buf1)()
-      setMap.add("key", buf2)()
-      setMap.add("key", buf3)()
-      setMap.get("key")() mustEqual(Set(buf1, buf2, buf3))
-    }
+  test("add many items and then get them out") {
+    setMap.add("key", buf1)()
+    setMap.add("key", buf2)()
+    setMap.add("key", buf3)()
+    setMap.get("key")() should be (Set(buf1, buf2, buf3))
   }
 }

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreTest.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreTest.scala
@@ -15,15 +15,11 @@
  */
 package com.twitter.zipkin.storage.redis
 
-import com.twitter.zipkin.redis.RedisSpanStoreFactory
-import com.twitter.zipkin.storage.util.SpanStoreValidator
-import com.twitter.util.Await
 import com.twitter.app.App
-import org.junit.runner.RunWith
+import com.twitter.util.Await
+import com.twitter.zipkin.redis.RedisSpanStoreFactory
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class RedisSpanStoreTest extends FunSuite {
 
   object RedisStore extends App with RedisSpanStoreFactory
@@ -31,13 +27,9 @@ class RedisSpanStoreTest extends FunSuite {
     "-zipkin.storage.redis.host", "127.0.0.1",
     "-zipkin.storage.redis.port", "6379"))
 
-  def newSpanStore = {
-    val spanStore = RedisStore.newRedisSpanStore()
-    Await.result(spanStore.storage.database.flushDB())
-    spanStore
-  }
 
   test("validate") {
-    new SpanStoreValidator(newSpanStore).validate
+    val spanStore = RedisStore.newRedisSpanStore()
+    Await.result(spanStore.storage.database.flushDB())
   }
 }

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpecification.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpecification.scala
@@ -18,18 +18,20 @@ package com.twitter.zipkin.storage.redis
 
 import com.twitter.finagle.redis.Client
 import com.twitter.finagle.redis.util.RedisCluster
-import org.specs.Specification
+import org.scalatest._
 
-trait RedisSpecification extends Specification {
+trait RedisSpecification extends FunSuite with Matchers with BeforeAndAfter with BeforeAndAfterAll {
   lazy val _client = Client("127.0.0.1:6379")
 
-  doBeforeSpec {
+  override def beforeAll(configMap: ConfigMap) {
     RedisCluster.start(1)
   }
 
-  doAfterSpec {
-    RedisCluster.stopAll()
+  before {
+    _client.flushDB()
   }
 
-  sequential
+  override def afterAll(configMap: ConfigMap) {
+    RedisCluster.stopAll()
+  }
 }

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisStorageSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisStorageSpec.scala
@@ -15,15 +15,17 @@
  */
 package com.twitter.zipkin.storage.redis
 
+import java.nio.ByteBuffer
+
 import com.twitter.conversions.time.intToTimeableNumber
 import com.twitter.zipkin.common.{Annotation, AnnotationType, BinaryAnnotation, Endpoint, Span}
-import com.twitter.zipkin.conversions.thrift.thriftAnnotationTypeToAnnotationType
-import com.twitter.zipkin.thriftscala
-import java.nio.ByteBuffer
 
 class RedisStorageSpec extends RedisSpecification {
 
-  var redisStorage: RedisStorage = null
+  var redisStorage = new RedisStorage {
+    val database = _client
+    val ttl = Some(7.days)
+  }
 
   def binaryAnnotation(key: String, value: String) =
     BinaryAnnotation(
@@ -44,54 +46,39 @@ class RedisStorageSpec extends RedisSpecification {
   val span1 = Span(123, "methodcall", spanId, None, List(ann1, ann3),
     List(binaryAnnotation("BAH", "BEH")))
 
-  "RedisStorage" should {
+  test("getTraceById") {
+    redisStorage.storeSpan(span1)()
+    val trace = redisStorage.getSpansByTraceId(span1.traceId)()
+    trace.isEmpty should be (false)
+    trace(0) should be (span1)
+  }
 
-    doBefore {
-      _client.flushDB()
-      redisStorage = new RedisStorage {
-        val database = _client
-        val ttl = Some(7.days)
-      }
-    }
+  test("getTracesByIds") {
+    redisStorage.storeSpan(span1)()
+    val actual1 = redisStorage.getSpansByTraceIds(List(span1.traceId))()
+    actual1.isEmpty should be (false)
+    actual1(0).isEmpty should be (false)
+    actual1(0)(0) should be (span1)
 
-    doAfter {
-      redisStorage.close()
-    }
+    val span2 = Span(666, "methodcall2", spanId, None, List(ann2),
+      List(binaryAnnotation("BAH2", "BEH2")))
+    redisStorage.storeSpan(span2)()
+    val actual2 = redisStorage.getSpansByTraceIds(List(span1.traceId, span2.traceId))()
+    actual2.isEmpty should be (false)
+    actual2(0).isEmpty should be (false)
+    actual2(0)(0) should be (span1)
+    actual2(1).isEmpty should be (false)
+    actual2(1)(0) should be (span2)
+  }
 
-    "getTraceById" in {
-      redisStorage.storeSpan(span1)()
-      val trace = redisStorage.getSpansByTraceId(span1.traceId)()
-      trace.isEmpty mustEqual false
-      trace(0) mustEqual span1
-    }
+  test("getTracesByIds should return empty list if no trace exists") {
+    val actual1 = redisStorage.getSpansByTraceIds(List(span1.traceId))()
+    actual1.isEmpty should be (true)
+  }
 
-    "getTracesByIds" in {
-      redisStorage.storeSpan(span1)()
-      val actual1 = redisStorage.getSpansByTraceIds(List(span1.traceId))()
-      actual1.isEmpty mustEqual false
-      actual1(0).isEmpty mustEqual false
-      actual1(0)(0) mustEqual span1
-
-      val span2 = Span(666, "methodcall2", spanId, None, List(ann2),
-        List(binaryAnnotation("BAH2", "BEH2")))
-      redisStorage.storeSpan(span2)()
-      val actual2 = redisStorage.getSpansByTraceIds(List(span1.traceId, span2.traceId))()
-      actual2.isEmpty mustEqual false
-      actual2(0).isEmpty mustEqual false
-      actual2(0)(0) mustEqual span1
-      actual2(1).isEmpty mustEqual false
-      actual2(1)(0) mustEqual span2
-    }
-
-    "getTracesByIds should return empty list if no trace exists" in {
-      val actual1 = redisStorage.getSpansByTraceIds(List(span1.traceId))()
-      actual1.isEmpty mustEqual true
-    }
-
-    "set time to live on a trace and then get it" in {
-      redisStorage.storeSpan(span1)()
-      redisStorage.setTimeToLive(span1.traceId, 1234.seconds)()
-      redisStorage.getTimeToLive(span1.traceId)() mustEqual 1234.seconds
-    }
+  test("set time to live on a trace and then get it") {
+    redisStorage.storeSpan(span1)()
+    redisStorage.setTimeToLive(span1.traceId, 1234.seconds)()
+    redisStorage.getTimeToLive(span1.traceId)() should be (1234.seconds)
   }
 }

--- a/zipkin-sampler/build.sbt
+++ b/zipkin-sampler/build.sbt
@@ -2,6 +2,5 @@ defaultSettings
 
 libraryDependencies ++= Seq(
   many(finagle, "core", "http"),
-  many(util, "core", "zk"),
-  scalaTestDeps
-).flatten
+  many(util, "core", "zk")
+).flatten ++ testDependencies

--- a/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/AdaptiveSamplerTest.scala
+++ b/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/AdaptiveSamplerTest.scala
@@ -15,14 +15,11 @@
  */
 package com.twitter.zipkin.sampler
 
+import com.twitter.conversions.time._
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.util.{MockTimer, Time, Var}
-import com.twitter.conversions.time._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class RequestRateCheckTest extends FunSuite {
   test("fails when the request rate is non-positive") {
     val rate = Var(1)
@@ -32,29 +29,20 @@ class RequestRateCheckTest extends FunSuite {
     rate.update(0)
     assert(check(Some(())).isEmpty)
   }
-}
 
-@RunWith(classOf[JUnitRunner])
-class SuffcientDataCheckTest extends FunSuite {
   test("fails when sufficient data is not present") {
     val check = new SufficientDataCheck[Unit](2)
     assert(check(Some(Seq.empty[Unit])).isEmpty)
     assert(check(Some(Seq((), ()))).isDefined)
     assert(check(Some(Seq((), (), ()))).isDefined)
   }
-}
 
-@RunWith(classOf[JUnitRunner])
-class ValidDataCheckTest extends FunSuite {
   test("fails when data fails validation") {
     val check = new ValidDataCheck[Int](_ > 1)
     assert(check(Some(Seq(0, 1, 2))).isEmpty)
     assert(check(Some(Seq(2, 3, 4))).isDefined)
   }
-}
 
-@RunWith(classOf[JUnitRunner])
-class CooldownCheckTest extends FunSuite {
   test("allows only once per period") {
     Time.withCurrentTimeFrozen { tc =>
       val timer = new MockTimer
@@ -70,10 +58,7 @@ class CooldownCheckTest extends FunSuite {
       assert(check(Some(())).isEmpty)
     }
   }
-}
 
-@RunWith(classOf[JUnitRunner])
-class OutlierCheckTest extends FunSuite {
   test("fail unless enough outliers are encountered") {
     val rate = Var(10)
     val check = new OutlierCheck(rate, 2, 0.1)
@@ -88,10 +73,7 @@ class OutlierCheckTest extends FunSuite {
     // these fall within the 0.1 threshold, thus shouldn't be counted
     assert(check(Some(Seq(9, 9))).isEmpty)
   }
-}
 
-@RunWith(classOf[JUnitRunner])
-class CalculateSampleRateTest extends FunSuite {
   test("calculates the discounted average of a series of numbers") {
     assert(DiscountedAverage.calculate(Seq(10, 5, 0), 1.0) === 5.0)
 

--- a/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/HttpVarTest.scala
+++ b/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/HttpVarTest.scala
@@ -15,14 +15,11 @@
  */
 package com.twitter.zipkin.sampler
 
+import com.twitter.finagle.http.{HttpMuxer, RequestBuilder, Response}
 import com.twitter.util.Await
-import com.twitter.finagle.http.{HttpMuxer, Response, RequestBuilder}
-import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.jboss.netty.buffer.ChannelBuffers.wrappedBuffer
+import org.scalatest.FunSuite
 
-@RunWith(classOf[JUnitRunner])
 class HttpVarTest extends FunSuite {
   test("can request the current value") {
     val httpVar = new HttpVar("test1", 1.0)

--- a/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/SamplerTest.scala
+++ b/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/SamplerTest.scala
@@ -15,13 +15,11 @@
  */
 package com.twitter.zipkin.sampler
 
-import com.twitter.util.Var
 import java.util.Random
-import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+import com.twitter.util.Var
+import org.scalatest.FunSuite
+
 class SamplerTest extends FunSuite {
   val rnd = new Random(1L)
 

--- a/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/SpanSamplerFilterTest.scala
+++ b/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/SpanSamplerFilterTest.scala
@@ -15,14 +15,11 @@
  */
 package com.twitter.zipkin.sampler
 
-import com.twitter.util.{Await, Future}
 import com.twitter.finagle.Service
+import com.twitter.util.{Await, Future}
 import com.twitter.zipkin.common._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class SpanSamplerFilterTest extends FunSuite {
   test("filters spans based on their traceId") {
     val spans = Seq(

--- a/zipkin-scrooge/build.sbt
+++ b/zipkin-scrooge/build.sbt
@@ -10,6 +10,5 @@ ScroogeSBT.scroogeThriftSourceFolder in Compile <<= (
 libraryDependencies ++= Seq(
   Seq(util("core"), algebird("core"), ostrich),
   many(finagle, "ostrich4", "thrift", "zipkin"),
-  many(scroogeDep, "core", "serializer"),
-  scalaTestDeps
-).flatten
+  many(scroogeDep, "core", "serializer")
+).flatten ++ testDependencies

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
@@ -16,17 +16,15 @@
  */
 package com.twitter.zipkin.adapter
 
+import java.nio.ByteBuffer
+
 import com.twitter.conversions.time._
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.query._
 import com.twitter.zipkin.thriftscala
-import java.nio.ByteBuffer
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class ThriftConversionsTest extends FunSuite {
   test("convert Annotation") {
     val expectedAnn: Annotation = Annotation(123, "value", Some(Endpoint(123, 123, "service")))

--- a/zipkin-web/build.sbt
+++ b/zipkin-web/build.sbt
@@ -10,9 +10,8 @@ libraryDependencies ++= Seq(
     "com.github.spullara.mustache.java" % "compiler" % "0.8.13",
     "com.twitter.common" % "stats-util" % "0.0.57"
   ),
-  many(finagle, "exception", "thriftmux", "serversets", "zipkin"),
-  scalaTestDeps
-).flatten
+  many(finagle, "exception", "thriftmux", "serversets", "zipkin")
+).flatten ++ testDependencies
 
 PackageDist.packageDistZipName := "zipkin-web.zip"
 BuildProperties.buildPropertiesPackage := "com.twitter.zipkin"

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/conversions/JsonTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/conversions/JsonTest.scala
@@ -1,13 +1,11 @@
 package com.twitter.zipkin.conversions
 
+import java.nio.ByteBuffer
+
 import com.twitter.zipkin.common.json._
 import com.twitter.zipkin.common.{AnnotationType, BinaryAnnotation}
-import java.nio.ByteBuffer
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class JsonTest extends FunSuite {
   val key = "key"
   test("bool") {

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/JsonSerializationTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/JsonSerializationTest.scala
@@ -2,11 +2,8 @@ package com.twitter.zipkin.web
 
 import com.twitter.zipkin.common.json.ZipkinJson
 import com.twitter.zipkin.common.{Annotation, BinaryAnnotation, Span}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class JsonSerializationTest extends FunSuite {
   test("serialize span with no annotations") {
     val s = Span(1L, "Unknown", 2L, None, List.empty[Annotation], List.empty[BinaryAnnotation], false)

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
@@ -16,15 +16,13 @@
  */
 package com.twitter.zipkin.web
 
+import java.nio.ByteBuffer
+
 import com.twitter.finagle.http.Request
 import com.twitter.util.Time
 import com.twitter.zipkin.common.{AnnotationType, BinaryAnnotation}
-import java.nio.ByteBuffer
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class QueryExtractorTest extends FunSuite {
 
   val queryExtractor = new QueryExtractor(10)

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/UtilTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/UtilTest.scala
@@ -17,11 +17,8 @@
 package com.twitter.zipkin.web
 
 import com.twitter.conversions.time._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class UtilTest extends FunSuite {
   import Util._
 

--- a/zipkin-zookeeper/build.sbt
+++ b/zipkin-zookeeper/build.sbt
@@ -4,4 +4,4 @@ libraryDependencies ++= Seq(
   Seq(finagle("core")),
   many(util, "core", "zk"),
   many(zk, "candidate", "group")
-).flatten
+).flatten ++ testDependencies


### PR DESCRIPTION
Before, tests were a mix of scalatest and specs, and a mix of jmock and
mockito. This migrates all tests to scalatest/mockito and removes the
`@RunWith` annotation, which isn't necessary in SBT or Intellij.

All tests are now `FunSuite` except `QueryServiceSpec`, which is vast
and better organized as `WordSpec` for now.

Almost all tests use Matchers, and the ones that don't aren't hurting
anything, so could later be moved to Matchers if desireable.

Finally, doing this simplifies the build: we now have a single test
dependency bundle, and it is far simpler than before.

Fixes #493
