### PR TITLE
Adding bintray repo for sbt plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += Resolver.bintrayRepo("sbt", "sbt-plugin-releases")
+resolvers += Resolver.url("bintray-sbt-plugins", url("http://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
 libraryDependencies ++= Seq(
     "com.google.collections" % "google-collections" % "0.8",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
+resolvers += Resolver.bintrayRepo("sbt", "sbt-plugin-releases")
+
 libraryDependencies ++= Seq(
     "com.google.collections" % "google-collections" % "0.8",
     "org.codehaus.plexus"    % "plexus-utils"       % "1.5.4",


### PR DESCRIPTION
Sbt plugin artifacts were migrated to Bintray - see https://www.typesafe.com/blog/migrating-repos-to-bintray .
