### PR TITLE
zipkin-mongodb: Replace JSR166y with Java 7 API

### DIFF
--- a/zipkin-mongodb/src/main/scala/com/twitter/zipkin/storage/mongodb/MongoDBSpanStore.scala
+++ b/zipkin-mongodb/src/main/scala/com/twitter/zipkin/storage/mongodb/MongoDBSpanStore.scala
@@ -2,12 +2,11 @@ package com.twitter.zipkin.storage.mongodb
 
 import java.nio.ByteBuffer
 import java.util.Date
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ForkJoinPool, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.mongodb.casbah.Imports._
 import com.mongodb.casbah.commons.conversions.scala._
-import com.twitter.finagle.jsr166y.ForkJoinPool
 import com.twitter.util._
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.Constants


### PR DESCRIPTION
This tracks upstream work in Finagle, by @vkostyukov. We shouldn't be
depending on custom ForkJoinPool, especially as we only target JRE 1.7+.
