### PR TITLE
Bumps mustache to 0.8.17

### DIFF
--- a/zipkin-web/build.sbt
+++ b/zipkin-web/build.sbt
@@ -7,7 +7,7 @@ libraryDependencies ++= Seq(
     zk("server-set"),
     algebird("core"),
     twitterServer,
-    "com.github.spullara.mustache.java" % "compiler" % "0.8.13",
+    "com.github.spullara.mustache.java" % "compiler" % "0.8.17",
     "com.twitter.common" % "stats-util" % "0.0.57"
   ),
   many(finagle, "exception", "thriftmux", "serversets", "zipkin")


### PR DESCRIPTION
Pants (and therefore twitter production) was running 0.8.13. SBT was
out-of-sync, specifying 0.8.13. This bridges the gap, and should be a
safe merge.
