### PR TITLE
Local copy of ScalaObjectHandler

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/common/mustache/ScalaObjectHandler.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/common/mustache/ScalaObjectHandler.scala
@@ -1,0 +1,72 @@
+package com.twitter.zipkin.common.mustache
+
+import collection.JavaConversions._
+import com.github.mustachejava.Iteration
+import com.github.mustachejava.reflect.ReflectionObjectHandler
+import java.io.Writer
+import java.lang.reflect.{Field, Method}
+import runtime.BoxedUnit
+import scala.reflect.ClassTag
+
+/**
+ * This class is borrowed from Mustache.java in scala-extensions. Its package
+ * has been renamed from com.twitter.mustache to com.twitter.zipkin.common.mustache,
+ * so it won't collide if a user also has included the scala-extensions jar in
+ * their classpath.
+ */
+private[zipkin] class ScalaObjectHandler extends ReflectionObjectHandler {
+
+  // Allow any method or field
+  override def checkMethod(member: Method) {}
+
+  override def checkField(member: Field) {}
+
+  override def coerce(value: AnyRef) = {
+    value match {
+      case m: collection.Map[_, _] => mapAsJavaMap(m)
+      case u: BoxedUnit => null
+      case Some(some: AnyRef) => coerce(some)
+      case None => null
+      case _ => value
+    }
+  }
+
+  override def iterate(iteration: Iteration, writer: Writer, value: AnyRef, scopes: Array[AnyRef]) = {
+    value match {
+      case TraversableAnyRef(t) => {
+        var newWriter = writer
+        t foreach {
+          next =>
+            newWriter = iteration.next(newWriter, coerce(next), scopes)
+        }
+        newWriter
+      }
+      case n: Number => if (n.intValue() == 0) writer else iteration.next(writer, coerce(value), scopes)
+      case _ => super.iterate(iteration, writer, value, scopes)
+    }
+  }
+
+  override def falsey(iteration: Iteration, writer: Writer, value: AnyRef, scopes: Array[AnyRef]) = {
+    value match {
+      case TraversableAnyRef(t) => {
+        if (t.isEmpty) {
+          iteration.next(writer, value, scopes)
+        } else {
+          writer
+        }
+      }
+      case n: Number => if (n.intValue() == 0) iteration.next(writer, coerce(value), scopes) else writer
+      case _ => super.falsey(iteration, writer, value, scopes)
+    }
+  }
+
+  val TraversableAnyRef = new Def[Traversable[AnyRef]]
+  class Def[C: ClassTag] {
+    def unapply[X: ClassTag](x: X): Option[C] = {
+      x match {
+        case c: C => Some(c)
+        case _ => None
+      }
+    }
+  }
+}

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/common/mustache/ZipkinMustache.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/common/mustache/ZipkinMustache.scala
@@ -1,7 +1,6 @@
 package com.twitter.zipkin.common.mustache
 
 import com.github.mustachejava.DefaultMustacheFactory
-import com.twitter.mustache.ScalaObjectHandler
 import java.io._
 import collection.JavaConversions.mapAsJavaMap
 


### PR DESCRIPTION
Copy of ScalaObjectHandler from scrooge as otherwise build will break.

Recent upgrade highlights we need this explicitly.

See https://github.com/twitter/scrooge/pull/198
