### PR TITLE
Moves to finagle.httpx

### DIFF
--- a/zipkin-example/src/main/scala/com/twitter/zipkin/example/Main.scala
+++ b/zipkin-example/src/main/scala/com/twitter/zipkin/example/Main.scala
@@ -1,20 +1,18 @@
 package com.twitter.zipkin.example
 
-import com.twitter.zipkin.conversions.thrift._
-import com.twitter.finagle.Http
-import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.Httpx
 import com.twitter.server.{Closer, TwitterServer}
-import com.twitter.util.{Await, Closable, Future}
+import com.twitter.util.{Await, Closable}
 import com.twitter.zipkin.anormdb.AnormDBSpanStoreFactory
-import com.twitter.zipkin.collector.SpanReceiver
 import com.twitter.zipkin.common.Span
-import com.twitter.zipkin.{thriftscala => thrift}
-import com.twitter.zipkin.receiver.scribe.ScribeSpanReceiverFactory
-import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
-import com.twitter.zipkin.web.ZipkinWebFactory
+import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.query.ThriftQueryService
 import com.twitter.zipkin.query.constants.DefaultAdjusters
+import com.twitter.zipkin.receiver.scribe.ScribeSpanReceiverFactory
 import com.twitter.zipkin.tracegen.ZipkinSpanGenerator
+import com.twitter.zipkin.web.ZipkinWebFactory
+import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
+import com.twitter.zipkin.{thriftscala => thrift}
 
 object Main extends TwitterServer with Closer
   with ZooKeeperClientFactory
@@ -34,7 +32,7 @@ object Main extends TwitterServer with Closer
     val receiver = newScribeSpanReceiver(convert andThen store, statsReceiver.scope("scribeSpanReceiver"))
     val query = new ThriftQueryService(store, adjusters = DefaultAdjusters)
     val webService = newWebServer(query, statsReceiver.scope("web"))
-    val web = Http.serve(webServerPort(), webService)
+    val web = Httpx.serve(webServerPort(), webService)
 
     val closer = Closable.sequence(web, receiver, store)
     closeOnExit(closer)

--- a/zipkin-redis-example/src/main/scala/com/twitter/zipkin/example/Main.scala
+++ b/zipkin-redis-example/src/main/scala/com/twitter/zipkin/example/Main.scala
@@ -1,19 +1,17 @@
 package com.twitter.zipkin.example
 
-import com.twitter.zipkin.conversions.thrift._
-import com.twitter.finagle.Http
-import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.Httpx
 import com.twitter.server.{Closer, TwitterServer}
-import com.twitter.util.{Await, Closable, Future}
-import com.twitter.zipkin.redis.RedisSpanStoreFactory
-import com.twitter.zipkin.collector.SpanReceiver
+import com.twitter.util.{Await, Closable}
 import com.twitter.zipkin.common.Span
-import com.twitter.zipkin.{thriftscala => thrift}
-import com.twitter.zipkin.receiver.scribe.ScribeSpanReceiverFactory
-import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
-import com.twitter.zipkin.web.ZipkinWebFactory
+import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.query.ThriftQueryService
 import com.twitter.zipkin.query.constants.DefaultAdjusters
+import com.twitter.zipkin.receiver.scribe.ScribeSpanReceiverFactory
+import com.twitter.zipkin.redis.RedisSpanStoreFactory
+import com.twitter.zipkin.web.ZipkinWebFactory
+import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
+import com.twitter.zipkin.{thriftscala => thrift}
 
 object Main extends TwitterServer with Closer
   with ZooKeeperClientFactory
@@ -28,7 +26,7 @@ object Main extends TwitterServer with Closer
     val receiver = newScribeSpanReceiver(convert andThen store, statsReceiver.scope("scribeSpanReceiver"))
     val query = new ThriftQueryService(store, adjusters = DefaultAdjusters)
     val webService = newWebServer(query, statsReceiver.scope("web"))
-    val web = Http.serve(webServerPort(), webService)
+    val web = Httpx.serve(webServerPort(), webService)
 
     val closer = Closable.sequence(web, receiver, store)
     closeOnExit(closer)

--- a/zipkin-sampler/build.gradle
+++ b/zipkin-sampler/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile project(':zipkin-zookeeper')
 
     compile "com.twitter:finagle-core_${scalaInterfaceVersion}:${commonVersions.finagle}"
-    compile "com.twitter:finagle-http_${scalaInterfaceVersion}:${commonVersions.finagle}"
+    compile "com.twitter:finagle-httpx_${scalaInterfaceVersion}:${commonVersions.finagle}"
 
     compile "com.twitter:util-core_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"
     compile "com.twitter:util-zk_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"

--- a/zipkin-sampler/build.sbt
+++ b/zipkin-sampler/build.sbt
@@ -1,6 +1,6 @@
 defaultSettings
 
 libraryDependencies ++= Seq(
-  many(finagle, "core", "http"),
+  many(finagle, "core", "httpx"),
   many(util, "core", "zk")
 ).flatten ++ testDependencies

--- a/zipkin-sampler/src/main/scala/com/twitter/zipkin/sampler/HttpVar.scala
+++ b/zipkin-sampler/src/main/scala/com/twitter/zipkin/sampler/HttpVar.scala
@@ -17,9 +17,8 @@
 package com.twitter.zipkin.sampler
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.http.{HttpMuxer, Request, Response}
+import com.twitter.finagle.httpx.{HttpMuxer, Method, Request, Response}
 import com.twitter.util.{Extractable, Future, Var}
-import org.jboss.netty.handler.codec.http.HttpMethod
 
 /**
  * A wrapper around a Var[Double] that exposes it to an HTTP endpoint
@@ -33,11 +32,11 @@ class HttpVar(name: String, default: Double = 1.0) {
   def apply(): Var[Double] with Extractable[Double] = underlying
 
   HttpMuxer.addRichHandler("/vars/"+name, Service.mk[Request, Response] {
-    case req if req.method == HttpMethod.GET =>
+    case req if req.method == Method.Get =>
       req.response.contentString = underlying().toString
       Future.value(req.response)
 
-    case req if req.method == HttpMethod.POST =>
+    case req if req.method == Method.Post =>
       val rep = req.response
 
       try {

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
@@ -15,7 +15,7 @@
  */
 package com.twitter.zipkin.web
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Time, TwitterDateFormat}
 import com.twitter.zipkin.common.{AnnotationType, BinaryAnnotation}
 import com.twitter.zipkin.query.{Order, QueryRequest}

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
@@ -18,7 +18,7 @@ package com.twitter.zipkin.web
 
 import java.nio.ByteBuffer
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.Time
 import com.twitter.zipkin.common.{AnnotationType, BinaryAnnotation}
 import org.scalatest.FunSuite


### PR DESCRIPTION
This is part of the larger project to upgrade Finagle
to Netty 4, which means getting rid of finagle-http
and moving everybody to finagle-httpx.
