### PR TITLE
Parallel test tasks in the Gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ sbt-launch.jar
 .history
 /*.db
 build
+.gradle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+sudo: false
 
 services:
   - redis-server

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,8 @@ subprojects {
     apply from: "$rootDir/gradle/dependencies.gradle"
     apply from: "$rootDir/gradle/scalatest.gradle"
 
-    ext {
-        // SBT migration note: start of zipkinSettings
-        group "io.zipkin"
-        version zipkinVersion
+    test {
+        maxParallelForks Runtime.runtime.availableProcessors()
     }
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
-zipkinVersion = 1.2.0-SNAPSHOT
+version=1.2.0-SNAPSHOT
+group=io.zipkin
 
 # Change this to one of the following values to use a different database engine
 # sqlite-memory, sqlite-persistent, h2-memory, h2-persistent, postgresql, mysql


### PR DESCRIPTION
This also moves the definition of the group and version into the `gradle.properties` which will properly apply to all subprojects
