### PR TITLE
Updates AnormDB and database library versions; Fixes SQLite

### DIFF
--- a/zipkin-anormdb/build.gradle
+++ b/zipkin-anormdb/build.gradle
@@ -5,20 +5,21 @@
 // The default value of dbEngine is sqlite-persistent, defined in gradle.properties
 // To override, run the build like this: ./gradlew build -PdbEngine=postgresql
 ext.anormDriverDependencies = [
-        "sqlite-memory": "org.xerial:sqlite-jdbc:3.7.2",
-        "sqlite-persistent": "org.xerial:sqlite-jdbc:3.7.2",
-        "h2-memory": "com.h2database:h2:1.3.172",
-        "h2-persistent": "com.h2database:h2:1.3.172",
-        "postgresql": "postgresql:postgresql:8.4-702.jdbc4", // or "9.1-901.jdbc4",
-        "mysql": "mysql:mysql-connector-java:5.1.25"
+        "sqlite-memory": "org.xerial:sqlite-jdbc:3.8.11",  // sqlite-jdbc4 isn't out, yet
+        "sqlite-persistent": "org.xerial:sqlite-jdbc:3.8.11",
+        "h2-memory": "com.h2database:h2:1.4.187",
+        "h2-persistent": "com.h2database:h2:1.4.187",
+        // Don't add EOL versions! http://www.postgresql.org/support/versioning
+        "postgresql": "org.postgresql:postgresql:9.3-1103-jdbc4",
+        "mysql": "mysql:mysql-connector-java:5.1.36"
 ]
 
 dependencies {
     compile project(':zipkin-common')
     compile project(':zipkin-scrooge')
 
-    compile "com.typesafe.play:anorm_${scalaInterfaceVersion}:2.3.7"
-    compile "com.zaxxer:HikariCP-java6:2.3.8"
+    compile "com.typesafe.play:anorm_${scalaInterfaceVersion}:2.3.9" // last version compatible w/ Java 7
+    compile "com.zaxxer:HikariCP:2.4.0"
 
     compile anormDriverDependencies[dbEngine]
 }

--- a/zipkin-anormdb/build.sbt
+++ b/zipkin-anormdb/build.sbt
@@ -8,17 +8,18 @@ defaultSettings
 
 // Database drivers
 val anormDriverDependencies = Map(
-  "sqlite-memory"     -> "org.xerial"     % "sqlite-jdbc"          % "3.7.2",
-  "sqlite-persistent" -> "org.xerial"     % "sqlite-jdbc"          % "3.7.2",
-  "h2-memory"         -> "com.h2database" % "h2"                   % "1.3.172",
-  "h2-persistent"     -> "com.h2database" % "h2"                   % "1.3.172",
-  "postgresql"        -> "postgresql"     % "postgresql"           % "8.4-702.jdbc4", // or "9.1-901.jdbc4",
-  "mysql"             -> "mysql"          % "mysql-connector-java" % "5.1.25"
+  "sqlite-memory"     -> "org.xerial"     % "sqlite-jdbc"          % "3.8.11", // sqlite-jdbc4 isn't out, yet
+  "sqlite-persistent" -> "org.xerial"     % "sqlite-jdbc"          % "3.8.11",
+  "h2-memory"         -> "com.h2database" % "h2"                   % "1.4.187",
+  "h2-persistent"     -> "com.h2database" % "h2"                   % "1.4.187",
+  // Don't add EOL versions! http://www.postgresql.org/support/versioning
+  "postgresql93"      -> "org.postgresql" % "postgresql"           % "9.3-1103-jdbc4",
+  "mysql"             -> "mysql"          % "mysql-connector-java" % "5.1.36"
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "anorm" % "2.3.7",
-  "com.zaxxer" % "HikariCP-java6" % "2.3.8",
+  "com.typesafe.play" %% "anorm" % "2.3.9", // last version compatible w/ Java 7
+  "com.zaxxer" % "HikariCP" % "2.4.0",
   anormDriverDependencies(dbEngine)
 ) ++ testDependencies
 

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -41,6 +41,7 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
   private val connpool = new HikariDataSource()
   connpool.setDriverClassName(dbconfig.driver)
   connpool.setJdbcUrl(dbconfig.location)
+  connpool.setConnectionTestQuery(if (dbconfig.jdbc3) "SELECT 1" else null)
   connpool.setMaximumPoolSize(32)
 
   /**

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
@@ -55,7 +55,13 @@ case class DBConfig(name: String = "sqlite-persistent",
                     params: DBParams = new DBParams(),
                     install: Boolean = false) {
 
-  case class DBInfo(driver: String, description: String, location: DBParams => String)
+  /**
+   * @param jdbc3 Whether this is a legacy JDBC3 driver
+   */
+  case class DBInfo(driver: String,
+                    description: String,
+                    location: DBParams => String,
+                    jdbc3: Boolean = false)
 
   /**
    * Database information.
@@ -73,12 +79,14 @@ case class DBConfig(name: String = "sqlite-persistent",
     "sqlite-memory" -> DBInfo(
       description = "SQLite in-memory",
       driver = "org.sqlite.JDBC",
-      location = { _ => "jdbc:sqlite::memory:" }
+      location = { _ => "jdbc:sqlite::memory:" },
+      jdbc3 = true
     ),
     "sqlite-persistent" -> DBInfo(
       description = "SQLite persistent",
       driver = "org.sqlite.JDBC",
-      location = { dbp: DBParams => "jdbc:sqlite:" + dbp.dbName + ".db" }
+      location = { dbp: DBParams => "jdbc:sqlite:" + dbp.dbName + ".db" },
+      jdbc3 = true
     ),
     "h2-memory" -> DBInfo(
       description = "H2 in-memory",
@@ -111,4 +119,5 @@ case class DBConfig(name: String = "sqlite-persistent",
   def description: String = dbinfo.description
   def driver: String = dbinfo.driver
   def location: String = dbinfo.location(params)
+  def jdbc3: Boolean = dbinfo.jdbc3
 }


### PR DESCRIPTION
This updates all db libraries to latest, and sets the base version of
PostgreSQL to 9.3. It also corrects HikariCP configuration for SQLite,
which prevents it from erroring out on account of JDBC variant mismatch.

AnormDB was using old versions of just about everything, including very
EOL PostgreSQL. More importantly, SQLite stopped working due to a recent
HikariCP change, which moved the default JDBC variant to 4.

Relates to #511
