### PR TITLE
Add build config for executable jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,12 @@
+buildscript {
+    repositories { jcenter() }
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.2'
+    }
+}
+
 subprojects {
+
     apply plugin: 'java'
     apply plugin: 'scala'
 

--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.collector.Main'
+
+tasks.build.dependsOn(shadowJar)
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-example/build.gradle
+++ b/zipkin-example/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.example.Main'
+
+tasks.build.dependsOn(shadowJar)
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.query.Main'
+
+tasks.build.dependsOn(shadowJar)
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-redis-example/build.gradle
+++ b/zipkin-redis-example/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.example.Main'
+
+tasks.build.dependsOn(shadowJar)
 
 dependencies {
     compile project(':zipkin-web')

--- a/zipkin-tracegen/build.gradle
+++ b/zipkin-tracegen/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.tracegen.Main'
+
+tasks.build.dependsOn(shadowJar)
 
 repositories {
     // For dependencies of zipkin-cassandra (via zipkin-query-service and zipkin-collector-service)

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.web.Main'
+
+tasks.build.dependsOn(shadowJar)
 
 dependencies {
     compile project(':zipkin-common')


### PR DESCRIPTION
All the executable projects (the zipkin-*-services and zipkin-web)now have a *-all.jar which is executable. Still to do: package theconfig files for the collector service along with the code (at the
moment you have to have them locally and run with `-f <path_to>/collector-<xxx>/scala`).

```
$ find . -name \*-all.jar
./zipkin-redis-example/build/libs/zipkin-redis-example-1.2.0-SNAPSHOT-all.jar
./zipkin-query-service/build/libs/zipkin-query-service-1.2.0-SNAPSHOT-all.jar
./zipkin-example/build/libs/zipkin-example-1.2.0-SNAPSHOT-all.jar
./zipkin-web/build/libs/zipkin-web-1.2.0-SNAPSHOT-all.jar
./zipkin-collector-service/build/libs/zipkin-collector-service-1.2.0-SNAPSHOT-all.jar
./zipkin-tracegen/build/libs/zipkin-tracegen-1.2.0-SNAPSHOT-all.jar
```

Example launch:

```
$ java -jar zipkin-query-service/build/libs/zipkin-query-service-1.2.0-SNAPSHOT-all.jar -f zipkin-query-service/config/query-redis.scala 
Jul 30, 2015 12:02:27 PM com.twitter.zipkin.query.Main$ main
INFO: Loading configuration
INF [20150730-12:02:34.908] stats: Starting LatchedStatsListener
700 [20150730-12:02:35.041] net: HttpServer created http 0.0.0.0/0.0.0.0:9901
700 [20150730-12:02:35.064] net: context created: /
700 [20150730-12:02:35.065] net: context created: /report/
700 [20150730-12:02:35.066] net: context created: /favicon.ico
700 [20150730-12:02:35.067] net: context created: /static
700 [20150730-12:02:35.068] net: context created: /pprof/heap
700 [20150730-12:02:35.069] net: context created: /pprof/profile
700 [20150730-12:02:35.070] net: context created: /pprof/contention
700 [20150730-12:02:35.071] net: context created: /tracing
700 [20150730-12:02:35.072] net: context created: /admin/registry
700 [20150730-12:02:35.073] net: context created: /health
700 [20150730-12:02:35.073] net: context created: /quitquitquit
700 [20150730-12:02:35.073] net: context created: /abortabortabort
700 [20150730-12:02:35.083] net: context created: /graph/
700 [20150730-12:02:35.084] net: context created: /graph_data
INF [20150730-12:02:35.085] admin: Starting TimeSeriesCollector
INF [20150730-12:02:35.086] admin: Admin HTTP interface started on port 9901.
DEB [20150730-12:02:35.668] twitter: LoadService: loaded instance of class com.twitter.finagle.stats.OstrichStatsReceiver for requested service com.twitter.finagle.stats.StatsReceiver
INF [20150730-12:02:35.861] twitter: Finagle version 6.27.0 (rev=65df1512aadc8b79871a6dcafbbd210fd088b055) built at 20150727-172410
DEB [20150730-12:02:36.439] nio: Using select timeout of 500
DEB [20150730-12:02:36.439] nio: Epoll-bug workaround enabled = false
INF [20150730-12:02:36.807] query: Starting query thrift service on addr /0.0.0.0:9411
...
```
