### PR TITLE
Ports example configuration and instructions to gradle

### DIFF
--- a/doc/src/sphinx/Quickstart.rst
+++ b/doc/src/sphinx/Quickstart.rst
@@ -14,7 +14,7 @@ The following command will start an instance of ZipkinExample using SQLite
 in-memory as the data store and populating it with a few example traces.
 
 .. parsed-literal::
-    ./bin/sbt "zipkin-example/run -zipkin.storage.anormdb.install=true -genSampleTraces=true"
+    ./gradlew :zipkin-example:run
 
 After it starts up open http://localhost:8080 in your browser and poke around
 the example traces. They're all randomly generated so they probably wont make
@@ -31,7 +31,7 @@ Run the following to see all the available configuration flags for the example
 project:
 
 .. parsed-literal::
-    ./bin/sbt "zipkin-example/run -help"
+    ./gradlew :zipkin-example:run -PrunArgs='-help'
 
 The list of flags include a bunch of global flags to configure Finagle but also
 many to configure the different Zipkin modules we've mixed in to zipkin-example.
@@ -56,14 +56,13 @@ Packaging for Production
 Build a distribution package
 
 .. parsed-literal::
-    ./bin/sbt zipkin-example/package-dist
+    ./gradlew installDist -x test
 
-A zip archive should now exist under zipkin-example/dist. That will contain all
-necessary packages and libraries to run the project. Unpack it then run it:
+A distribution should now exist under zipkin-example/build/install/zipkin-example. That will contain all
+necessary packages and libraries to run the project. Change to that directory and run it:
 
 .. parsed-literal::
-    cd [root directory of unpacked archive]
-    java -jar zipkin-example-1.2.0-SNAPSHOT.jar \
+    bin/zipkin-example \
       -zipkin.web.cacheResources=true \
       [any other config flags]
 

--- a/zipkin-example/README.md
+++ b/zipkin-example/README.md
@@ -1,0 +1,19 @@
+# zipkin-example
+The zipkin-example project combines all parts of the service into a single
+package and adds a trace generator to provide random example traces.
+
+## Starting the example server
+The following command will start an instance of ZipkinExample using SQLite
+in-memory as the data store and populating it with a few example traces.
+
+```bash
+./gradlew :zipkin-example:run
+```
+
+You can customize execution by specifying your own `runArgs`. Use `-help` to discover what's available.
+
+```bash
+./gradlew :zipkin-example:run -PrunArgs='-help'
+```
+## Using zipkin
+Once started, you can browse traces in a web browser http://localhost:8080/

--- a/zipkin-example/build.gradle
+++ b/zipkin-example/build.gradle
@@ -2,6 +2,16 @@ apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.example.Main'
 
+if (!project.hasProperty("runArgs")) {
+    ext.runArgs = '-zipkin.storage.anormdb.install=true -genSampleTraces=true ' +
+            '-zipkin.web.resourcesRoot=' + project(':zipkin-web').projectDir + '/src/main/resources'
+}
+
+run {
+    workingDir project.buildDir
+    args runArgs.split()
+}
+
 tasks.build.dependsOn(shadowJar)
 
 repositories {

--- a/zipkin-redis-example/README.md
+++ b/zipkin-redis-example/README.md
@@ -1,0 +1,19 @@
+# zipkin-redis-example
+The zipkin-redis-example project combines all parts of the service into a single
+package pointed at a local redis server.
+
+## Starting the example server
+The following command will start an instance of ZipkinExample using the `redis-server`
+you already have running.
+
+```bash
+./gradlew :zipkin-redis-example:run
+```
+
+You can customize execution by specifying your own `runArgs`. Use `-help` to discover what's available.
+
+```bash
+./gradlew :zipkin-redis-example:run -PrunArgs='-help'
+```
+## Using zipkin
+Once started, you can browse traces in a web browser http://localhost:8080/

--- a/zipkin-redis-example/build.gradle
+++ b/zipkin-redis-example/build.gradle
@@ -2,6 +2,16 @@ apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.example.Main'
 
+if (!project.hasProperty("runArgs")) {
+    ext.runArgs =
+            '-zipkin.web.resourcesRoot=' + project(':zipkin-web').projectDir + '/src/main/resources'
+}
+
+run {
+    workingDir project.buildDir
+    args runArgs.split()
+}
+
 tasks.build.dependsOn(shadowJar)
 
 dependencies {


### PR DESCRIPTION
Formerly, `zipkin-example` and `zipkin-redis-example` were described as
a series of SBT steps. This ports those steps to gradle, and backfills
configuration needed.
