### PR TITLE
Uses Gradle daemon to assign memory args

### DIFF
--- a/doc/mac-quickstart.md
+++ b/doc/mac-quickstart.md
@@ -29,8 +29,6 @@ cd WORKSPACE
 # If you don't have git, `brew install git` or just download Zipkin directly
 git clone https://github.com/twitter/zipkin.git
 cd zipkin
-# Note the 4GB memory usage. You can use less but your build may fail.
-export GRADLE_OPTS='-Xms512m -Xmx4G -XX:MaxPermSize=1G'
 # Install the Zipkin schema
 cassandra-cli -host localhost -port 9160 -f zipkin-cassandra/src/schema/cassandra-schema.txt
 ```

--- a/doc/ubuntu-quickstart.txt
+++ b/doc/ubuntu-quickstart.txt
@@ -55,9 +55,6 @@ git clone https://github.com/twitter/zipkin.git
 
 cd zipkin
 
-# Note the 4GB memory usage. You can use less but your build may fail.
-export GRADLE_OPTS='-Xms512m -Xmx4G -XX:MaxPermSize=1G'
-
 9. Create Zipkin namespace in Cassandra
 cassandra-cli -host localhost -port 9160 -f zipkin-cassandra/src/schema/cassandra-schema.txt
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,16 @@
 version=1.2.0-SNAPSHOT
 group=io.zipkin
 
+# The gradle daemon increases performance and allows control of memory args.
+org.gradle.daemon=true
+# Memory args must be set in context of Travis limits, or the build gets killed.
+#
+# When solving this, bear in mind there's more overhead than just heap.
+# limit 4GB > max heap + max meta + (threadcount * stacksize) + overhead
+#
+# Args are optimized for Java 7, as Java 8 doesn't tend to run out of meta space.
+org.gradle.jvmargs=-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -Xms2G -Xmx2G -Xss512k -XX:MaxPermSize=256m
+
 # configKey applies to zipkin-(collector|query)-service
 #
 # configKey is a partial path to a scala file, and primarily configures span


### PR DESCRIPTION
Instead of telling developers to set GRADLE_OPTS, this uses the Gradle
daemon to implicitly provide mem args. This also solves the problem
where Travis builds timeout on PermGen on JDK 7.
