### PR TITLE
settings.gradle: Merge include statements into a single one

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,61 +4,61 @@ rootProject.name = 'zipkin'
 // Zipkin's mostly common library //
 ////////////////////////////////////
 // Not all projects depend on this!
-include 'zipkin-common'
+include 'zipkin-common',
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // Projects with outputs that are useful on their own: documentation, examples, services //
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-//include 'doc'
-include 'zipkin-example'
-include 'zipkin-redis-example'
-include 'zipkin-collector-service'
-include 'zipkin-query-service'
-include 'zipkin-web'
-include 'zipkin-aggregate'
+//'doc'
+'zipkin-example',
+'zipkin-redis-example',
+'zipkin-collector-service',
+'zipkin-query-service',
+'zipkin-web',
+'zipkin-aggregate',
 
 /////////////////////////////////////
 // Collector, and Collector inputs //
 /////////////////////////////////////
 
-include 'zipkin-collector'
-include 'zipkin-collector-core'
-include 'zipkin-collector-scribe'
+'zipkin-collector',
+'zipkin-collector-core',
+'zipkin-collector-scribe',
 
 ///////////////
 // Receivers //
 ///////////////
 
-include 'zipkin-receiver-scribe'
-include 'zipkin-receiver-kafka'
+'zipkin-receiver-scribe',
+'zipkin-receiver-kafka',
 
 /////////////////
 // Query logic //
 /////////////////
 
-include 'zipkin-query'
-include 'zipkin-query-core'
+'zipkin-query',
+'zipkin-query-core',
 
 /////////////////////////////////////////////////////
 // Libraries wrapping clients to external services //
 /////////////////////////////////////////////////////
 
-include 'zipkin-zookeeper'
-include 'zipkin-cassandra'
-include 'zipkin-anormdb'
-include 'zipkin-redis'
+'zipkin-zookeeper',
+'zipkin-cassandra',
+'zipkin-anormdb',
+'zipkin-redis',
 
 ////////////
 // Thrift //
 ////////////
 
-include 'zipkin-thrift'
-include 'zipkin-scrooge'
+'zipkin-thrift',
+'zipkin-scrooge',
 
 //////////
 // Misc //
 //////////
 
-include 'zipkin-tracegen'
-include 'zipkin-sampler'
+'zipkin-tracegen',
+'zipkin-sampler'


### PR DESCRIPTION
For some reason having several include statements where the included projects depend on each other confuse IntelliJ and cause null-pointer exceptions when importing the project. Merging them into a single `include` fixes the issue.
