### PR TITLE
Transitive reduction on inter-project dependencies

### DIFF
--- a/zipkin-aggregate/build.gradle
+++ b/zipkin-aggregate/build.gradle
@@ -25,5 +25,4 @@ repositories {
 
 dependencies {
     compile project(':zipkin-cassandra')
-    compile project(':zipkin-common')
 }

--- a/zipkin-anormdb/build.gradle
+++ b/zipkin-anormdb/build.gradle
@@ -15,7 +15,6 @@ ext.anormDriverDependencies = [
 ]
 
 dependencies {
-    compile project(':zipkin-common')
     compile project(':zipkin-scrooge')
 
     compile "com.typesafe.play:anorm_${scalaInterfaceVersion}:2.3.9" // last version compatible w/ Java 7

--- a/zipkin-collector-core/build.gradle
+++ b/zipkin-collector-core/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    compile project(':zipkin-common')
     compile project(':zipkin-scrooge')
 
     compile "com.twitter:algebird-core_${scalaInterfaceVersion}:${commonVersions.algebird}"

--- a/zipkin-collector-scribe/build.gradle
+++ b/zipkin-collector-scribe/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     compile project(':zipkin-collector-core')
-    compile project(':zipkin-scrooge')
 
     compile "com.twitter:scrooge-serializer_${scalaInterfaceVersion}:${commonVersions.scrooge}"
 }

--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -17,7 +17,6 @@ repositories {
 }
 
 dependencies {
-    compile project(':zipkin-collector-core')
     compile project(':zipkin-collector-scribe')
     compile project(':zipkin-receiver-kafka')
     compile project(':zipkin-cassandra')

--- a/zipkin-collector/build.gradle
+++ b/zipkin-collector/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    compile project(':zipkin-common')
     compile project(':zipkin-scrooge')
 
     compile "com.twitter:twitter-server_${scalaInterfaceVersion}:${commonVersions.twitterServer}"

--- a/zipkin-example/build.gradle
+++ b/zipkin-example/build.gradle
@@ -23,10 +23,7 @@ repositories {
 dependencies {
     compile project(':zipkin-tracegen')
     compile project(':zipkin-web')
-    compile project(':zipkin-anormdb')
-    compile project(':zipkin-query')
     compile project(':zipkin-receiver-scribe')
-    compile project(':zipkin-zookeeper')
 
     compile "com.twitter:twitter-server_${scalaInterfaceVersion}:${commonVersions.twitterServer}"
 

--- a/zipkin-query-core/build.gradle
+++ b/zipkin-query-core/build.gradle
@@ -1,7 +1,5 @@
 dependencies {
-    compile project(':zipkin-common')
     compile project(':zipkin-query')
-    compile project(':zipkin-scrooge')
 
     compile "com.twitter:algebird-core_${scalaInterfaceVersion}:${commonVersions.algebird}"
     compile "com.twitter:ostrich_${scalaInterfaceVersion}:${commonVersions.ostrich}"

--- a/zipkin-query/build.gradle
+++ b/zipkin-query/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    compile project(':zipkin-common')
     compile project(':zipkin-scrooge')
 
     compile "com.twitter:finagle-thriftmux_${scalaInterfaceVersion}:${commonVersions.finagle}"

--- a/zipkin-receiver-kafka/build.gradle
+++ b/zipkin-receiver-kafka/build.gradle
@@ -1,9 +1,7 @@
 dependencies {
-    compile project(':zipkin-common')
     compile project(':zipkin-collector')
     compile project(':zipkin-zookeeper')
-    compile project(':zipkin-scrooge')
-    
+
     compile "com.twitter:twitter-server_${scalaInterfaceVersion}:${commonVersions.twitterServer}"
     compile "org.apache.kafka:kafka_${scalaInterfaceVersion}:0.8.2.1"
     compile 'org.apache.commons:commons-io:1.3.2'

--- a/zipkin-receiver-scribe/build.gradle
+++ b/zipkin-receiver-scribe/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     compile project(':zipkin-collector')
     compile project(':zipkin-zookeeper')
-    compile project(':zipkin-scrooge')
 
     compile "com.twitter:finagle-thriftmux_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:util-zk_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"

--- a/zipkin-redis-example/build.gradle
+++ b/zipkin-redis-example/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     compile project(':zipkin-redis')
     compile project(':zipkin-query')
     compile project(':zipkin-receiver-scribe')
-    compile project(':zipkin-zookeeper')
 
     compile "com.twitter:twitter-server_${scalaInterfaceVersion}:${commonVersions.twitterServer}"
     compile "com.twitter:finagle-zipkin_${scalaInterfaceVersion}:${commonVersions.finagle}"

--- a/zipkin-redis/build.gradle
+++ b/zipkin-redis/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    compile project(':zipkin-common')
     compile project(':zipkin-scrooge')
 
     compile "com.twitter:finagle-redis_${scalaInterfaceVersion}:${commonVersions.finagle}"

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -10,7 +10,6 @@ run {
 tasks.build.dependsOn(shadowJar)
 
 dependencies {
-    compile project(':zipkin-common')
     compile project(':zipkin-scrooge')
 
     compile "com.twitter.common.zookeeper:server-set:${commonVersions.zookeeper.serverSet}"


### PR DESCRIPTION
## What

For example a set of dependencies
- `a` -> `b`
- `b` -> `c`
- `a` -> `c`

Becomes
- `a` -> `b`
- `b` -> `c`

Due to the way Gradle resolves dependencies, these are exactly equivalent.
## How

I ran the output of `./gradlew dependencyReport` through `tred` and manually translated the result back to the Gradle build definition.
## Result

The inter-project dependency graph goes from this:
![project-dependencies before](https://cloud.githubusercontent.com/assets/59982/9012843/5f4b1474-37b8-11e5-8195-4a3291b0c3d7.jpg)
To this:
![project-dependencies dot](https://cloud.githubusercontent.com/assets/59982/9012848/6436332e-37b8-11e5-9b23-660536efeca6.jpg)
## Why?

There's a trade-off here I can't exactly formulate on a Friday evening. My gut says having the dependencies in reduced form is slightly better. Looking for your input.
