### PR TITLE
Workaround for marking config dirs as resource dir in idea

### DIFF
--- a/gradle/idea-mark-config-dir-as-resource.gradle
+++ b/gradle/idea-mark-config-dir-as-resource.gradle
@@ -1,0 +1,16 @@
+/**
+ * The idea gradle plugin (as of 2015. Aug. 05) doesn't support marking source directories as resources when
+ * translating sourceSet declarations to an idea model. This workaround marks the "config" dir in a module
+ * as "resources" in idea, without touching anything else.
+ *
+ * From: https://discuss.gradle.org/t/the-idea-plugin-breaks-the-new-intellij-13-iml-configuration/2456
+ *
+ * Related bugs:
+ *  https://issues.gradle.org/browse/GRADLE-3108
+ *  https://issues.gradle.org/browse/GRADLE-2975
+ */
+idea.module.iml.withXml {
+	it.asNode()
+			.component.content.sourceFolder
+			.find { it.@url == 'file://$MODULE_DIR$/config' }.attributes().put('type', 'java-resource')
+}

--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -24,6 +24,5 @@ dependencies {
     compile project(':zipkin-anormdb')
 }
 
-sourceSets.main.resources {
-    srcDirs = ['config']
-}
+sourceSets.main.resources.srcDirs += ['config']
+apply from: "${rootDir}/gradle/idea-mark-config-dir-as-resource.gradle"

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -23,6 +23,6 @@ dependencies {
     compile project(':zipkin-anormdb')
 }
 
-sourceSets.main.resources {
-    srcDirs = ['config']
-}
+sourceSets.main.resources.srcDirs += ['config']
+apply from: "${rootDir}/gradle/idea-mark-config-dir-as-resource.gradle"
+


### PR DESCRIPTION
The idea gradle plugin doesn't support marking source directories as resources when translating sourceSet declarations to an idea model. This workaround marks the "config" dir in a module as "resources" in idea, without touching anything else.

Fixes #543 

The workaround is from: https://discuss.gradle.org/t/the-idea-plugin-breaks-the-new-intellij-13-iml-configuration/2456

Related Gradle issues:
- https://issues.gradle.org/browse/GRADLE-3108
- https://issues.gradle.org/browse/GRADLE-2975
