### PR TITLE
Share redis client across storage and index

### DIFF
--- a/zipkin-collector-service/config/collector-redis.scala
+++ b/zipkin-collector-service/config/collector-redis.scala
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.twitter.finagle.builder.ClientBuilder
+import com.twitter.finagle.redis.{Redis, Client}
 import com.twitter.zipkin.builder.Scribe
 import com.twitter.zipkin.redis
 import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
 import com.twitter.zipkin.storage.Store
 
+val client = Client(ClientBuilder().hosts("0.0.0.0:6379")
+                                   .hostConnectionLimit(4)
+                                   .hostConnectionCoresize(4)
+                                   .codec(Redis())
+                                   .build())
+
 val redisBuilder = Store.Builder(
-    redis.StorageBuilder("0.0.0.0", 6379),
-    redis.IndexBuilder("0.0.0.0", 6379)
+    redis.StorageBuilder(client),
+    redis.IndexBuilder(client)
 )
 
 CollectorServiceBuilder(Scribe.Interface(categories = Set("zipkin")))

--- a/zipkin-query-service/config/query-redis.scala
+++ b/zipkin-query-service/config/query-redis.scala
@@ -13,13 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.twitter.finagle.builder.ClientBuilder
+import com.twitter.finagle.redis.{Redis, Client}
 import com.twitter.zipkin.builder.QueryServiceBuilder
 import com.twitter.zipkin.redis
 import com.twitter.zipkin.storage.Store
 
+val client = Client(ClientBuilder().hosts("0.0.0.0:6379")
+                                   .hostConnectionLimit(4)
+                                   .hostConnectionCoresize(4)
+                                   .codec(Redis())
+                                   .build())
+
 val storeBuilder = Store.Builder(
-  redis.StorageBuilder("0.0.0.0", 6379),
-  redis.IndexBuilder("0.0.0.0", 6379)
+  redis.StorageBuilder(client),
+  redis.IndexBuilder(client)
 )
 
 QueryServiceBuilder(storeBuilder)

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/IndexBuilder.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/IndexBuilder.scala
@@ -27,7 +27,7 @@ import com.twitter.util.Future
 
 case class IndexBuilder(
   client: Client,
-  ttl: Duration = 7.days,
+  ttl: Option[Duration] = Some(7.days),
   authPassword: Option[String] = None
 ) extends Builder[Index] { self =>
 
@@ -37,7 +37,7 @@ case class IndexBuilder(
     val authenticate = authPassword.map(p => client.auth(StringToChannelBuffer(p))) getOrElse Future.Done
     Await.result(authenticate before Future.value(new RedisIndex {
       val database = client
-      val ttl = Some(self.ttl)
+      val ttl = self.ttl
     }), 10.seconds)
   }
 }

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/IndexBuilder.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/IndexBuilder.scala
@@ -26,16 +26,14 @@ import com.twitter.util.Await
 import com.twitter.util.Future
 
 case class IndexBuilder(
-  host: String,
-  port: Int,
+  client: Client,
   ttl: Duration = 7.days,
   authPassword: Option[String] = None
 ) extends Builder[Index] { self =>
 
-  def ttl(t: Duration): IndexBuilder = copy(ttl = t)
+  def ttl(t: Duration): IndexBuilder = copy(ttl = Some(t))
 
   def apply() = {
-    val client = Client("%s:%d".format(host, port))
     val authenticate = authPassword.map(p => client.auth(StringToChannelBuffer(p))) getOrElse Future.Done
     Await.result(authenticate before Future.value(new RedisIndex {
       val database = client

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
@@ -4,17 +4,17 @@ import com.twitter.app.App
 import com.twitter.conversions.time._
 import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.finagle.redis.{Client, Redis}
+import com.twitter.util.Duration
 import com.twitter.zipkin.storage.redis.RedisSpanStore
 
 trait RedisSpanStoreFactory { self: App =>
   val redisHost = flag("zipkin.storage.redis.host", "0.0.0.0", "Host for Redis")
   val redisPort = flag("zipkin.storage.redis.port", 6379, "Port for Redis")
-  val redisTtl = flag("zipkin.storage.redis.ttl", 168, "Redis data TTL in hours")
+  val redisTtl = flag("zipkin.storage.redis.ttl", 168, "Redis data TTL in hours. A value smaller or equal to 0 means no ttl")
   val connectionCoreSize = flag("zipkin.storage.redis.connectionCoreSize", 20, "The core size of the connection pool")
   val connectionLimit = flag("zipkin.storage.redis.connectionLimit", 40, "The maximum number of connections that are allowed per host")
 
   def newRedisSpanStore(): RedisSpanStore = {
-
 
     val client = Client(ClientBuilder().hosts("%s:%d".format(redisHost(), redisPort()))
                                        .hostConnectionLimit(connectionLimit())
@@ -23,8 +23,15 @@ trait RedisSpanStoreFactory { self: App =>
                                        .daemon(true)
                                        .build())
 
-    val storage = StorageBuilder(client, redisTtl().hours)
-    val index = IndexBuilder(client, redisTtl().hours)
+    var optionalTtl:Option[Duration] = null
+    if (redisTtl() <= 0) {
+      optionalTtl = None
+    } else {
+      optionalTtl = Some(redisTtl().hours)
+    }
+
+    val storage = StorageBuilder(client, optionalTtl)
+    val index = IndexBuilder(client, optionalTtl)
     new RedisSpanStore(index.apply(), storage.apply())
   }
 }

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/RedisSpanStoreFactory.scala
@@ -2,16 +2,29 @@ package com.twitter.zipkin.redis
 
 import com.twitter.app.App
 import com.twitter.conversions.time._
+import com.twitter.finagle.builder.ClientBuilder
+import com.twitter.finagle.redis.{Client, Redis}
 import com.twitter.zipkin.storage.redis.RedisSpanStore
 
 trait RedisSpanStoreFactory { self: App =>
   val redisHost = flag("zipkin.storage.redis.host", "0.0.0.0", "Host for Redis")
   val redisPort = flag("zipkin.storage.redis.port", 6379, "Port for Redis")
   val redisTtl = flag("zipkin.storage.redis.ttl", 168, "Redis data TTL in hours")
+  val connectionCoreSize = flag("zipkin.storage.redis.connectionCoreSize", 20, "The core size of the connection pool")
+  val connectionLimit = flag("zipkin.storage.redis.connectionLimit", 40, "The maximum number of connections that are allowed per host")
 
   def newRedisSpanStore(): RedisSpanStore = {
-    val storage = StorageBuilder(redisHost(), redisPort(), redisTtl().hours)
-    val index = IndexBuilder(redisHost(), redisPort(), redisTtl().hours)
+
+
+    val client = Client(ClientBuilder().hosts("%s:%d".format(redisHost(), redisPort()))
+                                       .hostConnectionLimit(connectionLimit())
+                                       .hostConnectionCoresize(connectionCoreSize())
+                                       .codec(Redis())
+                                       .daemon(true)
+                                       .build())
+
+    val storage = StorageBuilder(client, redisTtl().hours)
+    val index = IndexBuilder(client, redisTtl().hours)
     new RedisSpanStore(index.apply(), storage.apply())
   }
 }

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/StorageBuilder.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/StorageBuilder.scala
@@ -26,16 +26,14 @@ import com.twitter.util.Await
 import com.twitter.util.Future
 
 case class StorageBuilder(
-  host: String,
-  port: Int,
+  client: Client,
   ttl: Duration = 7.days,
   authPassword: Option[String] = None
 ) extends Builder[Storage] { self =>
 
-  def ttl(t: Duration): StorageBuilder = copy(ttl = t)
+  def ttl(t: Duration): StorageBuilder = copy(ttl = Some(t))
 
   def apply() = {
-    val client = Client("%s:%d".format(host, port))
     val authenticate = authPassword.map(p => client.auth(StringToChannelBuffer(p))) getOrElse Future.Done
     Await.result(authenticate before Future.value(new RedisStorage {
       val database = client

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/StorageBuilder.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/redis/StorageBuilder.scala
@@ -27,7 +27,7 @@ import com.twitter.util.Future
 
 case class StorageBuilder(
   client: Client,
-  ttl: Duration = 7.days,
+  ttl: Option[Duration] = Some(7.days),
   authPassword: Option[String] = None
 ) extends Builder[Storage] { self =>
 
@@ -37,7 +37,7 @@ case class StorageBuilder(
     val authenticate = authPassword.map(p => client.auth(StringToChannelBuffer(p))) getOrElse Future.Done
     Await.result(authenticate before Future.value(new RedisStorage {
       val database = client
-      val ttl = Some(self.ttl)
+      val ttl = self.ttl
     }), 10.seconds)
   }
 }


### PR DESCRIPTION
- Make the number of connections in the redis client configurable
  in order to gain considerably more throughput.
- Share the client across the storage and the index builders in order
  to maintain the same connection pool
