### PR TITLE
add wait to kafka processor

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/util/Retry.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/util/Retry.scala
@@ -9,7 +9,7 @@ package com.twitter.zipkin.storage.util
  * supplied function is resilient to this fact.
  */
 object Retry {
-  def apply[T](n: Int)(f: => T) : T = {
+  def apply[T](n: Int, sleep: Boolean = false, sleeptime:Int = 1000)(f: => T) : T = {
     var result:Option[T] = None
     var throwable:Option[Throwable] = None
 
@@ -17,7 +17,10 @@ object Retry {
       try {
         result = Option(f)
       } catch {
-        case e:Throwable => { throwable = Some(e) }
+        case e: Throwable => {
+            if (sleep) Thread.sleep(sleeptime)
+            throwable = Some(e)
+          }
       }
     }
 

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/util/RetryTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/util/RetryTest.scala
@@ -1,0 +1,49 @@
+package com.twitter.zipkin.storage.util
+
+import org.scalatest.{FunSuite, Matchers}
+import java.util.concurrent.atomic.AtomicLong
+import com.twitter.zipkin.storage.util
+
+class RetryTest extends FunSuite with Matchers {
+  test("retry if success") {
+    val counter = new AtomicLong(0)
+    val result = Retry(10) {
+      val innerResult: Long = counter.incrementAndGet()
+      innerResult
+    }
+    result should be (1)
+  }
+  test("throw an error if retries are exhausted") {
+    a [Retry.RetriesExhaustedException] should be thrownBy {
+      val result = Retry(5) {
+        throw new Exception("No! No! No!")
+        1
+      }
+    }
+  }
+  test("return if fewer than max retries are needed") {
+    val counter = new AtomicLong(0)
+    val result = Retry(10) {
+      val innerResult: Long = counter.incrementAndGet()
+      if (innerResult < 10) {
+         throw new Exception("No No No")
+      }
+      innerResult
+    }
+    result should be (10)
+  }
+  test("sleeps when exception thrown and flag set") {
+    val t1 = System.currentTimeMillis
+    try {
+      val result = Retry(2, true) {
+        throw new Exception
+      }
+    }
+    catch {
+      case e: Throwable => null
+    }
+    val t2 = System.currentTimeMillis
+    val delta = t2 - t1
+    delta.toInt should be >= (2000)
+  }
+}


### PR DESCRIPTION
#### Problem

In this case the "process" method is the ItemQueue and if it gets too full it throws queue full exceptions.  

The retry test code was in Hbase O_o so moving it here.  Going to make another PR on hbase to remove that.  Converted to scalatest.
#### Solution

This retry gives it a second to process spans so that it doesn't overflow, while limiting the total number of retries in case of something catastrophic. 
