### PR TITLE
Adding a blocking queue for waiting on span storer

### DIFF
--- a/doc/redis.md
+++ b/doc/redis.md
@@ -16,3 +16,5 @@ If you have Redis installed and configured you can run Zipkin normally, except t
     bin/collector redis
     bin/query redis
     bin/web
+
+When running in production you should probably set the number of threads in the connection pool to a reasonable value to get a good throughput. The properties to use are: -zipkin.storage.redis.connectionCoreSize and -zipkin.storage.redis.connectionLimit

--- a/zipkin-collector/build.gradle
+++ b/zipkin-collector/build.gradle
@@ -4,4 +4,5 @@ dependencies {
     compile "com.twitter:twitter-server_${scalaInterfaceVersion}:${commonVersions.twitterServer}"
     compile "com.twitter:finagle-core_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:util-core_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"
+    compile "com.twitter:util-collection_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"
 }

--- a/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/BlockingItemQueue.scala
+++ b/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/BlockingItemQueue.scala
@@ -1,0 +1,36 @@
+package com.twitter.zipkin.collector
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
+import com.twitter.logging.Logger
+import com.twitter.util.{Duration, Future}
+
+/**
+ * This queue inherits from ItemQueue but instead of throwing an exception when its full it sleeps
+ * for a configurable amount of time until the span storer has enough time to consume records.
+ */
+class BlockingItemQueue [A, B](
+  maxSize: Int,
+  maxConcurrency: Int,
+  process: A => Future[B],
+  timeout: Duration = Duration.Top,
+  sleepOnFull: Duration = 1.seconds,
+  stats: StatsReceiver = DefaultStatsReceiver.scope("BlockingItemQueue"))
+    extends ItemQueue[A, B](maxSize, maxConcurrency, process, timeout, stats) {
+
+  val log = Logger(getClass())
+
+  override def add(item: A): Future[Unit] = {
+    if (!running) {
+      QueueClosed
+    }
+    while (!queue.offer(item)) {
+      queueFullCounter.incr()
+      log.debug(f"Queue is full, retrying: ${queue.size()}%d/$maxSize%d")
+      Thread.sleep(sleepOnFull.inMillis)
+      log.debug(f"After sleeping: ${queue.size()}%d/$maxSize%d")
+    }
+    Future.Done
+  }
+
+}

--- a/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/ZipkinCollectorFactory.scala
+++ b/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/ZipkinCollectorFactory.scala
@@ -57,10 +57,12 @@ trait ZipkinCollectorFactory {
 /**
  * A base collector that inserts a configurable queue between the receiver and store.
  */
-trait ZipkinQueuedCollectorFactory extends ZipkinCollectorFactory { self: App =>
+trait ZipkinQueuedCollectorFactory extends ZipkinCollectorFactory {
+  self: App =>
   val itemQueueTimeout = flag("zipkin.itemQueue.timeout", 30.seconds, "max amount of time to spend waiting for the processor to complete")
   val itemQueueMax = flag("zipkin.itemQueue.maxSize", 500, "max number of span items to buffer")
   val itemQueueConcurrency = flag("zipkin.itemQueue.concurrency", 10, "number of concurrent workers to process the write queue")
+  val itemQueueSleepOnFull = flag("zipkin.itemQueue.sleepOnFull", 1.seconds, "amount of time to sleep when the queue fills up")
 
   override def newCollector(stats: StatsReceiver): AwaitableCloser = new AwaitableCloser {
     val store = newSpanStore(stats)
@@ -78,4 +80,31 @@ trait ZipkinQueuedCollectorFactory extends ZipkinCollectorFactory { self: App =>
       Closable.sequence(receiver, queue, store).close(deadline)
     }
   }
+}
+
+/**
+ * Builds the receiver, filters and storers with a blocking queue in the middle. The receiver should
+ * attempt to add an item to the queue. If the queue is at capacity then the thread that is adding
+ * the element will sleep for a specified time and retry instead of throwing an exception.
+ */
+trait ZipkinBlockingQueuedCollectorFactory extends ZipkinQueuedCollectorFactory { self: App =>
+
+  override def newCollector(stats: StatsReceiver): AwaitableCloser = new AwaitableCloser {
+    val store = newSpanStore(stats)
+
+    val blockingQueue = new BlockingItemQueue[Seq[ThriftSpan], Unit](
+      itemQueueMax(),
+      itemQueueConcurrency(),
+      SpanConvertingFilter andThen spanStoreFilter andThen store,
+      itemQueueTimeout(),
+      itemQueueSleepOnFull(),
+      stats.scope("BlockingItemQueue"))
+
+    val receiver = newReceiver(blockingQueue.add, stats)
+
+    def close(deadline: Time): Future[Unit] = closeAwaitably {
+      Closable.sequence(receiver, blockingQueue, store).close(deadline)
+    }
+  }
+
 }

--- a/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/BlockingItemQueueTest.scala
+++ b/zipkin-collector/src/test/scala/com/twitter/zipkin/collector/BlockingItemQueueTest.scala
@@ -1,0 +1,43 @@
+package com.twitter.zipkin.collector
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.stats.InMemoryStatsReceiver
+import com.twitter.util.{Await, Future}
+import org.scalatest._
+
+/**
+ * Tests the BlockingItemQueue to make sure that it can store and consume elements even when adding
+ * more elements than what its initial capacity is
+ */
+class BlockingItemQueueTest extends FunSuite {
+
+  val Item = ()
+
+  def fill(queue: BlockingItemQueue[Unit, Unit], items: Int): Future[Boolean] = {
+    val results = (0 until items) map { _ =>
+      queue.add(Item) transform { e => Future.value(e) }
+    }
+    Future.collect(results).map(_.forall(_.isReturn))
+  }
+
+  test("Sleeps on a max queue and waits for the worker to drain") {
+
+    val stats:InMemoryStatsReceiver = new InMemoryStatsReceiver()
+    val queue = new BlockingItemQueue[Unit, Unit](10, 1, fallingBehindWorker, 100.millis,
+                                                  100.millis, stats)
+    // Add 11 and not 10 because the first one that's going to be added will be consumed right away
+    assert(Await.result(fill(queue, 11)))
+    assert(Await.ready(queue.add(Item)).poll.get.isReturn)
+    Await.ready(queue.close())
+    assert(stats.counter("queueFull").apply() >= 1)
+    assert(stats.counter("successes").apply() == 12)
+    assert(queue.size() == 0)
+  }
+
+  def fallingBehindWorker(param: Unit): Future[Unit] = {
+    Future { Thread.sleep(100)
+              param
+           }
+  }
+
+}


### PR DESCRIPTION
- Added a blocking queue that waits for the span storer
  to consume records instead of throwing a queue full exception.
  This queue will help in situations where the you're backfilling
  or when the receiver is a lot faster than the span storer (writer)
