### PR TITLE
fix bintray publish subproject description

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ subprojects { subproject ->
             userOrg = "openzipkin"
             version {
                 name = "${project.version}"
-                desc = 'Zipkin version ${project.version}'
+                desc = "Zipkin ${subproject.name} version ${project.version}"
                 released  = new Date()
                 vcsTag = "${project.version}"
             }


### PR DESCRIPTION
Fix by changing single quotes to double quotes, and add some more description.
