### PR TITLE
Upload fat jars to Bintray

### DIFF
--- a/zipkin-aggregate/build.gradle
+++ b/zipkin-aggregate/build.gradle
@@ -17,6 +17,7 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
+artifacts.archives shadowJar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -10,6 +10,7 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
+artifacts.archives shadowJar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-example/build.gradle
+++ b/zipkin-example/build.gradle
@@ -13,6 +13,7 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
+artifacts.archives shadowJar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -10,6 +10,7 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
+artifacts.archives shadowJar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-redis-example/build.gradle
+++ b/zipkin-redis-example/build.gradle
@@ -13,6 +13,7 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
+artifacts.archives shadowJar
 
 dependencies {
     compile project(':zipkin-web')

--- a/zipkin-tracegen/build.gradle
+++ b/zipkin-tracegen/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.tracegen.Main'
 
 tasks.build.dependsOn(shadowJar)
+artifacts.archives shadowJar
 
 repositories {
     // For dependencies of zipkin-cassandra (via zipkin-query-service and zipkin-collector-service)

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -8,6 +8,7 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
+artifacts.archives shadowJar
 
 dependencies {
     compile project(':zipkin-scrooge')


### PR DESCRIPTION
This change uploads the fat jar generated by the `shadow` plugin while leaving the current files in place. For an example, see https://bintray.com/abesto/zipkin-test/zipkin-web/view#files
- `zipkin-web/1.2.2/zipkin-web-1.2.2.jar` is a plain old jar, with no included dependencies (but the dependencies declared in the corresponding `.pom` file)
- `zipkin-web/1.2.2/zipkin-web-1.2.2.{tar.zip}` are the distributions created by the Gradle `application` plugin, with the dependencies included in a subfolder and shell scripts to launch the application
- `zipkin-web/1.2.2/zipkin-web-1.2.2-all.jar` is the fat jar generated by the Gradle `shadow` plugin
