### PR TITLE
Fixes ./gradle idea "Cannot infer Scala class path because.." failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,17 @@ allprojects {
     apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
+
+    // Following are workarounds to idea goal failing on:
+    // Cannot infer Scala class path because..
+    // - no repository is declared in root project 
+    repositories { jcenter() }
+
+    // - no Scala library Jar was found
+    apply from: "$rootDir/gradle/dependencies.gradle"
+    dependencies {
+        compile "org.scala-lang:scala-library:${scalaVersion}"
+    }
 }
 
 release {
@@ -41,7 +52,6 @@ release {
 
 subprojects { subproject ->
 
-    apply from: "$rootDir/gradle/dependencies.gradle"
     apply from: "$rootDir/gradle/scalatest.gradle"
 
     compileTestScala {
@@ -57,14 +67,11 @@ subprojects { subproject ->
     }
 
     repositories {
-        jcenter()
         maven { url 'http://repo.typesafe.com/typesafe/releases/' }
         maven { url 'https://maven.twttr.com/' }
     }
 
     dependencies {
-        compile "org.scala-lang:scala-library:${scalaVersion}"
-
         // Was dependencyOverrides in SBT, will probably cause issues
         compile 'org.apache.zookeeper:zookeeper:3.4.6' // internal twitter + kafka + curator
         compile 'org.slf4j:slf4j-api:1.6.4' // libthrift 0.5 otherwise pins 1.5.x


### PR DESCRIPTION
The idea goal failed due to problems understanding scala. This adds a
repository and the current scala version to the parent to address that.

Fixes #565
