### PR TITLE
Use Bintray Gradle plugin 1.3.1, fixing #559

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.jfrog.bintray' version '1.2'
+    id 'com.jfrog.bintray' version '1.3.1'
     id 'net.researchgate.release' version '2.1.2'
 }
 


### PR DESCRIPTION
Quoting #559:

See bintray/gradle-bintray-plugin#68

We need update the plugin when it is released.

This should solve the problem, when jars are bintrayUpload'ed they are not published and you need to bintray.com to click the publish link.
