### PR TITLE
Upload to a single package on Bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ subprojects { subproject ->
             licenses = ['Apache-2.0']
             repo = 'zipkin'
             vcsUrl = 'https://github.com/openzipkin/zipkin.git'
-            name = "${subproject.name}"
+            name = "zipkin"
             userOrg = "openzipkin"
             version {
                 name = "${project.version}"


### PR DESCRIPTION
This simplifies maintenance and configuration, especially when it comes to syncing to Maven Central.

For an example of what the result looks like: https://bintray.com/abesto/zipkin-test/zipkin/view#files
The artifacts are not published (=made public) on Bintray, expect another PR on that.

Side-note: uploading stuff takes long. Most of the fat jars are ~80MB, and they have a `.zip` and a `.tar` friend.
