### PR TITLE
Bintray auto publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ subprojects { subproject ->
             licenses = ['Apache-2.0']
             repo = 'zipkin'
             vcsUrl = 'https://github.com/openzipkin/zipkin.git'
-            name = "${subproject.name}"
+            name = "zipkin"
             userOrg = "openzipkin"
             version {
                 name = "${project.version}"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'net.researchgate.release' version '2.1.2'
 }
 
-allprojects {
+allprojects { thisProject ->
     apply plugin: 'idea'
     apply plugin: 'java'
     apply plugin: 'scala'
@@ -27,6 +27,37 @@ allprojects {
     apply from: "$rootDir/gradle/dependencies.gradle"
     dependencies {
         compile "org.scala-lang:scala-library:${scalaVersion}"
+    }
+
+    bintray {
+        // Read variables from travis encrypted config or local
+        user = System.getenv('BINTRAY_USER')
+        key = System.getenv('BINTRAY_KEY')
+
+        // Workaround: we don't want to publish anything from the root project.
+        // https://github.com/bintray/gradle-bintray-plugin/issues/74
+        if (thisProject == rootProject) {
+            configurations = []
+        } else {
+            configurations = ['archives']
+        }
+
+        dryRun = false
+        publish = true
+
+        pkg {
+            licenses = ['Apache-2.0']
+            repo = 'zipkin'
+            vcsUrl = 'https://github.com/openzipkin/zipkin.git'
+            name = "zipkin"
+            userOrg = "openzipkin"
+            version {
+                name = "${project.version}"
+                desc = "Zipkin ${thisProject.name} version ${project.version}"
+                released  = new Date()
+                vcsTag = "${project.version}"
+            }
+        }
     }
 }
 
@@ -82,42 +113,7 @@ subprojects { subproject ->
         testCompile "org.scalatest:scalatest_${scalaInterfaceVersion}:2.2.5"
     }
     // SBT migration note: end of zipkinSettings
-
-    bintray {
-        // Read variables from travis encrypted config or local
-        user = System.getenv('BINTRAY_USER')
-        key = System.getenv('BINTRAY_KEY')
-
-        configurations = ['archives']
-        dryRun = false
-        publish = true
-
-        pkg {
-            licenses = ['Apache-2.0']
-            repo = 'zipkin'
-            vcsUrl = 'https://github.com/openzipkin/zipkin.git'
-            name = "zipkin"
-            userOrg = "openzipkin"
-            version {
-                name = "${project.version}"
-                desc = "Zipkin ${subproject.name} version ${project.version}"
-                released  = new Date()
-                vcsTag = "${project.version}"
-            }
-        }
-    }
 }
-
-// Workaround:
-// only our subprojects have a bintray configuration. replace the root project's
-// `bintrayUpload` task with one that restricts the calls to the subprojects.
-// https://github.com/bintray/gradle-bintray-plugin/issues/74#issuecomment-126978089
-project.afterEvaluate {
-    task bintrayUpload(group: "publishing", overwrite: true) {
-        dependsOn subprojects.bintrayUpload
-    }
-}
-
 
 // Quick hack to visualize inter-project dependencies
 task dependencyReport {


### PR DESCRIPTION
Note: this is based off #573 

Problem: our workaround for making `bintrayUpload` work with an empty root project disabled all logic in the `bintrayUpload` task, which includes stuff like auto-publishing uploaded artifacts and maven central sync. 

This solution leaves the original logic in place, while still not publishing any artifacts for the (empty) root project, and also not failing the build process.

The output of `./gradlew bintrayUpload -i | grep 'Dry run'` with `dryRun = true`, note the "Published version" at the end and the lack of artifacts for the root project:

```
(Dry run) Created verion 'openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-aggregate/1.2.1-SNAPSHOT/zipkin-aggregate-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-aggregate/1.2.1-SNAPSHOT/zipkin-aggregate-1.2.1-SNAPSHOT.zip'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-aggregate/1.2.1-SNAPSHOT/zipkin-aggregate-1.2.1-SNAPSHOT.tar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-aggregate/1.2.1-SNAPSHOT/zipkin-aggregate-1.2.1-SNAPSHOT-all.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-aggregate/1.2.1-SNAPSHOT/zipkin-aggregate-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-anormdb/1.2.1-SNAPSHOT/zipkin-anormdb-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-anormdb/1.2.1-SNAPSHOT/zipkin-anormdb-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-cassandra/1.2.1-SNAPSHOT/zipkin-cassandra-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-cassandra/1.2.1-SNAPSHOT/zipkin-cassandra-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector/1.2.1-SNAPSHOT/zipkin-collector-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector/1.2.1-SNAPSHOT/zipkin-collector-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector-core/1.2.1-SNAPSHOT/zipkin-collector-core-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector-core/1.2.1-SNAPSHOT/zipkin-collector-core-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector-scribe/1.2.1-SNAPSHOT/zipkin-collector-scribe-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector-scribe/1.2.1-SNAPSHOT/zipkin-collector-scribe-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector-service/1.2.1-SNAPSHOT/zipkin-collector-service-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector-service/1.2.1-SNAPSHOT/zipkin-collector-service-1.2.1-SNAPSHOT.zip'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector-service/1.2.1-SNAPSHOT/zipkin-collector-service-1.2.1-SNAPSHOT.tar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector-service/1.2.1-SNAPSHOT/zipkin-collector-service-1.2.1-SNAPSHOT-all.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-collector-service/1.2.1-SNAPSHOT/zipkin-collector-service-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-common/1.2.1-SNAPSHOT/zipkin-common-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-common/1.2.1-SNAPSHOT/zipkin-common-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-example/1.2.1-SNAPSHOT/zipkin-example-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-example/1.2.1-SNAPSHOT/zipkin-example-1.2.1-SNAPSHOT.zip'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-example/1.2.1-SNAPSHOT/zipkin-example-1.2.1-SNAPSHOT.tar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-example/1.2.1-SNAPSHOT/zipkin-example-1.2.1-SNAPSHOT-all.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-example/1.2.1-SNAPSHOT/zipkin-example-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-query/1.2.1-SNAPSHOT/zipkin-query-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-query/1.2.1-SNAPSHOT/zipkin-query-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-query-core/1.2.1-SNAPSHOT/zipkin-query-core-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-query-core/1.2.1-SNAPSHOT/zipkin-query-core-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-query-service/1.2.1-SNAPSHOT/zipkin-query-service-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-query-service/1.2.1-SNAPSHOT/zipkin-query-service-1.2.1-SNAPSHOT.zip'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-query-service/1.2.1-SNAPSHOT/zipkin-query-service-1.2.1-SNAPSHOT.tar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-query-service/1.2.1-SNAPSHOT/zipkin-query-service-1.2.1-SNAPSHOT-all.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-query-service/1.2.1-SNAPSHOT/zipkin-query-service-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-receiver-kafka/1.2.1-SNAPSHOT/zipkin-receiver-kafka-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-receiver-kafka/1.2.1-SNAPSHOT/zipkin-receiver-kafka-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-receiver-scribe/1.2.1-SNAPSHOT/zipkin-receiver-scribe-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-receiver-scribe/1.2.1-SNAPSHOT/zipkin-receiver-scribe-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-redis/1.2.1-SNAPSHOT/zipkin-redis-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-redis/1.2.1-SNAPSHOT/zipkin-redis-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-redis-example/1.2.1-SNAPSHOT/zipkin-redis-example-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-redis-example/1.2.1-SNAPSHOT/zipkin-redis-example-1.2.1-SNAPSHOT.zip'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-redis-example/1.2.1-SNAPSHOT/zipkin-redis-example-1.2.1-SNAPSHOT.tar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-redis-example/1.2.1-SNAPSHOT/zipkin-redis-example-1.2.1-SNAPSHOT-all.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-redis-example/1.2.1-SNAPSHOT/zipkin-redis-example-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-sampler/1.2.1-SNAPSHOT/zipkin-sampler-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-sampler/1.2.1-SNAPSHOT/zipkin-sampler-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-scrooge/1.2.1-SNAPSHOT/zipkin-scrooge-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-scrooge/1.2.1-SNAPSHOT/zipkin-scrooge-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-thrift/1.2.1-SNAPSHOT/zipkin-thrift-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-thrift/1.2.1-SNAPSHOT/zipkin-thrift-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-tracegen/1.2.1-SNAPSHOT/zipkin-tracegen-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-tracegen/1.2.1-SNAPSHOT/zipkin-tracegen-1.2.1-SNAPSHOT.zip'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-tracegen/1.2.1-SNAPSHOT/zipkin-tracegen-1.2.1-SNAPSHOT.tar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-tracegen/1.2.1-SNAPSHOT/zipkin-tracegen-1.2.1-SNAPSHOT-all.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-tracegen/1.2.1-SNAPSHOT/zipkin-tracegen-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-web/1.2.1-SNAPSHOT/zipkin-web-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-web/1.2.1-SNAPSHOT/zipkin-web-1.2.1-SNAPSHOT.zip'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-web/1.2.1-SNAPSHOT/zipkin-web-1.2.1-SNAPSHOT.tar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-web/1.2.1-SNAPSHOT/zipkin-web-1.2.1-SNAPSHOT-all.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-web/1.2.1-SNAPSHOT/zipkin-web-1.2.1-SNAPSHOT.pom'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-zookeeper/1.2.1-SNAPSHOT/zipkin-zookeeper-1.2.1-SNAPSHOT.jar'.
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-zookeeper/1.2.1-SNAPSHOT/zipkin-zookeeper-1.2.1-SNAPSHOT.pom'.
(Dry run) Pulished verion 'openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT'.
```
