### PR TITLE
Make Bintray uploading more customizable via ENV vars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,15 +42,15 @@ allprojects { thisProject ->
             configurations = ['archives']
         }
 
-        dryRun = false
+        dryRun = System.getenv('BINTRAY_DRYRUN') != null
         publish = true
 
         pkg {
             licenses = ['Apache-2.0']
-            repo = 'zipkin'
+            repo = System.getenv('BINTRAY_ZIPKIN_REPO') ?: "zipkin"
             vcsUrl = 'https://github.com/openzipkin/zipkin.git'
-            name = "zipkin"
-            userOrg = "openzipkin"
+            name = System.getenv('BINTRAY_ZIPKIN_PACKAGE') ?: "zipkin"
+            userOrg = System.getenv('BINTRAY_ZIPKIN_ORG') ?: "openzipkin"
             version {
                 name = "${project.version}"
                 desc = "Zipkin ${thisProject.name} version ${project.version}"


### PR DESCRIPTION
This lets us play around with the bintray release process without having to modify `build.gradle`
