### PR TITLE
Adds getDataTimeToLive to ReadOnlySpanStore

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassieSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassieSpanStore.scala
@@ -338,6 +338,8 @@ class CassieSpanStore(
     }
   }
 
+  override def getDataTimeToLive = Future.value(spanTtl.inSeconds)
+
   def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] = {
     QueryTracesExistStat.add(traceIds.size)
     getSpansByTraceIds(traceIds, 1) map {

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
@@ -16,7 +16,7 @@
 package com.twitter.zipkin.storage
 
 import com.twitter.conversions.time._
-import com.twitter.finagle.{Filter => FFilter, Service}
+import com.twitter.finagle.{Filter => FFilter}
 import com.twitter.util.{Closable, CloseAwaitably, Duration, Future, Time}
 import com.twitter.zipkin.Constants
 import com.twitter.zipkin.common.Span
@@ -69,6 +69,13 @@ trait WriteSpanStore
 }
 
 trait ReadSpanStore {
+  /**
+   * Returns the time to live in seconds or [[Int.MaxValue]], if unknown.
+   *
+   * Corresponds to the thrift call `ZipkinQuery.getDataTimeToLive`.
+   */
+  def getDataTimeToLive(): Future[Int] = Future.value(Int.MaxValue)
+
   def getTimeToLive(traceId: Long): Future[Duration]
 
   def tracesExist(traceIds: Seq[Long]): Future[Set[Long]]

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -81,6 +81,11 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     result(store.getSpansByTraceIds(Seq(54321))) should be(empty)
   }
 
+  @Test def getDataTimeToLive() {
+    // If a store doesn't use TTLs this should return Int.Max
+    assert(result(store.getDataTimeToLive()) > 0)
+  }
+
   @Test def setTimeToLive() {
     ready(store(Seq(span1)))
     ready(store.setTimeToLive(span1.traceId, 1234.seconds))

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -42,6 +42,8 @@ class RedisSpanStore(client: Client, ttl: Option[Duration]) extends SpanStore {
     storage.getTimeToLive(traceId)
   }
 
+  override def getDataTimeToLive = Future.value(ttl.map(_.inSeconds).getOrElse(Int.MaxValue))
+
   def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] = {
     storage.tracesExist(traceIds)
   }


### PR DESCRIPTION
The query thrift api requires support of getDataTimeToLive, which is on
`Storage`, but not yet `SpanStore`. Adding this makes it possible to
implement the legacy `Storage` interface with a `SpanStore`.
