### PR TITLE
Aborts publish on shell script error; don't increment tentative versions

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -e
 
 echo "********************************"
 echo "***** Publishing Artifacts *****"
@@ -68,7 +69,9 @@ function publish_snapshots_to_bintray(){
 }
 
 function publish_release_to_bintray(){
-  new_version=`increment_version "${TRAVIS_TAG}"`
+  # do not increment if the version is tentative ex. 1.0.0-rc1
+  [[ "$TRAVIS_TAG" == *-* ]] && new_version=${TRAVIS_TAG} || new_version=$(increment_version "${TRAVIS_TAG}")
+
   echo "[Publishing] Starting Release Publish (${TRAVIS_TAG}) new version (${new_version})..."
   ./gradlew release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}-SNAPSHOT
   ./gradlew bintrayUpload


### PR DESCRIPTION
probably harmless, but spotted in latest build log

```
[Publishing] Branch (1.2.1-rc1) same as Tag (1.2.1-rc1)
./travis/publish.sh: line 18: 1.2.1-rc1+1: syntax error: invalid arithmetic operator (error token is ".2.1-rc1+1")
[Publishing] Starting Release Publish (1.2.1-rc1) new version (1.2.1-rc1)...
```
