### PR TITLE
Makes SpanStore and Aggregates implementable in Java

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormAggregates.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormAggregates.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.zipkin.storage.anormdb
 
-import com.twitter.util.{Await, Future, Time}
+import com.twitter.util.{Future, Time}
 import com.twitter.conversions.time._
 import com.twitter.zipkin.common.{Service, DependencyLink, Dependencies}
 import com.twitter.zipkin.storage.Aggregates
@@ -35,8 +35,6 @@ import AnormThreads.inNewThread
 case class AnormAggregates(
   val db: DB,
   val openCon: Option[Connection] = None) extends Aggregates with DBPool {
-
-  override def close() = Await.ready(close(Time.Top))
 
   /**
    * Get the dependencies in a time range.

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DBPool.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DBPool.scala
@@ -17,14 +17,12 @@
 package com.twitter.zipkin.storage.anormdb
 
 import com.twitter.ostrich.stats.Stats
-import com.twitter.util.Time
-import com.twitter.zipkin.storage.anormdb.AnormThreads._
 import java.sql.Connection
 
 /**
  * Common database connection code.
  */
-trait DBPool {
+trait DBPool extends java.io.Closeable {
 
   val db: DB
 
@@ -34,7 +32,7 @@ trait DBPool {
   /**
    * Closes all database connections.
    */
-  def close(deadline: Time) = inNewThread {
+  override def close() = {
     if (!openCon.isEmpty) {
       openCon.get.close()
     }

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -17,7 +17,7 @@ package com.twitter.zipkin.storage.cassandra
 
 import com.twitter.conversions.time._
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
-import com.twitter.util.{Future, FuturePool, Duration, Time}
+import com.twitter.util.{Future, FuturePool, Duration}
 import com.twitter.zipkin.Constants
 import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.conversions.thrift._
@@ -217,8 +217,7 @@ class CassandraSpanStore(
   /**
    * API Implementation
    */
-  override def close(deadline: Time): Future[Unit] =
-    FuturePool.unboundedPool { repository.close() }
+  override def close() = repository.close()
 
   def apply(spans: Seq[Span]): Future[Unit] = {
     SpansStoredCounter.incr(spans.size)

--- a/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/ZipkinCollectorFactory.scala
+++ b/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/ZipkinCollectorFactory.scala
@@ -19,11 +19,11 @@ import com.twitter.app.App
 import com.twitter.conversions.time._
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.{Filter, Service}
-import com.twitter.util.{Closable, CloseAwaitably, Future, Time}
+import com.twitter.util._
 import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
-import com.twitter.zipkin.storage.{SpanStore, WriteSpanStore}
+import com.twitter.zipkin.storage.SpanStore
 
 sealed trait AwaitableCloser extends Closable with CloseAwaitably
 
@@ -39,7 +39,7 @@ object SpanConvertingFilter extends Filter[Seq[ThriftSpan], Unit, Seq[Span], Uni
  */
 trait ZipkinCollectorFactory {
   def newReceiver(receive: Seq[ThriftSpan] => Future[Unit], stats: StatsReceiver): SpanReceiver
-  def newSpanStore(stats: StatsReceiver): WriteSpanStore
+  def newSpanStore(stats: StatsReceiver): SpanStore
 
   // overwrite in the Main trait to add a SpanStore filter to the SpanStore
   def spanStoreFilter: SpanStore.Filter = Filter.identity[Seq[Span], Unit]

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Aggregates.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Aggregates.scala
@@ -23,9 +23,7 @@ import com.twitter.zipkin.common.Dependencies
  * Storage and retrieval interface for aggregates that may be computed offline and reloaded into
  * online storage
  */
-trait Aggregates {
-
-  def close()
+abstract class Aggregates extends java.io.Closeable {
 
   def getDependencies(startDate: Option[Time], endDate: Option[Time]=None): Future[Dependencies]
   def storeDependencies(dependencies: Dependencies): Future[Unit]

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/AggregatesInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/AggregatesInJava.java
@@ -1,0 +1,54 @@
+package com.twitter.zipkin.storage;
+
+import scala.Option;
+import scala.collection.Seq;
+import scala.runtime.BoxedUnit;
+
+import com.twitter.util.Future;
+import com.twitter.util.Time;
+import com.twitter.zipkin.common.Dependencies;
+
+/**
+ * Shows that {@link Aggregates} is implementable in Java 7+.
+ */
+public class AggregatesInJava extends Aggregates {
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public Future<Dependencies> getDependencies(Option<Time> startDate, Option<Time> endDate) {
+        return null;
+    }
+
+    @Override
+    public Option<Time> getDependencies$default$2() {
+        return null;
+    }
+
+    @Override
+    public Future<BoxedUnit> storeDependencies(Dependencies dependencies) {
+        return null;
+    }
+
+    @Override
+    public Future<Seq<String>> getTopAnnotations(String serviceName) {
+        return null;
+    }
+
+    @Override
+    public Future<Seq<String>> getTopKeyValueAnnotations(String serviceName) {
+        return null;
+    }
+
+    @Override
+    public Future<BoxedUnit> storeTopAnnotations(String serviceName, Seq<String> a) {
+        return null;
+    }
+
+    @Override
+    public Future<BoxedUnit> storeTopKeyValueAnnotations(String serviceName, Seq<String> a) {
+        return null;
+    }
+}

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
@@ -1,0 +1,77 @@
+package com.twitter.zipkin.storage;
+
+import java.nio.ByteBuffer;
+
+import scala.Option;
+import scala.collection.Seq;
+import scala.collection.immutable.Set;
+import scala.runtime.BoxedUnit;
+
+import com.twitter.util.Duration;
+import com.twitter.util.Future;
+import com.twitter.zipkin.common.Span;
+
+/**
+ * Shows that {@link SpanStore} is implementable in Java 7+.
+ */
+public class SpanStoreInJava extends SpanStore {
+
+    @Override
+    public Future<Duration> getTimeToLive(long traceId) {
+        return null;
+    }
+
+    @Override
+    public Future<Set<Object>> tracesExist(Seq<Object> traceIds) {
+        return null;
+    }
+
+    @Override
+    public Future<Seq<Seq<Span>>> getSpansByTraceIds(Seq<Object> traceIds) {
+        return null;
+    }
+
+    @Override
+    public Future<Seq<Span>> getSpansByTraceId(long traceId) {
+        return null;
+    }
+
+    @Override
+    public Future<Seq<IndexedTraceId>> getTraceIdsByName(String serviceName, Option<String> spanName, long endTs, int limit) {
+        return null;
+    }
+
+    @Override
+    public Future<Seq<IndexedTraceId>> getTraceIdsByAnnotation(String serviceName, String annotation, Option<ByteBuffer> value, long endTs, int limit) {
+        return null;
+    }
+
+    @Override
+    public Future<Seq<TraceIdDuration>> getTracesDuration(Seq<Object> traceIds) {
+        return null;
+    }
+
+    @Override
+    public Future<Set<String>> getAllServiceNames() {
+        return null;
+    }
+
+    @Override
+    public Future<Set<String>> getSpanNames(String service) {
+        return null;
+    }
+
+    @Override
+    public Future<BoxedUnit> apply(Seq<Span> spans) {
+        return null;
+    }
+
+    @Override
+    public Future<BoxedUnit> setTimeToLive(long traceId, Duration ttl) {
+        return null;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/zipkin-example/src/main/scala/com/twitter/zipkin/example/Main.scala
+++ b/zipkin-example/src/main/scala/com/twitter/zipkin/example/Main.scala
@@ -36,6 +36,6 @@ object Main extends TwitterServer
     closeOnExit(closer)
 
     println("running and ready")
-    Await.all(web, receiver, store)
+    Await.all(web, receiver)
   }
 }

--- a/zipkin-redis-example/src/main/scala/com/twitter/zipkin/example/Main.scala
+++ b/zipkin-redis-example/src/main/scala/com/twitter/zipkin/example/Main.scala
@@ -30,6 +30,6 @@ object Main extends TwitterServer
     closeOnExit(closer)
 
     println("running and ready")
-    Await.all(web, receiver, store)
+    Await.all(web, receiver)
   }
 }

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -2,7 +2,7 @@ package com.twitter.zipkin.storage.redis
 
 import com.google.common.io.Closer
 import com.twitter.finagle.redis.Client
-import com.twitter.util.{Duration, Future, Time}
+import com.twitter.util.{Duration, Future}
 import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.storage._
 import java.nio.ByteBuffer
@@ -21,9 +21,7 @@ class RedisSpanStore(client: Client, ttl: Option[Duration]) extends SpanStore {
   /** For testing, clear this store. */
   private[redis] def clear(): Future[Unit] = client.flushDB()
 
-  def close(deadline: Time): Future[Unit] = closeAwaitably {
-    call { closer.close() }.unit
-  }
+  override def close() = closer.close()
 
   def apply(newSpans: Seq[Span]): Future[Unit] = Future.collect(newSpans.flatMap {
     span =>


### PR DESCRIPTION
This makes the critical storage interfaces, SpanStore and Aggregates,
abstract classes, and adds implementations in the java test tree to
prove they can compile with Java 7.

SpanStore was a mixture of traits, which made it impossible to write in
Java. Moreover, eventhough all implementations close synchronously, it
mixed in Twitter's Closeable, which was both a trait and also async.

Aggregates was a trait and implemented a synchronous close method
already.

See #451
Closes #584
