### PR TITLE
Release-related tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,12 @@ before_install:
   - git config --global user.email "${GH_USER_EMAIL}"
   - git config --global user.name "${GH_USER}"
 
+# Skip `./gradlew assemble`
+install: /bin/true
+
 before_script:
   - git remote set-url origin "https://${GH_TOKEN}@github.com/openzipkin/zipkin.git"
 
-after_success: ./travis/publish.sh
+script:
+  - ./travis/publish.sh
+

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-echo "********************************"
-echo "***** Publishing Artifacts *****"
-echo "********************************"
-
 declare -r PUBLISH_USING_JDK="oraclejdk7"
 
 function increment_version() {
@@ -19,46 +15,59 @@ function increment_version() {
   echo "$v" | perl -pe s/$rgx.*$'/${1}'`printf %0${#val}s $(($val+1))`/
 }
 
-function publish_release(){
+function should_publish_snapshots(){
   if [ "${TRAVIS_TAG}" == "" ]; then
-    echo "[Publishing] snapshot release"
-    return 1
-  else
-    echo "[Publishing] tag: ${TRAVIS_TAG}"
+    echo "[Publishing] This build was not started by a tag, starting snapshot release"
     return 0
-  fi
-}
-
-function check_is_pull_request(){
-  if [ "${TRAVIS_PULL_REQUEST}" == "true" ]; then
-    echo "[Not Publishing] this is a Pull Request"
-    exit 1
   else
-    echo "[Publishing] this is not a Pull Request"
+    echo "[Publishing] This build was started by the tag ${TRAVIS_TAG}, starting non-snapshot release"
+    return 1
   fi
 }
 
-function check_tag_valid(){
+function is_pull_request(){
+  if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    echo "[Not Publishing] This is a Pull Request"
+    return 0
+  else
+    echo "[Publishing] This is not a Pull Request"
+    return 1
+  fi
+}
+
+function is_travis_branch_master(){
+  if [ "${TRAVIS_BRANCH}" = master ]; then
+    echo "[Publishing] Travis branch is master"
+    return 0
+  else
+    echo "[Not Publishing] Travis branch is not master"
+    return 1
+  fi
+}
+
+function does_travis_branch_equal_travis_tag(){
   #Weird comparison comparing branch to tag because when you 'git push --tags'
   #the branch somehow becomes the tag value
   #github issue: https://github.com/travis-ci/travis-ci/issues/1675
   if [ "${TRAVIS_BRANCH}" != "${TRAVIS_TAG}" ]; then
     echo "[Not Publishing] Travis branch does not equal Travis tag, which it should: "
     echo "[Not Publishing]   github issue: https://github.com/travis-ci/travis-ci/issues/1675"
-    exit 1
+    return 1
   else
     echo "[Publishing] Branch (${TRAVIS_BRANCH}) same as Tag (${TRAVIS_TAG})"
+    return 0
   fi
 }
 
-function check_jdk_version(){
+function want_to_release_from_this_jdk(){
   if [ "${TRAVIS_JDK_VERSION}" != "${PUBLISH_USING_JDK}" ]; then
     echo "[Not Publishing] Current JDK(${TRAVIS_JDK_VERSION}) does not"
     echo "[Not Publishing]   equal PUBLISH_USING_JDK(${PUBLISH_USING_JDK})"
-    exit 1
+    return 1
   else
     echo "[Publishing] Current JDK is the same as PUBLISH_USING_JDK"
     echo "[Publishing]   environment variable (${TRAVIS_JDK_VERSION})"
+    return 0
   fi
 }
 
@@ -73,22 +82,32 @@ function publish_release_to_bintray(){
   [[ "$TRAVIS_TAG" == *-* ]] && new_version=${TRAVIS_TAG} || new_version=$(increment_version "${TRAVIS_TAG}")
 
   echo "[Publishing] Starting Release Publish (${TRAVIS_TAG}) new version (${new_version})..."
+  git checkout master
   ./gradlew release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}-SNAPSHOT
   ./gradlew bintrayUpload
   echo "[Publishing] Done"
 }
 
+function run_tests(){
+  echo "[Not Publishing] Running tests then exiting."
+  ./gradlew check
+}
+
 #----------------------
 # MAIN
 #----------------------
-git checkout -b master
-
-check_is_pull_request
-check_jdk_version
-
-if publish_release; then
-  check_tag_valid
-  publish_release_to_bintray
+if is_pull_request || ! is_travis_branch_master || ! want_to_release_from_this_jdk; then
+  action=run_tests
 else
-  publish_snapshots_to_bintray
+  if should_publish_snapshots; then
+    action=publish_snapshots_to_bintray
+  else
+    if does_travis_branch_equal_travis_tag; then
+      action=publish_release_to_bintray
+    else
+      action=run_tests
+    fi
+  fi
 fi
+
+$action


### PR DESCRIPTION
- In publish.sh, remove -b switch from git checkout master.
  It's slightly confusing that this didn't break previously,
  but there it is; the master branch should definitely already
  exist.
- In .travis.yml, override the default Travis behavior of
  ./gradlew assemble && ./gradlew check with
  running just publish.sh. The tasks run by publish.sh also run
  the tests, and we had duplicate execution between the Gradle runs
  started by Travis and publish.sh.
- If we don't want to release from this build, then just run
  ./gradlew check and exit. This can happen for four reasons:
  if this build was started by a PR, because we're not running
  on the JDK we want to use to build releases, because
  of travis-ci/travis-ci#1675,
  or because we're not on master.
- Fix: TRAVIS_PULL_REQUEST can be "false" or the PR number,
  but never "true".
