### PR TITLE
Run checks before snapshot release, call Gradle just once

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -73,7 +73,7 @@ function want_to_release_from_this_jdk(){
 
 function publish_snapshots_to_bintray(){
   echo "[Publishing] Starting Snapshot Publish..."
-  ./gradlew bintrayUpload
+  ./gradlew check bintrayUpload
   echo "[Publishing] Done"
 }
 
@@ -83,8 +83,9 @@ function publish_release_to_bintray(){
 
   echo "[Publishing] Starting Release Publish (${TRAVIS_TAG}) new version (${new_version})..."
   git checkout master
-  ./gradlew release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}-SNAPSHOT
-  ./gradlew bintrayUpload
+  ./gradlew check \
+            release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}-SNAPSHOT \
+            bintrayUpload
   echo "[Publishing] Done"
 }
 


### PR DESCRIPTION
According to https://docs.gradle.org/current/userguide/tutorial_gradle_command_line.html:
You can execute multiple tasks in a single build by listing each of the tasks on the command-line.

Plus, each task is run only once across the whole dependency graph of tasks, which can save some time.

I'm slightly concerned about the `-P` flags bleeding over into `bintrayUpload` and causing confusion, but didn't find evidence in https://github.com/bintray/gradle-bintray-plugin that it would cause issues.
