### PR TITLE
Removes legacy serverset registration

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,6 @@ ext {
                     candidate: '0.0.75',
                     group: '0.0.81',
                     client: '0.0.70',
-                    serverSet: '1.0.103'
             ],
             griddle: '1.7'
     ]

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     compile project(':zipkin-cassandra')
     compile project(':zipkin-redis')
     compile project(':zipkin-anormdb')
-    compile "com.twitter:finagle-serversets_${scalaInterfaceVersion}:${commonVersions.finagle}"
 }
 
 sourceSets.main.resources.srcDirs += ['config']

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -13,7 +13,6 @@ artifacts.archives shadowJar
 dependencies {
     compile project(':zipkin-scrooge')
 
-    compile "com.twitter.common.zookeeper:server-set:${commonVersions.zookeeper.serverSet}"
     compile "com.twitter:algebird-core_${scalaInterfaceVersion}:${commonVersions.algebird}"
     compile "com.twitter:twitter-server_${scalaInterfaceVersion}:${commonVersions.twitterServer}"
     compile 'com.github.spullara.mustache.java:compiler:0.8.17'
@@ -21,6 +20,5 @@ dependencies {
 
     compile "com.twitter:finagle-exception_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:finagle-thriftmux_${scalaInterfaceVersion}:${commonVersions.finagle}"
-    compile "com.twitter:finagle-serversets_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:finagle-zipkin_${scalaInterfaceVersion}:${commonVersions.finagle}"
 }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -1,5 +1,6 @@
 package com.twitter.zipkin.web
 
+import com.google.common.io.ByteStreams
 import com.twitter.finagle.httpx.{Request, Response}
 import com.twitter.finagle.stats.{StatsReceiver, Stat}
 import com.twitter.finagle.tracing.SpanId
@@ -13,7 +14,6 @@ import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.query.{SpanTimestamp, TraceCombo, TraceSummary, QueryRequest}
 import com.twitter.zipkin.thriftscala.{Adjust, ZipkinQuery}
 import java.io.{File, FileInputStream, InputStream}
-import org.apache.commons.io.IOUtils
 import scala.annotation.tailrec
 
 class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache, queryExtractor: QueryExtractor) {
@@ -45,8 +45,8 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache, que
 
   case class StaticRenderer(input: InputStream, typ: String) extends Renderer {
     private[this] val content = {
-      val bytes = IOUtils.toByteArray(input)
-      input.read(bytes)
+      val bytes = ByteStreams.toByteArray(input)
+      input.close()
       bytes
     }
 


### PR DESCRIPTION
When Zipkin used to be deployed internally at Twitter, it registered
itself in ZooKeeper using Twitter's serverset library. Nowadays,
services are announced as a side effect of deployment to Aurora.

Removing serverset has no impact to those using docker, either, as
services are hard-wired directly to corresponding ports.

Finally, removing serverset decomplicates the dependency graph and
gets us closer to being able to not have zookeeper version conflicts.
