### PR TITLE
fixes build from failing javadoc on zipkin-cassandra-core's Repository

### DIFF
--- a/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
+++ b/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
@@ -223,7 +223,6 @@ public final class Repository implements AutoCloseable {
 
     /**
      * Store the span in the underlying storage for later retrieval.
-     * @return a future for the operation
      */
     public void storeSpan(long traceId, String spanName, ByteBuffer span, int ttl) {
         Preconditions.checkNotNull(spanName);


### PR DESCRIPTION
remove apidoc for return value when method returns void.

this was failing the build on me.
