### PR TITLE
Adds test-jar for zipkin-common

### DIFF
--- a/zipkin-common/build.gradle
+++ b/zipkin-common/build.gradle
@@ -8,3 +8,16 @@ dependencies {
     compile "com.twitter:finagle-zipkin_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:finagle-exception_${scalaInterfaceVersion}:${commonVersions.finagle}"
 }
+
+task testJar(type: Jar) {
+    classifier = 'test'
+    from sourceSets.test.output
+}
+
+artifacts {
+    archives testJar
+}
+
+configurations {
+    archives.extendsFrom (testCompile)
+}


### PR DESCRIPTION
based on https://github.com/apache/kafka/blob/trunk/build.gradle#L716

tested via `mvn install`
