### PR TITLE
Upgrade cassandra's cql schema to use correct types and meaningful names

### DIFF
--- a/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
+++ b/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
@@ -1,82 +1,63 @@
 CREATE KEYSPACE IF NOT EXISTS zipkin WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
 
 CREATE TABLE IF NOT EXISTS zipkin.service_span_name_index (
-    key blob,
-    column1 bigint, -- timestamps. compaction strategy should be DTCS
-    value blob,
-    PRIMARY KEY (key, column1)
-) WITH CLUSTERING ORDER BY (column1 ASC)
-    AND COMPACT STORAGE
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+    service_span_name text,
+    ts                timestamp,
+    trace_id          bigint,
+    PRIMARY KEY (service_span_name, ts)
+) WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_sstable_age_days': '1'};
 
 CREATE TABLE IF NOT EXISTS zipkin.top_annotations (
-    key blob,
-    column1 bigint,
-    value blob,
-    PRIMARY KEY (key, column1)
-) WITH CLUSTERING ORDER BY (column1 ASC)
-    AND COMPACT STORAGE
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+    key        text,
+    idx        int,
+    annotation text,
+    PRIMARY KEY (key, idx)
+) WITH compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
 
 CREATE TABLE IF NOT EXISTS zipkin.service_name_index (
-    key blob,
-    column1 bigint, -- timestamps. compaction strategy should be DTCS
-    value blob,
-    PRIMARY KEY (key, column1)
-) WITH CLUSTERING ORDER BY (column1 ASC)
-    AND COMPACT STORAGE
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+    service_name      text,
+    ts                timestamp,
+    trace_id          bigint,
+    PRIMARY KEY (service_name, ts)
+) WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_sstable_age_days': '1'};
 
 CREATE TABLE IF NOT EXISTS zipkin.span_names (
-    key blob,
-    column1 blob,
-    value blob, -- not used. always blank.
-    PRIMARY KEY (key, column1)
-) WITH CLUSTERING ORDER BY (column1 ASC)
-    AND COMPACT STORAGE
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+    service_name text,
+    span_name    text,
+    PRIMARY KEY (service_name, span_name)
+) WITH compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
 
 CREATE TABLE IF NOT EXISTS zipkin.annotations_index (
-    key blob,
-    column1 bigint,  -- timestamps. compaction strategy should be DTCS
-    value blob,
-    PRIMARY KEY (key, column1)
-) WITH CLUSTERING ORDER BY (column1 ASC)
-    AND COMPACT STORAGE
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+    annotation     blob,
+    ts             timestamp,
+    trace_id       bigint,
+    PRIMARY KEY (annotation, ts)
+) WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_sstable_age_days': '1'};
 
 CREATE TABLE IF NOT EXISTS zipkin.dependencies (
-    key blob,
-    column1 bigint, -- always zero.
-    value blob,
-    PRIMARY KEY (key, column1)
-) WITH CLUSTERING ORDER BY (column1 ASC)
-    AND COMPACT STORAGE
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+    day          timestamp,
+    dependencies blob,
+    PRIMARY KEY (day)
+) WITH compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
 
 CREATE TABLE IF NOT EXISTS zipkin.service_names (
-    key blob, -- singleton "servicenames"
-    column1 blob,
-    value blob, -- not used. always blank.
-    PRIMARY KEY (key, column1)
-) WITH CLUSTERING ORDER BY (column1 ASC)
-    AND COMPACT STORAGE
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+    service_name text,
+    PRIMARY KEY (service_name)
+) WITH compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
 
 CREATE TABLE IF NOT EXISTS zipkin.duration_index (
-    key blob,
-    column1 bigint, -- timestamps. compaction strategy should be DTCS
-    value blob, -- not used. always blank
-    PRIMARY KEY (key, column1)
-) WITH CLUSTERING ORDER BY (column1 ASC)
-    AND COMPACT STORAGE
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+    trace_id bigint,
+    ts       timestamp,
+    PRIMARY KEY (trace_id, ts)
+) WITH compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_sstable_age_days': '1'};
 
 CREATE TABLE IF NOT EXISTS zipkin.traces (
-    key blob,       -- trace_id
-    column1 blob,   -- span_id
-    value blob,     -- span
-    PRIMARY KEY (key, column1)
-) WITH CLUSTERING ORDER BY (column1 ASC)
-    //AND COMPACT STORAGE
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+    trace_id  bigint,
+    ts        timestamp,
+    span_name text,
+    span      blob,
+    PRIMARY KEY (trace_id, ts, span_name)
+) WITH compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_sstable_age_days': '1'};

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactory.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactory.scala
@@ -16,49 +16,51 @@
 package com.twitter.zipkin.cassandra
 
 import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.policies.LatencyAwarePolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.google.common.net.HostAndPort
 import com.twitter.app.App
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.zipkin.storage.cassandra._
 import org.twitter.zipkin.storage.cassandra.Repository
+import org.twitter.zipkin.storage.cassandra.ZipkinRetryPolicy
 
 trait CassandraSpanStoreFactory {self: App =>
 
   import com.twitter.zipkin.storage.cassandra.{CassandraSpanStoreDefaults => Defaults}
 
-  val cassieColumnFamilies = Defaults.ColumnFamilyNames
-  val cassieSpanCodec = Defaults.SpanCodec
 
   val keyspace = flag("zipkin.store.cassandra.keyspace", Defaults.KeyspaceName, "name of the keyspace to use")
-  val cassandraDest = flag("zipkin.store.cassandra.dest", "localhost:9160", "dest of the cassandra cluster")
+  val cassandraDest = flag("zipkin.store.cassandra.dest", "localhost:9042", "dest of the cassandra cluster")
 
-  val cassieSpanTtl = flag("zipkin.store.cassie.spanTTL", Defaults.SpanTtl, "length of time cassandra should store spans")
-  val cassieIndexTtl = flag("zipkin.store.cassie.indexTTL", Defaults.IndexTtl, "length of time cassandra should store span indexes")
-  val cassieIndexBuckets = flag("zipkin.store.cassie.indexBuckets", Defaults.IndexBuckets, "number of buckets to split index data into")
+  val cassieSpanTtl = flag("zipkin.store.cassandra.spanTTL", Defaults.SpanTtl, "length of time cassandra should store spans")
+  val cassieIndexTtl = flag("zipkin.store.cassandra.indexTTL", Defaults.IndexTtl, "length of time cassandra should store span indexes")
 
-  val cassieMaxTraceCols = flag("zipkin.store.cassie.maxTraceCols", Defaults.MaxTraceCols, "max number of spans to return from a query")
-  val cassieReadBatchSize = flag("zipkin.store.cassie.readBatchSize", Defaults.ReadBatchSize, "max number of rows per query")
+  val cassieMaxTraceCols = flag("zipkin.store.cassandra.maxTraceCols", Defaults.MaxTraceCols, "max number of spans to return from a query")
 
-  def newCassandraStore(stats: StatsReceiver = DefaultStatsReceiver.scope("cassie")): CassandraSpanStore = {
-    val clusterBuilder = addContactPoint(Cluster.builder())
-    val repository = new Repository(keyspace(), clusterBuilder.build())
+  def newCassandraStore(stats: StatsReceiver = DefaultStatsReceiver.scope("CassandraSpanStore")): CassandraSpanStore = {
+    val repository = new Repository(keyspace(), createClusterBuilder().build())
 
     new CassandraSpanStore(
       repository,
       stats.scope(keyspace()),
-      cassieColumnFamilies,
       cassieSpanTtl(),
       cassieIndexTtl(),
-      cassieIndexBuckets(),
-      cassieMaxTraceCols(),
-      cassieReadBatchSize(),
-      cassieSpanCodec)
+      cassieMaxTraceCols())
+  }
+
+  def createClusterBuilder(): Cluster.Builder = {
+    addContactPoint(Cluster.builder())
+      .withRetryPolicy(ZipkinRetryPolicy.INSTANCE)
+      .withLoadBalancingPolicy(new TokenAwarePolicy(new LatencyAwarePolicy.Builder(new RoundRobinPolicy()).build()))
   }
 
   def addContactPoint(builder: Cluster.Builder): Cluster.Builder = {
     val contactPoint = HostAndPort.fromString(cassandraDest())
 
     builder.addContactPoint(contactPoint.getHostText)
-      .withPort(contactPoint.getPortOrDefault(9160))
+      .withPort(contactPoint.getPortOrDefault(9042))
   }
 }

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
@@ -13,7 +13,7 @@ class CassandraSpanStoreFactorySpec extends FunSuite with Matchers {
     TestFactory.nonExitingMain(Array())
 
     TestFactory.addContactPoint(Cluster.builder()).getContactPoints should be(
-      asList(new InetSocketAddress("127.0.0.1", 9160))
+      asList(new InetSocketAddress("127.0.0.1", 9042))
     )
   }
 
@@ -23,7 +23,7 @@ class CassandraSpanStoreFactorySpec extends FunSuite with Matchers {
     ))
 
     TestFactory.addContactPoint(Cluster.builder()).getContactPoints should be(
-      asList(new InetSocketAddress("1.1.1.1", 9160))
+      asList(new InetSocketAddress("1.1.1.1", 9042))
     )
   }
 

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
@@ -38,5 +38,5 @@ class CassandraSpanStoreSpec extends SpanStoreSpec {
 
   override lazy val store = new CassandraSpanStore(new Repository(keyspace, cluster))
 
-  override def clear = cluster.connect().execute("DROP KEYSPACE " + keyspace)
+  override def clear = cluster.connect().execute("DROP KEYSPACE IF EXISTS " + keyspace)
 }


### PR DESCRIPTION
- column names are meaningful
- columns are of specific types
- remove unused columns
- use correct clustering order
- use DateTieredCompactionStrategy on tables that are time-series

because this is an incompatible change to the previous schema if there has been a release then the keyspace name should be bumped to "zipkin_v0". (but AFAICT there's been no such release, and developers will just need to know to drop any existing testing keyspaces they have).

original branch from https://github.com/thelastpickle/zipkin/tree/feature%2Fcassandra-transparent-persistence
