### PR TITLE
Supports CASSANDRA_CONTACT_POINTS comma-separated environment variable

### DIFF
--- a/zipkin-collector-service/config/collector-cassandra.scala
+++ b/zipkin-collector-service/config/collector-cassandra.scala
@@ -22,8 +22,11 @@ import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
 import com.twitter.zipkin.storage.Store
 import org.twitter.zipkin.storage.cassandra.ZipkinRetryPolicy
 
+val contactPoints: Array[String] = sys.env.get("CASSANDRA_CONTACT_POINTS").getOrElse("localhost")
+  .split(",")
+
 val cluster = Cluster.builder()
-  .addContactPoint("localhost")
+  .addContactPoints(contactPoints:_*)
   .withSocketOptions(new SocketOptions().setConnectTimeoutMillis(10000).setReadTimeoutMillis(20000))
   .withRetryPolicy(ZipkinRetryPolicy.INSTANCE)
   .build()

--- a/zipkin-query-service/config/query-cassandra.scala
+++ b/zipkin-query-service/config/query-cassandra.scala
@@ -20,8 +20,11 @@ import com.twitter.zipkin.cassandra
 import com.twitter.zipkin.storage.Store
 import org.twitter.zipkin.storage.cassandra.ZipkinRetryPolicy
 
+val contactPoints: Array[String] = sys.env.get("CASSANDRA_CONTACT_POINTS").getOrElse("localhost")
+  .split(",")
+
 val cluster = Cluster.builder()
-  .addContactPoint("localhost")
+  .addContactPoints(contactPoints:_*)
   .withSocketOptions(new SocketOptions().setConnectTimeoutMillis(10000).setReadTimeoutMillis(20000))
   .withRetryPolicy(ZipkinRetryPolicy.INSTANCE)
   .build()


### PR DESCRIPTION
Hopefully eliminates the need to make copies of the cassandra scala files in the docker project.

See https://github.com/openzipkin/docker-zipkin/pull/22

ex.

``` bash
$ CASSANDRA_CONTACT_POINTS=google.com,yahoo.com,localhost bin/query cassandra
```
