### PR TITLE
Don't build, test during the Travis job doing gradle release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     id 'com.jfrog.bintray' version '1.3.1'
-    id 'net.researchgate.release' version '2.1.2'
+    id 'net.researchgate.release' version '2.2.1'
 }
 
 allprojects { thisProject ->
@@ -129,6 +129,11 @@ artifactory {
 task createReleaseTag(overwrite: true, group: 'Release') {
     // Zipkin is released by pushing tags manually, so
     // we need the release plugin to NOT create tags when it runs.
+}
+
+task runBuildTasks(overwrite: true, group: 'Release') {
+    // During the release process, building and testing in the Travis job running `gradle release`
+    // is redundant. We can save time by running the build and tests only on commits to master.
 }
 
 subprojects { subproject ->

--- a/travis/README.md
+++ b/travis/README.md
@@ -1,6 +1,14 @@
 # Zipkin release process
 
-The Zipkin release process is controlled by [publish.sh](publish.sh). Releases are initiated by pushing a tag `major.minor.revision` or `major.minor.revision-qualifier`, where `qualifier` is usually something like `rc3`. A high-level overview of how the release happens in each case:
+The Zipkin release process is controlled by [publish.sh](publish.sh).
+Releases are initiated by pushing a tag `major.minor.revision` or `major.minor.revision-qualifier`,
+where `qualifier` is usually something like `rc3`.
+
+There is currently no automated testing during the release process. As the person pushing a release tag, you're
+expected to manually check that the test [run on Travis](https://travis-ci.org/openzipkin/zipkin) is green for
+the commit you're tagging. (Building tooling for this would be awesome.)
+
+A high-level overview of how the release happens for RC and final releases:
 
 ![Release example](examples.png)
 

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -73,7 +73,7 @@ function want_to_release_from_this_jdk(){
 
 function publish(){
   echo "[Publishing] Publishing..."
-  ./gradlew check zipkinUpload
+  ./gradlew zipkinUpload
   echo "[Publishing] Done"
 }
 
@@ -96,8 +96,7 @@ function do_gradle_release(){
 
   git checkout -B master
 
-  ./gradlew check \
-            release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}
+  ./gradlew release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}
   echo "[Publishing] Done"
 }
 


### PR DESCRIPTION
## What?

Before this PR, the Travis job that does a build + check, which is re-done by the Travis job that does the upload. This PR changes that so that `gradle release` ONLY creates new commits and nothing else; the Travis job doing the upload also doesn't run tests.
## Why?

Two reasons:
- tests fail in mysterious ways during the build started by `gradle release` on Travis, may be related to OOM, but near impossible to debug
- With the old setup, we run tests four times for a release (the PR job of the last merged PR, the test run on master when the PR is merged, release and upload). With the new setup, that's just two, and we reduce the number of test runs inside the release process from two to zero.
## How?
- Remove `check` from the release and upload part of `publish.sh`
- Override the Gradle task `runBuildTasks` to do nothing, similarly to how `createReleaseTag` was already overridden

This change also upgrades the release plugin, because https://github.com/researchgate/gradle-release/issues/120 is nice to have.
