### PR TITLE
Build only the distributions we really want

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,11 @@ plugins {
 }
 
 ext.isSnapshot = VersionNumber.parse(rootProject.version).qualifier == "SNAPSHOT"
+ext.wantDistTar = [
+        project(':zipkin-collector-service'),
+        project(':zipkin-query-service'),
+        project(':zipkin-web')
+]
 
 allprojects { thisProject ->
     apply plugin: 'idea'
@@ -94,6 +99,20 @@ allprojects { thisProject ->
     // Workaround: we don't want to publish anything from the root project.
     if (thisProject == rootProject) {
         artifactoryPublish.publishConfigs()
+    }
+
+    // Never build zip distributions (to save space and time)
+    // Only build tar distributions for stand-alone services
+    thisProject.plugins.withType(DistributionPlugin) {
+        thisProject.tasks.distZip.enabled = false
+        if (thisProject in rootProject.wantDistTar) {
+            thisProject.tasks.distTar {
+                compression = Compression.GZIP
+                extension = 'tar.gz'
+            }
+        } else {
+            thisProject.tasks.distTar.enabled = false
+        }
     }
 }
 

--- a/zipkin-example/build.gradle
+++ b/zipkin-example/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'application'
-apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.example.Main'
 
 if (!project.hasProperty("runArgs")) {
@@ -11,9 +10,6 @@ run {
     workingDir project.buildDir
     args runArgs.split()
 }
-
-tasks.build.dependsOn(shadowJar)
-artifacts.archives shadowJar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-redis-example/build.gradle
+++ b/zipkin-redis-example/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'application'
-apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.example.Main'
 
 if (!project.hasProperty("runArgs")) {
@@ -11,9 +10,6 @@ run {
     workingDir project.buildDir
     args runArgs.split()
 }
-
-tasks.build.dependsOn(shadowJar)
-artifacts.archives shadowJar
 
 dependencies {
     compile project(':zipkin-web')

--- a/zipkin-tracegen/build.gradle
+++ b/zipkin-tracegen/build.gradle
@@ -1,9 +1,5 @@
 apply plugin: 'application'
-apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'com.twitter.zipkin.tracegen.Main'
-
-tasks.build.dependsOn(shadowJar)
-artifacts.archives shadowJar
 
 repositories {
     // For dependencies of zipkin-cassandra (via zipkin-query-service and zipkin-collector-service)


### PR DESCRIPTION
To save build and upload time plus some space as well, let's generate only the distributions we need:
- fat jars for `zipkin-{aggregate,collector-service,query-service,web}`
- `.tar.gz` for `zipkin-{collector-service,query-service,web}`

We don't need the `.tar.gz` for `-aggregate` because it's only used for running on Hadoop.

For `*-example`, it's enough to be able to run them via gradle (think `./gradlew :zipkin-example:run`)
## `./gradlew zipkin-aggregate:build`

Note that we built a shadow jar, but skipped the tar and zip.

```
Starting a new Gradle Daemon for this build (subsequent builds will be faster).
[buildinfo] Not using buildInfo properties file for this build.
None of the specified publish configurations matched for project ':' - nothing to publish.
:zipkin-common:compileJava UP-TO-DATE
:zipkin-common:compileScala UP-TO-DATE
:zipkin-common:processResources UP-TO-DATE
:zipkin-common:classes UP-TO-DATE
:zipkin-common:jar UP-TO-DATE
:zipkin-scrooge:idlJar UP-TO-DATE
:zipkin-scrooge:copyDependencyIdl UP-TO-DATE
:zipkin-scrooge:copyIncludedIdl UP-TO-DATE
:zipkin-scrooge:generateInterfaces UP-TO-DATE
:zipkin-scrooge:compileJava UP-TO-DATE
:zipkin-scrooge:compileScala
:zipkin-scrooge:processResources UP-TO-DATE
:zipkin-scrooge:classes
:zipkin-scrooge:jar
:zipkin-aggregate:compileJava
:zipkin-aggregate:compileScala
:zipkin-aggregate:processResources UP-TO-DATE
:zipkin-aggregate:classes
:zipkin-aggregate:jar
:zipkin-aggregate:startScripts
:zipkin-aggregate:distTar SKIPPED
:zipkin-aggregate:distZip SKIPPED
:zipkin-common:javadoc UP-TO-DATE
:zipkin-scrooge:javadoc UP-TO-DATE
:zipkin-aggregate:javadoc
:zipkin-aggregate:javadocJar
:zipkin-aggregate:shadowJar
:zipkin-aggregate:sourceJar
:zipkin-aggregate:assemble
:zipkin-aggregate:compileTestJava UP-TO-DATE
:zipkin-aggregate:compileTestScala UP-TO-DATE
:zipkin-aggregate:processTestResources UP-TO-DATE
:zipkin-aggregate:testClasses UP-TO-DATE
:zipkin-aggregate:test UP-TO-DATE
:zipkin-aggregate:check UP-TO-DATE
:zipkin-aggregate:build

BUILD SUCCESSFUL

Total time: 50.009 secs
```
## `./gradlew zipkin-web:build`

Shadow jar and tar built, zip skipped

```
None of the specified publish configurations matched for project ':' - nothing to publish.
:zipkin-common:compileJava UP-TO-DATE
:zipkin-common:compileScala UP-TO-DATE
:zipkin-common:processResources UP-TO-DATE
:zipkin-common:classes UP-TO-DATE
:zipkin-common:jar UP-TO-DATE
:zipkin-scrooge:idlJar UP-TO-DATE
:zipkin-scrooge:copyDependencyIdl UP-TO-DATE
:zipkin-scrooge:copyIncludedIdl UP-TO-DATE
:zipkin-scrooge:generateInterfaces UP-TO-DATE
:zipkin-scrooge:compileJava UP-TO-DATE
:zipkin-scrooge:compileScala UP-TO-DATE
:zipkin-scrooge:processResources UP-TO-DATE
:zipkin-scrooge:classes UP-TO-DATE
:zipkin-scrooge:jar UP-TO-DATE
:zipkin-web:compileJava UP-TO-DATE
:zipkin-web:compileScala
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala:75: warning: postfix operator distinct should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[ant:scalac] or by setting the compiler option -language:postfixOps.
[ant:scalac] See the Scala docs for value scala.language.postfixOps for a discussion
[ant:scalac] why the feature should be explicitly enabled.
[ant:scalac]           client.getTraceSummariesByIds(ids distinct, adjusters) map { _.map { _.toTraceSummary } }
[ant:scalac]                                             ^
[ant:scalac] one warning found
:zipkin-web:processResources
:zipkin-web:classes
:zipkin-web:jar
:zipkin-web:startScripts
:zipkin-web:distTar
:zipkin-web:distZip SKIPPED
:zipkin-common:javadoc UP-TO-DATE
:zipkin-scrooge:javadoc UP-TO-DATE
:zipkin-web:javadoc UP-TO-DATE
:zipkin-web:javadocJar
:zipkin-web:shadowJar
:zipkin-web:sourceJar
:zipkin-web:assemble
:zipkin-web:compileTestJava UP-TO-DATE
:zipkin-web:compileTestScala
:zipkin-web:processTestResources UP-TO-DATE
:zipkin-web:testClasses
:zipkin-web:test
Discovery starting.
Discovery completed in 121 milliseconds.
Run starting. Expected test count is: 19
JsonTest:
- bool (26 milliseconds)
- short (1 millisecond)
- int (0 milliseconds)
- long (1 millisecond)
- double (0 milliseconds)
- string (0 milliseconds)
QueryExtractorTest:
- require serviceName (83 milliseconds)
- parse params (11 milliseconds)
- default endDateTime (2 milliseconds)
- parse limit (0 milliseconds)
- default limit (1 millisecond)
- parse spanName 'all' (0 milliseconds)
- parse spanName '' (0 milliseconds)
- parse spanName (0 milliseconds)
- parse annotations (1 millisecond)
- parse key value annotations (1 millisecond)
- parse key value annotations with slash (1 millisecond)
JsonSerializationTest:
- serialize span with no annotations (233 milliseconds)
UtilTest:
- durationStr (40 milliseconds)
Run completed in 420 milliseconds.
Total number of tests run: 19
Suites: completed 5, aborted 0
Tests: succeeded 19, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
:zipkin-web:check
:zipkin-web:build

BUILD SUCCESSFUL

Total time: 22.919 secs
```
## `./gradlew zipkin-tracegen:build`

No shadow jar, zip and tar skipped.

```
Starting a new Gradle Daemon for this build (subsequent builds will be faster).
[buildinfo] Not using buildInfo properties file for this build.
None of the specified publish configurations matched for project ':' - nothing to publish.
:zipkin-common:compileJava UP-TO-DATE
:zipkin-common:compileScala UP-TO-DATE
:zipkin-common:processResources UP-TO-DATE
:zipkin-common:classes UP-TO-DATE
:zipkin-common:jar UP-TO-DATE
:zipkin-scrooge:idlJar UP-TO-DATE
:zipkin-scrooge:copyDependencyIdl UP-TO-DATE
:zipkin-scrooge:copyIncludedIdl UP-TO-DATE
:zipkin-scrooge:generateInterfaces UP-TO-DATE
:zipkin-scrooge:compileJava UP-TO-DATE
:zipkin-scrooge:compileScala UP-TO-DATE
:zipkin-scrooge:processResources UP-TO-DATE
:zipkin-scrooge:classes UP-TO-DATE
:zipkin-scrooge:jar UP-TO-DATE
:zipkin-anormdb:compileJava UP-TO-DATE
:zipkin-anormdb:compileScala
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormAggregates.scala:68: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[ant:scalac] or by setting the compiler option -language:postfixOps.
[ant:scalac] See the Scala docs for value scala.language.postfixOps for a discussion
[ant:scalac] why the feature should be explicitly enabled.
[ant:scalac]     }) *)
[ant:scalac]        ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:135: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]       ).as(long("trace_id") *).toSet
[ant:scalac]                             ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:156: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]         }) *)
[ant:scalac]            ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:167: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]         }) *)
[ant:scalac]            ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:180: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]         }) *)
[ant:scalac]            ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:251: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]           .as((long("trace_id") ~ long("MAX(a_timestamp)") map flatten) *)
[ant:scalac]                                                                         ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:294: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]               .as((long("trace_id") ~ long("created_ts") map flatten) *)
[ant:scalac]                                                                       ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:312: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]               .as((long("trace_id") ~ long("MAX(a_timestamp)") map flatten) *)
[ant:scalac]                                                                             ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:335: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]         .as((long("trace_id") ~ long("MIN(a_timestamp)") ~ long("MAX(a_timestamp)") map flatten) *)
[ant:scalac]                                                                                                  ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:355: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]         .as(str("service_name") *).toSet
[ant:scalac]                                 ^
[ant:scalac] /Users/abesto/playground/zipkin/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala:374: warning: postfix operator * should be enabled
[ant:scalac] by making the implicit value scala.language.postfixOps visible.
[ant:scalac]         .as(str("span_name") *)
[ant:scalac]                              ^
[ant:scalac] 11 warnings found
:zipkin-anormdb:processResources UP-TO-DATE
:zipkin-anormdb:classes
:zipkin-anormdb:jar
:zipkin-cassandra-core:compileJava
:zipkin-cassandra-core:compileScala UP-TO-DATE
:zipkin-cassandra-core:processResources
:zipkin-cassandra-core:classes
:zipkin-cassandra-core:jar
:zipkin-cassandra:compileJava UP-TO-DATE
:zipkin-cassandra:compileScala
/Users/abesto/playground/zipkin/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/SnappyCodec.scala:18: warning: imported `Codec' is permanently hidden by definition of trait Codec in package cassandra
import com.twitter.zipkin.storage.cassandra.Codec
                                            ^
/Users/abesto/playground/zipkin/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala:227: warning: method get in class Future is deprecated: Use Await.result
    getSpansByTraceId(traceId).get foreach { span =>
                               ^
two warnings found
:zipkin-cassandra:processResources UP-TO-DATE
:zipkin-cassandra:classes
:zipkin-cassandra:jar
:zipkin-collector:compileJava UP-TO-DATE
:zipkin-collector:compileScala
:zipkin-collector:processResources UP-TO-DATE
:zipkin-collector:classes
:zipkin-collector:jar
:zipkin-collector-scribe:compileJava UP-TO-DATE
:zipkin-collector-scribe:compileScala
:zipkin-collector-scribe:processResources UP-TO-DATE
:zipkin-collector-scribe:classes
:zipkin-collector-scribe:jar
:zipkin-receiver-kafka:compileJava UP-TO-DATE
:zipkin-receiver-kafka:compileScala
:zipkin-receiver-kafka:processResources UP-TO-DATE
:zipkin-receiver-kafka:classes
:zipkin-receiver-kafka:jar
:zipkin-redis:compileJava UP-TO-DATE
:zipkin-redis:compileScala
:zipkin-redis:processResources UP-TO-DATE
:zipkin-redis:classes
:zipkin-redis:jar
:zipkin-collector-service:compileJava UP-TO-DATE
:zipkin-collector-service:compileScala
/Users/abesto/playground/zipkin/zipkin-collector-service/src/main/scala/com/twitter/zipkin/config/ConfigRequestHandler.scala:46: warning: This catches all Throwables. If this is really intended, use `case e : Throwable` to clear this warning.
              case e =>
                   ^
/Users/abesto/playground/zipkin/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala:32: warning: object RuntimeEnvironment in package admin is deprecated: Runtime evaluation of scala code will not be supported going forward. Please switch to flags for configuration.
    val runtime = RuntimeEnvironment(BuildProperties, args)
                  ^
/Users/abesto/playground/zipkin/zipkin-collector-service/src/main/scala/com/twitter/zipkin/config/sampler/AdaptiveSamplerConfig.scala:21: warning: trait Config in package util is deprecated: use a Plain Old Scala Object
trait AdaptiveSamplerConfig extends Config[AdaptiveSampler] {
                                    ^
three warnings found
:zipkin-collector-service:processResources
:zipkin-collector-service:classes
:zipkin-collector-service:jar
:zipkin-query:compileJava UP-TO-DATE
:zipkin-query:compileScala
/Users/abesto/playground/zipkin/zipkin-query/src/main/scala/com/twitter/zipkin/query/ThriftQueryService.scala:56: warning: match may not be exhaustive.
It would fail on the following input: EnumUnknownOrder(_)
    order match {
    ^
one warning found
:zipkin-query:processResources UP-TO-DATE
:zipkin-query:classes
:zipkin-query:jar
:zipkin-query-service:compileJava UP-TO-DATE
:zipkin-query-service:compileScala
/Users/abesto/playground/zipkin/zipkin-query-service/src/main/scala/com/twitter/zipkin/query/Main.scala:33: warning: object RuntimeEnvironment in package admin is deprecated: Runtime evaluation of scala code will not be supported going forward. Please switch to flags for configuration.
    val runtime = RuntimeEnvironment(BuildProperties, args)
                  ^
/Users/abesto/playground/zipkin/zipkin-query-service/src/main/scala/com/twitter/zipkin/builder/QueryServiceBuilder.scala:39: warning: UseOnceFactory$2 has a main method with parameter type Array[String], but com.twitter.zipkin.builder.QueryServiceBuilder.$anonfun$apply$1.UseOnceFactory$2 will not be a runnable program.
  Reason: companion contains its own main method, which means no static forwarder can be generated.

    object UseOnceFactory extends com.twitter.app.App with ZipkinQueryServerFactory
           ^
two warnings found
:zipkin-query-service:processResources
:zipkin-query-service:classes
:zipkin-query-service:jar
:zipkin-tracegen:compileJava UP-TO-DATE
:zipkin-tracegen:compileScala
/Users/abesto/playground/zipkin/zipkin-tracegen/src/main/scala/com/twitter/zipkin/tracegen/TraceGen.scala:106: warning: postfix operator toList should be enabled
by making the implicit value scala.language.postfixOps visible.
This can be achieved by adding the import clause 'import scala.language.postfixOps'
or by setting the compiler option -language:postfixOps.
See the Scala docs for value scala.language.postfixOps for a discussion
why the feature should be explicitly enabled.
    } toList
      ^
one warning found
:zipkin-tracegen:processResources UP-TO-DATE
:zipkin-tracegen:classes
:zipkin-tracegen:jar
:zipkin-tracegen:startScripts
:zipkin-tracegen:distTar SKIPPED
:zipkin-tracegen:distZip SKIPPED
:zipkin-common:javadoc UP-TO-DATE
:zipkin-scrooge:javadoc UP-TO-DATE
:zipkin-anormdb:javadoc UP-TO-DATE
:zipkin-cassandra-core:javadoc
/Users/abesto/playground/zipkin/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java:229: warning: no @param for traceId
    public void storeSpan(long traceId, long timestamp, String spanName, ByteBuffer span, int ttl) {
                ^
/Users/abesto/playground/zipkin/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java:229: warning: no @param for timestamp
    public void storeSpan(long traceId, long timestamp, String spanName, ByteBuffer span, int ttl) {
                ^
/Users/abesto/playground/zipkin/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java:229: warning: no @param for spanName
    public void storeSpan(long traceId, long timestamp, String spanName, ByteBuffer span, int ttl) {
                ^
/Users/abesto/playground/zipkin/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java:229: warning: no @param for span
    public void storeSpan(long traceId, long timestamp, String spanName, ByteBuffer span, int ttl) {
                ^
/Users/abesto/playground/zipkin/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java:229: warning: no @param for ttl
    public void storeSpan(long traceId, long timestamp, String spanName, ByteBuffer span, int ttl) {
                ^
/Users/abesto/playground/zipkin/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java:279: warning: no @param for traceIds
    public Map<Long,List<ByteBuffer>> getSpansByTraceIds(Long[] traceIds, int limit) {
                                      ^
/Users/abesto/playground/zipkin/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java:279: warning: no @param for limit
    public Map<Long,List<ByteBuffer>> getSpansByTraceIds(Long[] traceIds, int limit) {
                                      ^
/Users/abesto/playground/zipkin/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java:279: warning: no @return
    public Map<Long,List<ByteBuffer>> getSpansByTraceIds(Long[] traceIds, int limit) {
                                      ^
8 warnings
:zipkin-cassandra:javadoc UP-TO-DATE
:zipkin-collector:javadoc UP-TO-DATE
:zipkin-collector-scribe:javadoc UP-TO-DATE
:zipkin-receiver-kafka:javadoc UP-TO-DATE
:zipkin-redis:javadoc UP-TO-DATE
:zipkin-collector-service:javadoc UP-TO-DATE
:zipkin-query:javadoc UP-TO-DATE
:zipkin-query-service:javadoc UP-TO-DATE
:zipkin-tracegen:javadoc UP-TO-DATE
:zipkin-tracegen:javadocJar
:zipkin-tracegen:sourceJar
:zipkin-tracegen:assemble
:zipkin-tracegen:compileTestJava UP-TO-DATE
:zipkin-tracegen:compileTestScala UP-TO-DATE
:zipkin-tracegen:processTestResources UP-TO-DATE
:zipkin-tracegen:testClasses UP-TO-DATE
:zipkin-tracegen:test UP-TO-DATE
:zipkin-tracegen:check UP-TO-DATE
:zipkin-tracegen:build

BUILD SUCCESSFUL

Total time: 29.197 secs
```
