### PR TITLE
Create, use custom configuration for collecting artifacts to upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,6 @@ plugins {
 }
 
 ext.isSnapshot = VersionNumber.parse(rootProject.version).qualifier == "SNAPSHOT"
-ext.wantDistTar = [
-        project(':zipkin-collector-service'),
-        project(':zipkin-query-service'),
-        project(':zipkin-web')
-]
 
 allprojects { thisProject ->
     apply plugin: 'idea'
@@ -28,6 +23,10 @@ allprojects { thisProject ->
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
     apply plugin: "com.jfrog.artifactory-upload"
+
+    configurations {
+        zipkinUpload
+    }
 
     // Following are workarounds to idea goal failing on:
     // Cannot infer Scala class path because..
@@ -53,7 +52,7 @@ allprojects { thisProject ->
     }
 
     artifacts {
-      archives javadocJar, sourceJar
+        zipkinUpload javadocJar, sourceJar
     }
 
     bintray {
@@ -66,7 +65,7 @@ allprojects { thisProject ->
         if (thisProject == rootProject) {
             configurations = []
         } else {
-            configurations = ['archives']
+            configurations = ['zipkinUpload']
         }
 
         dryRun = System.getenv('BINTRAY_DRYRUN') != null
@@ -101,18 +100,11 @@ allprojects { thisProject ->
         artifactoryPublish.publishConfigs()
     }
 
-    // Never build zip distributions (to save space and time)
-    // Only build tar distributions for stand-alone services
     thisProject.plugins.withType(DistributionPlugin) {
-        thisProject.tasks.distZip.enabled = false
-        if (thisProject in rootProject.wantDistTar) {
-            thisProject.tasks.distTar {
-                compression = Compression.GZIP
-                extension = 'tar.gz'
-            }
-        } else {
-            thisProject.tasks.distTar.enabled = false
-        }
+		thisProject.tasks.distTar {
+			compression = Compression.GZIP
+			extension = 'tar.gz'
+		}
     }
 }
 
@@ -147,6 +139,10 @@ artifactory {
             username = System.getenv('BINTRAY_USER')
             password = System.getenv('BINTRAY_KEY')
             maven = true
+        }
+
+        defaults {
+            publishConfigs 'zipkinUpload'
         }
     }
 }

--- a/zipkin-aggregate/build.gradle
+++ b/zipkin-aggregate/build.gradle
@@ -17,7 +17,7 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
-artifacts.archives shadowJar
+artifacts.zipkinUpload shadowJar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -10,7 +10,8 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
-artifacts.archives shadowJar
+artifacts.zipkinUpload shadowJar
+artifacts.zipkinUpload distTar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -10,7 +10,8 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
-artifacts.archives shadowJar
+artifacts.zipkinUpload shadowJar
+artifacts.zipkinUpload distTar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -8,7 +8,8 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
-artifacts.archives shadowJar
+artifacts.zipkinUpload shadowJar
+artifacts.zipkinUpload distTar
 
 dependencies {
     compile project(':zipkin-scrooge')


### PR DESCRIPTION
This lets us control exactly what gets uploaded to Bintray / OJO / Sonatype.
## Context

Disabling the `distTar` or `distZip` tasks confuses the hell out of later tasks that want to use the output of these tasks: just disabling them doesn’t remove their would-be output from the list of artifacts to upload (in gradle-speak: from the configuration ‘archives’). I couldn't find a clean, easy solution for this on the internets. Looking at the source of the bintray plugin (specifically https://github.com/bintray/gradle-bintray-plugin/blob/master/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy#L74 and the fact that it’s applied only if we use configurations)

We could hack further and manually try to remove the right artifacts from the right configurations, but apparently these are internals of the distribute plugin, so that may break in the future. Manually declaring the artifacts to be published would also give us more control and make the intentions explicit. The "old" way is using configurations, which is used in this PR for ease of implementation. The new way would be publications, which would require some more re-working.

For the reasons at the top, this solution builds everything and then uploads a subset. Room for further optimization (adding to #579): let's not build stuff we don't plan to upload.
