### PR TITLE
Disable syncing to Maven Central for now

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,11 +86,6 @@ allprojects { thisProject ->
                 gpg {
                     sign = true
                 }
-
-                mavenCentralSync {
-                    user = System.getenv('SONATYPE_TOKEN')
-                    password = System.getenv('SONATYPE_PASSWORD')
-                }
             }
         }
     }

--- a/zipkin-aggregate/build.gradle
+++ b/zipkin-aggregate/build.gradle
@@ -17,8 +17,7 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
-// TODO: revert me once we verify that 408s go away when we publish less bytes
-// artifacts.zipkinUpload shadowJar
+artifacts.zipkinUpload shadowJar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -10,9 +10,8 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
-// TODO: revert me once we verify that 408s go away when we publish less bytes
-// artifacts.zipkinUpload shadowJar
-// artifacts.zipkinUpload distTar
+artifacts.zipkinUpload shadowJar
+artifacts.zipkinUpload distTar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -10,9 +10,8 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
-// TODO: revert me once we verify that 408s go away when we publish less bytes
-// artifacts.zipkinUpload shadowJar
-// artifacts.zipkinUpload distTar
+artifacts.zipkinUpload shadowJar
+artifacts.zipkinUpload distTar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -8,9 +8,8 @@ run {
 }
 
 tasks.build.dependsOn(shadowJar)
-// TODO: revert me once we verify that 408s go away when we publish less bytes
-// artifacts.zipkinUpload shadowJar
-// artifacts.zipkinUpload distTar
+artifacts.zipkinUpload shadowJar
+artifacts.zipkinUpload distTar
 
 dependencies {
     compile project(':zipkin-scrooge')


### PR DESCRIPTION
Enabling syncing creates a situation where the plugin needs to wait until publishing of the version finishes on Bintray, but that takes longer than the request timeout, so we get failed builds that look like https://travis-ci.org/openzipkin/zipkin/jobs/76344895

At the same time, re-enable uploading of "big" artifacts (tars, fat jars)
