### PR TITLE
add authentication to cassandra

### DIFF
--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
@@ -1,10 +1,12 @@
 package com.twitter.zipkin.cassandra
 
-import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.{AuthProvider, Cluster}
 import com.twitter.app.App
 import java.net.InetSocketAddress
 import java.util.Arrays.asList
 import org.scalatest.{FunSuite, Matchers}
+import com.datastax.driver.core.exceptions.AuthenticationException
+
 
 class CassandraSpanStoreFactorySpec extends FunSuite with Matchers {
   object TestFactory extends App with CassandraSpanStoreFactory
@@ -45,5 +47,29 @@ class CassandraSpanStoreFactorySpec extends FunSuite with Matchers {
     TestFactory.addContactPoint(Cluster.builder()).getContactPoints should be(
       asList(new InetSocketAddress("1.1.1.1", 9143), new InetSocketAddress("2.2.2.2", 9042))
     )
+  }
+
+  test("creatingClusterBuilder with SASL authentication null delimited utf8 bytes") {
+    TestFactory.nonExitingMain(Array(
+      "-zipkin.store.cassandra.user", "user",
+      "-zipkin.store.cassandra.password", "pass"
+    ))
+    val SASLhandshake = Array[Byte](0, 'u', 's', 'e', 'r', 0, 'p', 'a', 's', 's')
+    val authProvider = TestFactory.createClusterBuilder()
+                         .getConfiguration()
+                         .getProtocolOptions()
+                         .getAuthProvider()
+                         .newAuthenticator(new InetSocketAddress("localhost", 8080))
+                         .initialResponse()
+    authProvider should be(SASLhandshake)
+  }
+
+  test("creatingClusterBuilder without authentication") {
+    TestFactory.nonExitingMain(Array())
+
+    TestFactory.createClusterBuilder()
+      .getConfiguration()
+      .getProtocolOptions()
+      .getAuthProvider() should be (AuthProvider.NONE)
   }
 }

--- a/zipkin-collector-service/README.md
+++ b/zipkin-collector-service/README.md
@@ -1,16 +1,26 @@
 # zipkin-collector-service
- 
+
 The Zipkin collector service accepts trace data via its Scribe interface.
 After validity checks, the collector stores and indexes trace data into a
 store, most typically SQL, Cassandra or Redis.
 
 ## Running locally
- 
+
 ```bash
 # to start a scribe listener on localhost:9410, sinking to a file-based SQL store.
 ./gradlew :zipkin-collector-service:run
 ```
- 
+
+#### Start with Cassandra Authentication
+
+Will throw an exception on startup if authentication failed
+```
+# specify user/pass as environment variables
+CASSANDRA_USER=user CASSANDRA_PASS=pass ./bin/collector cassandra
+
+```
+
+
 ## Building and running a fat jar
 
 ```bash

--- a/zipkin-collector-service/config/collector-cassandra.scala
+++ b/zipkin-collector-service/config/collector-cassandra.scala
@@ -16,20 +16,32 @@
 
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.SocketOptions
+import com.twitter.app.App
 import com.twitter.zipkin.builder.Scribe
 import com.twitter.zipkin.cassandra
+import com.twitter.zipkin.cassandra.CassandraSpanStoreFactory
 import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
 import com.twitter.zipkin.storage.Store
 import org.twitter.zipkin.storage.cassandra.ZipkinRetryPolicy
+import scala.collection.mutable.ListBuffer
 
 val contactPoints: Array[String] = sys.env.get("CASSANDRA_CONTACT_POINTS").getOrElse("localhost")
   .split(",")
 
-val cluster = Cluster.builder()
-  .addContactPoints(contactPoints:_*)
-  .withSocketOptions(new SocketOptions().setConnectTimeoutMillis(10000).setReadTimeoutMillis(20000))
-  .withRetryPolicy(ZipkinRetryPolicy.INSTANCE)
-  .build()
+val cassandraUser = sys.env.get("CASSANDRA_USER")
+val cassandraPass = sys.env.get("CASSANDRA_PASS")
+
+var args = new ListBuffer[String]()
+if (cassandraUser.isDefined && cassandraPass.isDefined) {
+  args += "-zipkin.store.cassandra.user"
+  args += cassandraUser.get
+  args += "-zipkin.store.cassandra.password"
+  args += cassandraPass.get
+}
+
+object CollectorService extends App with CassandraSpanStoreFactory
+CollectorService.nonExitingMain(args.toArray)
+val cluster = CollectorService.createClusterBuilder().build()
 
 val storeBuilder = Store.Builder(new cassandra.SpanStoreBuilder(cluster))
 

--- a/zipkin-query-service/README.md
+++ b/zipkin-query-service/README.md
@@ -1,15 +1,24 @@
 # zipkin-query-service
- 
+
 The Zipkin query service provides a thrift api over stored and indexed trace
 data, most typically SQL, Cassandra or Redis.
 
 ## Running locally
- 
+
 ```bash
 # to start a query service on localhost:9411, reading from a file-based SQL store.
 ./gradlew :zipkin-query-service:run
 ```
- 
+
+#### Start with Cassandra Authentication
+
+Will throw an exception on startup if authentication failed
+```
+# specify user/pass as environment variables
+CASSANDRA_USER=user CASSANDRA_PASS=pass ./bin/query cassandra
+
+```
+
 ## Building and running a fat jar
 
 ```bash


### PR DESCRIPTION
Adding authentication to cassandra.  Would have liked to do this inside of Repository.java but I think the entry point is at a higher level in the scala code.  So there are 3 entry points to passing user credentials.  If the user uses the config files (collector-cassandra.scala) they need to add environment variables as written in the submodule readme.
