### PR TITLE
Fix: Recent changes dropped publishing for zipkin-common test jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,3 +207,5 @@ task zipkinUpload(group: 'release') {
         dependsOn bintrayUpload
     }
 }
+
+

--- a/zipkin-common/build.gradle
+++ b/zipkin-common/build.gradle
@@ -15,9 +15,9 @@ task testJar(type: Jar) {
 }
 
 artifacts {
-    archives testJar
+    zipkinUpload testJar
 }
 
 configurations {
-    archives.extendsFrom (testCompile)
+    zipkinUpload.extendsFrom (testCompile)
 }


### PR DESCRIPTION
According to a `bintrayUpload` with `dryRun`:

```
Uploading to https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-common/1.2.1-SNAPSHOT/zipkin-common-1.2.1-SNAPSHOT-test.jar...
(Dry run) Uploaded to 'https://api.bintray.com/content/openzipkin/zipkin/zipkin/1.2.1-SNAPSHOT/io/zipkin/zipkin-common/1.2.1-SNAPSHOT/zipkin-common-1.2.1-SNAPSHOT-test.jar'.
```
