### PR TITLE
increases no-feedback threshold to 20m to avoid killing bintrayUpload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,6 @@ before_script:
   - git remote set-url origin "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git"
 
 script:
-  - ./travis/publish.sh
+# increases no-feedback threshold to 20m to avoid killing bintrayUpload
+  - travis_wait 20 ./travis/publish.sh
 


### PR DESCRIPTION
because last RC (20) was killed

```
:bintrayUpload
No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.
```
