### PR TITLE
Removes unused canned scripts and tar.gz publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 # https://github.com/openzipkin/zipkin/issues/534
 zipkin-collector-service/zipkin.db
 /.nb-gradle/
+
+# https://github.com/openzipkin/zipkin/pull/642
+travis_wait*.log

--- a/build.gradle
+++ b/build.gradle
@@ -37,16 +37,6 @@ allprojects {
     }
 }
 
-// We like compressed tars
-allprojects { thisProject ->
-    thisProject.plugins.withType(DistributionPlugin) {
-        thisProject.tasks.distTar {
-            compression = Compression.GZIP
-            extension = 'tar.gz'
-        }
-    }
-}
-
 // Source and JavaDoc jars for Maven Central
 allprojects {
     task sourceJar(type: Jar) {

--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -11,7 +11,6 @@ run {
 
 tasks.build.dependsOn(shadowJar)
 artifacts.zipkinUpload shadowJar
-artifacts.zipkinUpload distTar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-collector-service/src/scripts/collector.sh
+++ b/zipkin-collector-service/src/scripts/collector.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-VERSION=@VERSION@
-CONFIG=${DIR}/../config/collector-dev.scala
-exec java -cp "$DIR/../libs/*" -jar $DIR/../zipkin-collector-service-$VERSION.jar -f $CONFIG

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -11,7 +11,6 @@ run {
 
 tasks.build.dependsOn(shadowJar)
 artifacts.zipkinUpload shadowJar
-artifacts.zipkinUpload distTar
 
 repositories {
     // For dependencies of zipkin-cassandra

--- a/zipkin-query-service/src/scripts/query.sh
+++ b/zipkin-query-service/src/scripts/query.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-VERSION=@VERSION@
-CONFIG=${DIR}/../config/query-dev.scala
-exec java -cp "$DIR/../libs/*" -jar $DIR/../zipkin-query-service-$VERSION.jar -f ${CONFIG}

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -9,7 +9,6 @@ run {
 
 tasks.build.dependsOn(shadowJar)
 artifacts.zipkinUpload shadowJar
-artifacts.zipkinUpload distTar
 
 dependencies {
     compile project(':zipkin-scrooge')

--- a/zipkin-web/src/scripts/web.sh
+++ b/zipkin-web/src/scripts/web.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-VERSION=@VERSION@
-
-exec java -cp "$DIR/../libs/*" -jar $DIR/../zipkin-web-$VERSION.jar -zipkin.web.resourcesRoot=$DIR/../resources/ $@


### PR DESCRIPTION
We shouldn't be storing things not used, or complicating publication
with duplicate artifacts.

The scripts stored in zipkin's repo are not used at Twitter, not used by
the dist routine, not used by our bin directory, and not used in docker.

At the moment, the tar.gz dist isn't used by anything either. When our
artifact publication works, there's nothing in the tar.gz we can do that
we can't do with the fat jar. Once we have versioned fat jars, we should
change docker to use them.. we don't need a tar.gz IOTW.
