### PR TITLE
Make Gradle more verbose during release and upload

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -73,7 +73,7 @@ function want_to_release_from_this_jdk(){
 
 function publish(){
   echo "[Publishing] Publishing..."
-  ./gradlew zipkinUpload
+  ./gradlew --info --stacktrace zipkinUpload
   echo "[Publishing] Done"
 }
 
@@ -96,7 +96,7 @@ function do_gradle_release(){
 
   git checkout -B master
 
-  ./gradlew release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}
+  ./gradlew --info --stacktrace release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}
   echo "[Publishing] Done"
 }
 


### PR DESCRIPTION
Travis currently times out the build in the upload phase (see #644). This can have two reasons:
- Gradle is stuck
- Gradle is working, but not producing any output

In either case, this change takes us closer to the truth:
- If Gradle is stuck, then this will tell us where exactly it's stuck
- If Gradle is working, then this should produce output to keep Travis happy
