### PR TITLE
Allow excluding of non-core projects on publishing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,5 @@ configKey=dev
 #
 # Other values are sqlite-memory, h2-memory, h2-persistent, postgresql, mysql
 dbEngine=sqlite-persistent
+
+include_noncore_projects=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,61 +1,70 @@
 rootProject.name = 'zipkin'
 
+def coreProjects = new ArrayList()
+def noncoreProjects = new ArrayList()
+
 ////////////////////////////////////
 // Zipkin's mostly common library //
 ////////////////////////////////////
 // Not all projects depend on this!
-include 'zipkin-common',
+coreProjects << 'zipkin-common'
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // Projects with outputs that are useful on their own: documentation, examples, services //
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 //'doc'
-'zipkin-example',
-'zipkin-redis-example',
-'zipkin-collector-service',
-'zipkin-query-service',
-'zipkin-web',
+noncoreProjects << 'zipkin-example'
+noncoreProjects << 'zipkin-redis-example'
+
+coreProjects << 'zipkin-collector-service'
+coreProjects << 'zipkin-query-service'
+coreProjects << 'zipkin-web'
 
 /////////////////////////////////////
 // Collector, and Collector inputs //
 /////////////////////////////////////
 
-'zipkin-collector',
-'zipkin-collector-scribe',
+coreProjects << 'zipkin-collector'
+coreProjects << 'zipkin-collector-scribe'
 
 ///////////////
 // Receivers //
 ///////////////
 
-'zipkin-receiver-scribe',
-'zipkin-receiver-kafka',
+coreProjects << 'zipkin-receiver-scribe'
+coreProjects << 'zipkin-receiver-kafka'
 
 /////////////////
 // Query logic //
 /////////////////
 
-'zipkin-query',
+coreProjects << 'zipkin-query'
 
 /////////////////////////////////////////////////////
 // Libraries wrapping clients to external services //
 /////////////////////////////////////////////////////
 
-'zipkin-cassandra-core',
-'zipkin-cassandra',
-'zipkin-anormdb',
-'zipkin-redis',
+coreProjects << 'zipkin-cassandra-core'
+coreProjects << 'zipkin-cassandra'
+coreProjects << 'zipkin-anormdb'
+coreProjects << 'zipkin-redis'
 
 ////////////
 // Thrift //
 ////////////
 
-'zipkin-thrift',
-'zipkin-scrooge',
+coreProjects << 'zipkin-thrift'
+coreProjects << 'zipkin-scrooge'
 
 //////////
 // Misc //
 //////////
+noncoreProjects << 'zipkin-tracegen'
+coreProjects << 'zipkin-sampler'
 
-'zipkin-tracegen',
-'zipkin-sampler'
+println("[settings.gradle] Including non-core projects: ${include_noncore_projects}")
+
+def all_projects = include_noncore_projects ? coreProjects + noncoreProjects : coreProjects
+
+include all_projects.toArray(new String[0])

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -73,7 +73,7 @@ function want_to_release_from_this_jdk(){
 
 function publish(){
   echo "[Publishing] Publishing..."
-  ./gradlew --info --stacktrace zipkinUpload
+  ./gradlew --info --stacktrace zipkinUpload -Pinclude_noncore_projects=false
   echo "[Publishing] Done"
 }
 
@@ -96,7 +96,7 @@ function do_gradle_release(){
 
   git checkout -B master
 
-  ./gradlew --info --stacktrace release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version}
+  ./gradlew --info --stacktrace release -Prelease.useAutomaticVersion=true -PreleaseVersion=${TRAVIS_TAG} -PnewVersion=${new_version} -Pinclude_noncore_projects=false
   echo "[Publishing] Done"
 }
 


### PR DESCRIPTION
### Problem

Jar files are too big to publish, need to exclude some submodules
### Solution

Create property which controls excluding certain submodules from publishing.
If you pass the gradle property `-Pinclude_noncore_projects=false` to the gradle script it excludes non-core subprojects.  If you leave the property empty it defaults to including all subprojects.
This is allows, releasing smaller jar files.
