### PR TITLE
Propagates Cassandra environment variables as flags

### DIFF
--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
@@ -1,12 +1,10 @@
 package com.twitter.zipkin.cassandra
 
-import com.datastax.driver.core.{AuthProvider, Cluster}
+import com.datastax.driver.core.AuthProvider
 import com.twitter.app.App
 import java.net.InetSocketAddress
 import java.util.Arrays.asList
 import org.scalatest.{FunSuite, Matchers}
-import com.datastax.driver.core.exceptions.AuthenticationException
-
 
 class CassandraSpanStoreFactorySpec extends FunSuite with Matchers {
   object TestFactory extends App with CassandraSpanStoreFactory
@@ -14,7 +12,7 @@ class CassandraSpanStoreFactorySpec extends FunSuite with Matchers {
   test("zipkin.store.cassandra.dest default") {
     TestFactory.nonExitingMain(Array())
 
-    TestFactory.addContactPoint(Cluster.builder()).getContactPoints should be(
+    TestFactory.parseContactPoints() should be(
       asList(new InetSocketAddress("127.0.0.1", 9042))
     )
   }
@@ -24,7 +22,7 @@ class CassandraSpanStoreFactorySpec extends FunSuite with Matchers {
       "-zipkin.store.cassandra.dest", "1.1.1.1"
     ))
 
-    TestFactory.addContactPoint(Cluster.builder()).getContactPoints should be(
+    TestFactory.parseContactPoints() should be(
       asList(new InetSocketAddress("1.1.1.1", 9042))
     )
   }
@@ -34,7 +32,7 @@ class CassandraSpanStoreFactorySpec extends FunSuite with Matchers {
       "-zipkin.store.cassandra.dest", "1.1.1.1:9142"
     ))
 
-    TestFactory.addContactPoint(Cluster.builder()).getContactPoints should be(
+    TestFactory.parseContactPoints() should be(
       asList(new InetSocketAddress("1.1.1.1", 9142))
     )
   }
@@ -44,17 +42,17 @@ class CassandraSpanStoreFactorySpec extends FunSuite with Matchers {
       "-zipkin.store.cassandra.dest", "1.1.1.1:9143,2.2.2.2"
     ))
 
-    TestFactory.addContactPoint(Cluster.builder()).getContactPoints should be(
+    TestFactory.parseContactPoints() should be(
       asList(new InetSocketAddress("1.1.1.1", 9143), new InetSocketAddress("2.2.2.2", 9042))
     )
   }
 
   test("creatingClusterBuilder with SASL authentication null delimited utf8 bytes") {
     TestFactory.nonExitingMain(Array(
-      "-zipkin.store.cassandra.user", "user",
-      "-zipkin.store.cassandra.password", "pass"
+      "-zipkin.store.cassandra.username", "bob",
+      "-zipkin.store.cassandra.password", "secret"
     ))
-    val SASLhandshake = Array[Byte](0, 'u', 's', 'e', 'r', 0, 'p', 'a', 's', 's')
+    val SASLhandshake = Array[Byte](0, 'b', 'o', 'b', 0, 's', 'e', 'c', 'r', 'e', 't')
     val authProvider = TestFactory.createClusterBuilder()
                          .getConfiguration()
                          .getProtocolOptions()

--- a/zipkin-query-service/config/query-cassandra.scala
+++ b/zipkin-query-service/config/query-cassandra.scala
@@ -13,33 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.datastax.driver.core.Cluster
-import com.datastax.driver.core.SocketOptions
 import com.twitter.app.App
 import com.twitter.zipkin.builder.QueryServiceBuilder
 import com.twitter.zipkin.cassandra
 import com.twitter.zipkin.cassandra.CassandraSpanStoreFactory
 import com.twitter.zipkin.storage.Store
-import scala.collection.mutable.ListBuffer
 
-val contactPoints: Array[String] = sys.env.get("CASSANDRA_CONTACT_POINTS").getOrElse("localhost")
-  .split(",")
+object Factory extends App with CassandraSpanStoreFactory
 
-val cassandraUser = sys.env.get("CASSANDRA_USER")
-val cassandraPass = sys.env.get("CASSANDRA_PASS")
+Factory.cassandraDest.parse(sys.env.get("CASSANDRA_CONTACT_POINTS").getOrElse("localhost"))
 
-var args = new ListBuffer[String]()
-if (cassandraUser.isDefined && cassandraPass.isDefined) {
-  args += "-zipkin.store.cassandra.user"
-  args += cassandraUser.get
-  args += "-zipkin.store.cassandra.password"
-  args += cassandraPass.get
+val username = sys.env.get("CASSANDRA_USERNAME")
+val password = sys.env.get("CASSANDRA_PASSWORD")
+
+if (username.isDefined && password.isDefined) {
+  Factory.cassandraUsername.parse(username.get)
+  Factory.cassandraPassword.parse(password.get)
 }
 
-object QueryService extends App with CassandraSpanStoreFactory
-QueryService.nonExitingMain(args.toArray)
-val cluster = QueryService.createClusterBuilder().build()
-
+val cluster = Factory.createClusterBuilder().build()
 val storeBuilder = Store.Builder(new cassandra.SpanStoreBuilder(cluster))
 
 QueryServiceBuilder(storeBuilder)


### PR DESCRIPTION
This fixes docker. Note I also am using `CASSANDRA_PASSWORD` not `CASSANDRA_PASS` as the former is more consistent with the existing properties, as password isn't commonly abbreviated.
