### PR TITLE
reduce duplicates writes in cassandra to service_names and span_names tables

### DIFF
--- a/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
+++ b/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS zipkin.service_name_index (
 
 CREATE TABLE IF NOT EXISTS zipkin.span_names (
     service_name text,
-    bucket       int,
+    bucket       int,   -- no longer used. kept for compatibility
     span_name    text,
     PRIMARY KEY ((service_name, bucket), span_name)
 ) WITH compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -106,7 +106,6 @@ class CassandraSpanStore(
       case "" =>
         IndexServiceNameNoNameCounter.incr()
       case s =>
-        // @xxx so many identical writes going to the one partition key is bad. implement caching of writes.
         repository.storeServiceName(s.toLowerCase, indexTtl.inSeconds)
     }
   }


### PR DESCRIPTION
problem:
 storing spans in CassandraSpanStore involves writes to service_names and span_names tables.
 these tables are nothing more than lists of service names and span names active within the index ttl period (default of 3 days)
 there is both at the application level and in the database a large amount of wasted overhead with duplicate writes having to do this for
every span.

solution:
 keep a simple thread-local cache in the write path so within any given hour writes to either table that have already happened are avoided.
 this removes the need for the span_names.bucket column but it's kept for compatibilty and a value of zero always now used in it.
