### PR TITLE
Removes unused tracesExist query

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -110,19 +110,6 @@ class AnormSpanStore(val db: DB, val openCon: Option[Connection] = None) extends
 
   override def getTimeToLive(traceId: Long): Future[Duration] = Future.value(Duration.Top)
 
-  override def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] = db.inNewThreadWithRecoverableRetry {
-    implicit val (conn, borrowTime) = borrowConn()
-    try {
-
-      SQL(
-        "SELECT trace_id FROM zipkin_spans WHERE trace_id IN (%s)".format(traceIds.mkString(","))
-      ).as(long("trace_id") *).toSet
-
-    } finally {
-      returnConn(conn, borrowTime, "tracesExist")
-    }
-  }
-
   override def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = db.inNewThreadWithRecoverableRetry {
     implicit val (conn, borrowTime) = borrowConn()
     try {

--- a/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
+++ b/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
@@ -261,12 +261,6 @@ public final class Repository implements AutoCloseable {
                 .replace(":ttl_", String.valueOf(ttl));
     }
 
-    public Set<Long> tracesExist(Long[] traceIds) {
-        Preconditions.checkNotNull(traceIds);
-        Preconditions.checkArgument(0 < traceIds.length);
-        return getSpansByTraceIds(traceIds, 100000).keySet();
-    }
-
     /**
      * Get the available trace information from the storage system.
      * Spans in trace should be sorted by the first annotation timestamp

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -85,7 +85,6 @@ class CassandraSpanStore(
   private[this] val IndexBinaryAnnotationCounter = IndexStats.scope("annotation").counter("binary")
   private[this] val QueryStats = stats.scope("query")
   private[this] val QueryGetTtlCounter = QueryStats.counter("getTimeToLive")
-  private[this] val QueryTracesExistStat = QueryStats.stat("tracesExist")
   private[this] val QueryGetSpansByTraceIdsStat = QueryStats.stat("getSpansByTraceIds")
   private[this] val QueryGetSpansByTraceIdsTooBigCounter = QueryStats.scope("getSpansByTraceIds").counter("tooBig")
   private[this] val QueryGetServiceNamesCounter = QueryStats.counter("getServiceNames")
@@ -231,16 +230,6 @@ class CassandraSpanStore(
   }
 
   override def getDataTimeToLive = Future.value(spanTtl.inSeconds)
-
-  override def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] = {
-    QueryTracesExistStat.add(traceIds.size)
-    pool {
-      repository
-        .tracesExist(traceIds.toArray.map(Long.box))
-        .map(_.asInstanceOf[Long])
-        .toSet
-    }
-  }
 
   override def getSpansByTraceId(traceId: Long): Future[Seq[Span]] =
     getSpansByTraceIds(Seq(traceId)).map(_.head)

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
@@ -34,7 +34,10 @@ abstract class SpanStore extends java.io.Closeable {
 
   def getTimeToLive(traceId: Long): Future[Duration]
 
-  def tracesExist(traceIds: Seq[Long]): Future[Set[Long]]
+  @deprecated("This is no longer used; getSpansByTraceIds ignores absent ids", "1.2.3")
+  def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] = {
+    Future.exception(new UnsupportedOperationException("This is no longer used"))
+  }
 
   /**
    * Get the available trace information from the storage system.
@@ -142,10 +145,6 @@ class InMemorySpanStore extends SpanStore {
 
   override def getTimeToLive(traceId: Long): Future[Duration] = call {
     ttls(traceId)
-  }
-
-  override def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] = call {
-    spans.map(_.traceId).toSet & traceIds.toSet
   }
 
   override def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = call {

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
@@ -22,11 +22,6 @@ public class SpanStoreInJava extends SpanStore {
     }
 
     @Override
-    public Future<Set<Object>> tracesExist(Seq<Object> traceIds) {
-        return null;
-    }
-
-    @Override
     public Future<Seq<Seq<Span>>> getSpansByTraceIds(Seq<Object> traceIds) {
         return null;
     }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -72,7 +72,7 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     ready(store(Seq(span1, span2)))
 
     result(store.getSpansByTraceIds(Seq(span1.traceId))) should be(Seq(Seq(span1)))
-    result(store.getSpansByTraceIds(Seq(span1.traceId, span2.traceId))) should be(
+    result(store.getSpansByTraceIds(Seq(span1.traceId, span2.traceId, 111111))) should be(
       Seq(Seq(span1), Seq(span2))
     )
   }
@@ -93,14 +93,6 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     // If a store doesn't use TTLs this should return Duration.Top
     val ttl = result(store.getTimeToLive(span1.traceId))
     assert(ttl == Duration.Top || (ttl - 1234.seconds).abs.inMilliseconds <= 10)
-  }
-
-  @Test def tracesExist() {
-    ready(store(Seq(span1, span4)))
-
-    result(store.tracesExist(Seq(span1.traceId, span4.traceId, 111111))) should be(
-      Set(span1.traceId, span4.traceId)
-    )
   }
 
   @Test def getSpanNames() {

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ThriftQueryService.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ThriftQueryService.scala
@@ -205,12 +205,6 @@ class ThriftQueryService(
     }
   }
 
-  override def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] =
-    handle("tracesExist") {
-      FTrace.recordBinary("numIds", traceIds.length)
-      spanStore.tracesExist(traceIds)
-    }
-
   override def getTracesByIds(traceIds: Seq[Long], adjust: Seq[thriftscala.Adjust]): Future[Seq[thriftscala.Trace]] =
     handle("getTracesByIds") {
       FTrace.recordBinary("numIds", traceIds.length)

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisStorage.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisStorage.scala
@@ -53,12 +53,6 @@ class RedisStorage(
 
   def getDataTimeToLive: Int = (defaultTtl map (_.inSeconds)).getOrElse(Int.MaxValue)
 
-  def tracesExist(traceIds: Seq[Long]): Future[Set[Long]] =
-    Future.collect(traceIds map { id =>
-      // map the exists result to the trace id or none
-      client.exists(encodeTraceId(id)) map (exists => if (exists) Some(id) else None)
-    }).map(_.flatten.toSet)
-
   private def decodeSpan(buf: ChannelBuffer): Span = {
     val thrift = serializer.fromBytes(buf.copy().array)
     new WrappedSpan(thrift).toSpan

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinQuery.thrift
@@ -145,15 +145,6 @@ service ZipkinQuery {
     list<i64> getTraceIdsByAnnotation(1: string service_name, 2: string annotation, 3: binary value,
         5: i64 end_ts, 6: i32 limit, 7: Order OBSOLETE_order) throws (1: QueryException qe);
 
-
-    #************** Fetch traces from id **************
-
-    /**
-     * Get the traces that are in the database from the given list of trace ids.
-     */
-
-    set<i64> tracesExist(1: list<i64> trace_ids) throws (1: QueryException qe);
-
     /**
      * Get the full traces associated with the given trace ids.
      *

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -290,13 +290,6 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache, que
       Future(MustacheRenderer("v2/aggregate.mustache", data))
     }
 
-  private[this] def getExistingTracedId(
-    client: ZipkinQuery[Future],
-    traceIds: collection.Map[String, Seq[Long]]): Future[Seq[(String, Seq[Long])]] = {
-      Future.collect(traceIds.toList.map { case (svcName, traceIds) =>
-        client.tracesExist(traceIds) map {(svcName -> _.toSeq)} })
-  }
-
   // API Endpoints
 
   def handleQuery(client: ZipkinQuery[Future]): Service[Request, Renderer] =


### PR DESCRIPTION
`tracesExist` was only referenced by an unused private method in web.
`getSpansByTraceIds` ignores absent ids anyway.
