### PR TITLE
Removes TTL from Query API

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -106,10 +106,6 @@ class AnormSpanStore(val db: DB, val openCon: Option[Connection] = None) extends
     }
   }
 
-  override def setTimeToLive(traceId: Long, ttl: Duration): Future[Unit] = Future.Done
-
-  override def getTimeToLive(traceId: Long): Future[Duration] = Future.value(Duration.Top)
-
   override def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = db.inNewThreadWithRecoverableRetry {
     implicit val (conn, borrowTime) = borrowConn()
     try {

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
@@ -1,12 +1,8 @@
 package com.twitter.zipkin.storage.cassandra
 
 import com.datastax.driver.core.Cluster
-import com.twitter.conversions.time.intToTimeableNumber
-import com.twitter.util.Await.{ready, result}
-import com.twitter.util.Duration
 import com.twitter.zipkin.storage.SpanStoreSpec
 import java.util.Collections
-import junit.framework.Test
 import org.cassandraunit.CQLDataLoader
 import org.cassandraunit.dataset.CQLDataSet
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra
@@ -40,19 +36,4 @@ class CassandraSpanStoreSpec extends SpanStoreSpec {
   override lazy val store = new CassandraSpanStore(new Repository(keyspace, cluster))
 
   override def clear = cluster.connect().execute("DROP KEYSPACE IF EXISTS " + keyspace)
-
-  override def setTimeToLive() {
-    ready(store(Seq(span1)))
-    ready(store.setTimeToLive(span1.traceId, 1234.seconds))
-
-    for( i <- 1 to 100) {
-      // Repository.storeXXX() methods write asynchronously but don't return a Future so we can't reliably test.
-      //  just wait and loop instead
-      java.lang.Thread.sleep(50)
-      if ((result(store.getTimeToLive(span1.traceId)) - 1234.seconds).abs.inMilliseconds <= (i*50) + 100) {
-        return
-      }
-    }
-    throw new AssertionError
-  }
 }

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
@@ -7,7 +7,6 @@ import scala.collection.Seq;
 import scala.collection.immutable.Set;
 import scala.runtime.BoxedUnit;
 
-import com.twitter.util.Duration;
 import com.twitter.util.Future;
 import com.twitter.zipkin.common.Span;
 
@@ -15,11 +14,6 @@ import com.twitter.zipkin.common.Span;
  * Shows that {@link SpanStore} is implementable in Java 7+.
  */
 public class SpanStoreInJava extends SpanStore {
-
-    @Override
-    public Future<Duration> getTimeToLive(long traceId) {
-        return null;
-    }
 
     @Override
     public Future<Seq<Seq<Span>>> getSpansByTraceIds(Seq<Object> traceIds) {
@@ -53,11 +47,6 @@ public class SpanStoreInJava extends SpanStore {
 
     @Override
     public Future<BoxedUnit> apply(Seq<Span> spans) {
-        return null;
-    }
-
-    @Override
-    public Future<BoxedUnit> setTimeToLive(long traceId, Duration ttl) {
         return null;
     }
 

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/InMemorySpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/InMemorySpanStoreSpec.scala
@@ -5,6 +5,5 @@ class InMemorySpanStoreSpec extends SpanStoreSpec {
 
   override def clear = {
     store.spans.clear
-    store.ttls.clear
   }
 }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -1,9 +1,7 @@
 package com.twitter.zipkin.storage
 
 import com.google.common.net.InetAddresses._
-import com.twitter.conversions.time.intToTimeableNumber
 import com.twitter.util.Await.{ready, result}
-import com.twitter.util.Duration
 import com.twitter.zipkin.common.{Annotation, AnnotationType, BinaryAnnotation, Endpoint, Span}
 import java.net.InetAddress._
 import java.nio.ByteBuffer
@@ -79,20 +77,6 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
   @Test def getSpansByTraceIds_empty() {
     result(store.getSpansByTraceIds(Seq(54321))) should be(empty)
-  }
-
-  @Test def getDataTimeToLive() {
-    // If a store doesn't use TTLs this should return Int.Max
-    assert(result(store.getDataTimeToLive()) > 0)
-  }
-
-  @Test def setTimeToLive() {
-    ready(store(Seq(span1)))
-    ready(store.setTimeToLive(span1.traceId, 1234.seconds))
-
-    // If a store doesn't use TTLs this should return Duration.Top
-    val ttl = result(store.getTimeToLive(span1.traceId))
-    assert(ttl == Duration.Top || (ttl - 1234.seconds).abs.inMilliseconds <= 10)
   }
 
   @Test def getSpanNames() {

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ThriftQueryService.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ThriftQueryService.scala
@@ -18,7 +18,6 @@ package com.twitter.zipkin.query
 
 import java.nio.ByteBuffer
 
-import com.twitter.conversions.time._
 import com.twitter.finagle.stats.{DefaultStatsReceiver, Stat, StatsReceiver}
 import com.twitter.finagle.tracing.{Trace => FTrace}
 import com.twitter.logging.Logger
@@ -227,11 +226,6 @@ class ThriftQueryService(
       }
     }
 
-  override def getDataTimeToLive: Future[Int] =
-    handle("getDataTimeToLive") {
-      spanStore.getDataTimeToLive()
-    }
-
   override def getServiceNames: Future[Set[String]] =
     handle("getServiceNames") {
       spanStore.getAllServiceNames
@@ -240,16 +234,6 @@ class ThriftQueryService(
   override def getSpanNames(serviceName: String): Future[Set[String]] =
     handle("getSpanNames") {
       spanStore.getSpanNames(serviceName)
-    }
-
-  override def setTraceTimeToLive(traceId: Long, ttl: Int): Future[Unit] =
-    handle("setTraceTimeToLive") {
-      spanStore.setTimeToLive(traceId, ttl.seconds)
-    }
-
-  override def getTraceTimeToLive(traceId: Long): Future[Int] =
-    handle("getTraceTimeToLive") {
-      spanStore.getTimeToLive(traceId).map(_.inSeconds)
     }
 
   override def getDependencies(startTime: Option[Long], endTime: Option[Long]) : Future[thriftscala.Dependencies] =

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ThriftQueryServiceTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ThriftQueryServiceTest.scala
@@ -145,15 +145,4 @@ class ThriftQueryServiceTest extends FunSuite {
     val actual = Await.result(svc.getSpanNames("service3"))
     assert(actual === Set("methodcall", "otherMethod"))
   }
-
-  test("get/set trace TTL") {
-    val svc = newLoadedService()
-
-    val original = Await.result(svc.getTraceTimeToLive(1))
-    assert(original === 1)
-
-    Await.ready(svc.setTraceTimeToLive(1, 100))
-    val newVal = Await.result(svc.getTraceTimeToLive(1))
-    assert(newVal === 100)
-  }
 }

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/ExpirationSupport.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/ExpirationSupport.scala
@@ -8,9 +8,9 @@ trait ExpirationSupport {
   val client: Client
 
   /** Expires keys older than this many seconds. */
-  val defaultTtl: Option[Duration]
+  val ttl: Option[Duration]
 
-  def expireOnTtl(redisKey: ChannelBuffer, ttl: Option[Duration] = defaultTtl): Future[Unit] = {
+  def expireOnTtl(redisKey: ChannelBuffer): Future[Unit] = {
     if (ttl.isDefined) client.expire(redisKey, ttl.get.inLongSeconds).unit else Future.Unit
   }
 }

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/SetMultimap.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/SetMultimap.scala
@@ -9,12 +9,12 @@ import org.jboss.netty.buffer.ChannelBuffers._
  * Allows you to associate one or more string values with a string key.
  *
  * @param client the redis client to use
- * @param defaultTtl expires keys older than this many seconds.
+ * @param ttl expires keys older than this many seconds.
  * @param prefix prefix of the namespace/redis hash key
  */
 class SetMultimap(
   val client: Client,
-  val defaultTtl: Option[Duration],
+  val ttl: Option[Duration],
   prefix: String
 ) extends ExpirationSupport {
 

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/TraceIndex.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/TraceIndex.scala
@@ -8,11 +8,11 @@ import org.jboss.netty.buffer.{ChannelBuffers, ChannelBuffer}
 
 /**
  * @param client the redis client to use
- * @param defaultTtl expires keys older than this many seconds.
+ * @param ttl expires keys older than this many seconds.
  */
 abstract class TraceIndex[K](
   val client: Client,
-  val defaultTtl: Option[Duration]
+  val ttl: Option[Duration]
 ) extends ExpirationSupport {
 
   def encodeKey(key: K): ChannelBuffer
@@ -37,7 +37,7 @@ abstract class TraceIndex[K](
    * @param limit maximum number of items to return
    */
   def list(key: K, endTs: Long, limit: Long): Future[Seq[IndexedTraceId]] = {
-    val startTs: Long = defaultTtl map (dur => endTs - dur.inMicroseconds) getOrElse 0
+    val startTs: Long = ttl map (dur => endTs - dur.inMicroseconds) getOrElse 0
 
     client.zRevRangeByScore(encodeKey(key), ZInterval(endTs), ZInterval(startTs), true, Some(Limit(0, limit)))
       .map(_.left.get)

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisStorageSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisStorageSpec.scala
@@ -46,22 +46,4 @@ class RedisStorageSpec extends RedisSpecification {
       Seq(Seq(span), Seq(span2))
     )
   }
-
-  test("get default ttl") {
-    result(storage.storeSpan(span))
-    result(storage.getTimeToLive(span.traceId)) should be(7.days)
-  }
-
-  test("ttl is honored") {
-    result(storage.storeSpan(span))
-    result(storage.setTimeToLive(span.traceId, 1.seconds))
-    Thread.sleep(2 * 1000)
-    result(storage.getSpansByTraceIds(List(span.traceId))) should be(Seq())
-  }
-
-  test("reset ttl") {
-    result(storage.storeSpan(span))
-    result(storage.setTimeToLive(span.traceId, 1234.seconds))
-    result(storage.getTimeToLive(span.traceId)) should be(1234.seconds)
-  }
 }

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinQuery.thrift
@@ -171,24 +171,6 @@ service ZipkinQuery {
      */
     set<string> getSpanNames(1: string service_name) throws (1: QueryException qe);
 
-    #************** TTL related **************
-
-    /**
-     * Change the TTL of a trace. If we find an interesting trace we want to keep around for further
-     * investigation.
-     */
-    void setTraceTimeToLive(1: i64 trace_id, 2: i32 ttl_seconds) throws (1: QueryException qe);
-
-    /**
-     * Get the TTL in seconds of a specific trace.
-     */
-    i32 getTraceTimeToLive(1: i64 trace_id) throws (1: QueryException qe);
-
-    /**
-     * Get the data ttl. This is the number of seconds we keep the data around before deleting it.
-     */
-    i32 getDataTimeToLive() throws (1: QueryException qe);
-
     /**
      * Get an aggregate representation of all services paired with every service they call in to.
      * This includes information on call counts and mean/stdDev/etc of call durations.  The two arguments

--- a/zipkin-tracegen/src/main/scala/com/twitter/zipkin/tracegen/Main.scala
+++ b/zipkin-tracegen/src/main/scala/com/twitter/zipkin/tracegen/Main.scala
@@ -102,9 +102,6 @@ object Main extends App with ZipkinSpanGenerator {
       _ = println("TraceCombo:")
       _ = println(traceCombo.toString)
 
-      ttl <- client.getDataTimeToLive()
-      _ = println("Data ttl: " + ttl)
-
       svcNames <- client.getServiceNames()
       _ = println("Service names: " + svcNames)
 

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -51,7 +51,6 @@ trait ZipkinWebFactory { self: App =>
   val webRootUrl = flag("zipkin.web.rootUrl", "http://localhost:8080/", "Url where the service is located")
   val webCacheResources = flag("zipkin.web.cacheResources", false, "cache static resources and mustache templates")
   val webResourcesRoot = flag("zipkin.web.resourcesRoot", "zipkin-web/src/main/resources", "on-disk location of resources")
-  val webPinTtl = flag("zipkin.web.pinTtl", 30.days, "Length of time pinned traces should exist")
 
   val queryDest = flag("zipkin.web.query.dest", "127.0.0.1:9411", "Location of the query server")
   val queryLimit = flag("zipkin.web.query.limit", 10, "Default query limit for trace results")
@@ -85,9 +84,7 @@ trait ZipkinWebFactory { self: App =>
       ("/api/dependencies", handleDependencies(queryClient)),
       ("/api/dependencies/?:startTime/?:endTime", handleDependencies(queryClient)),
       ("/api/get/:id", handleGetTrace(queryClient)),
-      ("/api/trace/:id", handleGetTrace(queryClient)),
-      ("/api/is_pinned/:id", handleIsPinned(queryClient)),
-      ("/api/pin/:id/:state", handleTogglePin(queryClient, webPinTtl()))
+      ("/api/trace/:id", handleGetTrace(queryClient))
     ).foldLeft(new HttpMuxer) { case (m , (p, handler)) =>
       val path = p.split("/").toList
       val handlePath = path.takeWhile { t => !(t.startsWith(":") || t.startsWith("?:")) }


### PR DESCRIPTION
TTLs in zipkin are backend-specific and at best partially supported as
they aren't exposed in the UI. This change removes TTL from the query
api, and removes trace-specific TTL controls. It leaves support for
global TTLs in Cassandra and Redis.

`getDataTimeToLive` was implemented by Cassandra and Redis, but not used
by the UI. `setTimeToLive` by trace was implemented by Cassandra and
Redis, but silently fails when unsupported. Cassandra support of this
feature led to brittle tests and corresponding complexity. When we
consider TTL by trace wasn't used by the UI either, but rather an
undocumented "pin" api, the feature's existence becomes more curious.
This isn't helped by no history of this feature in any GitHub issue.
