### PR TITLE
Removes top annotation aggregates

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormAggregates.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormAggregates.scala
@@ -113,32 +113,4 @@ case class AnormAggregates(
       returnConn(conn, borrowTime, "storeDependencies")
     }
   }
-
-  /**
-   * Get the top annotations for a service name
-   */
-  def getTopAnnotations(serviceName: String): Future[Seq[String]] = {
-    Future.value(Seq.empty[String])
-  }
-
-  /**
-   * Get the top key value annotation keys for a service name
-   */
-  def getTopKeyValueAnnotations(serviceName: String): Future[Seq[String]] = {
-    Future.value(Seq.empty[String])
-  }
-
-  /**
-   * Override the top annotations for a service
-   */
-  def storeTopAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = {
-    Future.Unit
-  }
-
-  /**
-   * Override the top key value annotation keys for a service
-   */
-  def storeTopKeyValueAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = {
-    Future.Unit
-  }
 }

--- a/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
+++ b/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
@@ -8,13 +8,6 @@ CREATE TABLE IF NOT EXISTS zipkin.service_span_name_index (
 ) WITH CLUSTERING ORDER BY (ts DESC)
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_sstable_age_days': '1'};
 
-CREATE TABLE IF NOT EXISTS zipkin.top_annotations (
-    key        text,
-    idx        int,
-    annotation text,
-    PRIMARY KEY (key, idx)
-) WITH compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
-
 CREATE TABLE IF NOT EXISTS zipkin.service_name_index (
     service_name      text,
     bucket            int,

--- a/zipkin-collector-scribe/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorService.scala
+++ b/zipkin-collector-scribe/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorService.scala
@@ -79,7 +79,7 @@ class ScribeCollectorService(
     }
   }
 
-  def storeDependencies(dependencies: thriftscala.Dependencies): Future[Unit] = {
+  override def storeDependencies(dependencies: thriftscala.Dependencies): Future[Unit] = {
 
     Stats.timeFutureMillisLazy("collector.storeDependencies") {
       Future.join {
@@ -90,38 +90,6 @@ class ScribeCollectorService(
         log.error(e, "storeDependencies failed")
         Stats.incr("collector.storeDependencies")
         Future.exception(thriftscala.StoreAggregatesException(e.toString))
-    }
-  }
-
-  def storeTopAnnotations(serviceName: String, annotations: Seq[String]): Future[Unit] = {
-    Stats.incr("collector.storeTopAnnotations")
-    log.info("storeTopAnnotations: " + serviceName + "; " + annotations)
-
-    Stats.timeFutureMillisLazy("collector.storeTopAnnotations") {
-      Future.join {
-        stores map { _.aggregates.storeTopAnnotations(serviceName, annotations) }
-      }
-    } rescue {
-      case e: Exception =>
-        log.error(e, "storeTopAnnotations failed")
-        Stats.incr("collector.storeTopAnnotations")
-        Future.exception(thriftscala.AdjustableRateException(e.toString))
-    }
-  }
-
-  def storeTopKeyValueAnnotations(serviceName: String, annotations: Seq[String]): Future[Unit] = {
-    Stats.incr("collector.storeTopKeyValueAnnotations")
-    log.info("storeTopKeyValueAnnotations: " + serviceName + ";" + annotations)
-
-    Stats.timeFutureMillisLazy("collector.storeTopKeyValueAnnotations") {
-      Future.join {
-        stores map { _.aggregates.storeTopKeyValueAnnotations(serviceName, annotations) }
-      }
-    } rescue {
-      case e: Exception =>
-        log.error(e, "storeTopKeyValueAnnotations failed")
-        Stats.incr("collector.storeTopKeyValueAnnotations")
-        Future.exception(thriftscala.AdjustableRateException(e.toString))
     }
   }
 }

--- a/zipkin-collector-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
+++ b/zipkin-collector-scribe/src/test/scala/com/twitter/zipkin/collector/ScribeCollectorServiceSpec.scala
@@ -82,20 +82,4 @@ class ScribeCollectorServiceSpec extends FunSuite with OneInstancePerTest with M
 
     verify(mockAggregates).storeDependencies(deps1)
   }
-
-  test("store top annotations") {
-    when(mockAggregates.storeTopAnnotations(serviceName, annotations)) thenReturn Future.Done
-
-    cs.storeTopAnnotations(serviceName, annotations)
-
-    verify(mockAggregates).storeTopAnnotations(serviceName, annotations)
-  }
-
-  test("store top key value annotations") {
-    when(mockAggregates.storeTopKeyValueAnnotations(serviceName, annotations)) thenReturn Future.Done
-
-    cs.storeTopKeyValueAnnotations(serviceName, annotations)
-
-    verify(mockAggregates).storeTopKeyValueAnnotations(serviceName, annotations)
-  }
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Aggregates.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Aggregates.scala
@@ -16,7 +16,7 @@
 package com.twitter.zipkin.storage
 
 import com.twitter.algebird.Monoid
-import com.twitter.util.{Time, Future}
+import com.twitter.util.{Future, Time}
 import com.twitter.zipkin.common.Dependencies
 
 /**
@@ -28,10 +28,22 @@ abstract class Aggregates extends java.io.Closeable {
   def getDependencies(startDate: Option[Time], endDate: Option[Time]=None): Future[Dependencies]
   def storeDependencies(dependencies: Dependencies): Future[Unit]
 
-  def getTopAnnotations(serviceName: String): Future[Seq[String]]
-  def getTopKeyValueAnnotations(serviceName: String): Future[Seq[String]]
-  def storeTopAnnotations(serviceName: String, a: Seq[String]): Future[Unit]
-  def storeTopKeyValueAnnotations(serviceName: String, a: Seq[String]): Future[Unit]
+  @deprecated("This didn't have UI support", "1.2.3")
+  def getTopAnnotations(serviceName: String): Future[Seq[String]] = {
+    Future.exception(new UnsupportedOperationException("This is no longer used"))
+  }
+  @deprecated("This didn't have UI support", "1.2.3")
+  def getTopKeyValueAnnotations(serviceName: String): Future[Seq[String]] = {
+    Future.exception(new UnsupportedOperationException("This is no longer used"))
+  }
+  @deprecated("This didn't have UI support", "1.2.3")
+  def storeTopAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = {
+    Future.exception(new UnsupportedOperationException("This is no longer used"))
+  }
+  @deprecated("This didn't have UI support", "1.2.3")
+  def storeTopKeyValueAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = {
+    Future.exception(new UnsupportedOperationException("This is no longer used"))
+  }
 }
 
 class NullAggregates extends Aggregates {
@@ -40,9 +52,4 @@ class NullAggregates extends Aggregates {
 
   def getDependencies(startDate: Option[Time], endDate: Option[Time] = None) = Future(Monoid.zero[Dependencies])
   def storeDependencies(dependencies: Dependencies): Future[Unit]                    = Future.Unit
-
-  def getTopAnnotations(serviceName: String)         = Future(Seq.empty[String])
-  def getTopKeyValueAnnotations(serviceName: String) = Future(Seq.empty[String])
-  def storeTopAnnotations(serviceName: String, a: Seq[String]): Future[Unit]         = Future.Unit
-  def storeTopKeyValueAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = Future.Unit
 }

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/AggregatesInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/AggregatesInJava.java
@@ -1,7 +1,6 @@
 package com.twitter.zipkin.storage;
 
 import scala.Option;
-import scala.collection.Seq;
 import scala.runtime.BoxedUnit;
 
 import com.twitter.util.Future;
@@ -29,26 +28,6 @@ public class AggregatesInJava extends Aggregates {
 
     @Override
     public Future<BoxedUnit> storeDependencies(Dependencies dependencies) {
-        return null;
-    }
-
-    @Override
-    public Future<Seq<String>> getTopAnnotations(String serviceName) {
-        return null;
-    }
-
-    @Override
-    public Future<Seq<String>> getTopKeyValueAnnotations(String serviceName) {
-        return null;
-    }
-
-    @Override
-    public Future<BoxedUnit> storeTopAnnotations(String serviceName, Seq<String> a) {
-        return null;
-    }
-
-    @Override
-    public Future<BoxedUnit> storeTopKeyValueAnnotations(String serviceName, Seq<String> a) {
         return null;
     }
 }

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ThriftQueryService.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ThriftQueryService.scala
@@ -272,14 +272,4 @@ class ThriftQueryService(
       val end = endTime map { Time.fromMicroseconds(_) }
       aggsStore.getDependencies(start, end).map(_.toThrift)
     }
-
-  override def getTopAnnotations(serviceName: String): Future[Seq[String]] =
-    handle("getTopAnnotations") {
-      aggsStore.getTopAnnotations(serviceName)
-    }
-
-  override def getTopKeyValueAnnotations(serviceName: String): Future[Seq[String]] =
-    handle("getTopKeyValueAnnotations") {
-      aggsStore.getTopKeyValueAnnotations(serviceName)
-    }
 }

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCollector.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCollector.thrift
@@ -27,9 +27,5 @@ exception StoreAggregatesException {
 }
 
 service ZipkinCollector extends scribe.Scribe {
-
-    /** Aggregates methods */
-    void storeTopAnnotations(1: string service_name, 2: list<string> annotations) throws (1: StoreAggregatesException e);
-    void storeTopKeyValueAnnotations(1: string service_name, 2: list<string> annotations) throws (1: StoreAggregatesException e);
     void storeDependencies(1: zipkinDependencies.Dependencies dependencies) throws (1: StoreAggregatesException e);
 }

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinQuery.thrift
@@ -228,7 +228,4 @@ service ZipkinQuery {
      * start time.
      */
     zipkinDependencies.Dependencies getDependencies(1: optional i64 start_time, 2: optional i64 end_time) throws (1: QueryException qe);
-
-    list<string> getTopAnnotations(1: string service_name) throws (1: QueryException qe);
-    list<string> getTopKeyValueAnnotations(1: string service_name) throws (1: QueryException qe);
 }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -320,16 +320,6 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache, que
       }
     }
 
-  def handleTopAnnotations(client: ZipkinQuery[Future]): Service[Request, Renderer] =
-    Service.mk[Request, Renderer] { req =>
-      client.getTopAnnotations(req.params("serviceName")) map { ann => JsonRenderer(ann.toSeq.sorted) }
-    }
-
-  def handleTopKVAnnotations(client: ZipkinQuery[Future]): Service[Request, Renderer] =
-    Service.mk[Request, Renderer] { req =>
-      client.getTopKeyValueAnnotations(req.params("serviceName")) map { ann => JsonRenderer(ann.toSeq.sorted) }
-    }
-
   def handleDependencies(client: ZipkinQuery[Future]): Service[Request, Renderer] =
     new Service[Request, Renderer] {
       private[this] val PathMatch = """/api/dependencies(/([^/]+))?(/([^/]+))?/?""".r

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -82,8 +82,6 @@ trait ZipkinWebFactory { self: App =>
       ("/api/query", handleQuery(queryClient)),
       ("/api/services", handleServices(queryClient)),
       ("/api/spans", requireServiceName andThen handleSpans(queryClient)),
-      ("/api/top_annotations", requireServiceName andThen handleTopAnnotations(queryClient)),
-      ("/api/top_kv_annotations", requireServiceName andThen handleTopKVAnnotations(queryClient)),
       ("/api/dependencies", handleDependencies(queryClient)),
       ("/api/dependencies/?:startTime/?:endTime", handleDependencies(queryClient)),
       ("/api/get/:id", handleGetTrace(queryClient)),


### PR DESCRIPTION
Top annotations was introduced in 2012 and not mentioned since. The
corresponding hadoop jobs at Twitter have been broken since last year.

This removes the dead apis from the UI and the corresponding code in
cassandra (which incidentally wasn't used).
