### PR TITLE
Deprecates getSpansByTraceId and bumps to 1.3.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Sat, 15 Aug 2015 15:15:18 +0000
-version=1.2.3-SNAPSHOT
+version=1.3.0-SNAPSHOT
 group=io.zipkin
 repo=https://github.com/openzipkin/zipkin
 description=A distributed tracing system

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -184,9 +184,6 @@ class AnormSpanStore(val db: DB, val openCon: Option[Connection] = None) extends
     }
   }
 
-  override def getSpansByTraceId(traceId: Long): Future[Seq[Span]] =
-    getSpansByTraceIds(Seq(traceId)).map(_.head)
-
   override def getTraceIdsByName(serviceName: String, spanName: Option[String],
     endTs: Long, limit: Int): Future[Seq[IndexedTraceId]] = db.inNewThreadWithRecoverableRetry {
 

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -208,9 +208,6 @@ class CassandraSpanStore(
     Future.Unit
   }
 
-  override def getSpansByTraceId(traceId: Long): Future[Seq[Span]] =
-    getSpansByTraceIds(Seq(traceId)).map(_.head)
-
   override def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = {
     QueryGetSpansByTraceIdsStat.add(traceIds.size)
     getSpansByTraceIds(traceIds, maxTraceCols)

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Aggregates.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/Aggregates.scala
@@ -28,19 +28,19 @@ abstract class Aggregates extends java.io.Closeable {
   def getDependencies(startDate: Option[Time], endDate: Option[Time]=None): Future[Dependencies]
   def storeDependencies(dependencies: Dependencies): Future[Unit]
 
-  @deprecated("This didn't have UI support", "1.2.3")
+  @deprecated("This didn't have UI support", "1.3.0")
   def getTopAnnotations(serviceName: String): Future[Seq[String]] = {
     Future.exception(new UnsupportedOperationException("This is no longer used"))
   }
-  @deprecated("This didn't have UI support", "1.2.3")
+  @deprecated("This didn't have UI support", "1.3.0")
   def getTopKeyValueAnnotations(serviceName: String): Future[Seq[String]] = {
     Future.exception(new UnsupportedOperationException("This is no longer used"))
   }
-  @deprecated("This didn't have UI support", "1.2.3")
+  @deprecated("This didn't have UI support", "1.3.0")
   def storeTopAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = {
     Future.exception(new UnsupportedOperationException("This is no longer used"))
   }
-  @deprecated("This didn't have UI support", "1.2.3")
+  @deprecated("This didn't have UI support", "1.3.0")
   def storeTopKeyValueAnnotations(serviceName: String, a: Seq[String]): Future[Unit] = {
     Future.exception(new UnsupportedOperationException("This is no longer used"))
   }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/package.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/package.scala
@@ -15,7 +15,7 @@
  */
 package com.twitter.zipkin.storage
 
-@deprecated("This is no longer used: it only supported query order, which is obsolete", "1.2.3")
+@deprecated("This is no longer used: it only supported query order, which is obsolete", "1.3.0")
 case class TraceIdDuration(traceId: Long, duration: Long, startTimestamp: Long)
 
 /* A trace ID and its associated timestamp */

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
@@ -21,11 +21,6 @@ public class SpanStoreInJava extends SpanStore {
     }
 
     @Override
-    public Future<Seq<Span>> getSpansByTraceId(long traceId) {
-        return null;
-    }
-
-    @Override
     public Future<Seq<IndexedTraceId>> getTraceIdsByName(String serviceName, Option<String> spanName, long endTs, int limit) {
         return null;
     }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -60,12 +60,6 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   val mergedSpan = Span(123, "methodcall", spanId, None,
     List(ann1, ann2), List(binaryAnnotation("BAH2", "BEH2")))
 
-  @Test def getSpansByTraceId() {
-    ready(store(Seq(span1)))
-
-    result(store.getSpansByTraceId(span1.traceId)) should be(Seq(span1))
-  }
-
   @Test def getSpansByTraceIds() {
     ready(store(Seq(span1, span2)))
 

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -26,14 +26,9 @@ class RedisSpanStore(client: Client, ttl: Option[Duration]) extends SpanStore {
     Seq(storage.storeSpan(span), index.index(span))
   })
 
-  override def getDataTimeToLive = Future.value(ttl.map(_.inSeconds).getOrElse(Int.MaxValue))
-
   override def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = {
     storage.getSpansByTraceIds(traceIds)
   }
-
-  override def getSpansByTraceId(traceId: Long): Future[Seq[Span]] =
-    getSpansByTraceIds(Seq(traceId)).map(_.head)
 
   override def getTraceIdsByName(
     serviceName: String,


### PR DESCRIPTION
fixed deprecation for other methods to say 1.3.0 not 1.2.3
