### PR TITLE
Format numbers with explicit Locale

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Util.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Util.scala
@@ -16,6 +16,8 @@
  */
 package com.twitter.zipkin.web
 
+import java.util.Locale
+
 import com.twitter.util.Duration
 import com.twitter.zipkin.Constants.CoreAnnotationNames
 import java.util.concurrent.TimeUnit
@@ -43,13 +45,13 @@ object Util {
       case s if s.size == 0 => ""
 
       // seconds
-      case Seq(_, _, _) => "%.3fs".format(d.inMilliseconds / 1000.0)
+      case Seq(_, _, _) => "%.3fs".formatLocal(Locale.ENGLISH, d.inMilliseconds / 1000.0)
 
       // milliseconds
-      case Seq(_, _) => "%.3fms".format(d.inMicroseconds / 1000.0)
+      case Seq(_, _) => "%.3fms".formatLocal(Locale.ENGLISH, d.inMicroseconds / 1000.0)
 
       // microseconds
-      case Seq(_) => "%dμ".format(d.inMicroseconds)
+      case Seq(_) => "%dμ".formatLocal(Locale.ENGLISH, d.inMicroseconds)
 
       // seconds or more
       case _ =>


### PR DESCRIPTION
Some languages (e.g. Norwegian) format numbers
differently, which leads to failing tests, like this:

9,5 did not equal 9.5

The tests pass or fail depending on the Locale
settings in the JVM.
Hardcoding the locale to English solves the problem.
