### PR TITLE
remove oraclejdk7 from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ services:
 
 matrix:
   include:
-    - jdk: "oraclejdk7"
-      env: GRADLE_OPTS="-Dorg.gradle.daemon=false -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -Xms2G -Xmx2G -Xss512k -XX:MaxPermSize=256m"
     - jdk: "oraclejdk8"
       env: GRADLE_OPTS="-Dorg.gradle.daemon=false -Xms2G -Xmx2G -Xss512k -XX:MetaspaceSize=256m"
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ allprojects {
     apply plugin: 'com.jfrog.bintray'
     apply plugin: "com.jfrog.artifactory-upload"
     apply from: "$rootDir/gradle/dependencies.gradle"  // common dependency versions
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
 }
 
 import org.gradle.util.VersionNumber

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-declare -r PUBLISH_USING_JDK="oraclejdk7"
-
 function increment_version() {
   # TODO this would be cleaner in release.versionPatterns
   local v=$1
@@ -59,18 +57,6 @@ function check_travis_branch_equals_travis_tag(){
   fi
 }
 
-function want_to_release_from_this_jdk(){
-  if [ "${TRAVIS_JDK_VERSION}" != "${PUBLISH_USING_JDK}" ]; then
-    echo "[Not Publishing] Current JDK(${TRAVIS_JDK_VERSION}) does not"
-    echo "[Not Publishing]   equal PUBLISH_USING_JDK(${PUBLISH_USING_JDK})"
-    return 1
-  else
-    echo "[Publishing] Current JDK is the same as PUBLISH_USING_JDK"
-    echo "[Publishing]   environment variable (${TRAVIS_JDK_VERSION})"
-    return 0
-  fi
-}
-
 function publish(){
   echo "[Publishing] Publishing..."
   PUBLISHING=true ./gradlew --info --stacktrace zipkinUpload
@@ -109,7 +95,8 @@ function run_tests(){
 # MAIN
 #----------------------
 action=run_tests
-if want_to_release_from_this_jdk && ! is_pull_request; then
+
+if ! is_pull_request; then
   if build_started_by_tag; then
     check_travis_branch_equals_travis_tag
     action=do_gradle_release
@@ -119,4 +106,3 @@ if want_to_release_from_this_jdk && ! is_pull_request; then
 fi
 
 $action
-


### PR DESCRIPTION
Because 1.4.0 was released using scala 2.11 we can remove jdk7 from the build now.
