### PR TITLE
Integrates Kafka receiver into the zipkin-collector-service process

### DIFF
--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -21,6 +21,7 @@ repositories {
 }
 
 dependencies {
+    compile project(':zipkin-receiver-kafka')
     compile project(':zipkin-receiver-scribe')
     compile project(':zipkin-cassandra')
     compile project(':zipkin-redis')

--- a/zipkin-collector-service/config/collector-dev.scala
+++ b/zipkin-collector-service/config/collector-dev.scala
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import com.twitter.zipkin.anormdb.{SpanStoreBuilder, AggregatesBuilder}
+import com.twitter.zipkin.receiver.kafka.KafkaSpanReceiverFactory
 import com.twitter.zipkin.storage.anormdb.DB
 import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
 import com.twitter.zipkin.storage.Store
@@ -21,5 +23,8 @@ import com.twitter.zipkin.storage.Store
 val db = DB()
 
 val storeBuilder = Store.Builder(SpanStoreBuilder(db, true), AggregatesBuilder(db))
+val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
+  KafkaSpanReceiverFactory.factory(_, sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"))
+)
 
-CollectorServiceBuilder(storeBuilder)
+CollectorServiceBuilder(storeBuilder, kafkaReceiver)

--- a/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/SpanReceiver.scala
+++ b/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/SpanReceiver.scala
@@ -15,13 +15,18 @@
  */
 package com.twitter.zipkin.collector
 
-import com.twitter.util.{Closable, CloseAwaitably}
+import com.twitter.util.{Closable, CloseAwaitably, Future}
+import com.twitter.zipkin.thriftscala.Span
 
 /**
  * SpanReceivers are nothing special. They need only allow us to Await on them
  * and close them.
  *
- * At creation a SpanReceiver will be provided a function of Seq[Span] => Future[Unit]
- * that it should use to process incoming spans.
+ * At creation a SpanReceiver will be provided a [[SpanReceiver.Processor]] that it
+ * should use to process incoming spans.
  */
+object SpanReceiver {
+  type Processor = (Seq[Span]) => Future[Unit]
+}
+
 trait SpanReceiver extends Closable with CloseAwaitably

--- a/zipkin-receiver-kafka/README.md
+++ b/zipkin-receiver-kafka/README.md
@@ -1,11 +1,21 @@
 ## Kafka Receiver
+TODO: write me and include the flow and OSS instrumentation that logs spans to kafka.
 
-To change Zipkin's transport mechanism to use kafka.
- * drop code below into `zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala`
- * this config requires cassandra
- * remove '-f' from zipkin-collector-service/build.gradle (i.e. args '-f', "${projectDir}...")
- * ```bin/collector cassandra```
+### Enabling the Kafka receiver with zipkin-collector-service
+`zipkin-collector-service` typically receives spans from scribe. To enable kafka, you need to
+assign the `KAFKA_ZOOKEEPER` variable when starting the process.
 
+For example, if you are starting from a zipkin's source tree, you might assign this way:
+```bash
+$ KAFKA_ZOOKEEPER=127.0.0.1:2181 bin/collector
+# or if zipkin isn't the right topic name
+$ KAFKA_ZOOKEEPER=127.0.0.1:2181 KAFKA_TOPIC=notzipkin bin/collector
+```
+
+### Creating a custom Kafka Receiver process
+
+You can also create a custom receiver and start that. Here's an example main class that directs
+spans from Kakfa into Cassandra:
 
 ```scala
 package com.twitter.zipkin.collector
@@ -20,17 +30,16 @@ import com.twitter.zipkin.storage.cassandra.CassandraSpanStore
 
 import com.twitter.zipkin.receiver.kafka.SpanDecoder
 
-// 'Main' object referenced by project's build.gradle
 object Main extends TwitterServer
-with ZipkinQueuedCollectorFactory
-with CassandraSpanStoreFactory
-with KafkaSpanReceiverFactory
+ with ZipkinQueuedCollectorFactory
+ with CassandraSpanStoreFactory
+ with KafkaSpanReceiverFactory
 {
-  // set the admin port to the same as the existing collector
+  // you may want the admin port to be the same as the default collector
   override val defaultHttpPort = 9900
 
-  def newReceiver(receive: Seq[ThriftSpan] => Future[Unit], stats: StatsReceiver): SpanReceiver = {
-    newKafkaSpanReceiver(receive, stats.scope("kafkaSpanReceiver"), Some(new SpanDecoder()), new SpanDecoder())
+  def newReceiver(process: Seq[ThriftSpan] => Future[Unit], stats: StatsReceiver): SpanReceiver = {
+    newKafkaSpanReceiver(receive, stats.scope("kafkaSpanReceiver"))
   }
 
   def newSpanStore(stats: StatsReceiver): CassandraSpanStore =

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
@@ -1,6 +1,7 @@
 package com.twitter.zipkin.receiver.kafka
 
 import java.util.Properties
+
 import com.twitter.app.App
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.util.{Closable, Future, Time}
@@ -9,6 +10,21 @@ import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
 import kafka.consumer.ConsumerConfig
 import kafka.serializer.Decoder
 
+object KafkaSpanReceiverFactory {
+
+  /**
+   * Returns a factory function which can be applied to [[SpanReceiver.Processor]].
+   *
+   * @param zookeeper the zookeeper connect string, ex. 127.0.0.1:2181
+   * @param topic  the topic zipkin spans will be consumed from
+   */
+  def factory(zookeeper: String, topic: String) = {
+    object KafkaFactory extends App with KafkaSpanReceiverFactory
+    KafkaFactory.kafkaZookeeperConnect.parse(zookeeper)
+    KafkaFactory.kafkaTopics.parse(topic + "=1")
+    (process: SpanReceiver.Processor) => KafkaFactory.newKafkaSpanReceiver(process)
+  }
+}
 trait KafkaSpanReceiverFactory { self: App =>
   val defaultKafkaServer = "127.0.0.1:2181"
   val defaultKafkaGroupId = "zipkinId"
@@ -16,10 +32,10 @@ trait KafkaSpanReceiverFactory { self: App =>
   val defaultKafkaSessionTimeout = "4000"
   val defaultKafkaSyncTime = "200"
   val defaultKafkaAutoOffset = "smallest"
-  val defaultKafkaTopics = Map("topic" -> 1)
+  val defaultKafkaTopics = Map("zipkin" -> 1)
 
   val kafkaTopics = flag[Map[String, Int]]("zipkin.kafka.topics", defaultKafkaTopics, "kafka topics to collect from")
-  val kafkaServer = flag("zipkin.kafka.server", defaultKafkaServer, "kafka server to connect")
+  val kafkaZookeeperConnect = flag("zipkin.kafka.server", defaultKafkaServer, "kafka zk connect string")
   val kafkaGroupId = flag("zipkin.kafka.groupid", defaultKafkaGroupId, "kafka group id")
   val kafkaZkConnectionTimeout = flag("zipkin.kafka.zk.connectionTimeout", defaultKafkaZkConnectionTimeout, "kafka zk connection timeout in ms")
   val kafkaSessionTimeout = flag("zipkin.kafka.zk.sessionTimeout", defaultKafkaSessionTimeout, "kafka zk session timeout in ms")
@@ -29,14 +45,14 @@ trait KafkaSpanReceiverFactory { self: App =>
   def newKafkaSpanReceiver[T](
     process: Seq[ThriftSpan] => Future[Unit],
     stats: StatsReceiver = DefaultStatsReceiver.scope("KafkaSpanReceiver"),
-    keyDecoder: Option[Decoder[T]],
-    valueDecoder: KafkaProcessor.KafkaDecoder
+    keyDecoder: Decoder[T] = KafkaProcessor.defaultKeyDecoder,
+    valueDecoder: KafkaProcessor.KafkaDecoder = new SpanCodec()
   ): SpanReceiver = new SpanReceiver {
 
 
     val receiverProps = new Properties() {
       put("group.id", kafkaGroupId())
-      put("zookeeper.connect", kafkaServer() )
+      put("zookeeper.connect", kafkaZookeeperConnect() )
       put("zookeeper.connection.timeout.ms", kafkaZkConnectionTimeout())
       put("zookeeper.session.timeout.ms", kafkaSessionTimeout())
       put("zookeeper.sync.time.ms", kafkaSyncTime())
@@ -48,7 +64,7 @@ trait KafkaSpanReceiverFactory { self: App =>
       put("num.consumer.fetchers", "2")
     }
 
-    val service = KafkaProcessor(kafkaTopics(), new ConsumerConfig(receiverProps), process, keyDecoder getOrElse KafkaProcessor.defaultKeyDecoder, valueDecoder)
+    val service = KafkaProcessor(kafkaTopics(), new ConsumerConfig(receiverProps), process, keyDecoder, valueDecoder)
 
     def close(deadline: Time): Future[Unit] = closeAwaitably {
       Closable.sequence(service).close(deadline)

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/SpanCodec.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/SpanCodec.scala
@@ -6,7 +6,7 @@ import com.twitter.zipkin.conversions.thrift.{thriftSpanToSpan, spanToThriftSpan
 import com.twitter.zipkin.common.Span
 import kafka.message.Message
 
-class SpanDecoder extends KafkaProcessor.KafkaDecoder {
+class SpanCodec extends KafkaProcessor.KafkaDecoder {
   val deserializer = new BinaryThriftStructSerializer[ThriftSpan] {
     def codec = ThriftSpan
   }

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -23,7 +23,7 @@ class KafkaProcessorSpecSimple extends JUnitSuite {
 
   val topic = Map("integration-test-topic" -> 1)
   val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)), Nil)
-  val decoder = new SpanDecoder()
+  val decoder = new SpanCodec()
   val defaultKafkaTopics = Map("zipkin_kafka" -> 1 )
 
   def validateSpan(spans: Seq[ThriftSpan]): Future[Unit] = {
@@ -42,7 +42,7 @@ class KafkaProcessorSpecSimple extends JUnitSuite {
   def createMessage(): Array[Byte] = {
     val annotation = Annotation(1, "value", Some(Endpoint(1, 2, "service")))
     val message = Span(1234, "methodName", 4567, None, List(annotation), Nil)
-    val codec = new SpanDecoder()
+    val codec = new SpanCodec()
     codec.encode(message)
   }
 
@@ -58,7 +58,7 @@ class KafkaProcessorSpecSimple extends JUnitSuite {
     val service = KafkaProcessor(defaultKafkaTopics, kafkaRule.consumerConfig(), { s =>
         recvdSpan.setValue(s)
         Future.value(true)
-      }, new SpanDecoder, new SpanDecoder)
+      }, new SpanCodec, new SpanCodec)
 
     validateSpan(Await.result(recvdSpan))
   }

--- a/zipkin-receiver-scribe/src/main/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiver.scala
+++ b/zipkin-receiver-scribe/src/main/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiver.scala
@@ -42,7 +42,7 @@ trait ScribeSpanReceiverFactory { self: App =>
     "a whitelist of categories to process")
 
   def newScribeSpanReceiver(
-    process: Seq[ThriftSpan] => Future[Unit],
+    process: SpanReceiver.Processor,
     stats: StatsReceiver = DefaultStatsReceiver.scope("ScribeSpanReceiver")
   ): SpanReceiver = new SpanReceiver {
 
@@ -56,7 +56,7 @@ trait ScribeSpanReceiverFactory { self: App =>
 
 class ScribeReceiver(
   categories: Set[String],
-  process: Seq[ThriftSpan] => Future[Unit],
+  process: SpanReceiver.Processor,
   stats: StatsReceiver = DefaultStatsReceiver.scope("ScribeReceiver")
 ) extends Scribe[Future] {
   private[this] val deserializer = new BinaryThriftStructSerializer[ThriftSpan] {


### PR DESCRIPTION
Integrates Kafka receiver into the zipkin-collector-service process

This starts integration with kafka by triggering it on presence of the
`KAFKA_ZOOKEEPER` environment variable. Refinements to defaults will 
occur in later change, with a goal to have the minimum viable setup and 
one that is easy to configure with docker.

For example, if you are starting from a zipkin's source tree, you might 
assign this way:

``` bash
$ KAFKA_ZOOKEEPER=127.0.0.1:2181 bin/collector
# or if zipkin isn't the right topic name
$ KAFKA_ZOOKEEPER=127.0.0.1:2181 KAFKA_TOPIC=notzipkin bin/collector
```

Note: Enabling Kafka doesn't disable the Scribe listener as it's part of
the Collector's thrift api alongside aggregate dependencies. Future work
might decouple that relationshop.

See #682
Closes #547
