### PR TITLE
exits early on no trace ids

### DIFF
--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ThriftQueryService.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ThriftQueryService.scala
@@ -154,6 +154,9 @@ class ThriftQueryService(
 
   override def getTracesByIds(traceIds: Seq[Long], adjustClockSkew: Boolean = true): Future[Seq[thriftscala.Trace]] =
     handle("getTracesByIds") {
+      if (traceIds.isEmpty) {
+        return Future.value(Seq.empty)
+      }
       FTrace.recordBinary("numIds", traceIds.length)
       spanStore.getSpansByTraceIds(traceIds) map { adjustedTraces(_, adjustClockSkew).map(_.toThrift) }
     }


### PR DESCRIPTION
This guard can be at the top-level
