### PR TITLE
Adds mysql span storage and consolidates configuration docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,5 +14,5 @@ master.
 # License
 By contributing your code, you agree to license your contribution under the 
 terms of the Apache Public License v2: 
-https://github.com/twitter/zipkin/blob/master/LICENSE
+https://github.com/openzipkin/zipkin/blob/master/LICENSE
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin) [![Build Status](https://travis-ci.org/openzipkin/zipkin.svg?branch=master)](https://travis-ci.org/openzipkin/zipkin) [![Download](https://api.bintray.com/packages/openzipkin/zipkin/zipkin/images/download.svg) ](https://bintray.com/openzipkin/zipkin/zipkin/_latestVersion)
 
-![Zipkin (doc/zipkin-logo-200x119.jpg)](https://github.com/twitter/zipkin/raw/master/doc/zipkin-logo-200x119.jpg)
+![Zipkin (doc/zipkin-logo-200x119.jpg)](https://github.com/openzipkin/zipkin/raw/master/doc/zipkin-logo-200x119.jpg)
 
 [Zipkin](http://twitter.github.com/zipkin) is a distributed tracing system. It is used by Twitter to help gather timing data for all their disparate services. The front end is a "waterfall" style graph of service calls showing call durations as horizontal bars:
 
-![Screenshot](https://github.com/twitter/zipkin/raw/master/doc/web-screenshot.png)
+![Screenshot](https://github.com/openzipkin/zipkin/raw/master/doc/web-screenshot.png)
 
 ## Running Zipkin
 
@@ -12,7 +12,7 @@ Zipkin is a collection of processes (a backend for the data, a
 "collector", and query engine, and a web UI) and all of them need to
 be running to make any progress:
 
-![Architecture](https://github.com/twitter/zipkin/raw/master/doc/architecture-0.png)
+![Architecture](https://github.com/openzipkin/zipkin/raw/master/doc/architecture-0.png)
 
 If you are familiar with Docker, the
 quickest way to get started quickly is to use the

--- a/doc/mac-quickstart.md
+++ b/doc/mac-quickstart.md
@@ -1,7 +1,7 @@
 This page explains how to set up Zipkin on a single Mac (typically for local
 testing) with Cassandra, the most common choice of database for use with Zipkin.
 To run Zipkin out of the box without using Cassandra, see
-[install.md](https://github.com/twitter/zipkin/blob/master/doc/install.md).
+[install.md](https://github.com/openzipkin/zipkin/blob/master/doc/install.md).
 
 Scala 2.10.5 or later is required.
 
@@ -27,7 +27,7 @@ Now we can install Zipkin itself:
 # WORKSPACE is wherever you want your Zipkin folder
 cd WORKSPACE
 # If you don't have git, `brew install git` or just download Zipkin directly
-git clone https://github.com/twitter/zipkin.git
+git clone https://github.com/openzipkin/zipkin.git
 cd zipkin
 # Install the Zipkin schema
 cassandra-cli -host localhost -port 9160 -f zipkin-cassandra/src/schema/cassandra-schema.txt
@@ -56,8 +56,8 @@ with the collector (e.g. by using Scribe) to record trace data. There are
 several libraries to make this easier to do in different environments. Twitter
 uses [Finagle](https://github.com/twitter/finagle/tree/master/finagle-zipkin);
 external libraries (currently for Python, REST, node, and Java) are listed in the
-[wiki](https://github.com/twitter/zipkin/wiki#external-projects-that-use-zipkin);
+[wiki](https://github.com/openzipkin/zipkin/wiki#external-projects-that-use-zipkin);
 and there is also a [Ruby gem](https://rubygems.org/gems/finagle-thrift) and
 [Ruby Thrift client](https://github.com/twitter/thrift_client). Additional
 information is available in
-[install.md](https://github.com/twitter/zipkin/blob/master/doc/install.md).
+[install.md](https://github.com/openzipkin/zipkin/blob/master/doc/install.md).

--- a/doc/sql-databases.md
+++ b/doc/sql-databases.md
@@ -31,24 +31,11 @@ configuration. For example, to run Zipkin on a MySQL database named
     val db = new DB(new DBConfig("mysql", new DBParams("production", "127.0.0.1")))
 
 The connection parameters you can specify are defined in
-[`DBConfig.scala`](https://github.com/twitter/zipkin/blob/master/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala)
+[`DBConfig.scala`](https://github.com/openzipkin/zipkin/blob/master/zipkin-anormdb/src/main/scala/com/openzipkin/zipkin/util/DBConfig.scala)
 in the Anorm module.
 
 Additionally, you need to make sure Zipkin loads the correct database driver.
-To do this, find the line in `project/Project.scala` that looks like this:
-
-    anormDriverDependencies("sqlite-persistent")
-
-Change "sqlite-persistent" to the name of the database you want to use (valid
-names are specified in the definition of `anormDriverDependencies` near the top
-of the file).
-
-Note that although Zipkin technically supports in-memory SQL databases, they
-can only be used effectively in the tests for now. This is because in-memory
-databases disappear once their connection is closed, and the collector and
-query daemons open different connections. However, we would like to combine
-all three daemons (including the web one) into a single thread that could share
-one connection.
+Typically you are looking at `zipkin-collector-service/build.gradle` and `zipkin-query-service/build.gradle`.
 
 ### Setting up the schema
 
@@ -63,16 +50,6 @@ slower startup.
 
 You can also manually install the schema by running the `install()` method of
 a `DB` instance.
-
-### Adding a new database type
-
-There are two places Zipkin needs to know about new SQL database types: in
-`DBConfig.scala` in the `zipkin-anormdb` module and in `project/Project.scala`.
-In the DBConfig class, the `private val dbmap` holds a map of database types
-and how to connect to them, and in the Project file the
-`val anormDriverDependencies` holds driver dependency information. Once the
-relevant information for your database type is added in both places, you can
-continue with the connection and schema setup processes described above.
 
 ## Usage
 

--- a/doc/src/sphinx/Architecture.rst
+++ b/doc/src/sphinx/Architecture.rst
@@ -115,4 +115,4 @@ Modules
 .. _finagle-zipkin: https://github.com/twitter/finagle/tree/master/finagle-zipkin
 .. _gem: https://rubygems.org/gems/finagle-thrift
 .. _Ruby thrift client: https://github.com/twitter/thrift_client
-.. _thrift idl: https://github.com/twitter/zipkin/blob/master/zipkin-thrift/src/main/thrift/zipkinQuery.thrift
+.. _thrift idl: https://github.com/openzipkin/zipkin/blob/master/zipkin-thrift/src/main/thrift/zipkinQuery.thrift

--- a/zipkin-anormdb/README.md
+++ b/zipkin-anormdb/README.md
@@ -1,0 +1,22 @@
+# zipkin-anormdb
+
+AnormDB is a SQL layer for zipkin span storage.
+See [sql-databases](https://github.com/openzipkin/zipkin/blob/master/doc/sql-databases.db) for details.
+
+## Service Configuration
+
+"dev" and "mysql" are anormdb storage backends to the following services
+* [zipkin-collector-service](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector-service/README.md)
+* [zipkin-query-service](https://github.com/openzipkin/zipkin/blob/master/zipkin-query-service/README.md)
+
+Currently, only MySQL is configurable through environment variables. It uses the database `zipkin`:
+
+    * `MYSQL_USER` and `MYSQL_PASS`: MySQL authentication, which defaults to empty string.
+    * `MYSQL_HOST`: Defaults to localhost
+    * `MYSQL_TCP_PORT`: Defaults to 3306
+
+Example usage:
+```bash
+$ mysql -uroot -e "create database if not exists zipkin"
+$ MYSQL_USER=root ./bin/collector mysql
+```

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -155,9 +155,6 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
    *
    * Recommended indexes for MySQL deployments:
    *
-   * alter table zipkin_service_spans add primary key(service_name(64),span_name(128));
-   * alter table zipkin_service_spans add index(last_span_ts);
-   *
    * alter table zipkin_spans add primary key(span_id);
    * alter table zipkin_spans add index(trace_id);
    * alter table zipkin_spans add index(span_name(64));

--- a/zipkin-cassandra/README.md
+++ b/zipkin-cassandra/README.md
@@ -1,0 +1,28 @@
+# zipkin-cassandra
+
+## Service Configuration
+
+"cassandra" is a storage backend to the following services
+* [zipkin-collector-service](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector-service/README.md)
+* [zipkin-query-service](https://github.com/openzipkin/zipkin/blob/master/zipkin-query-service/README.md)
+
+These services apply configuration through environment variables:
+
+   * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails
+   * `CASSANDRA_CONTACT_POINTS`: Comma separated list of hosts / ip addresses part of Cassandra cluster
+   * `COLLECTOR_SAMPLE_RATE`: Sample rate. Double value between 0.0 (nothing ends up in back-end store) and 1.0 (everything ends up in back-end store)
+   * `COLLECTOR_QUEUE_NUM_WORKERS`: Number of worker threads that pick spans from internal bounded queue and write to back-end store
+   * `COLLECTOR_QUEUE_MAX_SIZE`: Internal queue size. If queue runs full offered spans are dropped. 
+   * `COLLECTOR_PORT`: Collector port
+   * `COLLECTOR_ADMIN_PORT`: Collector admin port. Port for admin http service. Admin service provides operational metrics for zipkin-collector-service.
+   * `COLLECTOR_LOG_LEVEL`: Collector log level. Valid values: OFF, FATAL, CRITICAL, ERROR, WARNING, INFO, DEBUG, TRACE, ALL
+
+For default values see:
+* [zipkin-collector-service/config/collector-cassandra.scala](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector-service/config/collector-cassandra.scala).
+* [zipkin-query-service/config/query-cassandra.scala](https://github.com/openzipkin/zipkin/blob/master/zipkin-query-service/config/query-cassandra.scala).
+
+Example usage:
+
+```bash
+$ CASSANDRA_USERNAME=user CASSANDRA_PASSWORD=pass COLLECTOR_LOG_LEVEL=ERROR ./bin/collector cassandra
+```

--- a/zipkin-collector-service/README.md
+++ b/zipkin-collector-service/README.md
@@ -13,24 +13,23 @@ store, most typically SQL, Cassandra or Redis.
 
 #### Configuration
 
-The Cassandra configuration file supports configuring following parameters through environment variables:
+`zipkin-collector-service` applies configuration parameters through environment variables.
 
-   * `CASSANDRA_USER` and `CASSANDRA_PASS`: Cassandra authentication. Will throw an exception on startup if authentication fails
-   * `CASSANDRA_CONTACT_POINTS`: Comma separated list of hosts / ip addresses part of Cassandra cluster
-   * `COLLECTOR_SAMPLE_RATE`: Sample rate. Double value between 0.0 (nothing ends up in back-end store) and 1.0 (everything ends up in back-end store)
-   * `COLLECTOR_QUEUE_NUM_WORKERS`: Number of worker threads that pick spans from internal bounded queue and write to back-end store
-   * `COLLECTOR_QUEUE_MAX_SIZE`: Internal queue size. If queue runs full offered spans are dropped. 
-   * `COLLECTOR_PORT`: Collector port
-   * `COLLECTOR_ADMIN_PORT`: Collector admin port. Port for admin http service. Admin service provides operational metrics for zipkin-collector-service.
-   * `COLLECTOR_LOG_LEVEL`: Collector log level. Valid values: OFF, FATAL, CRITICAL, ERROR, WARNING, INFO, DEBUG, TRACE, ALL
+Below are links to environment variables definitions.
 
-For default values see [zipkin-collector-service/config/collector-cassandra.scala](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector-service/config/collector-cassandra.scala).
+* Span Receivers
+  * [kafka](https://github.com/openzipkin/zipkin/blob/master/zipkin-receiver-kafka/README.md)
+
+* Span Storage
+  * [dev and mysql](https://github.com/openzipkin/zipkin/blob/master/zipkin-anormdb/README.md)
+  * [cassandra](https://github.com/openzipkin/zipkin/blob/master/zipkin-cassandra/README.md)
+  * [redis](https://github.com/openzipkin/zipkin/blob/master/zipkin-redis/README.md)
 
 Example usage:
 
+```bash
+$ MYSQL_USER=root ./bin/collector mysql
 ```
-CASSANDRA_USER=user CASSANDRA_PASS=pass COLLECTOR_LOG_LEVEL=ERROR ./bin/collector cassandra
-```   
 
 ## Building and running a fat jar
 
@@ -50,4 +49,5 @@ bundled configurations below.
 
 * `/collector-dev.scala` - file-based SQL backend
 * `/collector-cassandra.scala` - localhost cassandra backend
+* `/collector-mysql.scala` - MySQL backend
 * `/collector-redis.scala` - localhost redis backend

--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     compile project(':zipkin-cassandra')
     compile project(':zipkin-redis')
     compile project(':zipkin-anormdb')
+    compile 'mysql:mysql-connector-java:5.1.36' // for collector-mysql
 }
 
 sourceSets.main.resources.srcDirs += ['config']

--- a/zipkin-collector-service/config/collector-mysql.scala
+++ b/zipkin-collector-service/config/collector-mysql.scala
@@ -1,0 +1,19 @@
+import com.twitter.zipkin.anormdb.{AggregatesBuilder, SpanStoreBuilder}
+import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
+import com.twitter.zipkin.receiver.kafka.KafkaSpanReceiverFactory
+import com.twitter.zipkin.storage.Store
+import com.twitter.zipkin.storage.anormdb.{DB, DBConfig, DBParams}
+
+val db = DB(DBConfig("mysql", new DBParams(
+  dbName = "zipkin",
+  sys.env.get("MYSQL_HOST").getOrElse("localhost"),
+  sys.env.get("MYSQL_TCP_PORT").map(_.toInt),
+  sys.env.get("MYSQL_USER").getOrElse(""),
+  sys.env.get("MYSQL_PASS").getOrElse(""))))
+
+val storeBuilder = Store.Builder(SpanStoreBuilder(db, true), AggregatesBuilder(db))
+val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
+  KafkaSpanReceiverFactory.factory(_, sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"))
+)
+
+CollectorServiceBuilder(storeBuilder, kafkaReceiver)

--- a/zipkin-collector-service/config/collector-redis.scala
+++ b/zipkin-collector-service/config/collector-redis.scala
@@ -21,13 +21,16 @@ import com.twitter.zipkin.receiver.kafka.KafkaSpanReceiverFactory
 import com.twitter.zipkin.storage.Store
 import com.twitter.zipkin.redis
 
-val client = Client(ClientBuilder().hosts("0.0.0.0:6379")
+val host = sys.env.get("REDIS_HOST").getOrElse("0.0.0.0")
+val port = sys.env.get("REDIS_PORT").map(_.toInt).getOrElse(6379)
+
+val client = Client(ClientBuilder().hosts(host + ":" + port)
                                    .hostConnectionLimit(4)
                                    .hostConnectionCoresize(4)
                                    .codec(Redis())
                                    .build())
 
-val storeBuilder = Store.Builder(redis.SpanStoreBuilder(client))
+val storeBuilder = Store.Builder(redis.SpanStoreBuilder(client, authPassword = sys.env.get("REDIS_PASSWORD")))
 val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
   KafkaSpanReceiverFactory.factory(_, sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"))
 )

--- a/zipkin-query-service/README.md
+++ b/zipkin-query-service/README.md
@@ -10,13 +10,21 @@ data, most typically SQL, Cassandra or Redis.
 ./gradlew :zipkin-query-service:run
 ```
 
-#### Start with Cassandra Authentication
+#### Configuration
 
-Will throw an exception on startup if authentication failed
-```
-# specify user/pass as environment variables
-CASSANDRA_USER=user CASSANDRA_PASS=pass ./bin/query cassandra
+`zipkin-query-service` applies configuration parameters through environment variables.
 
+Below are links to environment variables definitions.
+
+* Span Storage
+  * [dev and mysql](https://github.com/openzipkin/zipkin/blob/master/zipkin-anormdb/README.md)
+  * [cassandra](https://github.com/openzipkin/zipkin/blob/master/zipkin-cassandra/README.md)
+  * [redis](https://github.com/openzipkin/zipkin/blob/master/zipkin-redis/README.md)
+
+Example usage:
+
+```bash
+$ CASSANDRA_USER=user CASSANDRA_PASS=pass COLLECTOR_LOG_LEVEL=ERROR ./bin/query cassandra
 ```
 
 ## Building and running a fat jar
@@ -37,4 +45,5 @@ bundled configurations below.
 
 * `/query-dev.scala` - file-based SQL backend
 * `/query-cassandra.scala` - localhost cassandra backend
+* `/query-mysql.scala` - MySQL backend
 * `/query-redis.scala` - localhost redis backend

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile project(':zipkin-cassandra')
     compile project(':zipkin-redis')
     compile project(':zipkin-anormdb')
+    compile 'mysql:mysql-connector-java:5.1.36' // for query-mysql
 }
 
 sourceSets.main.resources.srcDirs += ['config']

--- a/zipkin-query-service/config/query-mysql.scala
+++ b/zipkin-query-service/config/query-mysql.scala
@@ -1,0 +1,15 @@
+import com.twitter.zipkin.anormdb.{AggregatesBuilder, SpanStoreBuilder}
+import com.twitter.zipkin.builder.QueryServiceBuilder
+import com.twitter.zipkin.storage.Store
+import com.twitter.zipkin.storage.anormdb.{DB, DBConfig, DBParams}
+
+val db = DB(DBConfig("mysql", new DBParams(
+  dbName = "zipkin",
+  sys.env.get("MYSQL_HOST").getOrElse("localhost"),
+  sys.env.get("MYSQL_TCP_PORT").map(_.toInt),
+  sys.env.get("MYSQL_USER").getOrElse(""),
+  sys.env.get("MYSQL_PASS").getOrElse(""))))
+
+val storeBuilder = Store.Builder(SpanStoreBuilder(db), AggregatesBuilder(db))
+
+QueryServiceBuilder(storeBuilder)

--- a/zipkin-query-service/config/query-redis.scala
+++ b/zipkin-query-service/config/query-redis.scala
@@ -15,17 +15,20 @@
  */
 
 import com.twitter.finagle.builder.ClientBuilder
-import com.twitter.finagle.redis.{Redis, Client}
+import com.twitter.finagle.redis.{Client, Redis}
 import com.twitter.zipkin.builder.QueryServiceBuilder
 import com.twitter.zipkin.redis
 import com.twitter.zipkin.storage.Store
 
-val client = Client(ClientBuilder().hosts("0.0.0.0:6379")
+val host = sys.env.get("REDIS_HOST").getOrElse("0.0.0.0")
+val port = sys.env.get("REDIS_PORT").map(_.toInt).getOrElse(6379)
+
+val client = Client(ClientBuilder().hosts(host + ":" + port)
                                    .hostConnectionLimit(4)
                                    .hostConnectionCoresize(4)
                                    .codec(Redis())
                                    .build())
 
-val storeBuilder = Store.Builder(redis.SpanStoreBuilder(client))
+val storeBuilder = Store.Builder(redis.SpanStoreBuilder(client, authPassword = sys.env.get("REDIS_PASSWORD")))
 
 QueryServiceBuilder(storeBuilder)

--- a/zipkin-receiver-kafka/README.md
+++ b/zipkin-receiver-kafka/README.md
@@ -1,11 +1,17 @@
 ## Kafka Receiver
 TODO: write me and include the flow and OSS instrumentation that logs spans to kafka.
 
-### Enabling the Kafka receiver with zipkin-collector-service
-`zipkin-collector-service` typically receives spans from scribe. To enable kafka, you need to
-assign the `KAFKA_ZOOKEEPER` variable when starting the process.
+## Service Configuration
 
-For example, if you are starting from a zipkin's source tree, you might assign this way:
+Kafka is an alternate receiver to the [zipkin-collector-service](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector-service/README.md)
+
+It is enabled when the `KAFKA_ZOOKEEPER` environment variable is set. Here are the available options:
+
+   * `KAFKA_ZOOKEEPER`: ZooKeeper host string, comma-separated host:port value. no default.
+   * `KAFKA_TOPIC`: Defaults to zipkin
+
+Example usage:
+
 ```bash
 $ KAFKA_ZOOKEEPER=127.0.0.1:2181 bin/collector
 # or if zipkin isn't the right topic name

--- a/zipkin-redis/README.md
+++ b/zipkin-redis/README.md
@@ -1,0 +1,21 @@
+# zipkin-redis
+
+## Service Configuration
+
+"redis" is a storage backend to the following services
+* [zipkin-collector-service](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector-service/README.md)
+* [zipkin-query-service](https://github.com/openzipkin/zipkin/blob/master/zipkin-query-service/README.md)
+
+Redis is configurable through environment variables. It uses the database `zipkin`:
+
+   * `REDIS_PASSWORD`: Optional
+   * `REDIS_HOST`: Defaults to 0.0.0.0
+   * `REDIS_PORT`: Defaults to 6379
+
+Example usage:
+```bash
+# in one terminal, install and start redis
+$ redis-server
+# in another terminal, start the collector and query services
+$ REDIS_PASSWORD=secret ./bin/collector redis
+```


### PR DESCRIPTION
There have been a number of questions about how to configure zipkin's
storage backends. This consolidates the way that they are presented,
ensuring all storage options have configuration notes.

See #687 #682 #466
Closes #686 #655 #207
