### PR TITLE
Unbinds slf4j except edges, and uses slf4j-simple there

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,19 +230,7 @@ subprojects { subproject ->
         testCompile 'junit:junit:4.12'
         testCompile 'org.mockito:mockito-all:1.10.19'
         testCompile "org.scalatest:scalatest_${scalaInterfaceVersion}:2.2.5"
-    }
-}
-
-// Ensures libthrift 0.5.0 isn't accidentally in the classpath
-subprojects { subproject ->
-    configurations.all {
-        resolutionStrategy {
-            eachDependency { DependencyResolveDetails details ->
-                if (details.requested.group == 'org.apache.thrift') {
-                    details.useVersion '0.9.0' // https://github.com/twitter/scrooge/issues/203
-                }
-            }
-        }
+        testRuntime "org.slf4j:slf4j-simple:" + commonVersions.slf4j
     }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,10 +11,31 @@ ext {
             twitterUtil: '6.27.0',
             twitterServer: '1.13.0',
             ostrich: '9.11.0',
-            griddle: '1.7'
+            griddle: '1.7',
+            slf4j: '1.7.2'
     ]
+}
 
-    commonDependencies = [
-            slf4jLog4j12: "org.slf4j:slf4j-log4j12:1.6.4"  // Don't forget to use for configuration 'runtime' only
-    ]
+subprojects { subproject ->
+    configurations.all {
+        resolutionStrategy {
+            eachDependency { DependencyResolveDetails details ->
+                // Ensures libthrift 0.5.0 isn't accidentally in the classpath
+                if (details.requested.group == 'org.apache.thrift') {
+                  details.useVersion '0.9.0' // https://github.com/twitter/scrooge/issues/203
+                }
+                // Don't use mixed versions of SLF4J
+                if (details.requested.group == 'org.slf4j') {
+                  details.useVersion commonVersions.slf4j
+                }
+            }
+        }
+
+        // Some dependencies early bound slf4j impl
+        exclude module: "log4j-over-slf4j"
+        exclude module: "slf4j-logback"
+        // logback shouldn't be bound, yet, and also http://jira.qos.ch/browse/LOGBACK-1071
+        exclude module: "logback-classic"
+        exclude module: "logback-core"
+     }
 }

--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compile project(':zipkin-redis')
     compile project(':zipkin-anormdb')
     compile 'mysql:mysql-connector-java:5.1.36' // for collector-mysql
+    compile "org.slf4j:slf4j-simple:" + commonVersions.slf4j
 }
 
 sourceSets.main.resources.srcDirs += ['config']

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     compile project(':zipkin-redis')
     compile project(':zipkin-anormdb')
     compile 'mysql:mysql-connector-java:5.1.36' // for query-mysql
+    compile "org.slf4j:slf4j-simple:" + commonVersions.slf4j
 }
 
 sourceSets.main.resources.srcDirs += ['config']

--- a/zipkin-receiver-scribe/build.gradle
+++ b/zipkin-receiver-scribe/build.gradle
@@ -3,6 +3,4 @@ dependencies {
 
     compile "com.twitter:finagle-thriftmux_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:util-zk_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"
-
-    runtime commonDependencies.slf4jLog4j12
 }

--- a/zipkin-redis/build.gradle
+++ b/zipkin-redis/build.gradle
@@ -4,8 +4,6 @@ dependencies {
     compile "com.twitter:finagle-redis_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:util-logging_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"
 
-    runtime commonDependencies.slf4jLog4j12
-
     // for SpanStoreSpec
     testCompile project(':zipkin-common').sourceSets.test.output
 }

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile "com.twitter:twitter-server_${scalaInterfaceVersion}:${commonVersions.twitterServer}"
     compile 'com.github.spullara.mustache.java:compiler:0.8.17'
     compile 'com.twitter.common:stats-util:0.0.58'
+    compile "org.slf4j:slf4j-simple:" + commonVersions.slf4j
 
     compile "com.twitter:finagle-exception_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:finagle-thriftmux_${scalaInterfaceVersion}:${commonVersions.finagle}"


### PR DESCRIPTION
Some of our dependencies pulled in multiple versions and implementations
of slf4j. This causes confusion including console warnings. This removes
all bindings and instead enforces `slf4j-simple` at the edges, namely
`testRuntime` and our service packages.

slf4j-simple doesn't use the `java.beans` package, so safe to run in our
docker containers. To avoid `java.beans` errors we also explicitly 
exclude logback.

See http://jira.qos.ch/browse/LOGBACK-1071#comment-16687
