### PR TITLE
anormDB: move the DB schema out of the code in the case of MySQL

### DIFF
--- a/zipkin-anormdb/src/main/resources/mysql-indexes.sql
+++ b/zipkin-anormdb/src/main/resources/mysql-indexes.sql
@@ -1,0 +1,18 @@
+ALTER TABLE zipkin_spans ADD PRIMARY KEY(span_id);
+ALTER TABLE zipkin_spans ADD INDEX(trace_id);
+ALTER TABLE zipkin_spans ADD INDEX(span_name(64));
+ALTER TABLE zipkin_spans ADD INDEX(created_ts);
+
+ALTER TABLE zipkin_annotations ADD FOREIGN KEY(span_id) REFERENCES zipkin_spans(span_id) ON DELETE CASCADE;
+ALTER TABLE zipkin_annotations ADD INDEX(trace_id);
+ALTER TABLE zipkin_annotations ADD INDEX(span_name(64));
+ALTER TABLE zipkin_annotations ADD INDEX(value(64));
+ALTER TABLE zipkin_annotations ADD INDEX(a_timestamp);
+
+ALTER TABLE zipkin_binary_annotations ADD FOREIGN KEY(span_id) REFERENCES zipkin_spans(span_id) ON DELETE CASCADE;
+ALTER TABLE zipkin_binary_annotations ADD INDEX(trace_id);
+ALTER TABLE zipkin_binary_annotations ADD INDEX(span_name(64));
+ALTER TABLE zipkin_binary_annotations ADD INDEX(annotation_key(64));
+ALTER TABLE zipkin_binary_annotations ADD INDEX(annotation_value(64));
+ALTER TABLE zipkin_binary_annotations ADD INDEX(annotation_key(64),annotation_value(64));
+ALTER TABLE zipkin_binary_annotations ADD INDEX(annotation_ts);

--- a/zipkin-anormdb/src/main/resources/mysql-schema.sql
+++ b/zipkin-anormdb/src/main/resources/mysql-schema.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS zipkin_spans (
+  span_id BIGINT NOT NULL,
+  parent_id BIGINT,
+  trace_id BIGINT NOT NULL,
+  span_name VARCHAR(255) NOT NULL,
+  debug SMALLINT NOT NULL,
+  duration BIGINT,
+  created_ts BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS zipkin_annotations (
+  span_id BIGINT NOT NULL,
+  trace_id BIGINT NOT NULL,
+  span_name VARCHAR(255) NOT NULL,
+  service_name VARCHAR(255) NOT NULL,
+  value TEXT,
+  ipv4 INT,
+  port INT,
+  a_timestamp BIGINT NOT NULL,
+  duration BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS zipkin_binary_annotations (
+  span_id BIGINT NOT NULL,
+  trace_id BIGINT NOT NULL,
+  span_name VARCHAR(255) NOT NULL,
+  service_name VARCHAR(255) NOT NULL,
+  annotation_key VARCHAR(255) NOT NULL,
+  annotation_value MEDIUMBLOB, /* 16MB */
+  annotation_type_value INT NOT NULL,
+  ipv4 INT,
+  port INT,
+  annotation_ts BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS zipkin_dependencies (
+  dlid BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  start_ts BIGINT NOT NULL,
+  end_ts BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS zipkin_dependency_links (
+  dlid BIGINT NOT NULL,
+  parent VARCHAR(255) NOT NULL,
+  child VARCHAR(255) NOT NULL,
+  m0 BIGINT NOT NULL,
+  m1 DOUBLE PRECISION NOT NULL,
+  m2 DOUBLE PRECISION NOT NULL,
+  m3 DOUBLE PRECISION NOT NULL,
+  m4 DOUBLE PRECISION NOT NULL
+);

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -149,33 +149,17 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
 
   /**
    * Set up the database tables.
+   * In the case of MySQL this method has no effect, please load the schema using
+   * the files at zipkin/zipkin-anormdb/src/main/resources
    *
    * Returns an open database connection, so remember to close it, for example
    * with `(new DB()).install().close()`
    *
-   * Recommended indexes for MySQL deployments:
-   *
-   * alter table zipkin_spans add primary key(span_id);
-   * alter table zipkin_spans add index(trace_id);
-   * alter table zipkin_spans add index(span_name(64));
-   * alter table zipkin_spans add index(created_ts);
-   *
-   * alter table zipkin_annotations add foreign key(span_id) references zipkin_spans(span_id) on delete cascade;
-   * alter table zipkin_annotations add index(trace_id);
-   * alter table zipkin_annotations add index(span_name(64));
-   * alter table zipkin_annotations add index(value(64));
-   * alter table zipkin_annotations add index(a_timestamp);
-   *
-   * alter table zipkin_binary_annotations add foreign key(span_id) references zipkin_spans(span_id) on delete cascade;
-   * alter table zipkin_binary_annotations add index(trace_id);
-   * alter table zipkin_binary_annotations add index(span_name(64));
-   * alter table zipkin_binary_annotations add index(annotation_key(64));
-   * alter table zipkin_binary_annotations add index(annotation_value(64));
-   * alter table zipkin_binary_annotations add index(annotation_key(64),annotation_value(64));
-   * alter table zipkin_binary_annotations add index(annotation_ts);
    */
   def install(): Connection = {
     implicit val con = this.getConnection()
+    if (dbconfig.description == "MySQL") return con
+
     SQL(
       """CREATE TABLE IF NOT EXISTS zipkin_spans (
         |  span_id BIGINT NOT NULL,
@@ -242,7 +226,6 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
   // Get the column the current database type uses for BLOBs.
   private def getBlobType = dbconfig.description match {
     case "PostgreSQL" => "BYTEA" /* As usual PostgreSQL has to be different */
-    case "MySQL" => "MEDIUMBLOB" /* MySQL has length limits, in this case 16MB */
     case _ => "BLOB"
   }
 
@@ -252,7 +235,6 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
     case "H2 in-memory" => "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY"
     case "H2 persistent" => "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY"
     case "PostgreSQL" => "BIGSERIAL PRIMARY KEY"
-    case "MySQL" => "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY"
   }
 
   /**


### PR DESCRIPTION
The user will have to load the schema manually, just like when using Cassandra.

This is following a discussion on the chat about how docker-zipkin has to fetch the cassandra schema at build time while a mysql based version wouldn't have such a step.
The benefit of manually loading the schema is that we wouldn't need the collector service to start before the query service so that it can setup the schema auto-magically.

Note that the code changes are untested, I am not a scala hacker.
In other words,

![enhanced-14836-1414320930-8](https://cloud.githubusercontent.com/assets/13656490/9795310/2555dcce-57f0-11e5-81b5-e90a67b38aec.jpg)

@adriancole have a look when you have a minute please.
