### PR TITLE
Decouples HikariCP so that MySQL work can complete

### DIFF
--- a/zipkin-anormdb/src/main/java/com/twitter/zipkin/storage/anormdb/DataSource.java
+++ b/zipkin-anormdb/src/main/java/com/twitter/zipkin/storage/anormdb/DataSource.java
@@ -1,0 +1,29 @@
+package com.twitter.zipkin.storage.anormdb;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Temporarily extracted until Hikari no longer uses the {@code java.beans} api.
+ *
+ * https://github.com/brettwooldridge/HikariCP/issues/415
+ */
+final class DataSource {
+  private final com.zaxxer.hikari.HikariDataSource delegate;
+
+  DataSource(String driver, String location, boolean jdbc3) {
+    delegate = new com.zaxxer.hikari.HikariDataSource();
+    delegate.setDriverClassName(driver);
+    delegate.setJdbcUrl(location);
+    delegate.setConnectionTestQuery(jdbc3 ? "SELECT 1" : null);
+    delegate.setMaximumPoolSize(32);
+  }
+
+  void close() throws SQLException {
+    delegate.close();
+  }
+
+  Connection getConnection() throws SQLException {
+    return delegate.getConnection();
+  }
+}

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -21,7 +21,6 @@ import anorm.SqlParser._
 import java.sql.{Blob, Connection, DriverManager, SQLException, SQLRecoverableException, PreparedStatement}
 import com.twitter.util.{Try, Return, Throw, Future}
 import AnormThreads.inNewThread
-import com.zaxxer.hikari.HikariDataSource
 
 /**
  * Provides SQL database access via Anorm from the Play framework.
@@ -38,11 +37,7 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
   if (dbconfig.install) this.install().close()
 
   // Initialize connection pool
-  private val connpool = new HikariDataSource()
-  connpool.setDriverClassName(dbconfig.driver)
-  connpool.setJdbcUrl(dbconfig.location)
-  connpool.setConnectionTestQuery(if (dbconfig.jdbc3) "SELECT 1" else null)
-  connpool.setMaximumPoolSize(32)
+  private val connpool = new DataSource(dbconfig.driver, dbconfig.location, dbconfig.jdbc3)
 
   /**
    * Gets a dedicated java.sql.Connection to the SQL database. Note that auto-commit is


### PR DESCRIPTION
Decouples HikariCP code so we can temporarily override it in Docker.

See https://github.com/brettwooldridge/HikariCP/issues/415
See #687
