### PR TITLE
Add snappy compression to redis

### DIFF
--- a/zipkin-redis/build.gradle
+++ b/zipkin-redis/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 
     compile "com.twitter:finagle-redis_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:util-logging_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"
+    compile 'org.iq80.snappy:snappy:0.4'
 
     runtime commonDependencies.slf4jLog4j12
 

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSnappyCodec.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSnappyCodec.scala
@@ -1,0 +1,26 @@
+package com.twitter.zipkin.storage.redis
+
+import com.twitter.scrooge.{ThriftStruct, ThriftStructSerializer}
+import org.iq80.snappy.Snappy
+import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+
+/**
+ * Snappy serializer and deserializer for thrift structs
+ */
+class RedisSnappyThriftCodec[T <: ThriftStruct](val serializer: ThriftStructSerializer[T]) {
+
+  def encode(t: T): ChannelBuffer = {
+    val arr = serializer.toBytes(t)
+    val compressArr = new Array[Byte](Snappy.maxCompressedLength(arr.length))
+    val compressLen = Snappy.compress(arr, 0, arr.length, compressArr, 0)
+    ChannelBuffers.copiedBuffer(compressArr, 0, compressLen)
+  }
+
+  def decode(cb: ChannelBuffer): T = {
+    val compressedArr = new Array[Byte](cb.capacity())
+    cb.readBytes(compressedArr)
+    val uncompressedArr = Snappy.uncompress(compressedArr, 0, compressedArr.length)
+    serializer.fromBytes(uncompressedArr)
+  }
+
+}

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSnappyThriftCodec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSnappyThriftCodec.scala
@@ -1,0 +1,29 @@
+package com.twitter.zipkin.storage.redis
+
+import scala.collection.immutable.List
+
+import com.twitter.scrooge.BinaryThriftStructSerializer
+import com.twitter.zipkin.thriftscala
+import com.twitter.zipkin.conversions.thrift._
+import com.twitter.zipkin.common.{Annotation, BinaryAnnotation, Span}
+
+
+/**
+ * Tests the RedisSnappyThriftCodec
+ */
+class RedisSnappyThriftCodecSpec extends RedisSpecification {
+
+  val thriftCodec = new RedisSnappyThriftCodec(new BinaryThriftStructSerializer[thriftscala.Span] {
+    override def codec = thriftscala.Span
+  })
+
+  val span = Span(1L, "name", 2L, Option(3L), List[Annotation](),
+                  Seq[BinaryAnnotation](), true).toThrift
+
+  test("compress and decompress should yield an equal object") {
+    val bytes = thriftCodec.encode(span)
+    val actualOutput = thriftCodec.decode(bytes)
+    assertResult (span) (actualOutput)
+
+  }
+}


### PR DESCRIPTION
- This will reduce the footprint for redis by more than 50% according to benchmarks.
- Thrift serializer has also been changed from Binary to Compact
