### PR TITLE
Resurrects ability to change collector and query ports

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Sat, 15 Aug 2015 15:15:18 +0000
-version=1.7.2-SNAPSHOT
+version=1.8.0-SNAPSHOT
 group=io.zipkin
 repo=https://github.com/openzipkin/zipkin
 description=A distributed tracing system

--- a/zipkin-collector-service/README.md
+++ b/zipkin-collector-service/README.md
@@ -15,7 +15,12 @@ store, most typically SQL, Cassandra or Redis.
 
 `zipkin-collector-service` applies configuration parameters through environment variables.
 
-Below are links to environment variables definitions.
+Below are environment variables definitions.
+
+    * `COLLECTOR_PORT`: Listen port for the thrift scribe and dependency apis; Defaults to 9410
+    * `COLLECTOR_ADMIN_PORT`: Listen port for the ostrich admin http server; Defaults to 9900
+    * `COLLECTOR_LOG_LEVEL`: Log level written to the console; Defaults to INFO
+    * `COLLECTOR_SAMPLE_RATE`: Updatable via POST /config/sampleRate; Defaults to always sample (1.0).
 
 * Span Receivers
   * [kafka](https://github.com/openzipkin/zipkin/blob/master/zipkin-receiver-kafka/README.md)

--- a/zipkin-collector-service/config/collector-cassandra.scala
+++ b/zipkin-collector-service/config/collector-cassandra.scala
@@ -23,18 +23,17 @@ import com.twitter.zipkin.collector.builder.{Adjustable, CollectorServiceBuilder
 import com.twitter.zipkin.receiver.kafka.KafkaSpanReceiverFactory
 import com.twitter.zipkin.storage.Store
 
+val serverPort = sys.env.get("COLLECTOR_PORT").getOrElse("9410").toInt
+val adminPort = sys.env.get("COLLECTOR_ADMIN_PORT").getOrElse("9900").toInt
+val logLevel = sys.env.get("COLLECTOR_LOG_LEVEL").getOrElse("INFO")
+val sampleRate = sys.env.get("COLLECTOR_SAMPLE_RATE").getOrElse("1.0").toDouble
+
 object Factory extends App with CassandraSpanStoreFactory
 
 Factory.cassandraDest.parse(sys.env.get("CASSANDRA_CONTACT_POINTS").getOrElse("localhost"))
 
 val username = sys.env.get("CASSANDRA_USERNAME")
 val password = sys.env.get("CASSANDRA_PASSWORD")
-val sampleRate = sys.env.get("COLLECTOR_SAMPLE_RATE").getOrElse("1.0").toDouble
-val queueNumWorkers = sys.env.get("COLLECTOR_QUEUE_NUM_WORKERS").getOrElse("10").toInt
-val queueMaxSize = sys.env.get("COLLECTOR_QUEUE_MAX_SIZE").getOrElse("500").toInt
-val serverPort = sys.env.get("COLLECTOR_PORT").getOrElse("9410").toInt
-val adminPort = sys.env.get("COLLECTOR_ADMIN_PORT").getOrElse("9900").toInt
-val logLevel = sys.env.get("COLLECTOR_LOG_LEVEL").getOrElse("DEBUG")
 
 
 if (username.isDefined && password.isDefined) {
@@ -59,5 +58,3 @@ CollectorServiceBuilder(
   kafkaReceiver,
   serverBuilder = ZipkinServerBuilder(serverPort, adminPort).loggers(List(loggerFactory))
 ).sampleRate(Adjustable.local(sampleRate))
- .queueNumWorkers(queueNumWorkers)
- .queueMaxSize(queueMaxSize)

--- a/zipkin-collector-service/config/collector-mysql.scala
+++ b/zipkin-collector-service/config/collector-mysql.scala
@@ -1,8 +1,15 @@
+import com.twitter.logging.{ConsoleHandler, Level, LoggerFactory}
 import com.twitter.zipkin.anormdb.{DependencyStoreBuilder, SpanStoreBuilder}
-import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
+import com.twitter.zipkin.builder.ZipkinServerBuilder
+import com.twitter.zipkin.collector.builder.{Adjustable, CollectorServiceBuilder}
 import com.twitter.zipkin.receiver.kafka.KafkaSpanReceiverFactory
 import com.twitter.zipkin.storage.Store
 import com.twitter.zipkin.storage.anormdb.{DB, DBConfig, DBParams}
+
+val serverPort = sys.env.get("COLLECTOR_PORT").getOrElse("9410").toInt
+val adminPort = sys.env.get("COLLECTOR_ADMIN_PORT").getOrElse("9900").toInt
+val logLevel = sys.env.get("COLLECTOR_LOG_LEVEL").getOrElse("INFO")
+val sampleRate = sys.env.get("COLLECTOR_SAMPLE_RATE").getOrElse("1.0").toDouble
 
 val db = DB(DBConfig("mysql", new DBParams(
   dbName = "zipkin",
@@ -18,4 +25,14 @@ val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
   KafkaSpanReceiverFactory.factory(_, sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"))
 )
 
-CollectorServiceBuilder(storeBuilder, kafkaReceiver)
+val loggerFactory = new LoggerFactory(
+  node = "",
+  level = Level.parse(logLevel),
+  handlers = List(ConsoleHandler())
+)
+
+CollectorServiceBuilder(
+  storeBuilder,
+  kafkaReceiver,
+  serverBuilder = ZipkinServerBuilder(serverPort, adminPort).loggers(List(loggerFactory))
+).sampleRate(Adjustable.local(sampleRate))

--- a/zipkin-query-service/README.md
+++ b/zipkin-query-service/README.md
@@ -14,7 +14,11 @@ data, most typically SQL, Cassandra or Redis.
 
 `zipkin-query-service` applies configuration parameters through environment variables.
 
-Below are links to environment variables definitions.
+Below are environment variables definitions.
+
+    * `QUERY_PORT`: Listen port for the query thrift api; Defaults to 9411
+    * `QUERY_ADMIN_PORT`: Listen port for the ostrich admin http server; Defaults to 9901
+    * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
 
 * Span Storage
   * [dev and mysql](https://github.com/openzipkin/zipkin/blob/master/zipkin-anormdb/README.md)

--- a/zipkin-query-service/config/query-redis.scala
+++ b/zipkin-query-service/config/query-redis.scala
@@ -16,9 +16,14 @@
 
 import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.finagle.redis.{Client, Redis}
-import com.twitter.zipkin.builder.QueryServiceBuilder
+import com.twitter.logging.{ConsoleHandler, Level, LoggerFactory}
+import com.twitter.zipkin.builder.{ZipkinServerBuilder, QueryServiceBuilder}
 import com.twitter.zipkin.redis
 import com.twitter.zipkin.storage.Store
+
+val serverPort = sys.env.get("QUERY_PORT").getOrElse("9411").toInt
+val adminPort = sys.env.get("QUERY_ADMIN_PORT").getOrElse("9901").toInt
+val logLevel = sys.env.get("QUERY_LOG_LEVEL").getOrElse("INFO")
 
 val host = sys.env.get("REDIS_HOST").getOrElse("0.0.0.0")
 val port = sys.env.get("REDIS_PORT").map(_.toInt).getOrElse(6379)
@@ -31,4 +36,13 @@ val client = Client(ClientBuilder().hosts(host + ":" + port)
 
 val storeBuilder = Store.Builder(redis.SpanStoreBuilder(client, authPassword = sys.env.get("REDIS_PASSWORD")))
 
-QueryServiceBuilder(storeBuilder)
+val loggerFactory = new LoggerFactory(
+  node = "",
+  level = Level.parse(logLevel),
+  handlers = List(ConsoleHandler())
+)
+
+QueryServiceBuilder(
+  storeBuilder,
+  serverBuilder = ZipkinServerBuilder(serverPort, adminPort).loggers(List(loggerFactory))
+)


### PR DESCRIPTION
The collector and query ports used to be possible to change. This makes
that possible for all non-dev configurations. It also documents them.

Here are the new properties:

```
* `COLLECTOR_PORT`: Listen port for scribe and dependency apis
* `COLLECTOR_ADMIN_PORT`: Listen port for the ostrich admin http
* `COLLECTOR_LOG_LEVEL`: Log level written to the console
* `COLLECTOR_SAMPLE_RATE`: Updatable via POST /config/sampleRate

* `QUERY_PORT`: Listen port for the query thrift api
* `QUERY_ADMIN_PORT`: Listen port for the ostrich admin http
* `QUERY_LOG_LEVEL`: Log level written to the console
```

Note this removes some extraneous configuration and sets default log
level to INFO, not DEBUG.

Fixes #659
