### PR TITLE
Enables tracing of zipkin itself when SCRIBE_HOST or SCRIBE_PORT are set

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -49,6 +49,7 @@ subprojects { subproject ->
 
         // Some dependencies early bound slf4j impl
         exclude module: "log4j-over-slf4j"
+        exclude module: "slf4j-log4j12"
         exclude module: "slf4j-logback"
         // logback shouldn't be bound, yet, and also http://jira.qos.ch/browse/LOGBACK-1071
         exclude module: "logback-classic"

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -224,7 +224,7 @@ class AnormSpanStore(val db: DB, val openCon: Option[Connection] = None) extends
 
   override def getTraceIdsByAnnotation(serviceName: String, annotation: String, value: Option[ByteBuffer],
     endTs: Long, limit: Int): Future[Seq[IndexedTraceId]] = db.inNewThreadWithRecoverableRetry {
-    if ((Constants.CoreAnnotations ++ Constants.CoreAddress).contains(annotation) || endTs <= 0 || limit <= 0) {
+    if ((Constants.CoreAnnotations).contains(annotation) || endTs <= 0 || limit <= 0) {
       Seq.empty
     }
     else {

--- a/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala
+++ b/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala
@@ -18,6 +18,7 @@ package com.twitter.zipkin.collector
 
 import com.google.common.base.Charsets.UTF_8
 import com.google.common.io.{Resources, Files}
+import com.twitter.finagle.tracing.{NullTracer, DefaultTracer}
 import com.twitter.logging.Logger
 import com.twitter.ostrich.admin.{ServiceTracker, RuntimeEnvironment}
 import com.twitter.util.Eval
@@ -29,6 +30,8 @@ object Main {
 
   def main(args: Array[String]) {
     log.info("Loading configuration")
+    DefaultTracer.self = NullTracer // Disable tracing within the collector
+
     val runtime = RuntimeEnvironment(BuildProperties, args)
 
     // Fallback to bundled config resources, if there's no file at the path specified as -f

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/Constants.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/Constants.scala
@@ -21,15 +21,17 @@ object Constants {
   val ClientRecv: String = "cr"
   val ServerSend: String = "ss"
   val ServerRecv: String = "sr"
-
   val ClientAddr: String = "ca"
   val ServerAddr: String = "sa"
+  val WireSend: String = "ws"
+  val WireRecv: String = "wr"
 
   val CoreClient: Set[String] = Set(ClientSend, ClientRecv)
   val CoreServer: Set[String] = Set(ServerRecv, ServerSend)
   val CoreAddress: Set[String] = Set(ClientAddr, ServerAddr)
+  val CoreWire: Set[String] = Set(WireSend, WireRecv)
 
-  val CoreAnnotations: Set[String] = CoreClient ++ CoreServer
+  val CoreAnnotations: Set[String] = CoreClient ++ CoreServer ++ CoreWire
 
   val CoreAnnotationNames: Map[String, String] = Map(
     ClientSend -> "Client Send",
@@ -37,7 +39,9 @@ object Constants {
     ServerSend -> "Server Send",
     ServerRecv -> "Server Receive",
     ClientAddr -> "Client Address",
-    ServerAddr -> "Server Address"
+    ServerAddr -> "Server Address",
+    WireSend -> "Wire Send",
+    WireRecv -> "Wire Receive"
   )
 
   /* 127.0.0.1 */

--- a/zipkin-query-service/README.md
+++ b/zipkin-query-service/README.md
@@ -19,6 +19,8 @@ Below are environment variables definitions.
     * `QUERY_PORT`: Listen port for the query thrift api; Defaults to 9411
     * `QUERY_ADMIN_PORT`: Listen port for the ostrich admin http server; Defaults to 9901
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
+    * `SCRIBE_HOST`: Listen host for scribe, where traces will be sent
+    * `SCRIBE_PORT`: Listen port for scribe, where traces will be sent
 
 * Span Storage
   * [dev and mysql](https://github.com/openzipkin/zipkin/blob/master/zipkin-anormdb/README.md)

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     compile project(':zipkin-anormdb')
     compile anormDriverDependencies["mysql"] // for query-mysql
     compile "org.slf4j:slf4j-simple:" + commonVersions.slf4j
+
+    compile "com.twitter:finagle-zipkin_${scalaInterfaceVersion}:${commonVersions.finagle}"
 }
 
 sourceSets.main.resources.srcDirs += ['config']

--- a/zipkin-query-service/src/main/scala/com/twitter/zipkin/builder/QueryServiceBuilder.scala
+++ b/zipkin-query-service/src/main/scala/com/twitter/zipkin/builder/QueryServiceBuilder.scala
@@ -16,6 +16,8 @@
 package com.twitter.zipkin.builder
 
 import com.twitter.finagle.ListeningServer
+import com.twitter.finagle.tracing.{NullTracer, DefaultTracer}
+import com.twitter.finagle.zipkin.thrift.RawZipkinTracer
 import com.twitter.ostrich.admin.RuntimeEnvironment
 import com.twitter.zipkin.query.ZipkinQueryServerFactory
 import com.twitter.zipkin.storage.Store
@@ -28,6 +30,15 @@ case class QueryServiceBuilder(
   def apply(): (RuntimeEnvironment) => ListeningServer = (runtime: RuntimeEnvironment) => {
     serverBuilder.apply().apply(runtime)
     val store = storeBuilder.apply()
+
+    // If a scribe host is configured, send all traces to it, otherwise disable tracing
+    val scribeHost = sys.env.get("SCRIBE_HOST")
+    val scribePort = sys.env.get("SCRIBE_PORT")
+    DefaultTracer.self = if (scribeHost.isDefined || scribePort.isDefined) {
+      RawZipkinTracer(scribeHost.getOrElse("localhost"), scribePort.getOrElse("1463").toInt)
+    } else {
+      NullTracer
+    }
 
     object UseOnceFactory extends com.twitter.app.App with ZipkinQueryServerFactory
     UseOnceFactory.nonExitingMain(Array(

--- a/zipkin-query-service/src/main/scala/com/twitter/zipkin/query/Main.scala
+++ b/zipkin-query-service/src/main/scala/com/twitter/zipkin/query/Main.scala
@@ -17,13 +17,15 @@
 package com.twitter.zipkin.query
 
 import com.google.common.base.Charsets.UTF_8
-import com.google.common.io.{Resources, Files}
+import com.google.common.io.{Files, Resources}
+import com.twitter.finagle.tracing.NullTracer
+import com.twitter.finagle.zipkin.thrift.RawZipkinTracer
 import com.twitter.finagle.ListeningServer
 import com.twitter.logging.Logger
-import com.twitter.ostrich.admin.{Service, ServiceTracker, RuntimeEnvironment}
+import com.twitter.ostrich.admin.{RuntimeEnvironment, Service, ServiceTracker}
 import com.twitter.util.{Await, Eval}
-import com.twitter.zipkin.builder.Builder
 import com.twitter.zipkin.BuildProperties
+import com.twitter.zipkin.builder.Builder
 
 object Main {
   val log = Logger.get(getClass.getName)

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServerFactory.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServerFactory.scala
@@ -19,7 +19,7 @@ import java.net.InetSocketAddress
 
 import com.twitter.app.App
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
-import com.twitter.finagle.{ListeningServer, ThriftMux}
+import com.twitter.finagle.{param, ListeningServer, ThriftMux}
 import com.twitter.logging.Logger
 import com.twitter.zipkin.storage.{DependencyStore, NullDependencyStore, SpanStore}
 import com.twitter.zipkin.thriftscala.{DependencySource$FinagleService, ZipkinQuery$FinagleService}
@@ -36,7 +36,9 @@ trait ZipkinQueryServerFactory { self: App =>
     log: Logger = Logger.get("QueryService")
   ): ListeningServer = {
     val impl = new ThriftQueryService(spanStore, dependencyStore, queryServiceDurationBatchSize())
-    ThriftMux.serve(queryServicePort(), composeQueryService(impl, stats))
+    ThriftMux.server
+             .configured(param.Label("zipkin-query"))
+             .serve(queryServicePort(), composeQueryService(impl, stats))
   }
 
   /**

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
@@ -15,13 +15,18 @@ namespace java com.twitter.zipkin.thriftjava
 #@namespace scala com.twitter.zipkin.thriftscala
 namespace rb Zipkin
 
-#************** Collection related structs **************
-
-# these are the annotations we always expect to find in a span
+#************** Common annotation values **************
 const string CLIENT_SEND = "cs"
 const string CLIENT_RECV = "cr"
 const string SERVER_SEND = "ss"
 const string SERVER_RECV = "sr"
+const string WIRE_SEND = "ws"
+const string WIRE_RECV = "wr"
+
+#************** Common binary annotation keys **************
+const string CLIENT_ADDR = "ca"
+const string SERVER_ADDR = "sa"
+
 
 # this represents a host and port in a network
 struct Endpoint {

--- a/zipkin-web/README.md
+++ b/zipkin-web/README.md
@@ -1,0 +1,10 @@
+# zipkin-web-service
+
+#### Configuration
+
+`zipkin-web` applies configuration parameters through environment variables.
+
+Below are environment variables definitions.
+
+    * `SCRIBE_HOST`: Listen host for scribe, where traces will be sent
+    * `SCRIBE_PORT`: Listen port for scribe, where traces will be sent


### PR DESCRIPTION
If `SCRIBE_HOST` or `SCRIBE_PORT` are set, Finagle's `DefaultTracer`
sends all traces to the specified destination, often the
`zipkin-collector`. Otherwise, the `DefaultTracer` is disabled.

This applies to the `zipkin-web` and `zipkin-query` services, which are
now labeled correctly as services. `zipkin-collector` has tracing
explicitly disabled to discourage cyclic relationships.
