### PR TITLE
Drops support for annotation.duration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Sat, 15 Aug 2015 15:15:18 +0000
-version=1.8.2-SNAPSHOT
+version=1.9.0-SNAPSHOT
 group=io.zipkin
 repo=https://github.com/openzipkin/zipkin
 description=A distributed tracing system

--- a/zipkin-anormdb/src/main/resources/mysql.sql
+++ b/zipkin-anormdb/src/main/resources/mysql.sql
@@ -4,7 +4,6 @@ CREATE TABLE IF NOT EXISTS zipkin_spans (
   trace_id BIGINT NOT NULL,
   span_name VARCHAR(255) NOT NULL,
   debug SMALLINT NOT NULL,
-  duration BIGINT,
   created_ts BIGINT
 );
 
@@ -21,8 +20,7 @@ CREATE TABLE IF NOT EXISTS zipkin_annotations (
   value TEXT,
   ipv4 INT,
   port INT,
-  a_timestamp BIGINT NOT NULL,
-  duration BIGINT
+  a_timestamp BIGINT NOT NULL
 );
 
 ALTER TABLE zipkin_annotations ADD FOREIGN KEY(span_id) REFERENCES zipkin_spans(span_id) ON DELETE CASCADE;

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Annotation.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Annotation.scala
@@ -16,15 +16,12 @@
  */
 package com.twitter.zipkin.common
 
-import com.twitter.util.Duration
-
 /**
  * @param timestamp when was this annotation created? microseconds from epoch
  * @param value description of what happened at the timestamp could for example be "cache miss for key: x"
  * @param host host this annotation was created on
- * @param duration how long did the operation this annotation represent take?
  */
-case class Annotation(timestamp: Long, value: String, host: Option[Endpoint], duration: Option[Duration] = None)
+case class Annotation(timestamp: Long, value: String, host: Option[Endpoint])
   extends Ordered[Annotation]{
   def serviceName = host.map(_.serviceName).getOrElse("Unknown service name")
 
@@ -40,8 +37,6 @@ case class Annotation(timestamp: Long, value: String, host: Option[Endpoint], du
       this.value compare that.value
     else if (this.host != that.host)
       this.host.getOrElse {return -1} compare that.host.getOrElse {return 1}
-    else if (this.duration != that.duration)
-      this.duration.getOrElse {return -1} compare that.duration.getOrElse {return 1}
     else
       0
   }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/AnnotationTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/AnnotationTest.scala
@@ -16,7 +16,6 @@
  */
 package com.twitter.zipkin.common
 
-import com.twitter.conversions.time._
 import org.scalatest.FunSuite
 
 class AnnotationTest extends FunSuite {
@@ -29,16 +28,16 @@ class AnnotationTest extends FunSuite {
   }
 
   test("compare correctly") {
-    val ann1 = Annotation(1, "a", None, None)
+    val ann1 = Annotation(1, "a", None)
     val ann2 = Annotation(2, "a", None)
     val ann3 = Annotation(1, "b", None)
     val ann4 = Annotation(1, "a", Some(Endpoint(1, 2, "service")))
-    val ann5 = Annotation(1, "a", None, Some(1.second))
+    val ann5 = Annotation(1, "a", None)
 
     assert(ann1.compare(ann1) === 0)
     assert(ann1.compare(ann2) < 0)
     assert(ann1.compare(ann3) < 0)
     assert(ann1.compare(ann4) < 0)
-    assert(ann1.compare(ann5) < 0)
+    assert(ann1.compare(ann5) === 0)
   }
 }

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -16,7 +16,6 @@
 package com.twitter.zipkin.conversions
 
 import com.twitter.algebird.Moments
-import com.twitter.conversions.time._
 import com.twitter.util.Time
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.query._
@@ -57,7 +56,7 @@ object thrift {
   /* Annotation */
   class ThriftAnnotation(a: Annotation) {
     lazy val toThrift = {
-      thriftscala.Annotation(a.timestamp, a.value, a.host.map { _.toThrift }, a.duration.map(_.inMicroseconds.toInt))
+      thriftscala.Annotation(a.timestamp, a.value, a.host.map(_.toThrift))
     }
   }
   class WrappedAnnotation(a: thriftscala.Annotation) {
@@ -68,7 +67,7 @@ object thrift {
       if ("".equals(a.value))
         throw new IllegalArgumentException("Annotation must have a value: %s".format(a.toString))
 
-      new Annotation(a.timestamp, a.value, a.host.map { _.toEndpoint }, a.duration.map { _.microseconds })
+      new Annotation(a.timestamp, a.value, a.host.map(_.toEndpoint))
     }
   }
   implicit def annotationToThriftAnnotation(a: Annotation) = new ThriftAnnotation(a)
@@ -77,12 +76,12 @@ object thrift {
   /* BinaryAnnotation */
   class ThriftBinaryAnnotation(b: BinaryAnnotation) {
     lazy val toThrift = {
-      thriftscala.BinaryAnnotation(b.key, b.value, b.annotationType.toThrift, b.host.map { _.toThrift })
+      thriftscala.BinaryAnnotation(b.key, b.value, b.annotationType.toThrift, b.host.map(_.toThrift))
     }
   }
   class WrappedBinaryAnnotation(b: thriftscala.BinaryAnnotation) {
     lazy val toBinaryAnnotation = {
-      BinaryAnnotation(b.key, b.value, b.annotationType.toAnnotationType, b.host.map { _.toEndpoint })
+      BinaryAnnotation(b.key, b.value, b.annotationType.toAnnotationType, b.host.map(_.toEndpoint))
     }
   }
   implicit def binaryAnnotationToThriftBinaryAnnotation(b: BinaryAnnotation) = new ThriftBinaryAnnotation(b)

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
@@ -18,7 +18,6 @@ package com.twitter.zipkin.adapter
 
 import java.nio.ByteBuffer
 
-import com.twitter.conversions.time._
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.query._
@@ -30,7 +29,7 @@ class ThriftConversionsTest extends FunSuite {
     val expectedAnn: Annotation = Annotation(123, "value", Some(Endpoint(123, 123, "service")))
     assert(expectedAnn.toThrift.toAnnotation === expectedAnn)
 
-    val expectedAnn2: Annotation = Annotation(123, "value", Some(Endpoint(123, 123, "service")), Some(1.seconds))
+    val expectedAnn2: Annotation = Annotation(123, "value", Some(Endpoint(123, 123, "service")))
     assert(expectedAnn2.toThrift.toAnnotation === expectedAnn2)
   }
 

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
@@ -40,7 +40,6 @@ struct Annotation {
   1: i64 timestamp                 # microseconds from epoch
   2: string value                  # what happened at the timestamp?
   3: optional Endpoint host        # host this happened on
-  4: optional i32 duration         # how long did the operation take? microseconds
 }
 
 enum AnnotationType { BOOL, BYTES, I16, I32, I64, DOUBLE, STRING }

--- a/zipkin-web/src/main/resources/templates/v2/trace.mustache
+++ b/zipkin-web/src/main/resources/templates/v2/trace.mustache
@@ -68,13 +68,12 @@
         <div class='annotation{{#isCore}} core{{/isCore}}'
           style='left: {{left}}%; width: {{width}}px'
           title='{{value}}'
-          data-keys='endpoint,value,timestamp,relativeTime,serviceName,duration'
+          data-keys='endpoint,value,timestamp,relativeTime,serviceName'
           data-endpoint='{{endpoint}}'
           data-value='{{value}}'
           data-timestamp='{{timestamp}}'
           data-relative-time='{{relativeTime}}'
           data-service-name='{{serviceName}}'
-          data-duration='{{duration}}'
         ></div>
         {{/annotations}}
       </div>
@@ -105,7 +104,6 @@
           <thead><tr>
             <th>Date Time</th>
             <th>Relative Time</th>
-            <th>Duration</th>
             <th>Service</th>
             <th>Annotation</th>
             <th>Host</th>
@@ -114,7 +112,6 @@
             <tr>
               <td data-key='timestamp' class="local-datetime"></td>
               <td data-key='relativeTime'></td>
-              <td data-key='duration'></td>
               <td data-key='serviceName'></td>
               <td data-key='value'></td>
               <td data-key='endpoint'></td>
@@ -181,13 +178,12 @@
         <div class='annotation{{#isCore}} core{{/isCore}}'
           style='left: {{left}}%; width: {{width}}px'
           title='{{value}}'
-          data-keys='endpoint,value,timestamp,relativeTime,serviceName,duration'
+          data-keys='endpoint,value,timestamp,relativeTime,serviceName'
           data-endpoint='{{endpoint}}'
           data-value='{{value}}'
           data-timestamp='{{timestamp}}'
           data-relative-time='{{relativeTime}}'
           data-service-name='{{serviceName}}'
-          data-duration='{{duration}}'
         ></div>
         {{/annotations}}
       </div>

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/common/json/JsonAnnotation.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/common/json/JsonAnnotation.scala
@@ -17,14 +17,11 @@ package com.twitter.zipkin.common.json
 
 import com.twitter.zipkin.common.Annotation
 
-case class JsonAnnotation (timestamp: String,
-                           value: String,
-                           host: Option[JsonEndpoint],
-                           duration: Option[String]) // Duration in microseconds
+case class JsonAnnotation (timestamp: String, value: String, host: Option[JsonEndpoint])
   extends WrappedJson
 
 object JsonAnnotation {
   def wrap(a: Annotation) = {
-    JsonAnnotation(a.timestamp.toString, a.value, a.host.map(JsonEndpoint.wrap(_)), a.duration map { _.inMicroseconds.toString })
+    JsonAnnotation(a.timestamp.toString, a.value, a.host.map(JsonEndpoint.wrap(_)))
   }
 }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -361,8 +361,7 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache, que
             "timestamp" -> a.timestamp,
             "relativeTime" -> durationStr((a.timestamp - traceStartTimestamp) * 1000),
             "serviceName" -> a.host.map(_.serviceName),
-            "duration" -> a.duration,
-            "width" -> a.duration.getOrElse(8)
+            "width" -> 8
           )
         },
         "binaryAnnotations" -> binaryAnnotations


### PR DESCRIPTION
This drops annotation.duration, an optional field rarely used in zipkin.
It causes more problems than it solves.

Implementations handled `annotation.duration` in many ways. Some advised
against using it (circonus), others exposed hooks not used (brave), some
stored the result of timestamp subtraction (spring-cloud-sleuth), or put
constants like 1 (htrace), yet others stored bugs (wrong timeunit in
anormdb). Many didn't support it at all, like ruby and python tracers.

Internally, zipkin has a lot of logic around annotation durations, but
it does timestamp math, in other words, it ignores this value.

On the front end, `Annotation.duration` has space dedicated to it in
the UI, which is often blank. It is not queryable and actually was used
to set an incorrect width.

I could go on, but bottom-line is that this doesn't add value to the
zipkin experience, rather it subtracts from it. Dropping this field is
safe as it was an optional thrift field to begin with, and it wasn't
useful as implemented.

https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/filter/JvmFilter.scala#L23
https://github.com/apache/incubator-htrace/blob/master/htrace-zipkin/src/main/java/org/apache/htrace/zipkin/HTraceToZipkinConverter.java#L190
https://github.com/circonus-labs/libmtev/blob/master/src/utils/mtev_zipkin.h#L215
https://github.com/wadey/go-zipkin/blob/master/trace.go#L144
https://github.com/spring-cloud/spring-cloud-sleuth/blob/master/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java#L205
https://github.com/openzipkin/brave/blob/master/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java#L42

The only use of `Annotation.duration` I could find that wasn't derived
from other span data was finagle's gc annotation. Finagle's GC is a neat
annotation, but better stored as a binary one, instead of a semi-
structured string like this:

```
value=Gc(10,0.PSScavenge,2015-09-17 12:57:12 +0000,525.milliseconds+970.microseconds)
duration=525970
```

Note that even when we remove this, the duration is still present in the
string, in millis.

For example, if it were a binary annotation, you could store the entire
GC object as a json, and use the key `jvm.gc` instead. This is easier
than parsing the toString of a scala object.
