### PR TITLE
Compresses MySQL tables and shrinks binaryannotations.value column

### DIFF
--- a/zipkin-anormdb/README.md
+++ b/zipkin-anormdb/README.md
@@ -15,10 +15,15 @@ Currently, only MySQL is configurable through environment variables. It uses the
     * `MYSQL_HOST`: Defaults to localhost
     * `MYSQL_TCP_PORT`: Defaults to 3306
 
-Example usage:
+Example MySQL usage:
 ```bash
-$ mysql -uroot -e "create database if not exists zipkin"
+# Barracuda supports compression (In AWS RDS, this must be assigned in a parameter group)
+$ mysql -uroot -e "SET GLOBAL innodb_file_format=Barracuda"
+# This command should work even in RDS, and return "Barracuda"
+$ mysql -uroot -e "show global variables like 'innodb_file_format'"
+
 # install the schema and indexes
+$ mysql -uroot -e "create database if not exists zipkin"
 $ mysql -uroot -Dzipkin < zipkin-anormdb/src/main/resources/mysql.sql
 # load test data for http://localhost:8080/dependency
 $ mysql -uroot -Dzipkin < zipkin-tracegen/src/testdata/dependencies.sql

--- a/zipkin-anormdb/src/main/resources/mysql.sql
+++ b/zipkin-anormdb/src/main/resources/mysql.sql
@@ -5,9 +5,9 @@ CREATE TABLE IF NOT EXISTS zipkin_spans (
   span_name VARCHAR(255) NOT NULL,
   debug SMALLINT NOT NULL,
   created_ts BIGINT
-);
+) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 
-ALTER TABLE zipkin_spans ADD PRIMARY KEY(span_id);
+ALTER TABLE zipkin_spans ADD INDEX(span_id);
 ALTER TABLE zipkin_spans ADD INDEX(trace_id);
 ALTER TABLE zipkin_spans ADD INDEX(span_name(64));
 ALTER TABLE zipkin_spans ADD INDEX(created_ts);
@@ -21,9 +21,8 @@ CREATE TABLE IF NOT EXISTS zipkin_annotations (
   ipv4 INT,
   port INT,
   a_timestamp BIGINT NOT NULL
-);
+) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 
-ALTER TABLE zipkin_annotations ADD FOREIGN KEY(span_id) REFERENCES zipkin_spans(span_id) ON DELETE CASCADE;
 ALTER TABLE zipkin_annotations ADD INDEX(trace_id);
 ALTER TABLE zipkin_annotations ADD INDEX(span_name(64));
 ALTER TABLE zipkin_annotations ADD INDEX(value(64));
@@ -35,14 +34,13 @@ CREATE TABLE IF NOT EXISTS zipkin_binary_annotations (
   span_name VARCHAR(255) NOT NULL,
   service_name VARCHAR(255) NOT NULL,
   annotation_key VARCHAR(255) NOT NULL,
-  annotation_value MEDIUMBLOB, /* 16MB */
+  annotation_value BLOB, /* 64KB */
   annotation_type_value INT NOT NULL,
   ipv4 INT,
   port INT,
   annotation_ts BIGINT
-);
+) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 
-ALTER TABLE zipkin_binary_annotations ADD FOREIGN KEY(span_id) REFERENCES zipkin_spans(span_id) ON DELETE CASCADE;
 ALTER TABLE zipkin_binary_annotations ADD INDEX(trace_id);
 ALTER TABLE zipkin_binary_annotations ADD INDEX(span_name(64));
 ALTER TABLE zipkin_binary_annotations ADD INDEX(annotation_key(64));
@@ -54,7 +52,7 @@ CREATE TABLE IF NOT EXISTS zipkin_dependencies (
   dlid BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   start_ts BIGINT NOT NULL,
   end_ts BIGINT NOT NULL
-);
+) ENGINE=InnoDB; /* Not compressed as all numbers */
 
 CREATE TABLE IF NOT EXISTS zipkin_dependency_links (
   dlid BIGINT NOT NULL,
@@ -65,5 +63,4 @@ CREATE TABLE IF NOT EXISTS zipkin_dependency_links (
   m2 DOUBLE PRECISION NOT NULL,
   m3 DOUBLE PRECISION NOT NULL,
   m4 DOUBLE PRECISION NOT NULL
-);
-
+) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;


### PR DESCRIPTION
This adjusts the DDL commands for MySQL to use compression. It also
makes the binary annotation value column smaller, as 16MB was way too
large. Finally, this drops key references as they weren't helping anything.

Tested on local MySQL and also MySQL 5.6 on Amazon RDS
