### PR TITLE
Removes strange edge case when serviceName='client'

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -196,13 +196,11 @@ class CassandraSpanStore(
         spanCodec.encode(span.toThrift),
         spanTtl.inSeconds)
 
-      if (shouldIndex(span)) {
-        SpansIndexedCounter.incr()
-        indexServiceName(span)
-        indexSpanNameByService(span)
-        indexTraceIdByName(span)
-        indexByAnnotations(span)
-      }
+      SpansIndexedCounter.incr()
+      indexServiceName(span)
+      indexSpanNameByService(span)
+      indexTraceIdByName(span)
+      indexByAnnotations(span)
     }
 
     Future.Unit

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
@@ -203,14 +203,6 @@ trait Span { self =>
     clientSideAnnotations.map(_.host).flatten.headOption
 
   /**
-   * Assuming this is an RPC span, is it from the client side?
-   */
-  def isClientSide(): Boolean =
-    annotations.exists(a => {
-      a.value.equals(Constants.ClientSend) || a.value.equals(Constants.ClientRecv)
-    })
-
-  /**
    * Pick out the core client side annotations
    */
   def clientSideAnnotations: Seq[Annotation] =

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
@@ -80,11 +80,6 @@ class SpanTest extends FunSuite {
     assert(spanWith3Annotations.lastAnnotation.get === annotation3)
   }
 
-  test("know this is not a client side span") {
-    val spanSr = Span(1, "n", 2, None, List(Annotation(1, Constants.ServerRecv, None)), Nil)
-    assert(!spanSr.isClientSide)
-  }
-
   test("get duration") {
     assert(spanWith3Annotations.duration === Some(2))
   }


### PR DESCRIPTION
There was awkward code that special-cased the service name of "client". This was carried from cassie into its replacement, but not the other span stores. Better to remove this sort of cognitive hiccup than keep passing it along.
