### PR TITLE
Clarifies contract of DependencyStore and backfills tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Sat, 15 Aug 2015 15:15:18 +0000
-version=1.10.1-SNAPSHOT
+version=1.11.0-SNAPSHOT
 group=io.zipkin
 repo=https://github.com/openzipkin/zipkin
 description=A distributed tracing system

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStore.scala
@@ -1,12 +1,12 @@
 package com.twitter.zipkin.storage.cassandra
 
-import com.twitter.util.TimeConversions._
 import com.twitter.util._
 import com.twitter.zipkin.common.Dependencies
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.storage.DependencyStore
 import com.twitter.zipkin.thriftscala.{Dependencies => ThriftDependencies}
 import org.twitter.zipkin.storage.cassandra.Repository
+import java.util.concurrent.TimeUnit._
 
 import scala.collection.JavaConverters._
 
@@ -22,18 +22,30 @@ class CassandraDependencyStore(repository: Repository) extends DependencyStore {
 
   def close() = repository.close()
 
-  override def getDependencies(startDate: Option[Time],
-                               endDate: Option[Time]): Future[Dependencies] = pool {
-    val startTime = startDate.getOrElse(Time.now - 1.day)
-    val endTime = endDate.getOrElse(Time.now)
-    val dependencyLinks = repository.getDependencies(startTime.inMillis, endTime.inMillis).asScala
+  override def getDependencies(startTime: Option[Long], endTime: Option[Long] = None) = pool {
+    val endMicros = endTime.getOrElse(Time.now.inMicroseconds)
+
+    val endEpochDayMillis = floorEpochMicrosToDayMillis(endMicros)
+    val startEpochDayMillis = floorEpochMicrosToDayMillis(endMicros - MICROSECONDS.convert(1, DAYS))
+
+    val dependencies = repository.getDependencies(startEpochDayMillis, endEpochDayMillis).asScala
       .map(codec.decode(_))
-      .flatMap(thriftToDependencies(_).toDependencies.links)
-    Dependencies(startTime, endTime, dependencyLinks)
+      .map(thriftToDependencies(_).toDependencies)
+    if (dependencies.isEmpty) {
+      Dependencies.monoid.zero
+    } else {
+      val startMicros = dependencies.head.startTime
+      val endMicros = dependencies.last.endTime
+      Dependencies(startMicros, endMicros, dependencies.flatMap(_.links))
+    }
+  }
+
+  def floorEpochMicrosToDayMillis(micros: Long) = {
+    Time.fromMicroseconds(micros).floor(Duration.fromTimeUnit(1, DAYS)).inMilliseconds
   }
 
   override def storeDependencies(dependencies: Dependencies): Future[Unit] = pool {
     val thrift = codec.encode(dependenciesToThrift(dependencies).toThrift)
-    repository.storeDependencies(dependencies.startTime.inMillis, thrift)
+    repository.storeDependencies(floorEpochMicrosToDayMillis(dependencies.startTime), thrift)
   }
 }

--- a/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorInterface.scala
+++ b/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/ScribeCollectorInterface.scala
@@ -15,7 +15,7 @@ class ScribeCollectorInterface(
   categories: Set[String],
   process: Seq[thriftscala.Span] => Future[Unit],
   stats: StatsReceiver = DefaultStatsReceiver.scope("ScribeReceiver")
-) extends thriftscala.Scribe.FutureIface with thriftscala.DependencySink.FutureIface {
+) extends thriftscala.Scribe.FutureIface with thriftscala.DependencyStore.FutureIface {
 
   lazy val receiver = new ScribeReceiver(categories, process, stats)
 
@@ -32,5 +32,9 @@ class ScribeCollectorInterface(
         Stats.incr("collector.storeDependencies")
         Future.exception(thriftscala.DependenciesException(e.toString))
     }
+  }
+
+  override def getDependencies(startTime: Option[Long], endTime: Option[Long]) = {
+    store.dependencies.getDependencies(startTime, endTime).map(_.toThrift)
   }
 }

--- a/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/builder/CollectorServiceBuilder.scala
+++ b/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/builder/CollectorServiceBuilder.scala
@@ -102,7 +102,7 @@ case class CollectorServiceBuilder[T](
 
   /**
    * Finagle+Scrooge doesn't yet support multiple interfaces on the same socket. This combines
-   * Scribe and DependencySink until they do.
+   * Scribe and DependencyStore until they do.
    */
   private def composeCollectorService(impl: ScribeCollectorInterface, stats: StatsReceiver) = {
     val protocolFactory = new Factory()
@@ -110,9 +110,9 @@ case class CollectorServiceBuilder[T](
     new Scribe$FinagleService(
       impl, protocolFactory, stats, maxThriftBufferSize
     ) {
-      // Add functions from DependencySink until ThriftMux supports multiple interfaces on the
+      // Add functions from DependencyStore until ThriftMux supports multiple interfaces on the
       // same port.
-      functionMap ++= new DependencySink$FinagleService(
+      functionMap ++= new DependencyStore$FinagleService(
         impl, protocolFactory, stats, maxThriftBufferSize
       ) {
         val functions = functionMap // expose

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Dependencies.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Dependencies.scala
@@ -16,7 +16,6 @@
  */
 package com.twitter.zipkin.common
 
-import com.twitter.util.Time
 import com.twitter.algebird.{Monoid, Semigroup}
 
 /**
@@ -40,13 +39,13 @@ object DependencyLink {
 
 /**
  * This represents all dependencies across all services over a given time period.
- * @param startTime the startTime time for this period
- * @param endTime how long the period lasted
+ * @param startTime microseconds from epoch
+ * @param endTime microseconds from epoch
  * @param links link information for every dependent service
  */
 case class Dependencies(
-  startTime: Time,
-  endTime: Time,
+  startTime: Long,
+  endTime: Long,
   links: Seq[DependencyLink]
 )
 
@@ -66,6 +65,6 @@ object Dependencies {
       Dependencies(newStart, newEnd, newLinks)
     }
 
-    val zero = Dependencies(Time.Top, Time.Bottom, Seq.empty[DependencyLink])
+    val zero = Dependencies(0, 0, Seq.empty[DependencyLink])
   }
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/DependencyStore.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/DependencyStore.scala
@@ -16,8 +16,8 @@
 package com.twitter.zipkin.storage
 
 import com.twitter.algebird.Monoid
-import com.twitter.util.{Future, Time}
-import com.twitter.zipkin.common.Dependencies
+import com.twitter.util.Future
+import com.twitter.zipkin.common.{Dependencies, DependencyLink}
 
 /**
  * Storage and retrieval interface for aggregate dependencies that may be computed offline and
@@ -25,7 +25,12 @@ import com.twitter.zipkin.common.Dependencies
  */
 abstract class DependencyStore extends java.io.Closeable {
 
-  def getDependencies(startDate: Option[Time], endDate: Option[Time]=None): Future[Dependencies]
+  /**
+   * @param startTime  microseconds from epoch, defaults to one day before end_time
+   * @param endTime  microseconds from epoch, defaults to now
+   * @return dependency links in an interval contained by startTime and endTime
+   */
+  def getDependencies(startTime: Option[Long], endTime: Option[Long] = None): Future[Dependencies]
   def storeDependencies(dependencies: Dependencies): Future[Unit]
 }
 
@@ -33,6 +38,6 @@ class NullDependencyStore extends DependencyStore {
 
   def close() {}
 
-  def getDependencies(startDate: Option[Time], endDate: Option[Time] = None) = Future(Monoid.zero[Dependencies])
-  def storeDependencies(dependencies: Dependencies): Future[Unit]            = Future.Unit
+  def getDependencies(startDate: Option[Long], endDate: Option[Long] = None) = Future(Monoid.zero[Dependencies])
+  def storeDependencies(dependencies: Dependencies): Future[Unit] = Future.Unit
 }

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/DependencyStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/DependencyStoreInJava.java
@@ -4,7 +4,6 @@ import scala.Option;
 import scala.runtime.BoxedUnit;
 
 import com.twitter.util.Future;
-import com.twitter.util.Time;
 import com.twitter.zipkin.common.Dependencies;
 
 /**
@@ -17,12 +16,12 @@ public class DependencyStoreInJava extends DependencyStore {
     }
 
     @Override
-    public Future<Dependencies> getDependencies(Option<Time> startDate, Option<Time> endDate) {
+    public Future<Dependencies> getDependencies(Option<Object> startTime, Option<Object> endTime) {
         return null;
     }
 
     @Override
-    public Option<Time> getDependencies$default$2() {
+    public Option<Object> getDependencies$default$2() {
         return null;
     }
 

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/DependenciesTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/DependenciesTest.scala
@@ -17,9 +17,8 @@
 package com.twitter.zipkin.common
 
 import com.twitter.algebird.{Monoid, Semigroup}
-import com.twitter.conversions.time._
-import com.twitter.util.Time
 import org.scalatest.FunSuite
+import java.util.concurrent.TimeUnit.{HOURS, MICROSECONDS}
 
 class DependenciesTest extends FunSuite {
   test("DependencyLinks") {
@@ -48,8 +47,8 @@ class DependenciesTest extends FunSuite {
     val dl4 = DependencyLink("mobileweb", "Gizmoduck", callCount2)
     val dl5 = dl1.copy(callCount = callCount1 + callCount2)
 
-    val deps1 = Dependencies(Time.fromSeconds(0), Time.fromSeconds(0) + 1.hour, List(dl1, dl3))
-    val deps2 = Dependencies(Time.fromSeconds(0) + 1.hour, Time.fromSeconds(0) + 2.hours, List(dl2, dl4))
+    val deps1 = Dependencies(0L, MICROSECONDS.convert(1, HOURS), List(dl1, dl3))
+    val deps2 = Dependencies(MICROSECONDS.convert(1, HOURS), MICROSECONDS.convert(2, HOURS), List(dl2, dl4))
 
     // express identity when added to zero
     val result = Monoid.plus(deps1, Monoid.zero[Dependencies])
@@ -58,8 +57,8 @@ class DependenciesTest extends FunSuite {
     // combine
     val result2 = Monoid.plus(deps1, deps2)
 
-    assert(result2.startTime === Time.fromSeconds(0))
-    assert(result2.endTime === Time.fromSeconds(0) + 2.hours)
+    assert(result2.startTime === 0L)
+    assert(result2.endTime === MICROSECONDS.convert(2, HOURS))
 
     assert(result2.links == Seq(dl5, dl3, dl4))
   }

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServerFactory.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServerFactory.scala
@@ -22,7 +22,7 @@ import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.finagle.{param, ListeningServer, ThriftMux}
 import com.twitter.logging.Logger
 import com.twitter.zipkin.storage.{DependencyStore, NullDependencyStore, SpanStore}
-import com.twitter.zipkin.thriftscala.{DependencySource$FinagleService, ZipkinQuery$FinagleService}
+import com.twitter.zipkin.thriftscala.{DependencyStore$FinagleService, ZipkinQuery$FinagleService}
 import org.apache.thrift.protocol.TBinaryProtocol.Factory
 
 trait ZipkinQueryServerFactory { self: App =>
@@ -43,7 +43,7 @@ trait ZipkinQueryServerFactory { self: App =>
 
   /**
    * Finagle+Scrooge doesn't yet support multiple interfaces on the same socket. This combines
-   * ZipkinQuery and DependencySource$FinagleService until they do.
+   * ZipkinQuery and DependencyStore$FinagleService until they do.
    */
   private def composeQueryService(impl: ThriftQueryService, stats: StatsReceiver) = {
     val protocolFactory = new Factory()
@@ -51,9 +51,9 @@ trait ZipkinQueryServerFactory { self: App =>
     new ZipkinQuery$FinagleService(
       impl, protocolFactory, stats, maxThriftBufferSize
     ) {
-      // Add functions from DependencySource until ThriftMux supports multiple interfaces on the
+      // Add functions from DependencyStore until ThriftMux supports multiple interfaces on the
       // same port.
-      functionMap ++= new DependencySource$FinagleService(
+      functionMap ++= new DependencyStore$FinagleService(
         impl, protocolFactory, stats, maxThriftBufferSize
       ) {
         val functions = functionMap // expose

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -15,8 +15,6 @@
  */
 package com.twitter.zipkin.conversions
 
-import com.twitter.algebird.Moments
-import com.twitter.util.Time
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.query._
 import com.twitter.zipkin.thriftscala
@@ -140,14 +138,10 @@ object thrift {
   implicit def dependencyLinkToThrift(dl: DependencyLink) = new WrappedDependencyLink(dl)
   implicit def thriftToDependencyLink(dl: thriftscala.DependencyLink) = new ThriftDependencyLink(dl)
   class WrappedDependencies(d: Dependencies) {
-    lazy val toThrift = thriftscala.Dependencies(d.startTime.inMicroseconds, d.endTime.inMicroseconds, d.links.map {_.toThrift}.toSeq )
+    lazy val toThrift = thriftscala.Dependencies(d.startTime, d.endTime, d.links.map(_.toThrift))
   }
   class ThriftDependencies(d: thriftscala.Dependencies) {
-    lazy val toDependencies = Dependencies(
-      Time.fromMicroseconds(d.startTime),
-      Time.fromMicroseconds(d.endTime),
-      d.links.map {_.toDependencyLink}
-    )
+    lazy val toDependencies = Dependencies(d.startTime, d.endTime, d.links.map(_.toDependencyLink))
   }
   implicit def dependenciesToThrift(d: Dependencies) = new WrappedDependencies(d)
   implicit def thriftToDependencies(d: thriftscala.Dependencies) = new ThriftDependencies(d)

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinDependencies.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinDependencies.thrift
@@ -26,6 +26,7 @@ struct DependencyLink {
   # histogram?
 }
 
+/* An aggregate representation of services paired with every service they call. */
 struct Dependencies {
   /** microseconds from epoch */
   1: i64 start_time
@@ -38,18 +39,18 @@ exception DependenciesException {
   1: string msg
 }
 
-service DependencySink {
+service DependencyStore {
 
-    void storeDependencies(1: Dependencies dependencies) throws (1: DependenciesException e);
-}
+    void storeDependencies(
+      /** replaces the links defined for the given interval */
+      1: Dependencies dependencies
+    ) throws (1: DependenciesException e);
 
-service DependencySource {
-
-    /**
-     * Get an aggregate representation of all services paired with every service they call in to.
-     * This includes information on call counts and mean/stdDev/etc of call durations.  The two arguments
-     * specify epoch time in microseconds. The end time is optional and defaults to one day after the
-     * start time.
-     */
-    Dependencies getDependencies(1: optional i64 start_time, 2: optional i64 end_time) throws (1: DependenciesException qe);
+    /* Return dependency links in an interval contained by start_time and end_time */
+    Dependencies getDependencies(
+      /* microseconds from epoch, defaults to one day before end_time */
+      1: optional i64 start_time,
+      /* microseconds from epoch, defaults to now */
+      2: optional i64 end_time
+    ) throws (1: DependenciesException qe);
 }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -11,7 +11,7 @@ import com.twitter.zipkin.common.json._
 import com.twitter.zipkin.common.mustache.ZipkinMustache
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.query._
-import com.twitter.zipkin.thriftscala.{DependencySource, QueryRequest, ZipkinQuery}
+import com.twitter.zipkin.thriftscala.{DependencyStore, QueryRequest, ZipkinQuery}
 import com.twitter.zipkin.{Constants => ZConstants}
 import java.io.{File, FileInputStream, InputStream}
 
@@ -293,7 +293,7 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache, que
       }
     }
 
-  def handleDependencies(client: DependencySource[Future]): Service[Request, Renderer] =
+  def handleDependencies(client: DependencyStore[Future]): Service[Request, Renderer] =
     new Service[Request, Renderer] {
       private[this] val PathMatch = """/api/dependencies(/([^/]+))?(/([^/]+))?/?""".r
       def apply(req: Request): Future[Renderer] = {


### PR DESCRIPTION
This standardizing on micros for dependency start/end interval and
backfills tests in a way that doesn't flake on timezones. It also
clarifies docs and converges the DependencySource/Sink as prior to our
move to json.

In the near future, we are going to migrate from Thrift to Json api.
This backfills tests and revises the contract around dependencies so
that future work isn't confusing or difficult to implement portably.

Dependencies implementations were confusing, using a combination of
microseconds, dates, milliseconds, Time, Duration and Calendar
instances to do the job. There were also incorrect docs, confusing
which of startTime or endTime was the default anchor of the interval.

This was very difficult to understand and easy to break, as there were
no tests that cover, for example, what the result value should be. It
was also difficult to understand the difference between the Dependencies
api and limitations of the Cassandra implementation.
