### PR TITLE
Squashes Span/Annotation ordering logic

### DIFF
--- a/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
+++ b/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -242,7 +242,7 @@ public final class Repository implements AutoCloseable {
     public Map<Long,List<ByteBuffer>> getSpansByTraceIds(Long[] traceIds, int limit) {
         Preconditions.checkNotNull(traceIds);
         try {
-            Map<Long,List<ByteBuffer>> spans = new HashMap<>();
+            Map<Long,List<ByteBuffer>> spans = new LinkedHashMap<>();
             if (0 < traceIds.length) {
 
                 BoundStatement bound = selectTraces.bind()
@@ -435,7 +435,7 @@ public final class Repository implements AutoCloseable {
             if (LOG.isDebugEnabled()) {
                 LOG.debug(debugSelectTraceIdsByServiceName(serviceName, to, limit));
             }
-            Map<Long,Long> traceIdsToTimestamps = new HashMap<>();
+            Map<Long,Long> traceIdsToTimestamps = new LinkedHashMap<>();
             for (Row row : session.execute(bound).all()) {
                 traceIdsToTimestamps.put(row.getLong("trace_id"), row.getDate("ts").getTime());
             }
@@ -498,7 +498,7 @@ public final class Repository implements AutoCloseable {
             if (LOG.isDebugEnabled()) {
                 LOG.debug(debugSelectTraceIdsBySpanName(serviceSpanName, to, limit));
             }
-            Map<Long,Long> traceIdsToTimestamps = new HashMap<>();
+            Map<Long,Long> traceIdsToTimestamps = new LinkedHashMap<>();
             for (Row row : session.execute(bound).all()) {
                 traceIdsToTimestamps.put(row.getLong("trace_id"), row.getDate("ts").getTime());
             }
@@ -559,7 +559,7 @@ public final class Repository implements AutoCloseable {
             if (LOG.isDebugEnabled()) {
                 LOG.debug(debugSelectTraceIdsByAnnotations(annotationKey, from, limit));
             }
-            Map<Long,Long> traceIdsToTimestamps = new HashMap<>();
+            Map<Long,Long> traceIdsToTimestamps = new LinkedHashMap<>();
             for (Row row : session.execute(bound).all()) {
                 traceIdsToTimestamps.put(row.getLong("trace_id"), row.getDate("ts").getTime());
             }
@@ -622,7 +622,7 @@ public final class Repository implements AutoCloseable {
         private static final String SCHEMA = "/cassandra-schema-cql3.txt";
 
         static Map<String,String> ensureExists(String keyspace, Cluster cluster) {
-            Map<String,String> metadata = new HashMap<>();
+            Map<String,String> metadata = new LinkedHashMap<>();
             try (Session session = cluster.connect()) {
                 try (Reader reader = new InputStreamReader(Schema.class.getResourceAsStream(SCHEMA))) {
                     for (String cmd : String.format(CharStreams.toString(reader)).split(";")) {

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Annotation.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Annotation.scala
@@ -32,7 +32,7 @@ case class Annotation(timestamp: Long, value: String, host: Option[Endpoint])
 
   override def compare(that: Annotation): Int = {
     if (this.timestamp != that.timestamp)
-      (this.timestamp - that.timestamp).toInt
+      this.timestamp compare that.timestamp
     else if (this.value != that.value)
       this.value compare that.value
     else if (this.host != that.host)

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
@@ -65,14 +65,6 @@ object Span {
     } catch {
       case NonFatal(_) => None
     }
-
-  /**
-   * Order annotations by timestamp.
-   */
-  val timestampOrdering = new Ordering[Annotation] {
-    def compare(a: Annotation, b: Annotation) = a.timestamp.compare(b.timestamp)
-  }
-
 }
 
 /**
@@ -162,7 +154,7 @@ trait Span { self =>
       def name = selectedName
       def id = self.id
       def parentId = self.parentId
-      def annotations = self.annotations ++ mergeFrom.annotations
+      def annotations = (self.annotations ++ mergeFrom.annotations).sorted
       def binaryAnnotations = self.binaryAnnotations ++ mergeFrom.binaryAnnotations
       def debug = self.debug | mergeFrom.debug
     }
@@ -171,24 +163,12 @@ trait Span { self =>
   /**
    * Get the first annotation by timestamp.
    */
-  def firstAnnotation: Option[Annotation] = {
-    try {
-      Some(annotations.min(Span.timestampOrdering))
-    } catch {
-      case e: UnsupportedOperationException => None
-    }
-  }
+  def firstAnnotation: Option[Annotation] = annotations.headOption
 
   /**
    * Get the last annotation by timestamp.
    */
-  def lastAnnotation: Option[Annotation] = {
-    try {
-      Some(annotations.max(Span.timestampOrdering))
-    } catch {
-      case e: UnsupportedOperationException => None
-    }
-  }
+  def lastAnnotation: Option[Annotation] = annotations.lastOption
 
   /**
    * Endpoints involved in this span

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/query/SpanTreeEntry.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/query/SpanTreeEntry.scala
@@ -33,7 +33,7 @@ case class SpanTreeEntry(span: Span, children: List[SpanTreeEntry]) {
         List[Span](entry.span)
 
       case children =>
-        val sorted = children.sortBy(_.span.firstAnnotation.map(_.timestamp))
+        val sorted = children.sortBy(_.span.firstTimestamp)
         entry.span :: sorted.map(childrenToList).flatten
     }
   }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/query/Trace.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/query/Trace.scala
@@ -16,7 +16,6 @@
 package com.twitter.zipkin.query
 
 import com.twitter.finagle.tracing.{Trace => FTrace}
-import com.twitter.logging.Logger
 import com.twitter.zipkin.common.{BinaryAnnotation, Endpoint, Span}
 import java.nio.ByteBuffer
 import scala.collection.mutable
@@ -35,12 +34,7 @@ object Trace {
 
 case class Trace(private val s: Seq[Span]) {
 
-  lazy val spans = mergeBySpanId(s).toSeq.sortWith {
-    (a, b) =>
-      val aTimestamp = a.firstAnnotation.map(_.timestamp).getOrElse(Long.MaxValue)
-      val bTimestamp = b.firstAnnotation.map(_.timestamp).getOrElse(Long.MaxValue)
-      aTimestamp < bTimestamp
-  }
+  lazy val spans = mergeBySpanId(s).toSeq.sortBy(_.firstTimestamp)
 
   /**
    * Find the trace id for this trace.

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceTest.scala
@@ -148,7 +148,7 @@ class TraceTest extends FunSuite {
     assert(expectedTrace.spans === actualTrace.spans)
   }
 
-  test("merge spans") {
+  test("merged spans are sorted") {
     val ann1 = List(Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
       Annotation(300, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
     val ann2 = List(Annotation(150, Constants.ServerRecv, Some(Endpoint(456, 456, "service2"))),
@@ -156,9 +156,9 @@ class TraceTest extends FunSuite {
 
     val annMerged = List(
       Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
-      Annotation(300, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))),
       Annotation(150, Constants.ServerRecv, Some(Endpoint(456, 456, "service2"))),
-      Annotation(200, Constants.ServerSend, Some(Endpoint(456, 456, "service2")))
+      Annotation(200, Constants.ServerSend, Some(Endpoint(456, 456, "service2"))),
+      Annotation(300, Constants.ClientRecv, Some(Endpoint(123, 123, "service1")))
     )
 
     val spanToMerge1 = Span(12345, "methodcall2", span2Id, Some(span1Id), ann1, Nil)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -62,11 +62,20 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
   @Test def getSpansByTraceIds() {
     ready(store(Seq(span1, span2)))
-
     result(store.getSpansByTraceIds(Seq(span1.traceId))) should be(Seq(Seq(span1)))
     result(store.getSpansByTraceIds(Seq(span1.traceId, span2.traceId, 111111))) should be(
       Seq(Seq(span1), Seq(span2))
     )
+    // ids in wrong order
+    result(store.getSpansByTraceIds(Seq(span2.traceId, span1.traceId))) should be(
+      Seq(Seq(span1), Seq(span2))
+    )
+  }
+
+  @Test def annotationsRetrieveInOrder() {
+    ready(store(Seq(span1.copy(annotations = List(ann3, ann1)))))
+
+    result(store.getSpansByTraceIds(Seq(span1.traceId))) should be(Seq(Seq(span1)))
   }
 
   @Test def getSpansByTraceIds_empty() {

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ThriftQueryServiceTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ThriftQueryServiceTest.scala
@@ -87,7 +87,7 @@ class ThriftQueryServiceTest extends FunSuite {
   test("find traces by service name") {
     val svc = newLoadedService()
     val actual = Await.result(svc.getTraces(thriftscala.QueryRequest("service3", None, None, None, 1000, 50)))
-    assert(actual.map(_.spans.head.traceId) === Seq(3, 5))
+    assert(actual.map(_.spans.head.traceId) === Seq(5, 3)) // Note trace 5's timestamp is before trace 3's
   }
 
   test("find traces by annotation name") {

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -22,9 +22,10 @@ class RedisSpanStore(client: Client, ttl: Option[Duration]) extends SpanStore {
 
   override def close() = closer.close()
 
-  override def apply(newSpans: Seq[Span]): Future[Unit] = Future.join(newSpans.flatMap { span =>
-    Seq(storage.storeSpan(span), index.index(span))
-  })
+  override def apply(newSpans: Seq[Span]): Future[Unit] = Future.join(
+    newSpans.map(s => s.copy(annotations = s.annotations.sorted))
+      .flatMap { span => Seq(storage.storeSpan(span), index.index(span))
+    })
 
   override def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = {
     storage.getSpansByTraceIds(traceIds)

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
@@ -66,8 +66,8 @@ struct Span {
   1: i64 trace_id                  # unique trace id, use for all spans in trace
   3: string name,                  # span name, rpc method for example
   4: i64 id,                       # unique span id, only used for this span
-  5: optional i64 parent_id,                # parent span id
-  6: list<Annotation> annotations, # list of all annotations/events that occured
+  5: optional i64 parent_id,       # parent span id
+  6: list<Annotation> annotations, # all annotations/events that occured, sorted by timestamp
   8: list<BinaryAnnotation> binary_annotations # any binary annotations
   9: optional bool debug = 0       # if true, we DEMAND that this span passes all samplers
 }

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinQuery.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinQuery.thrift
@@ -19,6 +19,7 @@ include "zipkinCore.thrift"
 include "zipkinDependencies.thrift"
 
 struct Trace {
+  /** spans having the same trace id, sorted on the timestamp of their first annotation */
   1: list<zipkinCore.Span> spans
 }
 
@@ -43,11 +44,13 @@ struct QueryRequest {
 
 service ZipkinQuery {
 
+    /** Results are sorted in order of the first span's timestamp */
     list<Trace> getTracesByIds(
       1: list<i64> trace_ids,
       # 2: list<Adjust> OBSOLETE_adjust,
       3: bool adjust_clock_skew = true) throws (1: QueryException qe);
 
+    /** Results are sorted in order of the first span's timestamp */
     list<Trace> getTraces(1: QueryRequest request) throws (1: QueryException qe);
 
     /**

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/common/json/JsonSpan.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/common/json/JsonSpan.scala
@@ -27,7 +27,7 @@ case class JsonSpan(
   startTimestamp: Option[Long],
   duration: Option[Long],
   annotations: List[JsonAnnotation],
-  binaryAnnotations: Seq[JsonBinaryAnnotation])  extends WrappedJson
+  binaryAnnotations: Seq[JsonBinaryAnnotation]) extends WrappedJson
 
 object JsonSpan {
   def wrap(s: Span) = {
@@ -39,7 +39,7 @@ object JsonSpan {
       s.serviceNames,
       s.firstAnnotation.map {_.timestamp},
       s.duration,
-      s.annotations.sortWith((a,b) => a.timestamp < b.timestamp).map { JsonAnnotation.wrap(_) },
+      s.annotations.map { JsonAnnotation.wrap(_) },
       s.binaryAnnotations.map { JsonBinaryAnnotation.wrap(_) })
   }
 }


### PR DESCRIPTION
Spans and annotation orderering were handled differently, and sometimes
(like redis) in opposite order. This fully specifies and consolidates
ordering logic, as well backfilling a test for out-of-order spans in a
trace.
