### PR TITLE
fix alphabet soup in handleIndex

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -240,10 +240,10 @@ class Handlers(jsonGenerator: ZipkinJson, mustacheGenerator: ZipkinMustache, que
       val spanResults = serviceName map(client.getSpanNames(_)) getOrElse(Future.value(Seq.empty))
 
       for (services <- client.getServiceNames(); results <- qResults; spans <- spanResults) yield {
-        val svcList = services.map(_.sorted) map {
+        val svcList = services.toList.sorted map {
           svc => Map("name" -> svc, "selected" -> (if (Some(svc) == serviceName) "selected" else ""))
         }
-        val spanList = spans.map(_.sorted) map {
+        val spanList = spans.toList.sorted map {
           span => Map("name" -> span, "selected" -> (if (Some(span) == spanName) "selected" else ""))
         }
 


### PR DESCRIPTION
77a41b9 introduces a bug where the service and span names get garbled (the string itself is sorted)
