### PR TITLE
Cassandra tests flake less when cassandra isn't started on demand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 sudo: false
 
 services:
-  - cassandra
   - redis-server
 
 matrix:
@@ -40,6 +39,7 @@ env:
 before_install:
   - git config --global user.email "${GH_USER_EMAIL}"
   - git config --global user.name "${GH_USER}"
+  - curl -SL http://downloads.datastax.com/community/dsc-cassandra-2.2.1-bin.tar.gz | tar xz && dsc-cassandra-2.2.1/bin/cassandra
 
 # Skip `./gradlew assemble`
 install: /bin/true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false
 
 services:
+  - cassandra
   - redis-server
 
 matrix:

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStoreSpec.scala
@@ -1,22 +1,24 @@
 package com.twitter.zipkin.storage.cassandra
 
+import java.util.Collections
+
 import com.datastax.driver.core.Cluster
 import com.twitter.zipkin.storage.DependencyStoreSpec
-import java.util.Collections
 import org.cassandraunit.CQLDataLoader
 import org.cassandraunit.dataset.CQLDataSet
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra
 import org.junit.BeforeClass
 import org.twitter.zipkin.storage.cassandra.Repository
 
 object CassandraDependencyStoreSpec {
   val keyspace = "test_zipkin_dependencystore"
   // Defer shared connection to the cluster
-  lazy val cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(9142).build()
+  lazy val cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(9042).build()
 
+  /**
+   * Skips all tests when the default cluster isn't present.
+   * @see [[com.datastax.driver.core.exceptions.NoHostAvailableException]]
+   */
   @BeforeClass def cassandra = {
-    startEmbeddedCassandra("cu-cassandra.yaml", "build/embeddedCassandra", 10 * 1000)
-
     new CQLDataLoader(cluster.connect).load(new CQLDataSet() {
       override def isKeyspaceDeletion = true
 

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
@@ -5,18 +5,19 @@ import com.twitter.zipkin.storage.SpanStoreSpec
 import java.util.Collections
 import org.cassandraunit.CQLDataLoader
 import org.cassandraunit.dataset.CQLDataSet
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra
 import org.junit.BeforeClass
 import org.twitter.zipkin.storage.cassandra.Repository
 
 object CassandraSpanStoreSpec {
   val keyspace = "test_zipkin_spanstore"
   // Defer shared connection to the cluster
-  lazy val cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(9142).build()
+  lazy val cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(9042).build()
 
+  /**
+   * Skips all tests when the default cluster isn't present.
+   * @see [[com.datastax.driver.core.exceptions.NoHostAvailableException]]
+   */
   @BeforeClass def cassandra = {
-    startEmbeddedCassandra("cu-cassandra.yaml", "build/embeddedCassandra", 10 * 1000)
-
     new CQLDataLoader(cluster.connect).load(new CQLDataSet() {
       override def isKeyspaceDeletion = true
 


### PR DESCRIPTION
Note: this skips cassandra tests if you aren't running locally. They will always run on pull-request, though.
