### PR TITLE
Add content type for Mustache

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -32,6 +32,7 @@ class Handlers(mapper: ObjectMapper, mustacheGenerator: ZipkinMustache, queryExt
 
   case class MustacheRenderer(template: String, data: Map[String, Object]) extends Renderer {
     def apply(response: Response) {
+      response.contentType = "text/html"
       response.contentString = generate
     }
 


### PR DESCRIPTION
I've noticed the HTML pages for zipkin aren't compressed.

It turns out finagle has auto-gzip, but only applies it to content types it believes are text. Adding the missing content-type header to Mustache generated responses fixes this.

In practices, this has huge improvements in page delivery time when requesting many traces.
