### PR TITLE
Allow partial maches in span names

### DIFF
--- a/zipkin-web/src/main/resources/app/js/component_ui/spanName.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/spanName.js
@@ -21,7 +21,10 @@ define(
       };
 
       this.after('initialize', function() {
-        this.$node.chosen();
+        this.$node.chosen(
+        {
+          search_contains: true
+        });
         this.on(document, 'dataSpanNames', this.updateSpans);
       });
     }


### PR DESCRIPTION
Small usability improvement.

Our span names tend to be pretty long - fully qualified java class names + method.
This tweak allows for search to look for matches contained with the span name.
