### PR TITLE
Javac 7 friendly ordering

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -168,7 +168,7 @@ class AnormSpanStore(val db: DB, val openCon: Option[Connection] = None) extends
         }
       }
       // Redundant sort as List.groupBy loses order of values
-      results.groupBy(_.traceId).values.toSeq.sortBy(_.head.firstTimestamp)
+      results.groupBy(_.traceId).values.toList.sortBy(_.head) // sort traces by the first span
     } finally {
       returnConn(conn, borrowTime, "getSpansByTraceIds")
     }

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -177,6 +177,7 @@ class CassandraSpanStore(
         .mapValues { case spans :java.util.List[ByteBuffer] => spans.asScala.map(spanCodec.decode(_).toSpan) }
 
       traceIds.map(traceId => spans.get(traceId)).flatten
+        .sortBy(_.head) // CQL doesn't allow order by with an "in" query
     }
   }
 
@@ -209,7 +210,6 @@ class CassandraSpanStore(
   override def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = {
     QueryGetSpansByTraceIdsStat.add(traceIds.size)
     getSpansByTraceIds(traceIds, maxTraceCols)
-      .map(_.sortBy(t => t.head.firstTimestamp)) // CQL doesn't allow order by with an "in" query
   }
 
   override def getAllServiceNames: Future[Set[String]] = {

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Endpoint.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Endpoint.scala
@@ -18,6 +18,7 @@ package com.twitter.zipkin.common
 
 import java.nio.ByteBuffer
 import java.net.{InetAddress, InetSocketAddress}
+import com.google.common.collect.ComparisonChain
 
 /**
  * Represents the client or server machine we traced.
@@ -61,14 +62,9 @@ case class Endpoint(ipv4: Int, port: Short, serviceName: String)
     port & 0xFFFF
   }
 
-  override def compare(that: Endpoint) = {
-    if (serviceName != that.serviceName)
-      serviceName compare that.serviceName
-    else if (ipv4 != that.ipv4)
-      ipv4 compare that.ipv4
-    else if (port != that.port)
-      port compare that.port
-    else
-      0
-  }
+  override def compare(that: Endpoint) = ComparisonChain.start()
+    .compare(serviceName, that.serviceName)
+    .compare(ipv4, that.ipv4)
+    .compare(port, that.port)
+    .result()
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
@@ -78,7 +78,7 @@ object Span {
  * serialized objects. Sorted ascending by timestamp. Sorted ascending by timestamp
  * @param debug if this is set we will make sure this span is stored, no matter what the samplers want
  */
-trait Span { self =>
+trait Span extends Ordered[Span] { self =>
   def traceId: Long
   def name: String
   def id: Long
@@ -86,6 +86,10 @@ trait Span { self =>
   def annotations: List[Annotation]
   def binaryAnnotations: Seq[BinaryAnnotation]
   def debug: Boolean
+
+  // TODO: cache first timestamp when this is a normal case class as opposed to a trait
+  override def compare(that: Span) =
+    java.lang.Long.compare(firstTimestamp.getOrElse(0L), that.firstTimestamp.getOrElse(0L))
 
   def copy(
     traceId: Long = self.traceId,

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/query/SpanTreeEntry.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/query/SpanTreeEntry.scala
@@ -33,8 +33,7 @@ case class SpanTreeEntry(span: Span, children: List[SpanTreeEntry]) {
         List[Span](entry.span)
 
       case children =>
-        val sorted = children.sortBy(_.span.firstTimestamp)
-        entry.span :: sorted.map(childrenToList).flatten
+        entry.span :: children.sortBy(_.span).map(childrenToList).flatten
     }
   }
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/query/Trace.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/query/Trace.scala
@@ -34,7 +34,7 @@ object Trace {
 
 case class Trace(private val s: Seq[Span]) {
 
-  lazy val spans = mergeBySpanId(s).toSeq.sortBy(_.firstTimestamp)
+  lazy val spans = mergeBySpanId(s).toList.sorted
 
   /**
    * Find the trace id for this trace.

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -72,10 +72,13 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     )
   }
 
-  @Test def annotationsRetrieveInOrder() {
-    ready(store(Seq(span1.copy(annotations = List(ann3, ann1)))))
+  /** Spans can come out of order, and so can annotations within them */
+  @Test def spansRetrieveInOrder() {
+    ready(store(Seq(span2, span1.copy(annotations = List(ann3, ann1)))))
 
-    result(store.getSpansByTraceIds(Seq(span1.traceId))) should be(Seq(Seq(span1)))
+    result(store.getSpansByTraceIds(Seq(span2.traceId, span1.traceId))) should be(
+      Seq(Seq(span1), Seq(span2))
+    )
   }
 
   @Test def getSpansByTraceIds_empty() {


### PR DESCRIPTION
Latest polishing on ordering, does the following:
- Uses ordering friendly with javac 7 (implicit ordering broke someone)
- Removes explicit instructions for ordering spans
- Consolidates "List of Spans" ordering to first span vs timestamp
  - First span in a sorted list is already first timestamp
  - This avoids redundant searching through annotations
