### PR TITLE
Fixes span name selector

### DIFF
--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
@@ -19,6 +19,10 @@ class ZipkinQueryController @Inject()(spanStore: SpanStore,
 
   private[this] val EmptyTraces = Future.value(Seq.empty[Seq[JsonSpan]])
 
+  get("/api/v1/spans") { request: GetSpanNamesRequest =>
+    spanStore.getSpanNames(request.serviceName)
+  }
+
   get("/api/v1/services") { request: Request =>
     spanStore.getAllServiceNames()
   }
@@ -51,6 +55,8 @@ class ZipkinQueryController @Inject()(spanStore: SpanStore,
 
   private[this] val timeSkewAdjuster = new TimeSkewAdjuster()
 }
+
+case class GetSpanNamesRequest(@QueryParam serviceName: String)
 
 case class GetDependenciesRequest(@RouteParam from: Long, @RouteParam to: Long)
 

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
@@ -80,6 +80,27 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
         """.stripMargin)
   }
 
+  "get span names" in {
+    app.injector.instance[SpanStore].apply(allSpans)
+
+    server.httpGet(
+      path = "/api/v1/spans?serviceName=service1",
+      andExpect = Ok,
+      withJsonBody =
+        """
+          |[
+          |  "methodcall"
+          |]
+        """.stripMargin)
+  }
+
+  "get span names when not found" in {
+    server.httpGet(
+      path = "/api/v1/spans?serviceName=service1",
+      andExpect = Ok,
+      withJsonBody = "[]")
+  }
+
   "get trace by hex id" in {
     app.injector.instance[SpanStore].apply(spans1)
 

--- a/zipkin-web/src/main/resources/app/js/component_data/spanNames.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/spanNames.js
@@ -11,7 +11,7 @@ define(
 
     function spanNames() {
       this.updateSpanNames = function(ev, serviceName) {
-        $.ajax("/api/spans?serviceName="+serviceName, {
+        $.ajax("/api/spans?serviceName=" + serviceName, {
           type: "GET",
           dataType: "json",
           context: this,

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -98,7 +98,7 @@ trait ZipkinWebFactory { self: App =>
       ("/", addLayout("Index", environment()) andThen handleIndex(queryClient)),
       ("/traces/:id", addLayout("Traces", environment()) andThen handleTraces(queryClient)),
       ("/dependency", addLayout("Dependency", environment()) andThen handleDependency()),
-      ("/api/spans", handleRoute(queryClient, "/api/v1/traces")),
+      ("/api/spans", handleRoute(queryClient, "/api/v1/spans")),
       ("/api/dependencies/?:startTime/?:endTime", handleRoute(queryClient, "/api/v1/dependencies"))
     ).foldLeft(new HttpMuxer) { case (m , (p, handler)) =>
       val path = p.split("/").toList


### PR DESCRIPTION
The span name selector UI was calling getTraces instead of getSpanNames.
This happened during the switch to the json api. This change fixes that
and clarifies the confusing naming that was used in the web handlers.

Fixes #748
