### PR TITLE
Initial implementation of cached service names

### DIFF
--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/Constants.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/Constants.scala
@@ -22,4 +22,7 @@ import com.twitter.util.Duration
 package object constants {
   /* Amount of time padding to use when resolving complex query timestamps */
   val TraceTimestampPadding: Duration = 1.minute
+
+  /* Max number of services for which there will be no HTTP Cache-Control header returned when getting services */
+  val MaxServicesWithoutCaching: Int = 3
 }

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServer.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServer.scala
@@ -32,6 +32,7 @@ class ZipkinQueryServer(spanStore: SpanStore, dependencyStore: DependencyStore) 
 
   val queryServiceDurationBatchSize = flag("zipkin.queryService.durationBatchSize", 500, "max number of durations to pull per batch")
   val queryLimit = flag("zipkin.queryService.limit", 10, "Default query limit for trace results")
+  val servicesMaxAge = flag("zipkin.queryService.servicesMaxAge", 5*60, "Get services cache TTL")
 
   object StorageModule extends TwitterModule {
     @Provides

--- a/zipkin-web/src/main/resources/app/js/component_data/serviceNames.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/serviceNames.js
@@ -1,0 +1,30 @@
+'use strict';
+
+define(
+  [
+    'flight/lib/component'
+  ],
+
+  function (defineComponent) {
+
+    return defineComponent(serviceNames);
+
+    function serviceNames() {
+      this.updateServiceNames = function(ev, lastServiceName) {
+        $.ajax("/api/services", {
+          type: "GET",
+          dataType: "json",
+          context: this,
+          success: function(serviceNames) {
+            this.trigger('dataServiceNames', {serviceNames: serviceNames, lastServiceName: lastServiceName});
+          }
+        });
+      };
+
+      this.after('initialize', function() {
+        this.on('uiChangeServiceName', this.updateServiceNames);
+      });
+    }
+
+  }
+);

--- a/zipkin-web/src/main/resources/app/js/component_ui/serviceName.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/serviceName.js
@@ -19,15 +19,25 @@ define(
         this.$node.trigger('uiChangeServiceName', name);
       };
 
+      this.updateServiceNameDropdown = function(ev, data) {
+        $.each(data.serviceNames, function(i, item) {
+            $('<option>').val(item).text(item).appendTo('#serviceName');
+        });
+
+        this.$node.find('[value="' + data.lastServiceName + '"]').attr('selected', 'selected');
+
+        this.trigger('chosen:updated');
+      };
+
       this.after('initialize', function() {
         var lastServiceName = $.cookie('last-serviceName');
         if (this.$node.val() === "" && $.cookie('last-serviceName') !== "") {
-          this.$node.find('[value="' + lastServiceName + '"]').attr('selected', 'selected');
           this.triggerChange(lastServiceName);
         }
 
         this.$node.chosen({search_contains: true});
         this.on('change', this.onChange);
+        this.on(document, 'dataServiceNames', this.updateServiceNameDropdown);
       });
     }
 

--- a/zipkin-web/src/main/resources/app/js/page/default.js
+++ b/zipkin-web/src/main/resources/app/js/page/default.js
@@ -3,6 +3,7 @@
 define(
   [
     'component_data/spanNames',
+    'component_data/serviceNames',
     'component_ui/serviceName',
     'component_ui/spanName',
     'component_ui/infoPanel',
@@ -16,6 +17,7 @@ define(
 
   function (
     SpanNamesData,
+    ServiceNamesData,
     ServiceNameUI,
     SpanNameUI,
     InfoPanelUI,
@@ -31,6 +33,7 @@ define(
 
     function initialize() {
       SpanNamesData.attachTo(document);
+      ServiceNamesData.attachTo(document);
       ServiceNameUI.attachTo('#serviceName');
       SpanNameUI.attachTo('#spanName');
       InfoPanelUI.attachTo('#infoPanel');

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -102,6 +102,7 @@ trait ZipkinWebFactory { self: App =>
       ("/traces/:id", addLayout("Traces", environment()) andThen handleTraces(queryClient)),
       ("/dependency", addLayout("Dependency", environment()) andThen handleDependency()),
       ("/api/spans", handleRoute(queryClient, "/api/v1/spans")),
+      ("/api/services", handleRoute(queryClient, "/api/v1/services")),
       ("/api/dependencies/?:startTime/?:endTime", handleRoute(queryClient, "/api/v1/dependencies"))
     ).foldLeft(new HttpMuxer) { case (m , (p, handler)) =>
       val path = p.split("/").toList


### PR DESCRIPTION
- ui service name dropdown is populated using ajax call to /api/services endpoint using serviceName component
- http response to /api/services includes "Cache-Control: max-age=300, must revalidate" header which makes browser return cached values of service names
- browser cache for /api/services call expires after 5 minutes (300 seconds) by default
- flag "zipkin.web.serviceNameCacheTimeoutInSec" can be used to set this cache timeout to a custom value
