### PR TITLE
Routes ZK logging to slf4j

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,7 +54,6 @@ subprojects { subproject ->
         }
 
         // Some dependencies early bound slf4j impl
-        exclude module: "log4j-over-slf4j"
         exclude module: "slf4j-log4j12"
         exclude module: "slf4j-logback"
      }

--- a/zipkin-receiver-kafka/build.gradle
+++ b/zipkin-receiver-kafka/build.gradle
@@ -4,6 +4,8 @@ dependencies {
     compile "org.apache.kafka:kafka_${scalaInterfaceVersion}:0.8.2.1"
     compile 'org.apache.commons:commons-io:1.3.2'
     compile "com.twitter:scrooge-serializer_${scalaInterfaceVersion}:${commonVersions.scrooge}"
+    // kafka's zk uses log4j: route to slf4j
+    compile "org.slf4j:log4j-over-slf4j:${commonVersions.slf4j}"
 
     testCompile 'com.github.charithe:kafka-junit:1.5'
 }

--- a/zipkin-sampler/build.gradle
+++ b/zipkin-sampler/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     compile "com.twitter:util-zk_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"
     compile "com.twitter.common.zookeeper:candidate:0.0.84"
     compile "com.twitter.common.zookeeper:group:0.0.90"
+    // zookeeper deps use log4j: route to slf4j
+    compile "org.slf4j:log4j-over-slf4j:${commonVersions.slf4j}"
 
     testCompile 'org.apache.curator:curator-test:2.8.0'
 }


### PR DESCRIPTION
When people set flags that spin up ZK, this avoids a log configuration error.
