### PR TITLE
Remove conflicts that prevent ZipkinQueryServer with ZipkinWebFactory

### DIFF
--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/QueryExtractor.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/QueryExtractor.scala
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import scala.collection.mutable
 
 // TODO: rewrite me into a normal finatra case class
-class QueryExtractor @Inject()(@Flag("zipkin.queryService.durationBatchSize") defaultQueryLimit: Int) {
+class QueryExtractor @Inject()(@Flag("zipkin.queryService.limit") defaultQueryLimit: Int) {
   /**
    * Takes a `Request` and produces the correct `QueryRequest` depending
    * on the GET parameters present

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServer.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServer.scala
@@ -30,9 +30,10 @@ import com.twitter.zipkin.storage._
 
 class ZipkinQueryServer(spanStore: SpanStore, dependencyStore: DependencyStore) extends HttpServer {
 
-  val queryServiceDurationBatchSize = flag("zipkin.queryService.durationBatchSize", 500, "max number of durations to pull per batch")
-  val queryLimit = flag("zipkin.queryService.limit", 10, "Default query limit for trace results")
-  val servicesMaxAge = flag("zipkin.queryService.servicesMaxAge", 5*60, "Get services cache TTL")
+  // Bind flags used with javax.Inject
+  flag("zipkin.queryService.durationBatchSize", 500, "max number of durations to pull per batch")
+  flag("zipkin.queryService.limit", 10, "Default query limit for trace results")
+  flag("zipkin.queryService.servicesMaxAge", 5*60, "Get services cache TTL")
 
   object StorageModule extends TwitterModule {
     @Provides


### PR DESCRIPTION
One of our users is mixing together zipkin-web and zipkin-query in the 
same JVM. We eventually will replace zipkin-web with a javascript app.
This change allows users to make a custom deployment on the same JVM
until that occurs.

``` scala
object QueryAndWebInSameJVM extends ZipkinQueryServer(
  new InMemorySpanStore, // replace with something real
  new NullDependencyStore // ^^
) with ZipkinWebFactory {

  // connect the query server to the web server
  override val defaultFinatraHttpPort = queryDest.apply()
  // provide a non-conflicting port for the query's admin server
  override val defaultHttpPort = 9901
  override val logLevel = "INFO"

  override def postWarmup() {
    // start the query server
    super.postWarmup()
    // start the web server
    val webServer = Httpx.server
      .configured(param.Label("zipkin-web"))
      .serve(webServerPort(), newWebServer(stats = statsReceiver.scope("zipkin-web")))
    onExit {
      webServer.close()
    }
    Await.ready(webServer)
  }
}
```
