### PR TITLE
Settles on startTs/endTs and fixes Dependencies UI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Sat, 15 Aug 2015 15:15:18 +0000
-version=1.15.2-SNAPSHOT
+version=1.16.0-SNAPSHOT
 group=io.zipkin
 repo=https://github.com/openzipkin/zipkin
 description=A distributed tracing system

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
             scrooge: '4.1.0',
             twitterUtil: '6.28.0',
             twitterServer: '1.13.0',
-            finatra: '2.0.1',
+            finatra: '2.1.0',
             jackson: '2.4.4', // from finatra's build.sbt
             ostrich: '9.12.0',
             griddle: '1.7',

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -152,10 +152,8 @@ abstract class CassandraSpanStore(
     span.lastAnnotation map { lastAnnotation =>
       val timestamp = lastAnnotation.timestamp
 
-      // skip core annotations since that query can be done by service name/span name anyway
       val annotationsFuture = Future.join(
         span.annotations
-          .filter { a => !Constants.CoreAnnotations.contains(a.value) }
           .groupBy(_.value)
           .flatMap { case (_, as) =>
             val a = as.min
@@ -214,7 +212,7 @@ abstract class CassandraSpanStore(
           FutureUtil.toFuture(
             repository.storeSpan(
               span.traceId,
-              span.lastTimestamp.getOrElse(span.firstTimestamp.getOrElse(0)),
+              span.startTs.getOrElse(0),
               createSpanColumnName(span),
               spanCodec.encode(span.copy(annotations = span.annotations.sorted).toThrift),
               spanTtl.inSeconds)),

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Dependencies.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Dependencies.scala
@@ -27,11 +27,11 @@ case class DependencyLink(parent: String, child: String, callCount: Long)
 
 /**
  * This represents all dependencies across all services over a given time period.
- * @param startTime microseconds from epoch
- * @param endTime microseconds from epoch
+ * @param startTs microseconds from epoch
+ * @param endTs microseconds from epoch
  * @param links link information for every dependent service
  */
-case class Dependencies(startTime: Long, endTime: Long, links: Seq[DependencyLink]) {
+case class Dependencies(startTs: Long, endTs: Long, links: Seq[DependencyLink]) {
   // used for summing/merging database rows
   def +(that: Dependencies): Dependencies = {
     // don't sum against Dependencies.zero
@@ -42,8 +42,8 @@ case class Dependencies(startTime: Long, endTime: Long, links: Seq[DependencyLin
     }
 
     // new start/end should be the inclusive time span of both items
-    val newStart = startTime min that.startTime
-    val newEnd = endTime max that.endTime
+    val newStart = startTs min that.startTs
+    val newEnd = endTs max that.endTs
 
     // links are merged by mapping to parent/child and summing corresponding links
     val lLinkMap = that.links.map { link => (link.parent, link.child) -> link }.toMap

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
@@ -89,7 +89,7 @@ trait Span extends Ordered[Span] { self =>
 
   // TODO: cache first timestamp when this is a normal case class as opposed to a trait
   override def compare(that: Span) =
-    java.lang.Long.compare(firstTimestamp.getOrElse(0L), that.firstTimestamp.getOrElse(0L))
+    java.lang.Long.compare(startTs.getOrElse(0L), that.startTs.getOrElse(0L))
 
   def copy(
     traceId: Long = self.traceId,
@@ -221,6 +221,6 @@ trait Span extends Ordered[Span] { self =>
   def getAnnotationsAsMap(): Map[String, Annotation] =
     annotations.map(a => a.value -> a)(breakOut)
 
-  def lastTimestamp: Option[Long] = lastAnnotation.map(_.timestamp)
-  def firstTimestamp: Option[Long] = firstAnnotation.map(_.timestamp)
+  def endTs: Option[Long] = lastAnnotation.map(_.timestamp)
+  def startTs: Option[Long] = firstAnnotation.map(_.timestamp)
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
@@ -65,7 +65,8 @@ trait CollectAnnotationQueries {
           }
         }
     }
-    ids.flatMap(getTracesByIds(_))
+    // only issue a query if trace ids were found
+    ids.flatMap(ids => if (ids.isEmpty) Future.value(Seq.empty) else getTracesByIds(ids))
   }
 
   private[this] def padTimestamp(timestamp: Long): Long =

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/DependencyStore.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/DependencyStore.scala
@@ -25,12 +25,12 @@ import com.twitter.zipkin.common.Dependencies
 abstract class DependencyStore extends java.io.Closeable {
 
   /**
-   * @param startTime  microseconds from epoch, defaults to one day before end_time
-   * @param endTime  microseconds from epoch, defaults to now
-   * @return dependency links in an interval contained by startTime and endTime,
+   * @param startTs  microseconds from epoch, defaults to one day before end_time
+   * @param endTs  microseconds from epoch, defaults to now
+   * @return dependency links in an interval contained by startTs and endTs,
    *         or [[Dependencies.zero]] if none are found
    */
-  def getDependencies(startTime: Option[Long], endTime: Option[Long] = None): Future[Dependencies]
+  def getDependencies(startTs: Option[Long], endTs: Option[Long] = None): Future[Dependencies]
   def storeDependencies(dependencies: Dependencies): Future[Unit]
 }
 
@@ -38,6 +38,6 @@ class NullDependencyStore extends DependencyStore {
 
   def close() {}
 
-  def getDependencies(startTime: Option[Long], endTime: Option[Long] = None) = Future.value(Dependencies.zero)
+  def getDependencies(startTs: Option[Long], endTs: Option[Long] = None) = Future.value(Dependencies.zero)
   def storeDependencies(dependencies: Dependencies): Future[Unit] = Future.Unit
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
@@ -1,6 +1,7 @@
 package com.twitter.zipkin.storage
 
 import com.twitter.util.Time
+import com.twitter.zipkin.util.Util.checkArgument
 
 /**
  * @param serviceName Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]]
@@ -10,7 +11,7 @@ import com.twitter.util.Time
  * @param binaryAnnotations Include traces whose [[com.twitter.zipkin.common.Span.binaryAnnotations]] include a
  *                          String whose key and value are an entry in this set.
  *                          This is an AND condition against the set, as well against [[annotations]]
- * @param endTs only return traces where all [[com.twitter.zipkin.common.Span.lastTimestamp]] are at
+ * @param endTs only return traces where all [[com.twitter.zipkin.common.Span.endTs]] are at
  *              or before this time in epoch microseconds. Defaults to current time.
  * @param limit maximum number of traces to return. Defaults to 10
  */
@@ -19,4 +20,10 @@ case class QueryRequest(serviceName: String,
                         annotations: Set[String] = Set.empty,
                         binaryAnnotations: Set[(String, String)] = Set.empty,
                         endTs: Long = Time.now.inMicroseconds,
-                        limit: Int = 10)
+                        limit: Int = 10) {
+
+  checkArgument(serviceName.nonEmpty, "serviceName was empty")
+  checkArgument(spanName.map(_.nonEmpty).getOrElse(true), "spanName was empty")
+  checkArgument(endTs > 0, () => "endTs should be positive, in epoch microseconds: was %d".format(endTs))
+  checkArgument(limit > 0, () => "limit should be positive: was %d".format(limit))
+}

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/util/Util.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/util/Util.scala
@@ -40,4 +40,20 @@ object Util {
     }
   }
 
+  /**
+   * Like [[require]], except it doesn't prefix the error message.
+   *
+   * <p/> Inspired by Guava's [[com.google.common.base.Preconditions.checkArgument]].
+   */
+  @inline final def checkArgument(expression: Boolean, message: String) {
+    if (!expression) {
+      throw new IllegalArgumentException(message)
+    }
+  }
+
+  @inline final def checkArgument(expression: Boolean, message: () => String) {
+    if (!expression) {
+      throw new IllegalArgumentException(message())
+    }
+  }
 }

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/DependencyStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/DependencyStoreInJava.java
@@ -16,7 +16,7 @@ public class DependencyStoreInJava extends DependencyStore {
     }
 
     @Override
-    public Future<Dependencies> getDependencies(Option<Object> startTime, Option<Object> endTime) {
+    public Future<Dependencies> getDependencies(Option<Object> startTs, Option<Object> endTs) {
         return null;
     }
 

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/DependenciesTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/DependenciesTest.scala
@@ -37,8 +37,8 @@ class DependenciesTest extends FunSuite with Matchers {
 
   test("sums where parent/child match") {
     val result = deps1 + deps2
-    result.startTime should be(deps1.startTime)
-    result.endTime should be(deps2.endTime)
+    result.startTs should be(deps1.startTs)
+    result.endTs should be(deps2.endTs)
     result.links.sortBy(_.parent) should be(Seq(
       dl1,
       dl2,

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/QueryRequestTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/QueryRequestTest.scala
@@ -1,0 +1,31 @@
+package com.twitter.zipkin.common
+
+import com.twitter.zipkin.storage.QueryRequest
+import org.scalatest.FunSuite
+
+class QueryRequestTest extends FunSuite {
+
+  test("serviceName can't be empty") {
+    intercept[IllegalArgumentException] {
+      QueryRequest("")
+    }
+  }
+
+  test("spanName can't be empty") {
+    intercept[IllegalArgumentException] {
+      QueryRequest("foo", Some(""))
+    }
+  }
+
+  test("endTs must be positive") {
+    intercept[IllegalArgumentException] {
+      QueryRequest("foo", endTs = 0)
+    }
+  }
+
+  test("limit must be positive") {
+    intercept[IllegalArgumentException] {
+      QueryRequest("foo", limit = 0)
+    }
+  }
+}

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -51,7 +51,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
   @Test def getDependencies_insideTheInterval() = {
     ready(store.storeDependencies(dep))
 
-    result(store.getDependencies(Some(dep.startTime), Some(dep.endTime))) should be(dep)
+    result(store.getDependencies(Some(dep.startTs), Some(dep.endTs))) should be(dep)
   }
 
   @Test def getDependencies_endTimeBeforeData() = {

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -120,8 +120,6 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     result(store.getTraces(QueryRequest("service", annotations = Set("custom")))) should be(
       Seq(Seq(span1))
     )
-    // should not find any traces since the core annotation doesn't exist in index
-    result(store.getTraces(QueryRequest("service", annotations = Set("cs")))) should be(empty)
 
     // should find traces by the key and value annotation
     result(store.getTraces(QueryRequest("service", binaryAnnotations = Set(("BAH", "BEH"))))) should be(

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisIndex.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisIndex.scala
@@ -85,25 +85,24 @@ class RedisIndex(
       result ++= services.map(spanNames.put(_, span.name))
     }
 
-    if (span.lastTimestamp.isDefined) {
-      val lastTimestamp = span.lastTimestamp.get
+    if (span.endTs.isDefined) {
+      val endTs = span.endTs.get
 
       result ++= services.map(serviceName =>
-        serviceIndex.add(serviceName, lastTimestamp, span.traceId))
+        serviceIndex.add(serviceName, endTs, span.traceId))
 
       result ++= services.map(serviceName =>
-        spanIndex.add(SpanKey(serviceName, span.name), lastTimestamp, span.traceId))
+        spanIndex.add(SpanKey(serviceName, span.name), endTs, span.traceId))
 
       result ++= services.flatMap(serviceName =>
         span.annotations.map(_.value)
-          .filter(!Constants.CoreAnnotations.contains(_))
           .map(AnnotationKey(serviceName, _))
-          .map(annotationIndex.add(_, lastTimestamp, span.traceId)))
+          .map(annotationIndex.add(_, endTs, span.traceId)))
 
       result ++= services.flatMap(serviceName =>
         span.binaryAnnotations
           .map(bin => BinaryAnnotationKey(serviceName, bin.key, encode(bin)))
-          .map(binaryAnnotationIndex.add(_, lastTimestamp, span.traceId)))
+          .map(binaryAnnotationIndex.add(_, endTs, span.traceId)))
     }
 
     Future.join(result)

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -127,10 +127,10 @@ object thrift {
   implicit def dependencyLinkToThrift(dl: DependencyLink) = new WrappedDependencyLink(dl)
   implicit def thriftToDependencyLink(dl: thriftscala.DependencyLink) = new ThriftDependencyLink(dl)
   class WrappedDependencies(d: Dependencies) {
-    lazy val toThrift = thriftscala.Dependencies(d.startTime, d.endTime, d.links.map(_.toThrift))
+    lazy val toThrift = thriftscala.Dependencies(d.startTs, d.endTs, d.links.map(_.toThrift))
   }
   class ThriftDependencies(d: thriftscala.Dependencies) {
-    lazy val toDependencies = Dependencies(d.startTime, d.endTime, d.links.map(_.toDependencyLink))
+    lazy val toDependencies = Dependencies(d.startTs, d.endTs, d.links.map(_.toDependencyLink))
   }
   implicit def dependenciesToThrift(d: Dependencies) = new WrappedDependencies(d)
   implicit def thriftToDependencies(d: thriftscala.Dependencies) = new ThriftDependencies(d)

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinDependencies.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinDependencies.thrift
@@ -29,8 +29,8 @@ struct DependencyLink {
 /* An aggregate representation of services paired with every service they call. */
 struct Dependencies {
   /** microseconds from epoch */
-  1: i64 start_time
+  1: i64 start_ts
   /** microseconds from epoch */
-  2: i64 end_time
+  2: i64 end_ts
   3: list<DependencyLink> links
 }

--- a/zipkin-web/src/main/resources/app/js/component_data/dependency.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/dependency.js
@@ -10,20 +10,20 @@ define(
     return defineComponent(dependency);
 
     function dependency() {
-      var _data = [];
+      var links = [];
       var services = {};
       var dependencies = {};
 
-      this.getDependency = function (from, to) {
-        var url = "/api/dependencies/" + from + '/' + to;
+      this.getDependency = function (startTs, endTs) {
+        var url = "/api/dependencies?startTs=" + startTs + '&endTs=' + endTs;
         $.ajax(url, {
           type: "GET",
           dataType: "json",
           context: this,
-          success: function (data) {
-            _data = data;
-            this.buildServiceData(data);
-            this.trigger('dependencyDataReceived', data);
+          success: function (links) {
+            this.links = links;
+            this.buildServiceData(links);
+            this.trigger('dependencyDataReceived', links);
           },
           failure: function (jqXHR, status, err) {
             var error = {
@@ -34,10 +34,10 @@ define(
         });
       };
 
-      this.buildServiceData = function (data) {
+      this.buildServiceData = function (links) {
         services = {};
         dependencies = {};
-        data.links.forEach(function (link) {
+        links.forEach(function (link) {
           var parent = link.parent;
           var child = link.child;
 

--- a/zipkin-web/src/main/resources/app/js/component_ui/dependencyGraph.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/dependencyGraph.js
@@ -13,9 +13,10 @@ define(
 
     function dependencyGraph() {
       this.after('initialize', function (container, options) {
-        this.on(document, 'dependencyDataReceived', function (ev, data) {
+        this.on(document, 'dependencyDataReceived', function () {
+          // drop the event, keep the links
+          var links = Array.prototype.slice.call(arguments, 1);
           var _this = this;
-
           var svg = d3.select('svg'),
             svgGroup = svg.append('g');
           var rootSvg = container.querySelector('svg');
@@ -75,7 +76,7 @@ define(
           // to render different arrow widths depending on number of calls
           var minCallCount = 0;
           var maxCallCount = 0;
-          data.links.filter(function (link) {
+          links.filter(function (link) {
             return link.parent != link.child;
           }).forEach(function (link) {
             var numCalls = link.callCount;
@@ -91,10 +92,10 @@ define(
 
 
           // Get the names of all nodes in the graph
-          var parentNames = data.links.map(function (link) {
+          var parentNames = links.map(function (link) {
             return link.parent;
           });
-          var childNames = data.links.map(function (link) {
+          var childNames = links.map(function (link) {
             return link.child;
           });
           var allNames = arrayUnique(parentNames.concat(childNames));
@@ -108,7 +109,7 @@ define(
           });
 
           // Add edges/dependency links to the graph
-          data.links.filter(function (link) {
+          links.filter(function (link) {
             return link.parent != link.child;
           }).forEach(function (link) {
             g.addEdge(link.parent + '->' + link.child, link.parent, link.child, {

--- a/zipkin-web/src/main/resources/templates/v2/index.mustache
+++ b/zipkin-web/src/main/resources/templates/v2/index.mustache
@@ -22,7 +22,7 @@
       <label for="timeStamp">End time</label>
       <input class="form-control input-sm date-input" type="text">
       <input class="form-control input-sm time-input" type="text">
-      <input class="" id="timestamp" name="timestamp" type="hidden" value="{{timestamp}}">
+      <input class="" id="endTs" name="endTs" type="hidden" value="{{endTs}}">
     </div>
 
     <div class="form-group">
@@ -95,7 +95,7 @@
       {{/serviceDurations}}
       </div>
       <div class="trace-details timestamp pull-right">
-        <time class="label timeago" datetime="{{startTime}}">{{startTime}}</time>
+        <time class="label timeago" datetime="{{startTs}}">{{startTs}}</time>
       </div>
     </li>
   {{/traces}}

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -103,7 +103,7 @@ trait ZipkinWebFactory { self: App =>
       ("/dependency", addLayout("Dependency", environment()) andThen handleDependency()),
       ("/api/spans", handleRoute(queryClient, "/api/v1/spans")),
       ("/api/services", handleRoute(queryClient, "/api/v1/services")),
-      ("/api/dependencies/?:startTime/?:endTime", handleRoute(queryClient, "/api/v1/dependencies"))
+      ("/api/dependencies", handleRoute(queryClient, "/api/v1/dependencies"))
     ).foldLeft(new HttpMuxer) { case (m , (p, handler)) =>
       val path = p.split("/").toList
       val handlePath = path.takeWhile { t => !(t.startsWith(":") || t.startsWith("?:")) }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
@@ -17,7 +17,6 @@ package com.twitter.zipkin.web
 
 import com.twitter.finagle.httpx.Request
 import com.twitter.util.Time
-
 import scala.collection.mutable
 
 class QueryExtractor(defaultQueryLimit: Int) {
@@ -27,7 +26,7 @@ class QueryExtractor(defaultQueryLimit: Int) {
   }
 
   def getTimestampStr(req: Request): String = {
-    req.params.getLong("timestamp").getOrElse(Time.now.inMicroseconds).toString
+    req.params.getLong("endTs").getOrElse(Time.now.inMicroseconds).toString
   }
 
   def getAnnotations(req: Request): Option[(Seq[String], Map[String, String])] =

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/TraceSummary.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/TraceSummary.scala
@@ -19,8 +19,8 @@ package com.twitter.zipkin.web
 import com.twitter.finagle.tracing.SpanId
 import com.twitter.zipkin.common.{Endpoint, Span, Trace}
 
-case class SpanTimestamp(name: String, startTimestamp: Long, endTimestamp: Long) {
-  def duration = endTimestamp - startTimestamp
+case class SpanTimestamp(name: String, startTs: Long, endTs: Long) {
+  def duration = endTs - startTs
 }
 
 object TraceSummary {
@@ -57,15 +57,15 @@ object TraceSummary {
  * json-friendly representation of a trace summary
  *
  * @param traceId id of this trace
- * @param startTimestamp when did the trace start?
- * @param endTimestamp when did the trace end?
+ * @param startTs when did the trace start?
+ * @param endTs when did the trace end?
  * @param durationMicro how long did the traced operation take?
  * @param endpoints endpoints involved in the traced operation
  */
 case class TraceSummary(
   traceId: String,
-  startTimestamp: Long,
-  endTimestamp: Long,
+  startTs: Long,
+  endTs: Long,
   durationMicro: Int,
   spanTimestamps: List[SpanTimestamp],
   endpoints: List[Endpoint])

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
@@ -27,16 +27,15 @@ class QueryExtractorTest extends FunSuite {
   def request(p: (String, String)*) = Request(p: _*)
 
   test("getTimestampStr") {
-    val endTs = Time.now
-    val endTimestamp = endTs.inMicroseconds.toString
+    val endTs = Time.now.inMicroseconds.toString
     val r = request(
       "serviceName" -> "myService",
       "spanName" -> "mySpan",
-      "timestamp" -> endTimestamp,
+      "endTs" -> endTs,
       "limit" -> "1000")
 
     val actual = queryExtractor.getTimestampStr(r)
-    assert(actual === endTs.inMicroseconds.toString)
+    assert(actual === endTs.toString)
   }
 
   test("default getTimestampStr") {


### PR DESCRIPTION
Troubleshooting subtle problems was unnecessarily difficult as we used
many ways to refer to the start and end of a span in epoch microseconds.

This settles on `startTs` and `endTs`, which are the dominant names. By
doing so, it is cognitively easier as, for example, we can see that
`Span.endTs` relates directly to the query parameter `endTs`, as well as
the upper bound of `Dependencies.endTs`.

This bumps the version because it fixes the dependencies api endpoint to
use normal query parameters as opposed to path expressions for `startTs`
and `endTs`. This also renames the thrift fields for dependencies,
although that isn't breaking as names aren't encoded in thrift
serialization.

Most importantly, this fixes the Dependencies UI, which has been broken
for a while.
