### PR TITLE
Simplified getDependencies and reworks tests to allow on-demand

### DIFF
--- a/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormDependencyStoreSpec.scala
+++ b/zipkin-anormdb/src/test/scala/com/twitter/zipkin/storage/anormdb/AnormDependencyStoreSpec.scala
@@ -1,10 +1,17 @@
 package com.twitter.zipkin.storage.anormdb
 
+import com.twitter.util.Await._
+import com.twitter.zipkin.common.{Dependencies, Span}
 import com.twitter.zipkin.storage.DependencyStoreSpec
 
 class AnormDependencyStoreSpec extends DependencyStoreSpec {
   val db = DB(new DBConfig("sqlite-memory", install = true))
   var store = new AnormDependencyStore(db, Some(db.install()))
+
+  override def processDependencies(spans: List[Span]) = {
+    val deps = new Dependencies(spans.head.startTs.get, spans.last.endTs.get, Dependencies.toLinks(spans))
+    result(store.storeDependencies(deps))
+  }
 
   override def clear = {
     store = new AnormDependencyStore(db, Some(db.install()))

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/DependencyStore.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/DependencyStore.scala
@@ -16,7 +16,7 @@
 package com.twitter.zipkin.storage
 
 import com.twitter.util.Future
-import com.twitter.zipkin.common.Dependencies
+import com.twitter.zipkin.common.{DependencyLink, Dependencies}
 
 /**
  * Storage and retrieval interface for aggregate dependencies that may be computed offline and
@@ -28,9 +28,9 @@ abstract class DependencyStore extends java.io.Closeable {
    * @param startTs  microseconds from epoch, defaults to one day before end_time
    * @param endTs  microseconds from epoch, defaults to now
    * @return dependency links in an interval contained by startTs and endTs,
-   *         or [[Dependencies.zero]] if none are found
+   *         or empty if none are found
    */
-  def getDependencies(startTs: Option[Long], endTs: Option[Long] = None): Future[Dependencies]
+  def getDependencies(startTs: Option[Long], endTs: Option[Long] = None): Future[Seq[DependencyLink]]
   def storeDependencies(dependencies: Dependencies): Future[Unit]
 }
 
@@ -38,6 +38,6 @@ class NullDependencyStore extends DependencyStore {
 
   def close() {}
 
-  def getDependencies(startTs: Option[Long], endTs: Option[Long] = None) = Future.value(Dependencies.zero)
+  def getDependencies(startTs: Option[Long], endTs: Option[Long] = None) = Future.value(Seq.empty)
   def storeDependencies(dependencies: Dependencies): Future[Unit] = Future.Unit
 }

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/DependencyStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/DependencyStoreInJava.java
@@ -1,10 +1,11 @@
 package com.twitter.zipkin.storage;
 
-import scala.Option;
-import scala.runtime.BoxedUnit;
-
 import com.twitter.util.Future;
 import com.twitter.zipkin.common.Dependencies;
+import com.twitter.zipkin.common.DependencyLink;
+import scala.Option;
+import scala.collection.Seq;
+import scala.runtime.BoxedUnit;
 
 /**
  * Shows that {@link DependencyStore} is implementable in Java 7+.
@@ -16,7 +17,7 @@ public class DependencyStoreInJava extends DependencyStore {
     }
 
     @Override
-    public Future<Dependencies> getDependencies(Option<Object> startTs, Option<Object> endTs) {
+    public Future<Seq<DependencyLink>> getDependencies(Option<Object> startTs, Option<Object> endTs) {
         return null;
     }
 

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -1,8 +1,9 @@
 package com.twitter.zipkin.storage
 
-import com.twitter.util.Await.{ready, result}
+import com.twitter.util.Await.result
 import com.twitter.util.{Duration, Time}
-import com.twitter.zipkin.common.{Dependencies, DependencyLink}
+import com.twitter.zipkin.Constants
+import com.twitter.zipkin.common.{Dependencies, DependencyLink, _}
 import org.junit.{Before, Test}
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitSuite
@@ -20,9 +21,28 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
   /** Notably, the cassandra implementation has day granularity */
   val day = MICROSECONDS.convert(1, DAYS)
   val today = Time.now.floor(Duration.fromMicroseconds(day)).inMicroseconds
+
+  val zipkinWeb = Endpoint(172 << 24 | 17 << 16 | 3, 8080, "zipkin-web")
+  val zipkinQuery = Endpoint(172 << 24 | 17 << 16 | 2, 9411, "zipkin-query")
+  val zipkinJdbc = Endpoint(172 << 24 | 17 << 16 | 2, 0, "zipkin-jdbc")
+
+  val trace = List(
+    Span(1L, "GET", 1L, None, List(
+      Annotation(today, Constants.ServerRecv, Some(zipkinWeb)),
+      Annotation(today + 350, Constants.ServerSend, Some(zipkinWeb))), Seq.empty),
+    Span(1L, "GET", 2L, Some(1L), List(
+      Annotation(today + 50, Constants.ServerRecv, Some(zipkinQuery)),
+      Annotation(today + 100, Constants.ClientSend, Some(zipkinQuery.copy(port = 0))),
+      Annotation(today + 250, Constants.ClientRecv, Some(zipkinQuery.copy(port = 0))),
+      Annotation(today + 300, Constants.ServerSend, Some(zipkinQuery))), Seq.empty),
+    Span(1L, "query", 3L, Some(2L), List(
+      Annotation(today + 150, Constants.ClientSend, Some(zipkinJdbc)),
+      Annotation(today + 200, Constants.ClientRecv, Some(zipkinJdbc))), Seq.empty)
+  )
+
   val dep = new Dependencies(today, today + 1000, List(
-    new DependencyLink("zipkin-web", "zipkin-query", 18),
-    new DependencyLink("zipkin-query", "cassandra", 42)
+    new DependencyLink("zipkin-web", "zipkin-query", 1),
+    new DependencyLink("zipkin-query", "zipkin-jdbc", 1)
   ))
 
   /**
@@ -36,33 +56,62 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
 
   @Before def before() = clear
 
-  @Test def getDependencies_defaultsToToday() = {
-    ready(store.storeDependencies(dep))
+  def processDependencies(spans: List[Span])
 
-    result(store.getDependencies(None, None)) should be(dep)
+  /**
+   * Normally, the root-span is where trace id == span id and parent id == null.
+   * The default is to look back one day from today.
+   */
+  @Test def getDependencies() = {
+    processDependencies(trace)
+
+    result(store.getDependencies(None, None)) should be(dep.links)
   }
 
-  @Test def getDependencies_looksBackOneDay() = {
-    ready(store.storeDependencies(dep))
 
-    result(store.getDependencies(None, Some(today + day))) should be(dep)
+  @Test def dependencies_loopback {
+    val traceWithLoopback = List(
+      trace(0),
+      trace(1).copy(annotations = trace(1).annotations.map( a => a.copy(host = Some(zipkinWeb))))
+    )
+
+    processDependencies(traceWithLoopback)
+
+    result(store.getDependencies(None, None)) should be(Dependencies.toLinks(traceWithLoopback))
+  }
+
+  /**
+   * Some systems log a different trace id than the root span. This seems "headless", as we won't
+   * see a span whose id is the same as the trace id.
+   */
+  @Test def dependencies_headlessTrace {
+    processDependencies(List(trace(1), trace(2)))
+
+    result(store.getDependencies(None, None)) should be(Dependencies.toLinks(List(trace(1), trace(2))))
+  }
+
+
+  @Test def getDependencies_looksBackOneDay() = {
+    processDependencies(trace)
+
+    result(store.getDependencies(None, Some(today + day))) should be(dep.links)
   }
 
   @Test def getDependencies_insideTheInterval() = {
-    ready(store.storeDependencies(dep))
+    processDependencies(trace)
 
-    result(store.getDependencies(Some(dep.startTs), Some(dep.endTs))) should be(dep)
+    result(store.getDependencies(Some(dep.startTs), Some(dep.endTs))) should be(dep.links)
   }
 
   @Test def getDependencies_endTimeBeforeData() = {
-    ready(store.storeDependencies(dep))
+    processDependencies(trace)
 
-    result(store.getDependencies(None, Some(today - day))) should be(Dependencies.zero)
+    result(store.getDependencies(None, Some(today - day))) should be(empty)
   }
 
   @Test def getDependencies_endTimeAfterData() = {
-    ready(store.storeDependencies(dep))
+    processDependencies(trace)
 
-    result(store.getDependencies(None, Some(today + 2 * day))) should be(Dependencies.zero)
+    result(store.getDependencies(None, Some(today + 2 * day))) should be(empty)
   }
 }

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
@@ -54,7 +54,7 @@ class ZipkinQueryController @Inject()(spanStore: SpanStore,
   }
 
   get("/api/v1/dependencies") { request: GetDependenciesRequest =>
-    dependencyStore.getDependencies(Some(request.startTs), Some(request.endTs)).map(_.links)
+    dependencyStore.getDependencies(Some(request.startTs), Some(request.endTs))
   }
 
   private[this] def adjustTimeskewAndRenderJson(spans: Seq[Seq[Span]]): Seq[List[JsonSpan]] = {

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
@@ -480,7 +480,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
   }
 
   "find dependencies starting at timestamp zero" in {
-    when(dependencyStore.getDependencies(Some(0), Some(deps.endTs))) thenReturn Future.value(deps)
+    when(dependencyStore.getDependencies(Some(0), Some(deps.endTs))) thenReturn Future.value(deps.links)
 
     server.httpGet(
       path = "/api/v1/dependencies?startTs=0&endTs=" + deps.endTs,
@@ -503,7 +503,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
   }
 
   "find dependencies when empty" in {
-    when(dependencyStore.getDependencies(Some(0), Some(deps.endTs))) thenReturn Future(Dependencies.zero)
+    when(dependencyStore.getDependencies(Some(0), Some(deps.endTs))) thenReturn Future(Seq.empty)
 
     server.httpGet(
       path = "/api/v1/dependencies?startTs=0&endTs=" + deps.endTs,


### PR DESCRIPTION
Before, `DependencyStore.getDependencies()` returned an envelope type
which was always unwrapped into links. This simplifies that by just
returning the links.

This also adds an in-memory parser which converts spans into dependency
links. This is needed to do tests on backends that don't compute links
on-demand. `DependencyStore.storeDependencies()` should be optional as
backends that aggregate on-demand don't need the intermediate form.
