### PR TITLE
fix span name indexing

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -114,7 +114,7 @@ abstract class CassandraSpanStore(
 
       Future.join(
         span.serviceNames.toSeq map { serviceName =>
-          FutureUtil.toFuture(repository.storeSpanName(serviceName, span.name.toLowerCase, indexTtl.inSeconds))
+          FutureUtil.toFuture(repository.storeSpanName(serviceName, span.name, indexTtl.inSeconds))
         })
     }
   }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
@@ -18,6 +18,7 @@ package com.twitter.zipkin.common
 
 import com.twitter.zipkin.Constants
 import scala.collection.breakOut
+import scala.util.hashing.MurmurHash3
 
 /**
  * A span represents one RPC request. A trace is made up of many spans.
@@ -29,7 +30,7 @@ import scala.collection.breakOut
  * such as cache hits/misses.
  *
  * @param traceId random long that identifies the trace, will be set in all spans in this trace
- * @param name name of span, can be rpc method name for example
+ * @param _name name of span, can be rpc method name for example
  * @param id random long that identifies this span
  * @param parentId reference to the parent span in the trace tree
  * @param annotations annotations, containing a timestamp and some value. both user generated and
@@ -38,15 +39,16 @@ import scala.collection.breakOut
  * serialized objects. Sorted ascending by timestamp. Sorted ascending by timestamp
  * @param debug if this is set we will make sure this span is stored, no matter what the samplers want
  */
-case class Span(
-  traceId: Long,
-  name: String,
-  id: Long,
-  parentId: Option[Long] = None,
-  annotations: List[Annotation] = List.empty,
-  binaryAnnotations: Seq[BinaryAnnotation] = Seq.empty,
-  debug: Option[Boolean] = None
-) extends Ordered[Span] {
+class Span(
+  val traceId: Long,
+  _name: String,
+  val id: Long,
+  val parentId: Option[Long],
+  val annotations: List[Annotation],
+  val binaryAnnotations: Seq[BinaryAnnotation],
+  val debug: Option[Boolean]) extends Ordered[Span] {
+
+  val name: String = _name.toLowerCase
 
   override def compare(that: Span) =
     java.lang.Long.compare(startTs.getOrElse(0L), that.startTs.getOrElse(0L))
@@ -92,7 +94,7 @@ case class Span(
     // ruby tracing can give us an empty name in one part of the span
     val selectedName = name match {
       case "" => mergeFrom.name
-      case "Unknown" => mergeFrom.name
+      case "unknown" => mergeFrom.name
       case _ => name
     }
 
@@ -166,4 +168,46 @@ case class Span(
 
   lazy val endTs: Option[Long] = lastAnnotation.map(_.timestamp)
   lazy val startTs: Option[Long] = firstAnnotation.map(_.timestamp)
+
+  override lazy val hashCode: Int = {
+    MurmurHash3.seqHash(List(traceId, name, id, parentId, annotations, binaryAnnotations, debug))
+  }
+
+  override def equals(other: Any): Boolean = {
+    other match {
+      case x: Span =>
+        x.traceId == traceId && x.name == name && x.id == id && x.parentId == parentId &&
+          x.annotations == annotations && x.binaryAnnotations == binaryAnnotations &&
+          x.debug == debug
+      case _ =>
+        false
+    }
+  }
+
+  def copy(
+    traceId: Long = this.traceId,
+    name: String = this.name,
+    id: Long = this.id,
+    parentId: Option[Long] = this.parentId,
+    annotations: List[Annotation] = this.annotations,
+    binaryAnnotations: Seq[BinaryAnnotation] = this.binaryAnnotations,
+    debug: Option[Boolean] = this.debug): Span = {
+
+    Span(traceId, name, id, parentId, annotations, binaryAnnotations, debug)
+  }
+
+}
+
+object Span {
+  def apply(
+    traceId: Long,
+    name: String,
+    id: Long,
+    parentId: Option[Long] = None,
+    annotations: List[Annotation] = List.empty,
+    binaryAnnotations: Seq[BinaryAnnotation] = Seq.empty,
+    debug: Option[Boolean] = None): Span = {
+
+    new Span(traceId, name, id, parentId, annotations, binaryAnnotations, debug)
+  }
 }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
@@ -11,13 +11,13 @@ class JsonConversionTest extends FunSuite with Matchers {
   test("span with null annotations, binaryAnnotations") {
     val convert = JsonSpan("0000000000000001", "GET", "0000000000003039", None, null, null)
 
-    JsonSpan(JsonSpan.invert(convert)) should be(JsonSpan("0000000000000001", "GET", "0000000000003039"))
+    JsonSpan(JsonSpan.invert(convert)) should be(JsonSpan("0000000000000001", "get", "0000000000003039"))
   }
 
   test("span with ids less trailing zeros") {
     val convert = JsonSpan("0000001", "GET", "3039")
 
-    JsonSpan(JsonSpan.invert(convert)) should be(JsonSpan("0000000000000001", "GET", "0000000000003039"))
+    JsonSpan(JsonSpan.invert(convert)) should be(JsonSpan("0000000000000001", "get", "0000000000003039"))
   }
 
   val endpoint = Endpoint((192 << 24 | 168 << 16 | 1), 9411, "zipkin-query")

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
@@ -31,7 +31,7 @@ class ZipkinJsonTest extends FunSuite with Matchers {
       """
         |{
         |  "traceId": "0000000000000001",
-        |  "name": "GET",
+        |  "name": "get",
         |  "id": "0000000000003039",
         |  "annotations": [
         |    {

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -218,4 +218,16 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
     result(store.getSpanNames(spanEmptySpanName.name)) should be(empty)
   }
+
+  @Test def spanNamesGoLowercase() {
+    val spanUpperCaseSpanName = Span(123, "SPAN_NAME", spanId, None, List(ann1, ann2), List())
+
+    result(store(Seq(spanUpperCaseSpanName)))
+
+    result(store.getSpanNames("service")) should be(List("span_name"))
+
+    result(store.getTraces(QueryRequest("service", Some("span_name")))) should be(
+      Seq(Seq(spanUpperCaseSpanName))
+    )
+  }
 }

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
@@ -272,7 +272,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |  [
           |    {
           |      "traceId" : "0000000000000005",
-          |      "name" : "otherMethod",
+          |      "name" : "othermethod",
           |      "id" : "000000000000029a",
           |      "parentId" : "0000000000000002",
           |      "annotations" : [
@@ -412,7 +412,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |  [
           |    {
           |      "traceId" : "0000000000000005",
-          |      "name" : "otherMethod",
+          |      "name" : "othermethod",
           |      "id" : "000000000000029a",
           |      "parentId" : "0000000000000002",
           |      "annotations" : [
@@ -483,7 +483,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |  [
           |    {
           |      "traceId" : "0000000000000005",
-          |      "name" : "otherMethod",
+          |      "name" : "othermethod",
           |      "id" : "000000000000029a",
           |      "parentId" : "0000000000000002",
           |      "annotations" : [

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -30,7 +30,7 @@ class KafkaProcessorSpecSimple extends JUnitSuite {
     assert( 1 == spans.length, "received more spans than sent" )
     val message = spans.head.toSpan
     assert(message.traceId == 1234, "traceId mismatch")
-    assert(message.name == "methodName", "method name mismatch")
+    assert(message.name == "methodname", "method name mismatch")
     assert(message.id == 4567, "spanId mismatch")
     message.annotations map { a =>
       assert(a.value == "value", "annotation name mismatch")


### PR DESCRIPTION
TraceIds indexed by spanNames were not always showing up if your span name had capital letters. This fixes the ingestion to be consistent.
