### PR TITLE
Only start traces for dynamic content on zipkin-web

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/FilteredHttpEntrypointTraceInitializer.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/FilteredHttpEntrypointTraceInitializer.scala
@@ -1,0 +1,40 @@
+package com.twitter.zipkin.web
+
+import com.twitter.finagle.httpx.{Response, Request}
+import com.twitter.finagle.tracing.{DefaultTracer, Trace}
+import com.twitter.finagle.{Filter, ServiceFactory, param, Stack}
+import com.twitter.util.Future
+
+/**
+ * Hacked variant of the private `com.twitter.finagle.httpx.codec.HttpServerTraceInitializer`
+ *
+ * <p/>This version only starts traces at certain entrypoints.
+ */
+object FilteredHttpEntrypointTraceInitializer extends Stack.Module1[param.Tracer, ServiceFactory[Request, Response]] {
+  val role = Stack.Role("TraceInitializerFilter")
+  val description = "Initialize the tracing system with trace info from the incoming request"
+
+  override def make(ignored: param.Tracer, next: ServiceFactory[Request, Response]) = {
+    val traceInitializer = Filter.mk[Request, Response, Request, Response] { (req, svc) =>
+      if (req.path.equals("/") || req.path.equals("/dependency") || req.path.startsWith("/api/")) {
+        newRootSpan(req, svc)
+      } else {
+        svc(req)
+      }
+    }
+    traceInitializer andThen next
+  }
+
+  /** Same behavior as `com.twitter.finagle.httpx.codec.HttpServerTraceInitializer` */
+  private def newRootSpan(req: Request, svc: (Request) => Future[Response]) = {
+    Trace.letTracerAndId(DefaultTracer.self, Trace.nextId) {
+      Trace.recordRpc(req.method.toString())
+      val withoutQuery = req.uri.indexOf('?') match {
+        case -1 => req.uri
+        case n => req.uri.substring(0, n)
+      }
+      Trace.recordBinary("http.uri", withoutQuery)
+      svc(req)
+    }
+  }
+}


### PR DESCRIPTION
Before, zipkin-web had the default finagle behavior of tracing all
http requests. Even if we were sampling, this would create junk traces
as we'd get spans for static assets like icons and javascript files.
These extra traces make troubleshooting real problems more difficult, at
least due to the distraction of spans that share the same name as spans
of interest.

This hard-codes a filter, as Finagle doesn't provide a visible means to
filter tracing based on uri path.
