### PR TITLE
Adds support for HTTP POST /api/v1/spans as an alternative to Scribe

### DIFF
--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
@@ -7,6 +7,19 @@ import com.twitter.zipkin.common.{Endpoint, AnnotationType, BinaryAnnotation}
 import org.scalatest.{FunSuite, Matchers}
 
 class JsonConversionTest extends FunSuite with Matchers {
+
+  test("span with null annotations, binaryAnnotations") {
+    val convert = JsonSpan("0000000000000001", "GET", "0000000000003039", None, null, null)
+
+    JsonSpan(JsonSpan.invert(convert)) should be(JsonSpan("0000000000000001", "GET", "0000000000003039"))
+  }
+
+  test("span with ids less trailing zeros") {
+    val convert = JsonSpan("0000001", "GET", "3039")
+
+    JsonSpan(JsonSpan.invert(convert)) should be(JsonSpan("0000000000000001", "GET", "0000000000003039"))
+  }
+
   val endpoint = Endpoint((192 << 24 | 168 << 16 | 1), 9411, "zipkin-query")
 
   test("endpoint") {

--- a/zipkin-query/build.gradle
+++ b/zipkin-query/build.gradle
@@ -4,6 +4,8 @@ repositories {
 
 dependencies {
     compile project(':zipkin-common')
+    compile project(':zipkin-scrooge') // for thrift codec needed in POST api
+
     compile "com.twitter.finatra:finatra-http_${scalaInterfaceVersion}:${commonVersions.finatra}"
     compile "com.twitter.finatra:finatra-slf4j_${scalaInterfaceVersion}:${commonVersions.finatra}"
 

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -130,8 +130,8 @@ object thrift {
     lazy val toThrift = thriftscala.Dependencies(d.startTs, d.endTs, d.links.map(_.toThrift))
   }
   class ThriftDependencies(d: thriftscala.Dependencies) {
-    lazy val toDependencies = Dependencies(d.startTs, d.endTs, d.links.map(_.toDependencyLink))
+    lazy val toDependencies: Dependencies = Dependencies(d.startTs, d.endTs, d.links.map(_.toDependencyLink))
   }
-  implicit def dependenciesToThrift(d: Dependencies) = new WrappedDependencies(d)
+  implicit def dependenciesToThrift(d: Dependencies): WrappedDependencies = new WrappedDependencies(d)
   implicit def thriftToDependencies(d: thriftscala.Dependencies) = new ThriftDependencies(d)
 }


### PR DESCRIPTION
It has come up regularly that people are sending spans directly to the
collector's scribe interface, not because they use scribe, but because
they want a simpler architecture when getting started with zipkin. For
example, they are not yet ready for a data pipeline and just want to run
without any dependencies.

While this works, scribe uses Thrift RPC, which is rarely supported, and
for example doesn't have load balancer support (except at TCP level) or
reverse proxies like HTTP does. The type of users who connect directly
to the Collector's scribe endpoint would be better off with an HTTP
option, this is that.

Details of the HTTP Api:

With no content type (or `application/json`) we accept JSON, and with
`content-type=application/x-thrift` we accept Thrift. In both cases
a List is POSTed to `/api/v1/spans` on the query service. The endpoint
returns immediately with a 202 or 400 if the input was malformed.

In either case, spans are written asynchronously to the span store.

Ex. from https://github.com/adrianco/spigo

``` bash
$ curl -s localhost:9411/api/v1/spans -X POST --data @json_metrics/cassandra_flow.json -H "Content-Type: application/json"
```
