### PR TITLE
Eliminates case class tech debt in Span and clarifies debug is an option

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -49,7 +49,7 @@ class AnormSpanStore(val db: DB,
           .on("id" -> span.id)
           .on("name" -> span.name)
           .on("parent_id" -> span.parentId)
-          .on("debug" -> (if (span.debug) 1 else 0))
+          .on("debug" -> span.debug.map(if (_) 1 else 0))
           .on("start_ts" -> span.startTs)
           .execute()
 
@@ -112,8 +112,8 @@ class AnormSpanStore(val db: DB,
             |ORDER BY start_ts
           """.stripMargin.format(traceIdsString))
           .as((long("id") ~ get[Option[Long]]("parent_id") ~
-          long("trace_id") ~ str("name") ~ int("debug") map {
-          case a~b~c~d~e => DBSpan(a, b, c, d, e > 0)
+          long("trace_id") ~ str("name") ~ get[Option[Int]]("debug") map {
+          case a~b~c~d~e => DBSpan(a, b, c, d, e.map(_ > 0))
         }) *)
       val annos:List[DBAnnotation] =
         SQL(
@@ -304,7 +304,7 @@ class AnormSpanStore(val db: DB,
     }
   }
 
-  case class DBSpan(spanId: Long, parentId: Option[Long], traceId: Long, spanName: String, debug: Boolean)
+  case class DBSpan(spanId: Long, parentId: Option[Long], traceId: Long, spanName: String, debug: Option[Boolean])
   case class DBAnnotation(spanId: Long, traceId: Long, serviceName: String, value: String, ipv4: Option[Int], port: Option[Int], timestamp: Long)
   case class DBBinaryAnnotation(spanId: Long, traceId: Long, serviceName: String, key: String, value: Array[Byte], annotationTypeValue: Int, ipv4: Option[Int], port: Option[Int])
 }

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -169,7 +169,7 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
         |  id BIGINT NOT NULL,
         |  name VARCHAR(255) NOT NULL,
         |  parent_id BIGINT,
-        |  debug SMALLINT NOT NULL,
+        |  debug SMALLINT,
         |  start_ts BIGINT
         |)
       """.stripMargin).execute()

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -18,7 +18,6 @@ package com.twitter.zipkin.storage.cassandra
 import com.twitter.conversions.time._
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.util.{Future, Duration}
-import com.twitter.zipkin.Constants
 import com.twitter.zipkin.common.{Trace, Span}
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}

--- a/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/filter/SamplerFilter.scala
+++ b/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/filter/SamplerFilter.scala
@@ -29,7 +29,7 @@ class SamplerFilter(sampler: GlobalSampler) {
        * If the span was created with debug mode on we guarantee that it will be
        * stored no matter what our sampler tells us
        */
-      if (span.debug) {
+      if (span.debug.getOrElse(false)) {
         Stats.incr("debugflag")
         (span.parentId, span.serviceName) match {
           case (None, Some(serviceName)) =>

--- a/zipkin-collector-service/src/test/scala/com/twitter/zipkin/collector/filter/SamplerFilterSpec.scala
+++ b/zipkin-collector-service/src/test/scala/com/twitter/zipkin/collector/filter/SamplerFilterSpec.scala
@@ -25,21 +25,21 @@ import org.scalatest.{FunSuite, Matchers}
 class SamplerFilterSpec extends FunSuite with Matchers with MockitoSugar {
 
   test("let the span pass if debug flag is set") {
-    val span = Span(12345, "methodcall", 666, None, List(), Nil, true)
+    val span = Span(12345, "methodcall", 666, None, List(), Seq(), Some(true))
     val samplerProcessor = new SamplerFilter(NullGlobalSampler)
 
     samplerProcessor(Seq(span)) should be (Seq(span))
   }
 
   test("let the span pass if debug flag false and sampler says yes") {
-    val span = Span(12345, "methodcall", 666, None, List(), Nil, false)
+    val span = Span(12345, "methodcall", 666, None, List(), Seq(), Some(false))
     val samplerProcessor = new SamplerFilter(EverythingGlobalSampler)
 
     samplerProcessor(Seq(span)) should be (Seq(span))
   }
 
   test("not let the span pass if debug flag false and sampler says no") {
-    val span = Span(12345, "methodcall", 666, None, List(), Nil, false)
+    val span = Span(12345, "methodcall", 666, None, List(), Seq(), Some(false))
     val samplerProcessor = new SamplerFilter(NullGlobalSampler)
 
     samplerProcessor(Seq(span)) should be (empty)

--- a/zipkin-collector-service/src/test/scala/com/twitter/zipkin/collector/processor/OstrichServiceSpec.scala
+++ b/zipkin-collector-service/src/test/scala/com/twitter/zipkin/collector/processor/OstrichServiceSpec.scala
@@ -41,7 +41,7 @@ class OstrichServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
     val annotation2 = Annotation(20, thriftscala.Constants.SERVER_SEND, Some(Endpoint(3, 4, "service")))
     val annotation3 = Annotation(30, "value3", Some(Endpoint(5, 6, "service")))
 
-    val span = Span(12345, "methodcall", 666, None, List(annotation1, annotation2, annotation3), Nil)
+    val span = Span(12345, "methodcall", 666, None, List(annotation1, annotation2, annotation3))
 
     agg.apply(span)
 
@@ -56,7 +56,7 @@ class OstrichServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
     val annotation2 = Annotation(20, thriftscala.Constants.CLIENT_RECV, Some(Endpoint(3, 4, "service")))
     val annotation3 = Annotation(30, "value3", Some(Endpoint(5, 6, "service")))
 
-    val span = Span(12345, "methodcall", 666, None, List(annotation1, annotation2, annotation3), Nil)
+    val span = Span(12345, "methodcall", 666, None, List(annotation1, annotation2, annotation3))
 
     agg.apply(span)
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonSpan.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonSpan.scala
@@ -20,18 +20,18 @@ object JsonSpan extends (Span => JsonSpan) {
     s.parentId.map(id(_)),
     s.annotations.map(JsonAnnotation),
     s.binaryAnnotations.map(JsonBinaryAnnotation),
-    if (s.debug) Some(true) else None
+    s.debug
   )
 
-  def invert(s: JsonSpan) = Span.apply(
+  def invert(s: JsonSpan) = Span(
     id(s.traceId),
     s.name,
     id(s.id),
     s.parentId.map(id(_)),
     /** If deserialized with jackson, these could be null, as it doesn't look at default values. */
-    if (s.annotations == null) List.empty else s.annotations.map(JsonAnnotation.invert),
+    if (s.annotations == null) List.empty else s.annotations.map(JsonAnnotation.invert).sorted,
     if (s.binaryAnnotations == null) Seq.empty else s.binaryAnnotations.map(JsonBinaryAnnotation.invert),
-    s.debug.getOrElse(false)
+    s.debug
   )
 
   /** Strictly looks at length, so for a long, expects 16 ascii hex chars */

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
@@ -25,8 +25,7 @@ class SpanTest extends FunSuite {
 
   val annotationValue = "NONSENSE"
   val expectedAnnotation = Annotation(1, annotationValue, Some(Endpoint(1, 2, "service")))
-  val expectedSpan = Span(12345, "methodcall", 666, None,
-    List(expectedAnnotation), Nil)
+  val expectedSpan = Span(12345, "methodcall", 666, None, List(expectedAnnotation))
 
   val annotation1 = Annotation(1, "value1", Some(Endpoint(1, 2, "service")))
   val annotation2 = Annotation(2, "value2", Some(Endpoint(3, 4, "Service"))) // upper case service name
@@ -36,9 +35,9 @@ class SpanTest extends FunSuite {
   val binaryAnnotation2 = BinaryAnnotation("key2", ByteBuffer.wrap("value2".getBytes), AnnotationType.String, Some(Endpoint(3, 4, "service2")))
 
   val spanWith3Annotations = Span(12345, "methodcall", 666, None,
-    List(annotation1, annotation2, annotation3), Nil)
+    List(annotation1, annotation2, annotation3))
   val spanWith2BinaryAnnotations = Span(12345, "methodcall", 666, None,
-    Nil, List(binaryAnnotation1, binaryAnnotation2))
+    List.empty, Seq(binaryAnnotation1, binaryAnnotation2))
 
 
   test("serviceNames is lowercase") {
@@ -57,9 +56,9 @@ class SpanTest extends FunSuite {
     val ann1 = Annotation(1, "value1", Some(Endpoint(1, 2, "service")))
     val ann2 = Annotation(2, "value2", Some(Endpoint(3, 4, "service")))
 
-    val span1 = Span(12345, "", 666, None, List(ann1), Nil, true)
-    val span2 = Span(12345, "methodcall", 666, None, List(ann2), Nil, false)
-    val expectedSpan = Span(12345, "methodcall", 666, None, List(ann1, ann2), Nil, true)
+    val span1 = Span(12345, "", 666, None, List(ann1), Seq(), Some(true))
+    val span2 = Span(12345, "methodcall", 666, None, List(ann2), Seq(), Some(false))
+    val expectedSpan = Span(12345, "methodcall", 666, None, List(ann1, ann2), Seq(), Some(true))
     val actualSpan = span1.mergeSpan(span2)
     assert(actualSpan === expectedSpan)
   }
@@ -85,7 +84,7 @@ class SpanTest extends FunSuite {
   }
 
   test("don't get duration duration when there are no annotations") {
-    val span = Span(1, "n", 2, None, List(), Nil)
+    val span = Span(1, "n", 2)
     assert(span.duration === None)
   }
 
@@ -97,10 +96,10 @@ class SpanTest extends FunSuite {
 
     val cs2 = Annotation(5, Constants.ClientSend, None)
 
-    val s1 = Span(1, "i", 123, None, List(cs, sr, ss, cr), Nil)
+    val s1 = Span(1, "i", 123, None, List(cs, sr, ss, cr))
     assert(s1.isValid)
 
-    val s3 = Span(1, "i", 123, None, List(cs, sr, ss, cr, cs2), Nil)
+    val s3 = Span(1, "i", 123, None, List(cs, sr, ss, cr, cs2))
     assert(!s3.isValid)
   }
 

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceTest.scala
@@ -40,31 +40,28 @@ class TraceTest extends FunSuite {
   val span3Id = 888L
   val span4Id = 999L
 
-  val span1 = Span(12345, "methodcall1", span1Id, None, annotations1, Nil)
-  val span2 = Span(12345, "methodcall2", span2Id, Some(span1Id), annotations2, Nil)
-  val span3 = Span(12345, "methodcall2", span3Id, Some(span2Id), annotations3, Nil)
-  val span4 = Span(12345, "methodcall2", span4Id, Some(span3Id), annotations4, Nil)
-  val span5 = Span(12345, "methodcall4", 1111L, Some(span4Id), List(), Nil) // no annotations
+  val span1 = Span(12345, "methodcall1", span1Id, None, annotations1)
+  val span2 = Span(12345, "methodcall2", span2Id, Some(span1Id), annotations2)
+  val span3 = Span(12345, "methodcall2", span3Id, Some(span2Id), annotations3)
+  val span4 = Span(12345, "methodcall2", span4Id, Some(span3Id), annotations4)
+  val span5 = Span(12345, "methodcall4", 1111L, Some(span4Id)) // no annotations
 
   val trace = Trace(List[Span](span1, span2, span3, span4))
 
   test("get duration of trace") {
     val annotations = List(Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
       Annotation(200, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
-    val span = Span(12345, "methodcall", 666, None,
-      annotations, Nil)
+    val span = Span(12345, "methodcall", 666, None, annotations)
     assert(Trace(List(span)).duration === 100)
   }
 
   test("get duration of trace without root span") {
     val annotations = List(Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
       Annotation(200, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
-    val span = Span(12345, "methodcall", 666, Some(123),
-      annotations, Nil)
+    val span = Span(12345, "methodcall", 666, Some(123), annotations)
     val annotations2 = List(Annotation(150, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
       Annotation(160, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
-    val span2 = Span(12345, "methodcall", 666, Some(123),
-      annotations2, Nil)
+    val span2 = Span(12345, "methodcall", 666, Some(123), annotations2)
     assert(Trace(List(span, span2)).duration === 100)
   }
 
@@ -77,8 +74,8 @@ class TraceTest extends FunSuite {
       Annotation(12, "Server send", None)
     )
 
-    val span1 = Span(123, "method_1", 100, None, ann1, Nil)
-    val span2 = Span(123, "method_2", 200, Some(100), ann2, Nil)
+    val span1 = Span(123, "method_1", 100, None, ann1)
+    val span2 = Span(123, "method_2", 200, Some(100), ann2)
 
     val trace = new Trace(Seq(span1, span2))
   }
@@ -134,7 +131,7 @@ class TraceTest extends FunSuite {
 
   test("return none due to missing annotations") {
     // no annotation at all
-    val spanNoAnn = Span(1, "method", 123L, None, List(), Nil)
+    val spanNoAnn = Span(1, "method", 123L)
     val noAnnTrace = Trace(List(spanNoAnn))
     assert(noAnnTrace.getStartAndEndTimestamp === None)
   }
@@ -160,22 +157,22 @@ class TraceTest extends FunSuite {
       Annotation(300, Constants.ClientRecv, Some(Endpoint(123, 123, "service1")))
     )
 
-    val spanToMerge1 = Span(12345, "methodcall2", span2Id, Some(span1Id), ann1, Nil)
-    val spanToMerge2 = Span(12345, "methodcall2", span2Id, Some(span1Id), ann2, Nil)
-    val spanMerged = Span(12345, "methodcall2", span2Id, Some(span1Id), annMerged, Nil)
+    val spanToMerge1 = Span(12345, "methodcall2", span2Id, Some(span1Id), ann1)
+    val spanToMerge2 = Span(12345, "methodcall2", span2Id, Some(span1Id), ann2)
+    val spanMerged = Span(12345, "methodcall2", span2Id, Some(span1Id), annMerged)
 
     assert(Trace(List(spanMerged)).spans === Trace(List(spanToMerge1, spanToMerge2)).spans)
   }
 
   test("get rootmost span from full trace") {
-    val spanNoneParent = Span(1, "", 100, None, List(), Nil)
-    val spanParent = Span(1, "", 200, Some(100), List(), Nil)
+    val spanNoneParent = Span(1, "", 100)
+    val spanParent = Span(1, "", 200, Some(100))
     assert(Trace(List(spanParent, spanNoneParent)).getRootMostSpan === Some(spanNoneParent))
   }
 
   test("get rootmost span from trace without real root") {
-    val spanNoParent = Span(1, "", 100, Some(0), List(), Nil)
-    val spanParent = Span(1, "", 200, Some(100), List(), Nil)
+    val spanNoParent = Span(1, "", 100, Some(0))
+    val spanParent = Span(1, "", 200, Some(100))
     assert(Trace(List(spanParent, spanNoParent)).getRootMostSpan === Some(spanNoParent))
   }
 
@@ -191,11 +188,11 @@ class TraceTest extends FunSuite {
     val ann1 = Annotation(1, "hello", None)
     val ann2 = Annotation(43, "goodbye", None)
 
-    val span1 = Span(12345, "methodcall", 6789, None, List(), Nil)
-    val span2 = Span(12345, "methodcall_2", 345, None, List(ann1, ann2), Nil)
+    val span1 = Span(12345, "methodcall", 6789)
+    val span2 = Span(12345, "methodcall_2", 345, None, List(ann1, ann2))
 
-    val span3 = Span(23456, "methodcall_3", 12, None, List(ann1), Nil)
-    val span4 = Span(23456, "methodcall_4", 34, None, List(ann2), Nil)
+    val span3 = Span(23456, "methodcall_3", 12, None, List(ann1))
+    val span4 = Span(23456, "methodcall_4", 34, None, List(ann2))
 
     // no spans
     val trace1 = new Trace(List())
@@ -222,8 +219,8 @@ class TraceTest extends FunSuite {
     val ann3 = Annotation(3, "ann3", ep3)
     val ann4 = Annotation(4, "ann4", ep2)
 
-    val span1 = Span(1234, "method1", 5678, None, List(ann1, ann2, ann3, ann4), Nil)
-    val span2 = Span(1234, "method2", 345, None, List(ann4), Nil)
+    val span1 = Span(1234, "method1", 5678, None, List(ann1, ann2, ann3, ann4))
+    val span2 = Span(1234, "method2", 345, None, List(ann4))
     val trace1 = new Trace(Seq(span1, span2))
 
     val expected = Map("ep1" -> 1, "ep2" -> 2, "ep3" -> 1)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
@@ -26,7 +26,7 @@ class ZipkinJsonTest extends FunSuite with Matchers {
       BinaryAnnotation("http.uri", ByteBuffer.wrap("/path".getBytes(UTF_8)), AnnotationType.String, Some(web.copy(port = 0))),
       BinaryAnnotation(Constants.ClientAddr, ByteBuffer.wrap(Array[Byte](1)), AnnotationType.Bool, Some(web)),
       BinaryAnnotation(Constants.ServerAddr, ByteBuffer.wrap(Array[Byte](1)), AnnotationType.Bool, Some(query))
-    ), true)
+    ), Some(true))
     assert(mapper.writeValueAsString(s) ==
       """
         |{
@@ -119,7 +119,7 @@ class ZipkinJsonTest extends FunSuite with Matchers {
   }
 
   test("doesn't serialize absent fields of span") { // like debug or parentId
-    val s = Span(1L, "zipkin-query", 2L, None, List.empty[Annotation], List.empty[BinaryAnnotation], false)
+    val s = Span(1L, "zipkin-query", 2L, None, List.empty[Annotation], List.empty[BinaryAnnotation])
     assert(mapper.writeValueAsString(s) ==
       """
         |{"traceId":"0000000000000001","name":"zipkin-query","id":"0000000000000002","annotations":[],"binaryAnnotations":[]}

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
@@ -34,19 +34,19 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
 
   val ann1 = Annotation(100, Constants.ClientSend, Some(ep1))
   val ann2 = Annotation(150, Constants.ClientRecv, Some(ep1))
-  val spans1 = List(Span(1, "methodcall", 666, Some(2), List(ann1, ann2), Nil))
+  val spans1 = List(Span(1, "methodcall", 666, Some(2), List(ann1, ann2)))
   val trace1 = Trace(spans1)
   // duration 50
 
   val ann3 = Annotation(101, Constants.ClientSend, Some(ep2))
   val ann4 = Annotation(501, Constants.ClientRecv, Some(ep2))
-  val spans2 = List(Span(2, "methodcall", 667, None, List(ann3, ann4), Nil))
+  val spans2 = List(Span(2, "methodcall", 667, None, List(ann3, ann4)))
   val trace2 = Trace(spans2)
   // duration 400
 
   val ann5 = Annotation(99, Constants.ClientSend, Some(ep3))
   val ann6 = Annotation(199, Constants.ClientRecv, Some(ep3))
-  val spans3 = List(Span(3, "methodcall", 668, None, List(ann5, ann6), Nil))
+  val spans3 = List(Span(3, "methodcall", 668, None, List(ann5, ann6)))
   val trace3 = Trace(spans3)
   // duration 100
 
@@ -54,8 +54,8 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
   val ann7 = Annotation(110, Constants.ServerRecv, Some(ep2))
   val ann8 = Annotation(140, Constants.ServerSend, Some(ep2))
   val spans4 = List(
-    Span(2, "methodcall", 666, Some(2), List(ann1, ann2), Nil),
-    Span(2, "methodcall", 666, Some(2), List(ann7, ann8), Nil))
+    Span(2, "methodcall", 666, Some(2), List(ann1, ann2)),
+    Span(2, "methodcall", 666, Some(2), List(ann7, ann8)))
   val trace4 = Trace(spans4)
 
   val ann9 = Annotation(60, Constants.ClientSend, Some(ep3))
@@ -68,7 +68,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
 
   val ann13 = Annotation(100, Constants.ClientSend, Some(ep4))
   val ann14 = Annotation(150, Constants.ClientRecv, Some(ep4))
-  val spans6 = List(Span(6, "someMethod", 669, Some(2), List(ann13, ann14), Nil))
+  val spans6 = List(Span(6, "someMethod", 669, Some(2), List(ann13, ann14)))
   // duration 50
 
 

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjusterSpec.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjusterSpec.scala
@@ -48,15 +48,13 @@ class TimeSkewAdjusterTest extends FunSuite {
   val skewAnn2 = Annotation(95, Constants.ServerRecv, endpoint2) // skewed
   val skewAnn3 = Annotation(120, Constants.ServerSend, endpoint2) // skewed
   val skewAnn4 = Annotation(135, Constants.ClientRecv, endpoint1)
-  val skewSpan1 = Span(1, "method1", 666, None,
-    List(skewAnn1, skewAnn2, skewAnn3, skewAnn4), Nil)
+  val skewSpan1 = Span(1, "method1", 666, None, List(skewAnn1, skewAnn2, skewAnn3, skewAnn4))
 
   val skewAnn5 = Annotation(100, Constants.ClientSend, endpoint2) // skewed
   val skewAnn6 = Annotation(115, Constants.ServerRecv, endpoint3)
   val skewAnn7 = Annotation(120, Constants.ServerSend, endpoint3)
   val skewAnn8 = Annotation(115, Constants.ClientRecv, endpoint2) // skewed
-  val skewSpan2 = Span(1, "method2", 777, Some(666),
-    List(skewAnn5, skewAnn6, skewAnn7, skewAnn8), Nil)
+  val skewSpan2 = Span(1, "method2", 777, Some(666), List(skewAnn5, skewAnn6, skewAnn7, skewAnn8))
 
   val inputTrace = new Trace(List[Span](skewSpan1, skewSpan2))
 
@@ -78,14 +76,14 @@ class TimeSkewAdjusterTest extends FunSuite {
   val expectedAnn3 = Annotation(130, Constants.ServerSend, endpoint2)
   val expectedAnn4 = Annotation(135, Constants.ClientRecv, endpoint1)
   val expectedSpan1 = Span(1, "method1", 666, None,
-    List(expectedAnn1, expectedAnn2, expectedAnn3, expectedAnn4), Nil)
+    List(expectedAnn1, expectedAnn2, expectedAnn3, expectedAnn4))
 
   val expectedAnn5 = Annotation(110, Constants.ClientSend, endpoint2)
   val expectedAnn6 = Annotation(115, Constants.ServerRecv, endpoint3)
   val expectedAnn7 = Annotation(120, Constants.ServerSend, endpoint3)
   val expectedAnn8 = Annotation(125, Constants.ClientRecv, endpoint2)
   val expectedSpan2 = Span(1, "method2", 777, Some(666),
-    List(expectedAnn5, expectedAnn6, expectedAnn7, expectedAnn8), Nil)
+    List(expectedAnn5, expectedAnn6, expectedAnn7, expectedAnn8))
 
   val expectedTrace = new Trace(List[Span](expectedSpan1, expectedSpan2))
 
@@ -106,7 +104,7 @@ class TimeSkewAdjusterTest extends FunSuite {
   val incompleteAnn1 = Annotation(100, Constants.ClientSend, endpoint1)
   val incompleteAnn4 = Annotation(135, Constants.ClientRecv, endpoint1)
   val incompleteSpan1 = Span(1, "method1", 666, None,
-    List(incompleteAnn1, incompleteAnn4), Nil)
+    List(incompleteAnn1, incompleteAnn4))
 
   val incompleteTrace = new Trace(List[Span](expectedSpan1))
 
@@ -124,16 +122,13 @@ class TimeSkewAdjusterTest extends FunSuite {
   val ann6 = Annotation(87, Constants.ClientRecv, epCassie)
   val ann6F = Annotation(86, Constants.ClientRecv, epCassie)
 
-  val span1a = Span(1, "ValuesFromSource", 2209720933601260005L, None,
-    List(ann3, ann6), Nil)
-  val span1aFixed = Span(1, "ValuesFromSource", 2209720933601260005L, None,
-    List(ann3F, ann6F), Nil)
-  val span1b = Span(1, "ValuesFromSource", 2209720933601260005L, None,
-    List(ann1, ann4), Nil)
+  val span1a = Span(1, "ValuesFromSource", 2209720933601260005L, None, List(ann3, ann6))
+  val span1aFixed = Span(1, "ValuesFromSource", 2209720933601260005L, None, List(ann3F, ann6F))
+  val span1b = Span(1, "ValuesFromSource", 2209720933601260005L, None, List(ann1, ann4))
   // the above two spans are part of the same actual span
 
   val span2 = Span(1, "multiget_slice", -855543208864892776L, Some(2209720933601260005L),
-    List(ann2, ann5), Nil)
+    List(ann2, ann5))
 
   val realTrace = new Trace(List(span1a, span1b, span2))
   val expectedRealTrace = new Trace(List(span1aFixed, span1b, span2))
@@ -161,7 +156,7 @@ class TimeSkewAdjusterTest extends FunSuite {
     val monorailSr = Annotation(2L, Constants.ServerRecv, epMonorail)
     val monorailSs = Annotation(3L, Constants.ServerSend, epMonorail)
     val unicornCr  = Annotation(4L, Constants.ClientRecv, epTfe)
-    val goodSpan = Span(1, "friendships/create", 12345L, None, List(unicornCs, monorailSr, monorailSs, unicornCr), Nil)
+    val goodSpan = Span(1, "friendships/create", 12345L, None, List(unicornCs, monorailSr, monorailSs, unicornCr))
     val goodTrace = new Trace(Seq(goodSpan))
 
     assert(adjuster.adjust(goodTrace) === goodTrace)
@@ -173,17 +168,17 @@ class TimeSkewAdjusterTest extends FunSuite {
 
     val rootSr     = Annotation(1330539326400951L, Constants.ServerRecv, epTfe)
     val rootSs     = Annotation(1330539327264251L, Constants.ServerSend, epTfe)
-    val spanTfe    = Span(1, "POST", 7264365917420400007L, None, List(rootSr, rootSs), Nil)
+    val spanTfe    = Span(1, "POST", 7264365917420400007L, None, List(rootSr, rootSs))
 
     val unicornCs  = Annotation(1330539326401999L, Constants.ClientSend, epTfe)
     val monorailSr = Annotation(1330539325900366L, Constants.ServerRecv, epMonorail)
     val monorailSs = Annotation(1330539326524407L, Constants.ServerSend, epMonorail)
     val unicornCr  = Annotation(1330539327263984L, Constants.ClientRecv, epTfe)
-    val spanMonorailUnicorn = Span(1, "friendships/create", 6379677665629798877L, Some(7264365917420400007L), List(unicornCs, monorailSr, monorailSs, unicornCr), Nil)
+    val spanMonorailUnicorn = Span(1, "friendships/create", 6379677665629798877L, Some(7264365917420400007L), List(unicornCs, monorailSr, monorailSs, unicornCr))
 
     val adjustedMonorailSr = Annotation(1330539326520971L, Constants.ServerRecv, epMonorail)
     val adjustedMonorailSs = Annotation(1330539327145012L, Constants.ServerSend, epMonorail)
-    val spanAdjustedMonorail = Span(1, "friendships/create", 6379677665629798877L, Some(7264365917420400007L), List(unicornCs, adjustedMonorailSr, adjustedMonorailSs, unicornCr), Nil)
+    val spanAdjustedMonorail = Span(1, "friendships/create", 6379677665629798877L, Some(7264365917420400007L), List(unicornCs, adjustedMonorailSr, adjustedMonorailSs, unicornCr))
 
     val realTrace = new Trace(Seq(spanTfe, spanMonorailUnicorn))
     val expectedAdjustedTrace = new Trace(Seq(spanTfe, spanAdjustedMonorail))
@@ -204,22 +199,22 @@ class TimeSkewAdjusterTest extends FunSuite {
 
     val tfeSr         = Annotation(1330647964054410L, Constants.ServerRecv, epTfe)
     val tfeSs         = Annotation(1330647964057394L, Constants.ServerSend, epTfe)
-    val spanTfe       = Span(1, "GET", 583798990668970003L, None, List(tfeSr, tfeSs), Nil)
+    val spanTfe       = Span(1, "GET", 583798990668970003L, None, List(tfeSr, tfeSs))
 
     val tfeCs         = Annotation(1330647964054881L, Constants.ClientSend, epTfe)
     val passbirdSr    = Annotation(1330647964055250L, Constants.ServerRecv, epPassbird)
     val passbirdSs    = Annotation(1330647964057394L, Constants.ServerSend, epPassbird)
     val tfeCr         = Annotation(1330647964057764L, Constants.ClientRecv, epTfe)
-    val spanPassbird  = Span(1, "get_user_by_auth_token", 7625434200987291951L, Some(583798990668970003L), List(tfeCs, passbirdSr, passbirdSs, tfeCr), Nil)
+    val spanPassbird  = Span(1, "get_user_by_auth_token", 7625434200987291951L, Some(583798990668970003L), List(tfeCs, passbirdSr, passbirdSs, tfeCr))
 
     // Gizmoduck server entries are missing
     val passbirdCs    = Annotation(1330647964055324L, Constants.ClientSend, epPassbird)
     val passbirdCr    = Annotation(1330647964057127L, Constants.ClientRecv, epPassbird)
-    val spanGizmoduck = Span(1, "get_by_auth_token", 119310086840195752L, Some(7625434200987291951L), List(passbirdCs, passbirdCr), Nil)
+    val spanGizmoduck = Span(1, "get_by_auth_token", 119310086840195752L, Some(7625434200987291951L), List(passbirdCs, passbirdCr))
 
     val gizmoduckCs   = Annotation(1330647963542175L, Constants.ClientSend, epGizmoduck)
     val gizmoduckCr   = Annotation(1330647963542565L, Constants.ClientRecv, epGizmoduck)
-    val spanMemcache  = Span(1, "Get", 3983355768376203472L, Some(119310086840195752L), List(gizmoduckCs, gizmoduckCr), Nil)
+    val spanMemcache  = Span(1, "Get", 3983355768376203472L, Some(119310086840195752L), List(gizmoduckCs, gizmoduckCr))
 
     // Adjusted/created annotations
     val createdGizmoduckSr   = Annotation(1330647964055324L, Constants.ServerRecv, epGizmoduck)
@@ -227,8 +222,8 @@ class TimeSkewAdjusterTest extends FunSuite {
     val adjustedGizmoduckCs  = Annotation(1330647964056030L, Constants.ClientSend, epGizmoduck)
     val adjustedGizmoduckCr = Annotation(1330647964056420L, Constants.ClientRecv, epGizmoduck)
 
-    val spanAdjustedGizmoduck = Span(1, "get_by_auth_token", 119310086840195752L, Some(7625434200987291951L), List(passbirdCs, passbirdCr, createdGizmoduckSr, createdGizmoduckSs), Nil)
-    val spanAdjustedMemcache = Span(1, "Get", 3983355768376203472L, Some(119310086840195752L), List(adjustedGizmoduckCs, adjustedGizmoduckCr), Nil)
+    val spanAdjustedGizmoduck = Span(1, "get_by_auth_token", 119310086840195752L, Some(7625434200987291951L), List(passbirdCs, passbirdCr, createdGizmoduckSr, createdGizmoduckSs))
+    val spanAdjustedMemcache = Span(1, "Get", 3983355768376203472L, Some(119310086840195752L), List(adjustedGizmoduckCs, adjustedGizmoduckCr))
 
     val realTrace = new Trace(Seq(spanTfe, spanPassbird, spanGizmoduck, spanMemcache))
     val adjustedTrace = new Trace(Seq(spanTfe, spanPassbird, spanAdjustedGizmoduck, spanAdjustedMemcache))
@@ -245,8 +240,8 @@ class TimeSkewAdjusterTest extends FunSuite {
     val ss = Annotation(11L, Constants.ServerSend, ep2)
     val cr    = Annotation(4L, Constants.ClientRecv, ep1)
     val cr2    = Annotation(5L, Constants.ClientRecv, ep1)
-    val spanBad   = Span(1, "method", 123L, None, List(cs, sr, ss, cr, cr2), Nil)
-    val spanGood   = Span(1, "method", 123L, None, List(cs, sr, ss, cr), Nil)
+    val spanBad   = Span(1, "method", 123L, None, List(cs, sr, ss, cr, cr2))
+    val spanGood   = Span(1, "method", 123L, None, List(cs, sr, ss, cr))
 
     val trace1 = new Trace(Seq(spanGood))
     assert(trace1 != adjuster.adjust(trace1))
@@ -262,7 +257,7 @@ class TimeSkewAdjusterTest extends FunSuite {
     val ss = Annotation(11L, Constants.ServerSend, ep2)
     val cr = Annotation(4L, Constants.ClientRecv, ep1)
 
-    val span = Span(1, "method", 123L, None, List(cs, sr, ss, cr), Nil)
+    val span = Span(1, "method", 123L, None, List(cs, sr, ss, cr))
 
     val trace1 = new Trace(Seq(span))
     assert(trace1 === adjuster.adjust(trace1))
@@ -274,7 +269,7 @@ class TimeSkewAdjusterTest extends FunSuite {
     val tfe = Span(142224153997690008L, "GET", 142224153997690008L, None, List(
       Annotation(60498165L, Constants.ServerRecv, Some(tfeService)),
       Annotation(61031100L, Constants.ServerSend, Some(tfeService))
-    ), Nil)
+    ))
 
     val monorailService = Endpoint(456, 8000, "monorail")
     val clusterTwitterweb = Endpoint(123, -13145, "cluster_twitterweb_unicorn")
@@ -284,7 +279,7 @@ class TimeSkewAdjusterTest extends FunSuite {
       Annotation(59934508L, Constants.ServerSend, Some(monorailService)),
       Annotation(60499730L, Constants.ClientSend, Some(clusterTwitterweb)),
       Annotation(61030844L, Constants.ClientRecv, Some(clusterTwitterweb))
-    ), Nil)
+    ))
 
     val tflockService = Endpoint(456, -14238, "tflock")
     val flockdbEdgesService = Endpoint(789, 6915, "flockdb_edges")
@@ -294,14 +289,14 @@ class TimeSkewAdjusterTest extends FunSuite {
       Annotation(59544889L, Constants.ClientRecv, Some(tflockService)),
       Annotation(59541031L, Constants.ServerRecv, Some(flockdbEdgesService)),
       Annotation(59542894L, Constants.ServerSend, Some(flockdbEdgesService))
-    ), Nil)
+    ))
 
     val flockService = Endpoint(2130706433, 0, "flock")
 
     val flock = Span(142224153997690008L, "select", 7330066031642813936L, Some(6924056367845423617L), List(
       Annotation(59541299L, Constants.ClientSend, Some(flockService)),
       Annotation(59542778L, Constants.ClientRecv, Some(flockService))
-    ), Nil)
+    ))
 
     val trace = new Trace(Seq(monorail, tflock, tfe, flock))
     val adjusted = adjuster.adjust(trace)

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -22,7 +22,7 @@ class KafkaProcessorSpecSimple extends JUnitSuite {
   import KafkaProcessorSpecSimple.kafkaRule
 
   val topic = Map("integration-test-topic" -> 1)
-  val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)), Nil)
+  val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)))
   val decoder = new SpanCodec()
   val defaultKafkaTopics = Map("zipkin_kafka" -> 1 )
 
@@ -41,7 +41,7 @@ class KafkaProcessorSpecSimple extends JUnitSuite {
 
   def createMessage(): Array[Byte] = {
     val annotation = Annotation(1, "value", Some(Endpoint(1, 2, "service")))
-    val message = Span(1234, "methodName", 4567, None, List(annotation), Nil)
+    val message = Span(1234, "methodName", 4567, None, List(annotation))
     val codec = new SpanCodec()
     codec.encode(message)
   }

--- a/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
+++ b/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
@@ -33,7 +33,7 @@ class ScribeSpanReceiverTest extends FunSuite {
   }
   val category = "zipkin"
 
-  val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)), Nil)
+  val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)))
   val validList = List(LogEntry(category, serializer.toString(validSpan.toThrift)))
 
   val base64 = "CgABAAAAAAAAAHsLAAMAAAADYm9vCgAEAAAAAAAAAcgPAAYMAAAAAQoAAQAAAAAAAAABCwACAAAAA2JhaAAPAAgMAAAAAAIACQAA"

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisIndexSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisIndexSpec.scala
@@ -49,8 +49,8 @@ class RedisIndexSpec extends RedisSpecification {
   val span3 = Span(123, "methodcall", spanId, None, List(ann2, ann3, ann4),
     List(binaryAnnotation("BAH2", "BEH2")))
 
-  val spanEmptySpanName = Span(123, "", spanId, None, List(ann1, ann2), List())
-  val spanEmptyServiceName = Span(123, "spanname", spanId, None, List(), List())
+  val spanEmptySpanName = Span(123, "", spanId, None, List(ann1, ann2))
+  val spanEmptyServiceName = Span(123, "spanname", spanId)
 
   val mergedSpan = Span(123, "methodcall", spanId, None,
     List(ann1, ann2), List(binaryAnnotation("BAH2", "BEH2")))

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSnappyThriftCodec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSnappyThriftCodec.scala
@@ -7,18 +7,13 @@ import com.twitter.zipkin.thriftscala
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.common.{Annotation, BinaryAnnotation, Span}
 
-
-/**
- * Tests the RedisSnappyThriftCodec
- */
 class RedisSnappyThriftCodecSpec extends RedisSpecification {
 
   val thriftCodec = new RedisSnappyThriftCodec(new BinaryThriftStructSerializer[thriftscala.Span] {
     override def codec = thriftscala.Span
   })
 
-  val span = Span(1L, "name", 2L, Option(3L), List[Annotation](),
-                  Seq[BinaryAnnotation](), true).toThrift
+  val span = Span(1L, "name", 2L, Option(3L), List.empty, Seq.empty, Some(true)).toThrift
 
   test("compress and decompress should yield an equal object") {
     val bytes = thriftCodec.encode(span)

--- a/zipkin-sampler/src/main/scala/com/twitter/zipkin/sampler/SpanSamplerFilter.scala
+++ b/zipkin-sampler/src/main/scala/com/twitter/zipkin/sampler/SpanSamplerFilter.scala
@@ -35,7 +35,7 @@ class SpanSamplerFilter(
 
   def apply(spans: Seq[Span], store: Service[Seq[Span], Unit]): Future[Unit] =
     store(spans collect {
-      case span if span.debug =>
+      case span if span.debug.getOrElse(false) =>
         DebugCounter.incr()
         if (span.parentId.isEmpty && !span.serviceName.isEmpty)
           DebugStats.counter(span.serviceName.get).incr()

--- a/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/SpanSamplerFilterTest.scala
+++ b/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/SpanSamplerFilterTest.scala
@@ -23,11 +23,11 @@ import org.scalatest.FunSuite
 class SpanSamplerFilterTest extends FunSuite {
   test("filters spans based on their traceId") {
     val spans = Seq(
-      Span(0, "svc", 123L, None, List.empty[Annotation], Seq.empty[BinaryAnnotation]),
-      Span(1, "svc", 123L, None, List.empty[Annotation], Seq.empty[BinaryAnnotation]),
-      Span(2, "svc", 123L, None, List.empty[Annotation], Seq.empty[BinaryAnnotation]),
-      Span(3, "svc", 123L, None, List.empty[Annotation], Seq.empty[BinaryAnnotation]),
-      Span(4, "svc", 123L, None, List.empty[Annotation], Seq.empty[BinaryAnnotation]))
+      Span(0, "svc", 123L),
+      Span(1, "svc", 123L),
+      Span(2, "svc", 123L),
+      Span(3, "svc", 123L),
+      Span(4, "svc", 123L))
 
     var rcvdSpans = Seq.empty[Span]
 
@@ -43,9 +43,9 @@ class SpanSamplerFilterTest extends FunSuite {
 
   test("will not filter debug spans") {
     val spans = Seq(
-      Span(0, "svc", 123L, None, List.empty[Annotation], Seq.empty[BinaryAnnotation], true),
-      Span(1, "svc", 123L, None, List.empty[Annotation], Seq.empty[BinaryAnnotation], true),
-      Span(1, "svc", 123L, None, List.empty[Annotation], Seq.empty[BinaryAnnotation], false))
+      Span(0, "svc", 123L, None, List.empty, Seq.empty, Some(true)),
+      Span(1, "svc", 123L, None, List.empty, Seq.empty, Some(true)),
+      Span(1, "svc", 123L))
 
     var rcvdSpans = Seq.empty[Span]
 

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -88,7 +88,7 @@ object thrift {
   class ThriftSpan(s: Span) {
     lazy val toThrift = {
       thriftscala.Span(s.traceId, s.name, s.id, s.parentId, s.annotations.map { _.toThrift },
-        s.binaryAnnotations.map { _.toThrift }, s.debug)
+        s.binaryAnnotations.map { _.toThrift }, s.debug.getOrElse(false))
     }
   }
   class WrappedSpan(s: thriftscala.Span) {
@@ -105,13 +105,13 @@ object thrift {
         s.parentId,
         s.annotations match {
           case null => List.empty[Annotation]
-          case as => as.map(_.toAnnotation)(breakOut)
+          case as => as.map(_.toAnnotation)(breakOut).toList.sorted
         },
         s.binaryAnnotations match {
           case null => List.empty[BinaryAnnotation]
           case b => b.map(_.toBinaryAnnotation)(breakOut)
         },
-        s.debug
+        if (s.debug) Some(true) else None // Scrooge treats optional bool as bool!
       )
     }
   }

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
@@ -61,8 +61,7 @@ class ThriftConversionsTest extends FunSuite {
   test("convert Span") {
     val annotationValue = "NONSENSE"
     val expectedAnnotation = Annotation(1, annotationValue, Some(Endpoint(1, 2, "service")))
-    val expectedSpan = Span(12345, "methodcall", 666, None,
-      List(expectedAnnotation), Nil)
+    val expectedSpan = Span(12345, "methodcall", 666, None, List(expectedAnnotation))
 
     assert(expectedSpan.toThrift.toSpan === expectedSpan)
 
@@ -70,9 +69,9 @@ class ThriftConversionsTest extends FunSuite {
     intercept[IncompleteTraceDataException] { noNameSpan.toSpan }
 
     val noAnnotationsSpan = thriftscala.Span(0, "name", 0, None, null, Seq())
-    assert(noAnnotationsSpan.toSpan === Span(0, "name", 0, None, List(), Seq()))
+    assert(noAnnotationsSpan.toSpan === Span(0, "name", 0))
 
     val noBinaryAnnotationsSpan = thriftscala.Span(0, "name", 0, None, Seq(), null)
-    assert(noBinaryAnnotationsSpan.toSpan === Span(0, "name", 0, None, List(), Seq()))
+    assert(noBinaryAnnotationsSpan.toSpan === Span(0, "name", 0))
   }
 }


### PR DESCRIPTION
Before, the common Span type was a strange trait, only used as a case
class. It mismatched the thrift Span struct as it treated debug as if it
weren't an option. This cleans up the tech debt and removes all passing
of `Nil` wrt instantiating a Span class. `Nil` should be very uncommon
in scala code.
