### PR TITLE
Reduces default database connections to 10; adds MYSQL_MAX_CONNECTIONS

### DIFF
--- a/zipkin-anormdb/README.md
+++ b/zipkin-anormdb/README.md
@@ -15,6 +15,7 @@ Currently, only MySQL is configurable through environment variables:
     * `MYSQL_USER` and `MYSQL_PASS`: MySQL authentication, which defaults to empty string.
     * `MYSQL_HOST`: Defaults to localhost
     * `MYSQL_TCP_PORT`: Defaults to 3306
+    * `MYSQL_MAX_CONNECTIONS`: Maximum concurrent connections, defaults to 10
 
 Example MySQL usage:
 ```bash

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -43,7 +43,7 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
   connpool.setDriverClassName(dbconfig.driver)
   connpool.setJdbcUrl(dbconfig.location)
   connpool.setConnectionTestQuery(if (dbconfig.jdbc3) "SELECT 1" else null)
-  connpool.setMaximumPoolSize(32)
+  connpool.setMaximumPoolSize(dbconfig.maxConnections)
 
   /**
    * Gets a dedicated java.sql.Connection to the SQL database. Note that auto-commit is

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
@@ -50,10 +50,12 @@ case class DBParams(
  * @param params Connection information
  * @param install Whether to set up the database schema.
  *                The schema can be installed multiple times with no problems.
+ * @param maxConnections Maximum count of concurrent connections to the database.
  */
 case class DBConfig(name: String = "sqlite-persistent",
                     params: DBParams = new DBParams(),
-                    install: Boolean = false) {
+                    install: Boolean = false,
+                    maxConnections: Int = 10) {
 
   /**
    * @param jdbc3 Whether this is a legacy JDBC3 driver

--- a/zipkin-collector-service/config/collector-mysql.scala
+++ b/zipkin-collector-service/config/collector-mysql.scala
@@ -9,12 +9,17 @@ val adminPort = sys.env.get("COLLECTOR_ADMIN_PORT").getOrElse("9900").toInt
 val logLevel = sys.env.get("COLLECTOR_LOG_LEVEL").getOrElse("INFO")
 val sampleRate = sys.env.get("COLLECTOR_SAMPLE_RATE").getOrElse("1.0").toDouble
 
-val db = DB(DBConfig("mysql", new DBParams(
-  dbName = sys.env.get("MYSQL_DB").getOrElse("zipkin"),
-  sys.env.get("MYSQL_HOST").getOrElse("localhost"),
-  sys.env.get("MYSQL_TCP_PORT").map(_.toInt),
-  sys.env.get("MYSQL_USER").getOrElse(""),
-  sys.env.get("MYSQL_PASS").getOrElse(""))))
+val db = DB(DBConfig(
+  name = "mysql",
+  params = new DBParams(
+    sys.env.get("MYSQL_DB").getOrElse("zipkin"),
+    sys.env.get("MYSQL_HOST").getOrElse("localhost"),
+    sys.env.get("MYSQL_TCP_PORT").map(_.toInt),
+    sys.env.get("MYSQL_USER").getOrElse(""),
+    sys.env.get("MYSQL_PASS").getOrElse("")
+  ),
+  maxConnections = sys.env.get("MYSQL_MAX_CONNECTIONS").map(_.toInt).getOrElse(10)
+))
 
 // Note: schema must be present prior to starting the collector or query
 //   - zipkin-anormdb/src/main/resources/mysql.sql

--- a/zipkin-query-service/config/query-mysql.scala
+++ b/zipkin-query-service/config/query-mysql.scala
@@ -5,12 +5,17 @@ val serverPort = sys.env.get("QUERY_PORT").getOrElse("9411").toInt
 val adminPort = sys.env.get("QUERY_ADMIN_PORT").getOrElse("9901").toInt
 val logLevel = sys.env.get("QUERY_LOG_LEVEL").getOrElse("INFO")
 
-val db = DB(DBConfig("mysql", new DBParams(
-  dbName = sys.env.get("MYSQL_DB").getOrElse("zipkin"),
-  sys.env.get("MYSQL_HOST").getOrElse("localhost"),
-  sys.env.get("MYSQL_TCP_PORT").map(_.toInt),
-  sys.env.get("MYSQL_USER").getOrElse(""),
-  sys.env.get("MYSQL_PASS").getOrElse(""))))
+val db = DB(DBConfig(
+  name = "mysql",
+  params = new DBParams(
+    sys.env.get("MYSQL_DB").getOrElse("zipkin"),
+    sys.env.get("MYSQL_HOST").getOrElse("localhost"),
+    sys.env.get("MYSQL_TCP_PORT").map(_.toInt),
+    sys.env.get("MYSQL_USER").getOrElse(""),
+    sys.env.get("MYSQL_PASS").getOrElse("")
+  ),
+  maxConnections = sys.env.get("MYSQL_MAX_CONNECTIONS").map(_.toInt).getOrElse(10)
+))
 
 // Note: schema must be present prior to starting the collector or query
 //   - zipkin-anormdb/src/main/resources/mysql.sql


### PR DESCRIPTION
Database tuning is site-specific. However, we should include smart
defaults. This moves from 32 to Hikari's default of 10 connections per
instance/pool. This adds a new env variable `MYSQL_MAX_CONNECTIONS` to
adjust that.

Fixes #787
