### PR TITLE
Fixes service name resolution of dependency graph

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormDependencyStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormDependencyStore.scala
@@ -60,6 +60,7 @@ case class AnormDependencyStore(val db: DB,
         """SELECT DISTINCT trace_id, span_id, endpoint_service_name
           |FROM zipkin_annotations
           |WHERE trace_id IN (%s)
+          |AND a_key in ("sr","sa")
           |AND endpoint_service_name is not null
           |GROUP BY trace_id, span_id
         """.stripMargin.format(parentChild.keys.mkString(",")))

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -29,15 +29,19 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
   val trace = List(
     Span(1L, "GET", 1L, None, List(
       Annotation(today, Constants.ServerRecv, Some(zipkinWeb)),
-      Annotation(today + 350, Constants.ServerSend, Some(zipkinWeb))), Seq.empty),
+      Annotation(today + 350, Constants.ServerSend, Some(zipkinWeb)))),
     Span(1L, "GET", 2L, Some(1L), List(
-      Annotation(today + 50, Constants.ServerRecv, Some(zipkinQuery)),
-      Annotation(today + 100, Constants.ClientSend, Some(zipkinQuery.copy(port = 0))),
-      Annotation(today + 250, Constants.ClientRecv, Some(zipkinQuery.copy(port = 0))),
-      Annotation(today + 300, Constants.ServerSend, Some(zipkinQuery))), Seq.empty),
+      Annotation(today + 50, Constants.ClientSend, Some(zipkinWeb)),
+      Annotation(today + 100, Constants.ServerRecv, Some(zipkinQuery.copy(port = 0))),
+      Annotation(today + 250, Constants.ServerSend, Some(zipkinQuery.copy(port = 0))),
+      Annotation(today + 300, Constants.ClientRecv, Some(zipkinWeb))), List(
+      BinaryAnnotation(Constants.ClientAddr, BinaryAnnotationValue(true), Some(zipkinWeb)),
+      BinaryAnnotation(Constants.ServerAddr, BinaryAnnotationValue(true), Some(zipkinQuery)))),
     Span(1L, "query", 3L, Some(2L), List(
-      Annotation(today + 150, Constants.ClientSend, Some(zipkinJdbc)),
-      Annotation(today + 200, Constants.ClientRecv, Some(zipkinJdbc))), Seq.empty)
+      Annotation(today + 150, Constants.ClientSend, Some(zipkinQuery)),
+      Annotation(today + 200, Constants.ClientRecv, Some(zipkinQuery))), List(
+      BinaryAnnotation(Constants.ClientAddr, BinaryAnnotationValue(true), Some(zipkinQuery)),
+      BinaryAnnotation(Constants.ServerAddr, BinaryAnnotationValue(true), Some(zipkinJdbc))))
   )
 
   val dep = new Dependencies(today, today + 1000, List(
@@ -68,6 +72,47 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
     result(store.getDependencies(None, None)) should be(dep.links)
   }
 
+  /**
+   * When all servers are instrumented, they all log a "sr" annotation, indicating the service.
+   */
+  @Test def getDependenciesAllInstrumented() = {
+    val one = Endpoint(127 << 24 | 1, 9410, "TraceProducerOne")
+    val two = Endpoint(127 << 24 | 2, 9410, "TraceProducerTwo")
+    val three = Endpoint(127 << 24 | 3, 9410, "TraceProducerThree")
+
+    val trace = List(
+      Span(10L, "GET", 10L, None, List(
+        Annotation(1445136539256150L, Constants.ServerRecv, Some(one)),
+        Annotation(1445136540408729L, Constants.ServerSend, Some(one)))),
+      Span(10L, "GET", 20L, Some(10L), List(
+        Annotation(1445136539764798L, Constants.ClientSend, Some(one.copy(port = 3001))),
+        Annotation(1445136539816432L, Constants.ServerRecv, Some(two)),
+        Annotation(1445136540401414L, Constants.ServerSend, Some(two)),
+        Annotation(1445136540404135L, Constants.ClientRecv, Some(one.copy(port = 3001))))),
+      Span(10L, "query", 30L, Some(20L), List(
+        Annotation(1445136540025751L, Constants.ClientSend, Some(two.copy(port = 3002))),
+        Annotation(1445136540072846L, Constants.ServerRecv, Some(three)),
+        Annotation(1445136540394644L, Constants.ServerSend, Some(three)),
+        Annotation(1445136540397049L, Constants.ClientRecv, Some(two.copy(port = 3002)))))
+    )
+    processDependencies(trace)
+
+    result(store.getDependencies(Some(trace(0).startTs.get), Some(trace(0).endTs.get))) should be(
+      List(
+        new DependencyLink("TraceProducerTwo", "TraceProducerThree", 1),
+        new DependencyLink("TraceProducerOne", "TraceProducerTwo", 1)
+      )
+    )
+  }
+
+  /**
+   * The primary annotation used in the dependency graph is [[Constants.ServerRecv]]
+   */
+  @Test def getDependenciesMultiLevel() = {
+    processDependencies(trace)
+
+    result(store.getDependencies(None, None)) should be(dep.links)
+  }
 
   @Test def dependencies_loopback {
     val traceWithLoopback = List(


### PR DESCRIPTION
Before this change, the dependency graph would display the _first_
serviceName in a span, and use that as the parent name. The problem is
that there are multiple endpoints in a span.

For example, the endpoint associated with "sr" or "cs" is the local
server, in this case the server _or_ the client. So, just picking any
endpoint and using it as the service name will certainly be inaccurate.

Moreover, sometimes the server isn't instrumented, so in this case it
won't be able to log an "sr" annotation. Unless you look at the "sa" or
Service Addr annotation, you won't be able to name that span, either.

This fixes both of these problems, by considering only service names of
"sr" or "sa" when building dependency links.

This also backfills tests for the previous span name parsing behavior.

Fixes #781
