### PR TITLE
Reverts Cassandra schema change from timestamp to bigint

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Sat, 15 Aug 2015 15:15:18 +0000
-version=1.18.2-SNAPSHOT
+version=1.19.0-SNAPSHOT
 group=io.zipkin
 repo=https://github.com/openzipkin/zipkin
 description=A distributed tracing system

--- a/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
+++ b/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
@@ -2,7 +2,7 @@ CREATE KEYSPACE IF NOT EXISTS zipkin WITH replication = {'class': 'SimpleStrateg
 
 CREATE TABLE IF NOT EXISTS zipkin.service_span_name_index (
     service_span_name text,
-    ts                bigint,
+    ts                timestamp,
     trace_id          bigint,
     PRIMARY KEY (service_span_name, ts)
 ) WITH CLUSTERING ORDER BY (ts DESC)
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS zipkin.service_span_name_index (
 CREATE TABLE IF NOT EXISTS zipkin.service_name_index (
     service_name      text,
     bucket            int,
-    ts                bigint,
+    ts                timestamp,
     trace_id          bigint,
     PRIMARY KEY ((service_name, bucket), ts)
 ) WITH CLUSTERING ORDER BY (ts DESC)
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS zipkin.span_names (
 CREATE TABLE IF NOT EXISTS zipkin.annotations_index (
     annotation     blob,
     bucket         int,
-    ts             bigint,
+    ts             timestamp,
     trace_id       bigint,
     PRIMARY KEY ((annotation, bucket), ts)
 ) WITH CLUSTERING ORDER BY (ts DESC)
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS zipkin.service_names (
 
 CREATE TABLE IF NOT EXISTS zipkin.traces (
     trace_id  bigint,
-    ts        bigint,
+    ts        timestamp,
     span_name text,
     span      blob,
     PRIMARY KEY (trace_id, ts, span_name)


### PR DESCRIPTION
I misunderstood the precision of Cassandra timestamps, distracted by
conflicting CQL documentation and the use of j.u.Date (which has millis
precision). This led to advice to change our schema to bigint to avoid
precision loss storing timestamps.

@yurishkuro's production environment broke on this change, pinning them
to zipkin 1.12. He noted that there's no precision problem, as zipkin
go ingesters are storing micros in timestamp fields!

Upon investigation, and by help of datastax, we found it is indeed
possible with custom code. This change reverts the schema, but without
a precision loss in java.

Reverts 521f209972db8b741cc0ceacc7e42be71420b8e4
See https://groups.google.com/a/lists.datastax.com/forum/#!topic/java-driver-user/PUpJh6cKaRA
