### PR TITLE
Updates from cassandra-driver-core 2.1.7.1 to 2.1.8

### DIFF
--- a/zipkin-cassandra-core/build.gradle
+++ b/zipkin-cassandra-core/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '2.1.7.1'
-    testCompile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', classifier: 'tests', version: '2.1.7.1'
+    compile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '2.1.8'
+    testCompile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', classifier: 'tests', version: '2.1.8'
     testCompile group: 'org.apache.commons', name: 'commons-exec', version: '1.3'
 }


### PR DESCRIPTION
Released 3 weeks ago, and no 2.1.8.1, so probably safe to update

https://github.com/datastax/java-driver/tree/2.1/changelog
