### PR TITLE
Enforces span and service names as lowercase

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -284,7 +284,8 @@ class AnormSpanStore(val db: DB,
     }
   }
 
-  override def getSpanNames(service: String): Future[Seq[String]] = db.inNewThreadWithRecoverableRetry {
+  override def getSpanNames(_service: String): Future[Seq[String]] = db.inNewThreadWithRecoverableRetry {
+    val service = _service.toLowerCase // service names are always lowercase!
     implicit val (conn, borrowTime) = borrowConn()
     try {
 

--- a/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
+++ b/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
@@ -414,6 +414,7 @@ public final class Repository implements AutoCloseable {
 
     public ListenableFuture<Set<String>> getSpanNames(String serviceName) {
         Preconditions.checkNotNull(serviceName);
+        serviceName = serviceName.toLowerCase(); // service names are always lowercase!
         try {
             if (!serviceName.isEmpty()) {
 

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -56,9 +56,6 @@ abstract class CassandraSpanStore(
   private[this] def createSpanColumnName(span: Span): String =
     "%d_%d_%d".format(span.id, span.annotations.hashCode, span.binaryAnnotations.hashCode)
 
-  private[this] def nameKey(serviceName: String, spanName: Option[String]): String =
-    (serviceName + spanName.map("." + _).getOrElse("")).toLowerCase
-
   private[this] def annotationKey(serviceName: String, annotation: String, value: Option[ByteBuffer]): ByteBuffer = {
     ByteBuffer.wrap(
       serviceName.getBytes ++ IndexDelimiterBytes ++ annotation.getBytes ++
@@ -101,7 +98,7 @@ abstract class CassandraSpanStore(
         IndexServiceNameNoNameCounter.incr()
         Future.value(())
       case s =>
-        FutureUtil.toFuture(repository.storeServiceName(s.toLowerCase, indexTtl.inSeconds))
+        FutureUtil.toFuture(repository.storeServiceName(s, indexTtl.inSeconds))
     })
   }
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
@@ -2,10 +2,11 @@ package com.twitter.zipkin.storage
 
 import com.twitter.util.Time
 import com.twitter.zipkin.util.Util.checkArgument
+import scala.util.hashing.MurmurHash3
 
 /**
- * @param serviceName Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]]
- * @param spanName When present, only include traces with this [[com.twitter.zipkin.common.Span.name]]
+ * @param _serviceName Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]]
+ * @param _spanName When present, only include traces with this [[com.twitter.zipkin.common.Span.name]]
  * @param annotations Include traces whose [[com.twitter.zipkin.common.Span.annotations]] include a value in this set.
  *                    This is an AND condition against the set, as well against [[binaryAnnotations]]
  * @param binaryAnnotations Include traces whose [[com.twitter.zipkin.common.Span.binaryAnnotations]] include a
@@ -15,15 +16,52 @@ import com.twitter.zipkin.util.Util.checkArgument
  *              or before this time in epoch microseconds. Defaults to current time.
  * @param limit maximum number of traces to return. Defaults to 10
  */
-case class QueryRequest(serviceName: String,
-                        spanName: Option[String] = None,
-                        annotations: Set[String] = Set.empty,
-                        binaryAnnotations: Set[(String, String)] = Set.empty,
-                        endTs: Long = Time.now.inMicroseconds,
-                        limit: Int = 10) {
+// This is not a case-class as we need to enforce serviceName and spanName as lowercase
+class QueryRequest(_serviceName: String,
+                   _spanName: Option[String] = None,
+                   val annotations: Set[String] = Set.empty,
+                   val binaryAnnotations: Set[(String, String)] = Set.empty,
+                   val endTs: Long = Time.now.inMicroseconds,
+                   val limit: Int = 10) {
+
+  /** Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]] */
+  val serviceName: String = _serviceName.toLowerCase
+
+  /** When present, only include traces with this [[com.twitter.zipkin.common.Span.name]] */
+  val spanName: Option[String] = _spanName.map(_.toLowerCase)
 
   checkArgument(serviceName.nonEmpty, "serviceName was empty")
   checkArgument(spanName.map(_.nonEmpty).getOrElse(true), "spanName was empty")
   checkArgument(endTs > 0, () => "endTs should be positive, in epoch microseconds: was %d".format(endTs))
   checkArgument(limit > 0, () => "limit should be positive: was %d".format(limit))
+
+  override lazy val hashCode =
+    MurmurHash3.seqHash(List(serviceName, spanName, annotations, binaryAnnotations, endTs, limit))
+
+  override def equals(other: Any) = other match {
+    case x: QueryRequest =>
+      x.serviceName == serviceName && x.spanName == spanName && x.annotations == annotations &&
+        x.binaryAnnotations == binaryAnnotations && x.endTs == endTs && x.limit == limit
+    case _ => false
+  }
+
+  def copy(
+    serviceName: String = this.serviceName,
+    spanName: Option[String] = this.spanName,
+    annotations: Set[String] = this.annotations,
+    binaryAnnotations: Set[(String, String)] = this.binaryAnnotations,
+    endTs: Long = this.endTs,
+    limit: Int = this.limit
+  ) = QueryRequest(serviceName, spanName, annotations, binaryAnnotations, endTs, limit)
+}
+
+object QueryRequest {
+  def apply(
+    serviceName: String,
+    spanName: Option[String] = None,
+    annotations: Set[String] = Set.empty,
+    binaryAnnotations: Set[(String, String)] = Set.empty,
+    endTs: Long = Time.now.inMicroseconds,
+    limit: Int = 10
+  ) = new QueryRequest(serviceName, spanName, annotations, binaryAnnotations, endTs, limit)
 }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
@@ -39,7 +39,7 @@ class SpanTest extends FunSuite {
   val spanWith2BinaryAnnotations = Span(12345, "methodcall", 666, None,
     List.empty, Seq(binaryAnnotation1, binaryAnnotation2))
 
-  test("serviceNames is lowercase") {
+  test("serviceNames are lowercase") {
     val names = spanWith3Annotations.serviceNames
     assert(names.size === 1)
     assert(names.toSeq(0) === "service")

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -76,9 +76,9 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
    * When all servers are instrumented, they all log a "sr" annotation, indicating the service.
    */
   @Test def getDependenciesAllInstrumented() = {
-    val one = Endpoint(127 << 24 | 1, 9410, "TraceProducerOne")
-    val two = Endpoint(127 << 24 | 2, 9410, "TraceProducerTwo")
-    val three = Endpoint(127 << 24 | 3, 9410, "TraceProducerThree")
+    val one = Endpoint(127 << 24 | 1, 9410, "trace-producer-one")
+    val two = Endpoint(127 << 24 | 2, 9410, "trace-producer-two")
+    val three = Endpoint(127 << 24 | 3, 9410, "trace-producer-three")
 
     val trace = List(
       Span(10L, "GET", 10L, None, List(
@@ -99,8 +99,8 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
 
     result(store.getDependencies(Some(trace(0).startTs.get), Some(trace(0).endTs.get))).sortBy(_.parent) should be(
       List(
-        new DependencyLink("TraceProducerOne", "TraceProducerTwo", 1),
-        new DependencyLink("TraceProducerTwo", "TraceProducerThree", 1)
+        new DependencyLink("trace-producer-one", "trace-producer-two", 1),
+        new DependencyLink("trace-producer-two", "trace-producer-three", 1)
       )
     )
   }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -220,14 +220,28 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   }
 
   @Test def spanNamesGoLowercase() {
-    val spanUpperCaseSpanName = Span(123, "SPAN_NAME", spanId, None, List(ann1, ann2), List())
+    val span = Span(123, "SPAN_NAME", spanId, None, List(ann1, ann2))
 
-    result(store(Seq(spanUpperCaseSpanName)))
+    result(store(Seq(span)))
 
     result(store.getSpanNames("service")) should be(List("span_name"))
 
-    result(store.getTraces(QueryRequest("service", Some("span_name")))) should be(
-      Seq(Seq(spanUpperCaseSpanName))
+    result(store.getTraces(QueryRequest("service", Some("SpAn_NaMe")))) should be(
+      Seq(Seq(Span(123, "span_name", spanId, None, List(ann1, ann2))))
+    )
+  }
+
+  @Test def serviceNamesGoLowercase() {
+    val span = span2.copy(
+      name = "foo",
+      annotations = List(ann2.copy(host = Some(ep.copy(serviceName = "SERVICE"))))
+    )
+    result(store(Seq(span)))
+
+    result(store.getSpanNames("SeRvIcE")) should be(List("foo"))
+
+    result(store.getTraces(QueryRequest("SeRvIcE", Some("foo")))) should be(
+      Seq(Seq(span))
     )
   }
 }

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
@@ -63,12 +63,12 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
   val ann11 = Annotation(100, Constants.ClientRecv, Some(ep3))
   val bAnn1 = BinaryAnnotation("annotation", ByteBuffer.wrap("ann".getBytes), AnnotationType.String, Some(ep3))
   val bAnn2 = BinaryAnnotation("binary", ByteBuffer.wrap("ann".getBytes), AnnotationType.Bytes, Some(ep3))
-  val spans5 = List(Span(5, "otherMethod", 666, Some(2), List(ann9, ann10, ann11), List(bAnn1, bAnn2)))
+  val spans5 = List(Span(5, "other-method", 666, Some(2), List(ann9, ann10, ann11), List(bAnn1, bAnn2)))
   // duration 40
 
   val ann13 = Annotation(100, Constants.ClientSend, Some(ep4))
   val ann14 = Annotation(150, Constants.ClientRecv, Some(ep4))
-  val spans6 = List(Span(6, "someMethod", 669, Some(2), List(ann13, ann14)))
+  val spans6 = List(Span(6, "some-method", 669, Some(2), List(ann13, ann14)))
   // duration 50
 
 
@@ -76,7 +76,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
 
   // no spans
   val emptyTrace = Trace(List())
-  val deps = Dependencies(0, Time.now.inMicroseconds, List(DependencyLink("tfe", "mobileweb", 1), DependencyLink("Gizmoduck", "tflock", 2)))
+  val deps = Dependencies(0, Time.now.inMicroseconds, List(DependencyLink("tfe", "mobileweb", 1), DependencyLink("gizmoduck", "tflock", 2)))
 
   "post spans" in {
     server.httpPost(
@@ -272,7 +272,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |  [
           |    {
           |      "traceId" : "0000000000000005",
-          |      "name" : "othermethod",
+          |      "name" : "other-method",
           |      "id" : "000000000000029a",
           |      "parentId" : "0000000000000002",
           |      "annotations" : [
@@ -412,7 +412,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |  [
           |    {
           |      "traceId" : "0000000000000005",
-          |      "name" : "othermethod",
+          |      "name" : "other-method",
           |      "id" : "000000000000029a",
           |      "parentId" : "0000000000000002",
           |      "annotations" : [
@@ -483,7 +483,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |  [
           |    {
           |      "traceId" : "0000000000000005",
-          |      "name" : "othermethod",
+          |      "name" : "other-method",
           |      "id" : "000000000000029a",
           |      "parentId" : "0000000000000002",
           |      "annotations" : [
@@ -557,7 +557,7 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |    "callCount" : 1
           |  },
           |  {
-          |    "parent" : "Gizmoduck",
+          |    "parent" : "gizmoduck",
           |    "child" : "tflock",
           |    "callCount" : 2
           |  }

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -50,7 +50,10 @@ class RedisSpanStore(client: Client, ttl: Option[Duration])
     index.getTraceIdsByAnnotation(serviceName, annotation, value, endTs, limit)
   }
 
-  override def getAllServiceNames(): Future[Seq[String]] = index.getServiceNames.map(_.toList.sorted)
+  override def getAllServiceNames() = index.getServiceNames.map(_.toList.sorted)
 
-  override def getSpanNames(serviceName: String): Future[Seq[String]] = index.getSpanNames(serviceName).map(_.toList.sorted)
+  override def getSpanNames(_serviceName: String) = {
+    val serviceName = _serviceName.toLowerCase // service names are always lowercase!
+    index.getSpanNames(serviceName).map(_.toList.sorted)
+  }
 }

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
@@ -137,8 +137,8 @@ struct Endpoint {
   // IPv4 port
   // Note: this is to be treated as an unsigned integer, so watch for negatives.
   2: i16 port
-  // Service name, such as "memcache" or "zipkin-web"
-  // Note: Some implementations set this to "Unknown"
+  // Service name in lowercase, such as "memcache" or "zipkin-web"
+  // Note: Some implementations set this to "unknown"
   3: string service_name
 }
 
@@ -198,7 +198,7 @@ struct BinaryAnnotation {
  */
 struct Span {
   1: i64 trace_id                  # unique trace id, use for all spans in trace
-  3: string name,                  # span name, rpc method for example
+  3: string name,                  # span name in lowercase, rpc method for example
   4: i64 id,                       # unique span id, only used for this span
   5: optional i64 parent_id,       # parent span id
   6: list<Annotation> annotations, # all annotations/events that occured, sorted by timestamp


### PR DESCRIPTION
There have been many subtle issues around span and service name case.
Particularly, not all indexes are case-insensitive, which makes search
behavior inconsistent across storage layers.

We discussed this topic at length on gitter, and decided that the best
route to take is to enforce strict lowercase on span and service names.

See #776
Fixes #767
