### PR TITLE
Enables duration queries by promoting Span.duration, timestamp

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Trace.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Trace.scala
@@ -7,7 +7,7 @@ object Trace {
   def duration(spans: List[Span]): Option[Long] = {
     // turns (timestamp, timestamp + duration) into an ordered list
     val timestamps: List[Long] = spans.flatMap(s => s.timestamp.map(ts =>
-      if (s.duration.nonEmpty) List(ts, ts + s.duration.get) else List(ts)
+      s.duration.map(d => List(ts, (ts + d))).getOrElse(List(ts))
     ).getOrElse(List.empty)).sorted
     // first and last timestamp are boundaries of the span, and their difference is the duration.
     timestamps.lastOption.flatMap { last =>

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.{FunSuite, Matchers}
 class JsonConversionTest extends FunSuite with Matchers {
 
   test("span with null annotations, binaryAnnotations") {
-    val convert = JsonSpan("0000000000000001", "GET", "0000000000003039", None, null, null)
+    val convert = JsonSpan("0000000000000001", "GET", "0000000000003039", None, None, None, null, null)
 
     JsonSpan(JsonSpan.invert(convert)) should be(JsonSpan("0000000000000001", "get", "0000000000003039"))
   }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
@@ -27,79 +27,85 @@ class ZipkinJsonTest extends FunSuite with Matchers {
       BinaryAnnotation(Constants.ClientAddr, ByteBuffer.wrap(Array[Byte](1)), AnnotationType.Bool, Some(web)),
       BinaryAnnotation(Constants.ServerAddr, ByteBuffer.wrap(Array[Byte](1)), AnnotationType.Bool, Some(query))
     ), Some(true))
-    assert(mapper.writeValueAsString(s) ==
-      """
-        |{
-        |  "traceId": "0000000000000001",
-        |  "name": "get",
-        |  "id": "0000000000003039",
-        |  "annotations": [
-        |    {
-        |      "timestamp": 1,
-        |      "value": "cs",
-        |      "endpoint": {
-        |        "serviceName": "zipkin-web",
-        |        "ipv4": "192.168.0.1"
-        |      }
-        |    },
-        |    {
-        |      "timestamp": 2,
-        |      "value": "sr",
-        |      "endpoint": {
-        |        "serviceName": "zipkin-query",
-        |        "ipv4": "192.168.0.1",
-        |        "port": 9411
-        |      }
-        |    },
-        |    {
-        |      "timestamp": 3,
-        |      "value": "ss",
-        |      "endpoint": {
-        |        "serviceName": "zipkin-query",
-        |        "ipv4": "192.168.0.1",
-        |        "port": 9411
-        |      }
-        |    },
-        |    {
-        |      "timestamp": 4,
-        |      "value": "cr",
-        |      "endpoint": {
-        |        "serviceName": "zipkin-web",
-        |        "ipv4": "192.168.0.1"
-        |      }
-        |    }
-        |  ],
-        |  "binaryAnnotations": [
-        |    {
-        |      "key": "http.uri",
-        |      "value": "/path",
-        |      "endpoint": {
-        |        "serviceName": "zipkin-web",
-        |        "ipv4": "192.168.0.1"
-        |      }
-        |    },
-        |    {
-        |      "key": "ca",
-        |      "value": true,
-        |      "endpoint": {
-        |        "serviceName": "zipkin-web",
-        |        "ipv4": "192.168.0.1",
-        |        "port": 8080
-        |      }
-        |    },
-        |    {
-        |      "key": "sa",
-        |      "value": true,
-        |      "endpoint": {
-        |        "serviceName": "zipkin-query",
-        |        "ipv4": "192.168.0.1",
-        |        "port": 9411
-        |      }
-        |    }
-        |  ],
-        |  "debug": true
-        |}
-      """.stripMargin.replaceAll("\\s",""))
+    val json = """
+                 |{
+                 |  "traceId": "0000000000000001",
+                 |  "name": "get",
+                 |  "id": "0000000000003039",
+                 |  "timestamp": 1,
+                 |  "duration": 3,
+                 |  "annotations": [
+                 |    {
+                 |      "timestamp": 1,
+                 |      "value": "cs",
+                 |      "endpoint": {
+                 |        "serviceName": "zipkin-web",
+                 |        "ipv4": "192.168.0.1"
+                 |      }
+                 |    },
+                 |    {
+                 |      "timestamp": 2,
+                 |      "value": "sr",
+                 |      "endpoint": {
+                 |        "serviceName": "zipkin-query",
+                 |        "ipv4": "192.168.0.1",
+                 |        "port": 9411
+                 |      }
+                 |    },
+                 |    {
+                 |      "timestamp": 3,
+                 |      "value": "ss",
+                 |      "endpoint": {
+                 |        "serviceName": "zipkin-query",
+                 |        "ipv4": "192.168.0.1",
+                 |        "port": 9411
+                 |      }
+                 |    },
+                 |    {
+                 |      "timestamp": 4,
+                 |      "value": "cr",
+                 |      "endpoint": {
+                 |        "serviceName": "zipkin-web",
+                 |        "ipv4": "192.168.0.1"
+                 |      }
+                 |    }
+                 |  ],
+                 |  "binaryAnnotations": [
+                 |    {
+                 |      "key": "http.uri",
+                 |      "value": "/path",
+                 |      "endpoint": {
+                 |        "serviceName": "zipkin-web",
+                 |        "ipv4": "192.168.0.1"
+                 |      }
+                 |    },
+                 |    {
+                 |      "key": "ca",
+                 |      "value": true,
+                 |      "endpoint": {
+                 |        "serviceName": "zipkin-web",
+                 |        "ipv4": "192.168.0.1",
+                 |        "port": 8080
+                 |      }
+                 |    },
+                 |    {
+                 |      "key": "sa",
+                 |      "value": true,
+                 |      "endpoint": {
+                 |        "serviceName": "zipkin-query",
+                 |        "ipv4": "192.168.0.1",
+                 |        "port": 9411
+                 |      }
+                 |    }
+                 |  ],
+                 |  "debug": true
+                 |}
+               """.stripMargin.replaceAll("\\s","")
+    assert(mapper.writeValueAsString(s) == json)
+    // This will catch any conversion problems such as stuffing integers into long fields
+    val readBack = JsonSpan.invert(mapper.readValue[JsonSpan](json))
+    // we can't compare byte buffers with equals.
+    assert(readBack.copy(binaryAnnotations = List.empty) == s.copy(binaryAnnotations = List.empty) )
   }
 
   test("endpoint") {

--- a/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/SpanStoreZipkinTracerTest.scala
+++ b/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/SpanStoreZipkinTracerTest.scala
@@ -14,6 +14,7 @@ class SpanStoreZipkinTracerTest extends JUnitSuite {
   val finagleEndpoint = Endpoint(172 << 24 | 17 << 16 | 3, 8080)
   val finagleSpan = Span(
     traceId = TraceId(Some(SpanId(1)), None, SpanId(1), None, Flags().setDebug),
+    // TODO: update finagle to do timestamp, duration on a span
     annotations = Seq(
       ZipkinAnnotation(Time.fromMicroseconds(123), "cs", finagleEndpoint),
       ZipkinAnnotation(Time.fromMicroseconds(456), "cr", finagleEndpoint)

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
@@ -210,6 +210,8 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |    "name" : "methodcall",
           |    "id" : "000000000000029a",
           |    "parentId" : "0000000000000002",
+          |    "timestamp" : 100,
+          |    "duration" : 50,
           |    "annotations" : [
           |      {
           |        "timestamp" : 100,
@@ -264,6 +266,8 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |      "name" : "other-method",
           |      "id" : "000000000000029a",
           |      "parentId" : "0000000000000002",
+          |      "timestamp" : 60,
+          |      "duration" : 40,
           |      "annotations" : [
           |        {
           |          "timestamp" : 60,
@@ -321,6 +325,8 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |      "traceId" : "0000000000000003",
           |      "name" : "methodcall",
           |      "id" : "000000000000029c",
+          |      "timestamp" : 99,
+          |      "duration" : 100,
           |      "annotations" : [
           |        {
           |          "timestamp" : 99,
@@ -362,6 +368,8 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |      "traceId" : "0000000000000003",
           |      "name" : "methodcall",
           |      "id" : "000000000000029c",
+          |      "timestamp" : 99,
+          |      "duration" : 100,
           |      "annotations" : [
           |        {
           |          "timestamp" : 99,
@@ -404,6 +412,8 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |      "name" : "other-method",
           |      "id" : "000000000000029a",
           |      "parentId" : "0000000000000002",
+          |      "timestamp" : 60,
+          |      "duration" : 40,
           |      "annotations" : [
           |        {
           |          "timestamp" : 60,
@@ -475,6 +485,8 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |      "name" : "other-method",
           |      "id" : "000000000000029a",
           |      "parentId" : "0000000000000002",
+          |      "timestamp" : 60,
+          |      "duration" : 40,
           |      "annotations" : [
           |        {
           |          "timestamp" : 60,

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -22,6 +22,7 @@ class KafkaProcessorSpec extends JUnitSuite {
   import KafkaProcessorSpec.kafkaRule
 
   val topic = Map("integration-test-topic" -> 1)
+  // Intentionally leaving timestamp and duration unset, as legacy instrumentation don't set this.
   val validSpan = Span(123, "boo", 456, annotations = List(new Annotation(1, "bah", None)))
   val decoder = new SpanCodec()
   val defaultKafkaTopics = Map("zipkin_kafka" -> 1 )
@@ -41,6 +42,7 @@ class KafkaProcessorSpec extends JUnitSuite {
 
   def createMessage(): Array[Byte] = {
     val annotation = Annotation(1, "value", Some(Endpoint(1, 2, "service")))
+    // Intentionally leaving timestamp and duration unset, as legacy instrumentation don't set this.
     val message = Span(1234, "methodname", 4567, annotations = List(annotation))
     val codec = new SpanCodec()
     codec.encode(message)

--- a/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
+++ b/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
@@ -33,6 +33,7 @@ class ScribeSpanReceiverTest extends FunSuite {
   }
   val category = "zipkin"
 
+  // Intentionally leaving timestamp and duration unset, as legacy instrumentation don't set this.
   val validSpan = Span(123, "boo", 456, annotations = List(new Annotation(1, "bah", None)))
   val validList = List(LogEntry(category, serializer.toString(validSpan.toThrift)))
 

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -90,8 +90,17 @@ object thrift {
   /* Span */
   class ThriftSpan(s: Span) {
     lazy val toThrift = {
-      thriftscala.Span(s.traceId, s.name, s.id, s.parentId, s.annotations.map { _.toThrift },
-        s.binaryAnnotations.map { _.toThrift }, s.debug.getOrElse(false))
+      thriftscala.Span(
+        s.traceId,
+        s.name,
+        s.id,
+        s.parentId,
+        s.annotations.map(_.toThrift),
+        s.binaryAnnotations.map(_.toThrift),
+        s.debug.getOrElse(false),
+        s.timestamp,
+        s.duration
+      )
     }
   }
   class WrappedSpan(s: thriftscala.Span) {
@@ -106,8 +115,8 @@ object thrift {
         s.name.toLowerCase,
         s.id,
         s.parentId,
-        None,
-        None,
+        s.timestamp,
+        s.duration,
         s.annotations match {
           case null => List.empty[Annotation]
           case as => as.map(_.toAnnotation)(breakOut).toList.sorted

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
@@ -63,9 +63,12 @@ class ThriftConversionsTest extends FunSuite {
   test("convert Span") {
     val annotationValue = "NONSENSE"
     val expectedAnnotation = Annotation(1, annotationValue, Some(Endpoint(1, 2, "service")))
-    val expectedSpan = Span(12345, "methodcall", 666, annotations = List(expectedAnnotation))
+    val expectedSpan = Span(12345, "methodcall", 666, None, Some(1L), Some(2L), List(expectedAnnotation))
 
     assert(expectedSpan.toThrift.toSpan === expectedSpan)
+
+    val timestampedSpan = expectedSpan.copy(timestamp = Some(13L), duration = Some(10L))
+    assert(timestampedSpan.toThrift.toSpan === timestampedSpan)
 
     val noNameSpan = thriftscala.Span(0, null, 0, None, Seq(), Seq())
     intercept[IncompleteTraceDataException] { noNameSpan.toSpan }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -8,7 +8,6 @@ import com.twitter.finagle.{Filter, Service}
 import com.twitter.finatra.httpclient.HttpClient
 import com.twitter.io.Buf
 import com.twitter.util.{Future, TwitterDateFormat}
-import com.twitter.zipkin.adjuster.ApplyTimestampAndDuration
 import com.twitter.zipkin.common.{Trace, SpanTreeEntry, Span}
 import com.twitter.zipkin.json._
 import com.twitter.zipkin.web.mustache.ZipkinMustache
@@ -229,7 +228,6 @@ class Handlers(mustacheGenerator: ZipkinMustache, queryExtractor: QueryExtractor
       val tracesCall = serviceName match {
         case Some(service) => route[Seq[List[JsonSpan]]](client, "/api/v1/traces", req.params)
           .map(traces => traces.map(_.map(JsonSpan.invert))
-                               .map(ApplyTimestampAndDuration) // TODO: remove when span.timestamp, duration are in json
           .flatMap(TraceSummary(_)))
         case None => EmptyTraces
       }
@@ -373,7 +371,6 @@ class Handlers(mustacheGenerator: ZipkinMustache, queryExtractor: QueryExtractor
       pathTraceId(req.path.split("/").lastOption) map { id =>
         client.executeJson[List[JsonSpan]](Request(s"/api/v1/trace/$id"))
           .map(_.map(JsonSpan.invert))
-          .map(ApplyTimestampAndDuration) // TODO: remove when span.timestamp, duration are in json
           .map(renderTrace(_))
       } getOrElse NotFound
     }

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/HttpZipkinTracerTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/HttpZipkinTracerTest.scala
@@ -23,6 +23,7 @@ class HttpZipkinTracerTest extends JUnitSuite {
 
   val finagleEndpoint = Endpoint(172 << 24 | 17 << 16 | 3, 8080)
   val finagleSpan = Span(
+    // TODO: update finagle to do timestamp, duration on a span
     traceId = TraceId(Some(SpanId(1)), None, SpanId(1), None, Flags().setDebug),
     annotations = Seq(
       ZipkinAnnotation(Time.fromMicroseconds(123), "cs", finagleEndpoint),


### PR DESCRIPTION
A commonly requested feature is querying by duration, for example showing traces longer than 1 minute. 

While the UI supports ordering by duration, it is a game of chance whether the traces returned happen to be long or not. Even if you put a limit of 1000, you still may not find the longest trace (as your storage system may have a million traces in it).

The path proposed is top-level Span.timestamp, and Span.duration, which formerly existed in the scala and mustache models, but not in the thrift.

We could implement duration queries without changing thrifts. For example, this could be an implementation detail of each storage system. However, this limits testing to side-effects and keeps essential details in scala code, making portability harder.

Also, we have other reasons to top-level these fields:
- local spans can be smaller (#808)
- non-rpc spans can't be supported without artificially logging annotations like cs/cr
- reduce redundant span.duration logic in several scala classes and mustache templates
- Dependency graph links can cheaply add duration aggregates

Here's a convenience paste of the definitions of Span.timestamp and Span.duration

``` java
  /**
   * Microseconds from epoch of the creation of this span.
   *
   * This value should be set directly by instrumentation, using the most
   * precise value possible. For example, gettimeofday or syncing nanoTime
   * against a tick of currentTimeMillis.
   *
   * For compatibilty with instrumentation that precede this field, collectors
   * or span stores can derive this via Annotation.timestamp.
   * For example, SERVER_RECV.timestamp or CLIENT_SEND.timestamp.
   *
   * This field is optional for compatibility with old data: first-party span
   * stores are expected to support this at time of introduction.
   */
  10: optional i64 timestamp,
  /**
   * Measurement of duration in microseconds, used to support queries.
   *
   * This value should be set directly, where possible. Doing so encourages
   * precise measurement decoupled from problems of clocks, such as skew or NTP
   * updates causing time to move backwards.
   *
   * For compatibilty with instrumentation that precede this field, collectors
   * or span stores can derive this by subtracting Annotation.timestamp.
   * For example, SERVER_SEND.timestamp - SERVER_RECV.timestamp.
   *
   * If this field is persisted as unset, zipkin will continue to work, except
   * duration query support will be implementation-specific. Similarly, setting
   * this field non-atomically is implementation-specific.
   *
   * This field is i64 vs i32 to support spans longer than 35 minutes.
   */
  11: optional i64 duration
```
