### PR TITLE
Enforces lowercase serviceName and span name by validation

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonEndpoint.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonEndpoint.scala
@@ -15,5 +15,5 @@ object JsonEndpoint extends (Endpoint => JsonEndpoint) {
     new JsonEndpoint(e.serviceName, e.getHostAddress, if (e.port == 0) None else Some(e.getUnsignedPort))
 
   def invert(e: JsonEndpoint) =
-    new Endpoint(coerceToInteger(forString(e.ipv4)), e.port.map(_.toShort).getOrElse(0), e.serviceName)
+    new Endpoint(coerceToInteger(forString(e.ipv4)), e.port.map(_.toShort).getOrElse(0), e.serviceName.toLowerCase)
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonSpan.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonSpan.scala
@@ -25,7 +25,7 @@ object JsonSpan extends (Span => JsonSpan) {
 
   def invert(s: JsonSpan) = Span(
     id(s.traceId),
-    s.name,
+    s.name.toLowerCase,
     id(s.id),
     s.parentId.map(id(_)),
     /** If deserialized with jackson, these could be null, as it doesn't look at default values. */

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/EndpointTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/EndpointTest.scala
@@ -25,6 +25,13 @@ class EndpointTest extends FunSuite {
   val example = Endpoint(-1073730806,  21, "example")
   val twitter = Endpoint( -952396249, 443, "twitter")
 
+  /** Representations should lowercase on the way in */
+  test("serviceName cannot be lowercase") {
+    intercept[IllegalArgumentException] {
+      Endpoint( -952396249, 443, "Twitter")
+    }
+  }
+
   test("compare correctly") {
     val e1 = Endpoint(123, 456, "a")
     val e2 = Endpoint(123, 457, "a")

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
@@ -28,7 +28,7 @@ class SpanTest extends FunSuite {
   val expectedSpan = Span(12345, "methodcall", 666, None, List(expectedAnnotation))
 
   val annotation1 = Annotation(1, "value1", Some(Endpoint(1, 2, "service")))
-  val annotation2 = Annotation(2, "value2", Some(Endpoint(3, 4, "Service"))) // upper case service name
+  val annotation2 = Annotation(2, "value2", Some(Endpoint(3, 4, "service")))
   val annotation3 = Annotation(3, "value3", Some(Endpoint(5, 6, "service")))
 
   val binaryAnnotation1 = BinaryAnnotation("key1", ByteBuffer.wrap("value1".getBytes), AnnotationType.String, Some(Endpoint(1, 2, "service1")))
@@ -39,10 +39,11 @@ class SpanTest extends FunSuite {
   val spanWith2BinaryAnnotations = Span(12345, "methodcall", 666, None,
     List.empty, Seq(binaryAnnotation1, binaryAnnotation2))
 
-  test("serviceNames are lowercase") {
-    val names = spanWith3Annotations.serviceNames
-    assert(names.size === 1)
-    assert(names.toSeq(0) === "service")
+  /** Representations should lowercase on the way in */
+  test("name cannot be lowercase") {
+    intercept[IllegalArgumentException] {
+      Span(12345, "Foo", 666)
+    }
   }
 
   test("serviceName preference") {
@@ -95,7 +96,7 @@ class SpanTest extends FunSuite {
   }
 
   test("merge span with Unknown span name with known span name") {
-    val span1 = Span(1, "Unknown", 2)
+    val span1 = Span(1, "unknown", 2)
     val span2 = Span(1, "get", 2)
 
     assert(span1.mergeSpan(span2).name === "get")

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
@@ -17,7 +17,7 @@ class ZipkinJsonTest extends FunSuite with Matchers {
   val query = Endpoint((192 << 24 | 168 << 16 | 1), 9411, "zipkin-query")
 
   test("complete span example") {
-    val s = Span(1, "GET", 12345L, None, List(
+    val s = Span(1, "get", 12345L, None, List(
       Annotation(1L, Constants.ClientSend, Some(web.copy(port = 0))),
       Annotation(2L, Constants.ServerRecv, Some(query)),
       Annotation(3L, Constants.ServerSend, Some(query)),

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -27,10 +27,10 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
   val zipkinJdbc = Endpoint(172 << 24 | 17 << 16 | 2, 0, "zipkin-jdbc")
 
   val trace = List(
-    Span(1L, "GET", 1L, None, List(
+    Span(1L, "get", 1L, None, List(
       Annotation(today, Constants.ServerRecv, Some(zipkinWeb)),
       Annotation(today + 350, Constants.ServerSend, Some(zipkinWeb)))),
-    Span(1L, "GET", 2L, Some(1L), List(
+    Span(1L, "get", 2L, Some(1L), List(
       Annotation(today + 50, Constants.ClientSend, Some(zipkinWeb)),
       Annotation(today + 100, Constants.ServerRecv, Some(zipkinQuery.copy(port = 0))),
       Annotation(today + 250, Constants.ServerSend, Some(zipkinQuery.copy(port = 0))),
@@ -81,10 +81,10 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
     val three = Endpoint(127 << 24 | 3, 9410, "trace-producer-three")
 
     val trace = List(
-      Span(10L, "GET", 10L, None, List(
+      Span(10L, "get", 10L, None, List(
         Annotation(1445136539256150L, Constants.ServerRecv, Some(one)),
         Annotation(1445136540408729L, Constants.ServerSend, Some(one)))),
-      Span(10L, "GET", 20L, Some(10L), List(
+      Span(10L, "get", 20L, Some(10L), List(
         Annotation(1445136539764798L, Constants.ClientSend, Some(one.copy(port = 3001))),
         Annotation(1445136539816432L, Constants.ServerRecv, Some(two)),
         Annotation(1445136540401414L, Constants.ServerSend, Some(two)),

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -220,28 +220,20 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   }
 
   @Test def spanNamesGoLowercase() {
-    val span = Span(123, "SPAN_NAME", spanId, None, List(ann1, ann2))
+    result(store(Seq(span1)))
 
-    result(store(Seq(span)))
-
-    result(store.getSpanNames("service")) should be(List("span_name"))
-
-    result(store.getTraces(QueryRequest("service", Some("SpAn_NaMe")))) should be(
-      Seq(Seq(Span(123, "span_name", spanId, None, List(ann1, ann2))))
+    result(store.getTraces(QueryRequest("service", Some("MeThOdCaLl")))) should be(
+      Seq(Seq(span1))
     )
   }
 
   @Test def serviceNamesGoLowercase() {
-    val span = span2.copy(
-      name = "foo",
-      annotations = List(ann2.copy(host = Some(ep.copy(serviceName = "SERVICE"))))
-    )
-    result(store(Seq(span)))
+    result(store(Seq(span1)))
 
-    result(store.getSpanNames("SeRvIcE")) should be(List("foo"))
+    result(store.getSpanNames("SeRvIcE")) should be(List("methodcall"))
 
-    result(store.getTraces(QueryRequest("SeRvIcE", Some("foo")))) should be(
-      Seq(Seq(span))
+    result(store.getTraces(QueryRequest("SeRvIcE"))) should be(
+      Seq(Seq(span1))
     )
   }
 }

--- a/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/SpanStoreZipkinTracerTest.scala
+++ b/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/SpanStoreZipkinTracerTest.scala
@@ -24,7 +24,7 @@ class SpanStoreZipkinTracerTest extends JUnitSuite {
     endpoint = finagleEndpoint)
 
   val endpoint = common.Endpoint(172 << 24 | 17 << 16 | 3, 8080, "zipkin-query")
-  val span = common.Span(1L, "GET", 1L, None, List(
+  val span = common.Span(1L, "get", 1L, None, List(
     Annotation(123, Constants.ClientSend, Some(endpoint)),
     Annotation(456, Constants.ClientRecv, Some(endpoint))),
     Seq.empty, Some(true)

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjusterSpec.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/adjusters/TimeSkewAdjusterSpec.scala
@@ -122,9 +122,9 @@ class TimeSkewAdjusterTest extends FunSuite {
   val ann6 = Annotation(87, Constants.ClientRecv, epCassie)
   val ann6F = Annotation(86, Constants.ClientRecv, epCassie)
 
-  val span1a = Span(1, "ValuesFromSource", 2209720933601260005L, None, List(ann3, ann6))
-  val span1aFixed = Span(1, "ValuesFromSource", 2209720933601260005L, None, List(ann3F, ann6F))
-  val span1b = Span(1, "ValuesFromSource", 2209720933601260005L, None, List(ann1, ann4))
+  val span1a = Span(1, "values-from-source", 2209720933601260005L, None, List(ann3, ann6))
+  val span1aFixed = Span(1, "values-from-source", 2209720933601260005L, None, List(ann3F, ann6F))
+  val span1b = Span(1, "values-from-source", 2209720933601260005L, None, List(ann1, ann4))
   // the above two spans are part of the same actual span
 
   val span2 = Span(1, "multiget_slice", -855543208864892776L, Some(2209720933601260005L),
@@ -168,7 +168,7 @@ class TimeSkewAdjusterTest extends FunSuite {
 
     val rootSr     = Annotation(1330539326400951L, Constants.ServerRecv, epTfe)
     val rootSs     = Annotation(1330539327264251L, Constants.ServerSend, epTfe)
-    val spanTfe    = Span(1, "POST", 7264365917420400007L, None, List(rootSr, rootSs))
+    val spanTfe    = Span(1, "post", 7264365917420400007L, None, List(rootSr, rootSs))
 
     val unicornCs  = Annotation(1330539326401999L, Constants.ClientSend, epTfe)
     val monorailSr = Annotation(1330539325900366L, Constants.ServerRecv, epMonorail)
@@ -199,7 +199,7 @@ class TimeSkewAdjusterTest extends FunSuite {
 
     val tfeSr         = Annotation(1330647964054410L, Constants.ServerRecv, epTfe)
     val tfeSs         = Annotation(1330647964057394L, Constants.ServerSend, epTfe)
-    val spanTfe       = Span(1, "GET", 583798990668970003L, None, List(tfeSr, tfeSs))
+    val spanTfe       = Span(1, "get", 583798990668970003L, None, List(tfeSr, tfeSs))
 
     val tfeCs         = Annotation(1330647964054881L, Constants.ClientSend, epTfe)
     val passbirdSr    = Annotation(1330647964055250L, Constants.ServerRecv, epPassbird)
@@ -214,7 +214,7 @@ class TimeSkewAdjusterTest extends FunSuite {
 
     val gizmoduckCs   = Annotation(1330647963542175L, Constants.ClientSend, epGizmoduck)
     val gizmoduckCr   = Annotation(1330647963542565L, Constants.ClientRecv, epGizmoduck)
-    val spanMemcache  = Span(1, "Get", 3983355768376203472L, Some(119310086840195752L), List(gizmoduckCs, gizmoduckCr))
+    val spanMemcache  = Span(1, "get", 3983355768376203472L, Some(119310086840195752L), List(gizmoduckCs, gizmoduckCr))
 
     // Adjusted/created annotations
     val createdGizmoduckSr   = Annotation(1330647964055324L, Constants.ServerRecv, epGizmoduck)
@@ -223,7 +223,7 @@ class TimeSkewAdjusterTest extends FunSuite {
     val adjustedGizmoduckCr = Annotation(1330647964056420L, Constants.ClientRecv, epGizmoduck)
 
     val spanAdjustedGizmoduck = Span(1, "get_by_auth_token", 119310086840195752L, Some(7625434200987291951L), List(passbirdCs, passbirdCr, createdGizmoduckSr, createdGizmoduckSs))
-    val spanAdjustedMemcache = Span(1, "Get", 3983355768376203472L, Some(119310086840195752L), List(adjustedGizmoduckCs, adjustedGizmoduckCr))
+    val spanAdjustedMemcache = Span(1, "get", 3983355768376203472L, Some(119310086840195752L), List(adjustedGizmoduckCs, adjustedGizmoduckCr))
 
     val realTrace = new Trace(Seq(spanTfe, spanPassbird, spanGizmoduck, spanMemcache))
     val adjustedTrace = new Trace(Seq(spanTfe, spanPassbird, spanAdjustedGizmoduck, spanAdjustedMemcache))
@@ -266,7 +266,7 @@ class TimeSkewAdjusterTest extends FunSuite {
   test("adjust even if we only have client send") {
     val tfeService = Endpoint(123, 9455, "api.twitter.com-ssl")
 
-    val tfe = Span(142224153997690008L, "GET", 142224153997690008L, None, List(
+    val tfe = Span(142224153997690008L, "get", 142224153997690008L, None, List(
       Annotation(60498165L, Constants.ServerRecv, Some(tfeService)),
       Annotation(61031100L, Constants.ServerSend, Some(tfeService))
     ))

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -9,7 +9,7 @@ import kafka.producer._
 import org.junit.{ClassRule, Test}
 import org.scalatest.junit.JUnitSuite
 
-object KafkaProcessorSpecSimple {
+object KafkaProcessorSpec {
   // Singleton as the test needs to read the actual port in use
   val kafkaRule = new KafkaJunitRule()
 
@@ -17,9 +17,9 @@ object KafkaProcessorSpecSimple {
   @ClassRule def kafkaRuleDef = kafkaRule
 }
 
-class KafkaProcessorSpecSimple extends JUnitSuite {
+class KafkaProcessorSpec extends JUnitSuite {
 
-  import KafkaProcessorSpecSimple.kafkaRule
+  import KafkaProcessorSpec.kafkaRule
 
   val topic = Map("integration-test-topic" -> 1)
   val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)))
@@ -41,7 +41,7 @@ class KafkaProcessorSpecSimple extends JUnitSuite {
 
   def createMessage(): Array[Byte] = {
     val annotation = Annotation(1, "value", Some(Endpoint(1, 2, "service")))
-    val message = Span(1234, "methodName", 4567, None, List(annotation))
+    val message = Span(1234, "methodname", 4567, None, List(annotation))
     val codec = new SpanCodec()
     codec.encode(message)
   }

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -37,7 +37,7 @@ object thrift {
         case (null | "") => Endpoint.UnknownServiceName
         case _ => e.serviceName
       }
-      new Endpoint(e.ipv4, e.port, serviceName)
+      new Endpoint(e.ipv4, e.port, serviceName.toLowerCase)
     }
   }
   implicit def endpointToThriftEndpoint(e: Endpoint) = new ThriftEndpoint(e)
@@ -103,7 +103,7 @@ object thrift {
 
       Span(
         s.traceId,
-        s.name,
+        s.name.toLowerCase,
         s.id,
         s.parentId,
         s.annotations match {

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
@@ -57,6 +57,9 @@ class ThriftConversionsTest extends FunSuite {
     val actualEndpoint = thriftscala.Endpoint(123, 456, null)
     val expectedEndpoint2 = Endpoint(123, 456, Endpoint.UnknownServiceName)
     assert(actualEndpoint.toEndpoint === expectedEndpoint2)
+
+    val mixedCaseEndpoint = thriftscala.Endpoint(123, 456, "SeRvIcE")
+    assert(mixedCaseEndpoint.toEndpoint === Endpoint(123, 456, "service"))
   }
 
   test("convert Span") {
@@ -71,6 +74,9 @@ class ThriftConversionsTest extends FunSuite {
 
     val noAnnotationsSpan = thriftscala.Span(0, "name", 0, None, null, Seq())
     assert(noAnnotationsSpan.toSpan === Span(0, "name", 0))
+
+    val mixedCaseSpan = thriftscala.Span(0, "NaMe", 0, None, null, Seq())
+    assert(mixedCaseSpan.toSpan === Span(0, "name", 0))
 
     val noBinaryAnnotationsSpan = thriftscala.Span(0, "name", 0, None, Seq(), null)
     assert(noBinaryAnnotationsSpan.toSpan === Span(0, "name", 0))

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/HttpZipkinTracerTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/HttpZipkinTracerTest.scala
@@ -34,7 +34,7 @@ class HttpZipkinTracerTest extends JUnitSuite {
     endpoint = finagleEndpoint)
 
   val endpoint = common.Endpoint(172 << 24 | 17 << 16 | 3, 8080, "zipkin-query")
-  val span = common.Span(1L, "GET", 1L, None, List(
+  val span = common.Span(1L, "get", 1L, None, List(
     Annotation(123, Constants.ClientSend, Some(endpoint)),
     Annotation(456, Constants.ClientRecv, Some(endpoint))),
     Seq.empty, Some(true)


### PR DESCRIPTION
Scala case class doesn't support custom construction, and the penalty
for working around this is high. For example, not only do we have to do
normal java toString, hashCode, equals, but also copy and apply methods.

Since zipkin already has multiple representation objects, ex for json
and thrift, it is far less tech debt to do lowercasing in their
conversion functions vs writing manual case classes.

See #805
