### PR TITLE
Clarifies a trace as a list of spans

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -99,7 +99,7 @@ class AnormSpanStore(val db: DB,
     }
   }
 
-  override def getTracesByIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = db.inNewThreadWithRecoverableRetry {
+  override def getTracesByIds(traceIds: Seq[Long]): Future[Seq[List[Span]]] = db.inNewThreadWithRecoverableRetry {
     implicit val (conn, borrowTime) = borrowConn()
     try {
 

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -180,7 +180,7 @@ abstract class CassandraSpanStore(
     } getOrElse Future.value(())
   }
 
-  private[this] def getSpansByTraceIds(traceIds: Seq[Long], count: Int): Future[Seq[Seq[Span]]] = {
+  private[this] def getSpansByTraceIds(traceIds: Seq[Long], count: Int): Future[Seq[List[Span]]] = {
     FutureUtil.toFuture(repository.getSpansByTraceIds(traceIds.toArray.map(Long.box), count))
       .map { spansByTraceId =>
         val spans =
@@ -219,7 +219,7 @@ abstract class CassandraSpanStore(
       })
   }
 
-  override def getTracesByIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = {
+  override def getTracesByIds(traceIds: Seq[Long]): Future[Seq[List[Span]]] = {
     QueryGetSpansByTraceIdsStat.add(traceIds.size)
     getSpansByTraceIds(traceIds, maxTraceCols)
   }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Trace.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Trace.scala
@@ -67,7 +67,7 @@ case class Trace(private val s: Seq[Span]) {
     }
   }
 
-  def getRootSpans(idSpan: Map[Long, Span] = getIdToSpanMap): Seq[Span] =
+  def getRootSpans(idSpan: Map[Long, Span] = getIdToSpanMap): List[Span] =
     spans filter { !_.parentId.flatMap(idSpan.get).isDefined }
 
   private def recursiveGetRootMostSpan(idSpan: Map[Long, Span], prevSpan: Span): Span = {

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
@@ -39,10 +39,10 @@ trait CollectAnnotationQueries {
   ): Future[Seq[IndexedTraceId]]
 
   /** @see [[com.twitter.zipkin.storage.SpanStore.getTracesByIds()]] */
-  def getTracesByIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]]
+  def getTracesByIds(traceIds: Seq[Long]): Future[Seq[List[Span]]]
 
   /** @see [[com.twitter.zipkin.storage.SpanStore.getTraces()]] */
-  def getTraces(qr: QueryRequest): Future[Seq[Seq[Span]]] = {
+  def getTraces(qr: QueryRequest): Future[Seq[List[Span]]] = {
     val sliceQueries = Seq[Set[SliceQuery]](
       qr.spanName.map(SpanSliceQuery(_)).toSet,
       qr.annotations.map(AnnotationSliceQuery(_, None)),

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
@@ -32,7 +32,7 @@ abstract class SpanStore extends java.io.Closeable {
    * <p/> Results are sorted in order of the first span's timestamp, and contain
    * up to [[QueryRequest.limit]] elements.
    */
-  def getTraces(qr: QueryRequest): Future[Seq[Seq[Span]]]
+  def getTraces(qr: QueryRequest): Future[Seq[List[Span]]]
 
   /**
    * Get the available trace information from the storage system.
@@ -42,7 +42,7 @@ abstract class SpanStore extends java.io.Closeable {
    * <p/> Results are sorted in order of the first span's timestamp, and contain
    * less elements than trace IDs when corresponding traces aren't available.
    */
-  def getTracesByIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]]
+  def getTracesByIds(traceIds: Seq[Long]): Future[Seq[List[Span]]]
 
   /**
    * Get all the service names for as far back as the ttl allows.
@@ -102,7 +102,7 @@ class InMemorySpanStore extends SpanStore with CollectAnnotationQueries {
     spans ++= newSpans.map(s => s.copy(annotations = s.annotations.sorted))
   }.unit
 
-  override def getTracesByIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = call {
+  override def getTracesByIds(traceIds: Seq[Long]): Future[Seq[List[Span]]] = call {
     spans.groupBy(_.traceId)
          .filterKeys(traceIds.contains(_))
          .values.filter(!_.isEmpty)

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
@@ -1,6 +1,7 @@
 package com.twitter.zipkin.storage;
 
 import scala.collection.Seq;
+import scala.collection.immutable.List;
 import scala.runtime.BoxedUnit;
 
 import com.twitter.util.Future;
@@ -12,12 +13,12 @@ import com.twitter.zipkin.common.Span;
 public class SpanStoreInJava extends SpanStore {
 
     @Override
-    public Future<Seq<Seq<Span>>> getTraces(QueryRequest qr) {
+    public Future<Seq<List<Span>>> getTraces(QueryRequest qr) {
         return null;
     }
 
     @Override
-    public Future<Seq<Seq<Span>>> getTracesByIds(Seq<Object> traceIds) {
+    public Future<Seq<List<Span>>> getTracesByIds(Seq<Object> traceIds) {
         return null;
     }
 

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
@@ -25,7 +25,7 @@ class ZipkinQueryController @Inject()(spanStore: SpanStore,
                                       @Flag("zipkin.queryService.servicesMaxAge") servicesMaxAge: Int) extends Controller {
 
   post("/api/v1/spans") { request: Request =>
-    val spans: Try[Seq[Span]] = try {
+    val spans: Try[List[Span]] = try {
       Success(request.mediaType match {
         case Some("application/x-thrift") => {
           val bytes = new Array[Byte](request.content.length)
@@ -33,7 +33,7 @@ class ZipkinQueryController @Inject()(spanStore: SpanStore,
           thriftListToSpans(bytes)
         }
         case _ => jsonSpansReader.readValue(request.contentString)
-          .asInstanceOf[Seq[JsonSpan]]
+          .asInstanceOf[List[JsonSpan]]
           .map(JsonSpan.invert(_))
       })
     } catch {
@@ -81,7 +81,7 @@ class ZipkinQueryController @Inject()(spanStore: SpanStore,
     dependencyStore.getDependencies(Some(request.startTs), Some(request.endTs))
   }
 
-  private[this] def adjustTimeskewAndRenderJson(spans: Seq[Seq[Span]]): Seq[List[JsonSpan]] = {
+  private[this] def adjustTimeskewAndRenderJson(spans: Seq[List[Span]]): Seq[List[JsonSpan]] = {
     spans.map(Trace(_))
       .map(timeSkewAdjuster.adjust)
       .map(_.spans.map(JsonSpan))

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -27,7 +27,7 @@ class RedisSpanStore(client: Client, ttl: Option[Duration])
       .flatMap { span => Seq(storage.storeSpan(span), index.index(span))
     })
 
-  override def getTracesByIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = {
+  override def getTracesByIds(traceIds: Seq[Long]): Future[Seq[List[Span]]] = {
     storage.getSpansByTraceIds(traceIds)
   }
 

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisStorage.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisStorage.scala
@@ -36,13 +36,13 @@ class RedisStorage(
     client.lPush(redisKey, List(buf)).flatMap(_ => expireOnTtl(redisKey))
   }
 
-  def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] =
+  def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[List[Span]]] =
     Future.collect(traceIds.map(getSpansByTraceId))
       .map(_.filterNot(_.isEmpty)) // prune empties
       .map(_.map(Trace(_).spans)) // merge by span id
       .map(_.sortBy(_.head)) // sort traces by the first span
 
-  private[this] def getSpansByTraceId(traceId: Long): Future[Seq[Span]] =
+  private[this] def getSpansByTraceId(traceId: Long): Future[List[Span]] =
     client.lRange(encodeTraceId(traceId), 0L, -1L) map
       (_.map(decodeSpan).sorted)
 

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -133,7 +133,7 @@ object thrift {
       result += thriftSpanToSpan(thrift).toSpan
     }
     proto.readListEnd()
-    result
+    result.toList
   }
 
   class WrappedDependencyLink(dl: DependencyLink) {

--- a/zipkin-tracegen/src/main/scala/com/twitter/zipkin/tracegen/Main.scala
+++ b/zipkin-tracegen/src/main/scala/com/twitter/zipkin/tracegen/Main.scala
@@ -126,7 +126,7 @@ object Main extends App with ZipkinSpanGenerator {
     } yield ()
   }
 
-  def getTraces(uri: String) = queryClient.executeJson[Seq[Seq[JsonSpan]]](Request(uri))
+  def getTraces(uri: String) = queryClient.executeJson[Seq[List[JsonSpan]]](Request(uri))
     .map(traces => traces.map(_.map(JsonSpan.invert)))
     .map(traces => traces.map(Trace(_)))
 }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -226,7 +226,7 @@ class Handlers(mustacheGenerator: ZipkinMustache, queryExtractor: QueryExtractor
 
       // only call get traces if the user entered a query
       val tracesCall = serviceName match {
-        case Some(service) => route[Seq[Seq[JsonSpan]]](client, "/api/v1/traces", req.params)
+        case Some(service) => route[Seq[List[JsonSpan]]](client, "/api/v1/traces", req.params)
           .map(traces => traces.map(_.map(JsonSpan.invert))
           .map(Trace.apply(_)).flatMap(TraceSummary(_).toSeq))
         case None => EmptyTraces


### PR DESCRIPTION
`Span.annotations` is a list because it is ordered. A trace is an
ordered list of spans, yet in scala we designate it as a Seq. This led
to numerous bugs where people tried to order seqs. The fixes to those
resulted in all implementations using `List` not `Seq`. This change
formalizes that relationship, which has a side-effect of making trace
transformations more likely to retain order.
