### PR TITLE
Settles on a single timestamp for Span

### DIFF
--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStoreSpec.scala
@@ -41,7 +41,7 @@ class CassandraDependencyStoreSpec extends DependencyStoreSpec {
   }
 
   override def processDependencies(spans: List[Span]) = {
-    val deps = new Dependencies(spans.head.startTs.get, spans.last.endTs.get, Dependencies.toLinks(spans))
+    val deps = new Dependencies(spans.head.timestamp.get, spans.last.timestamp.get, Dependencies.toLinks(spans))
     result(store.storeDependencies(deps))
   }
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
@@ -12,7 +12,7 @@ import scala.util.hashing.MurmurHash3
  * @param binaryAnnotations Include traces whose [[com.twitter.zipkin.common.Span.binaryAnnotations]] include a
  *                          String whose key and value are an entry in this set.
  *                          This is an AND condition against the set, as well against [[annotations]]
- * @param endTs only return traces where all [[com.twitter.zipkin.common.Span.endTs]] are at
+ * @param endTs only return traces where all [[com.twitter.zipkin.common.Span.timestamp]] are at
  *              or before this time in epoch microseconds. Defaults to current time.
  * @param limit maximum number of traces to return. Defaults to 10
  */

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
@@ -96,20 +96,17 @@ class SpanTest extends FunSuite {
     assert(span2.merge(span1).name === "get")
   }
 
-  test("return the first annotation") {
-    assert(spanWith3Annotations.firstAnnotation.get === annotation1)
-  }
-
-  test("return the last annotation") {
-    assert(spanWith3Annotations.lastAnnotation.get === annotation3)
-  }
-
   test("get duration") {
     assert(spanWith3Annotations.duration === Some(2))
   }
 
-  test("don't get duration duration when there are no annotations") {
+  test("get duration none when no annotations") {
     val span = Span(1, "n", 2)
+    assert(span.duration === None)
+  }
+
+  test("get duration none when one annotation") {
+    val span = Span(1, "n", 2, annotations = List(annotation1))
     assert(span.duration === None)
   }
 

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -97,7 +97,10 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
     )
     processDependencies(trace)
 
-    result(store.getDependencies(Some(trace(0).startTs.get), Some(trace(0).endTs.get))).sortBy(_.parent) should be(
+    result(store.getDependencies(
+      Some(trace.head.timestamp.get),
+      Some(trace.last.timestamp.get))
+    ).sortBy(_.parent) should be(
       List(
         new DependencyLink("trace-producer-one", "trace-producer-two", 1),
         new DependencyLink("trace-producer-two", "trace-producer-three", 1)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -36,7 +36,7 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   val spanId = 456
   val ann1 = Annotation(1, "cs", Some(ep))
   val ann2 = Annotation(2, "sr", None)
-  val ann3 = Annotation(20, "custom", Some(ep))
+  val ann3 = Annotation(10, "custom", Some(ep))
   val ann4 = Annotation(20, "custom", Some(ep))
   val ann5 = Annotation(5, "custom", Some(ep))
   val ann6 = Annotation(6, "custom", Some(ep))
@@ -220,14 +220,13 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     result(store.getTraces(QueryRequest("service", limit = 2))).size should be(2)
   }
 
-  /** Traces who have span annotations before or at endTs are returned */
+  /** Traces whose root span has timestamps before or at endTs are returned */
   @Test def getTraces_endTs() {
-    val spans = Seq(span1) // created at timestamp 1; updated at timestamp 20
-    result(store(spans))
+    result(store(Seq(span1, span3))) // span1's timestamp is 1, span3's timestamp is 2
 
-    result(store.getTraces(QueryRequest("service", endTs = 19))) should be(empty)
-    result(store.getTraces(QueryRequest("service", endTs = 20))) should be(Seq(Seq(span1)))
-    result(store.getTraces(QueryRequest("service", endTs = 21))) should be(Seq(Seq(span1)))
+    result(store.getTraces(QueryRequest("service", endTs = 1))) should be(Seq(List(span1)))
+    result(store.getTraces(QueryRequest("service", endTs = 2))) should be(Seq(List(span1), List(span3)))
+    result(store.getTraces(QueryRequest("service", endTs = 3))) should be(Seq(List(span1), List(span3)))
   }
 
   @Test def getAllServiceNames_emptyServiceName() {

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/TimeRange.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/TimeRange.scala
@@ -1,9 +1,0 @@
-package com.twitter.zipkin.storage.redis
-
-/**
- * Represents the range of time in microseconds from epoch.
- *
- * @param startTs microseconds from epoch for the first annotation in a trace.
- * @param stopTs microseconds from epoch for the first annotation in a trace.
- */
-case class TimeRange(startTs: Long, stopTs: Long)

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/TraceIndex.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/TraceIndex.scala
@@ -37,9 +37,9 @@ abstract class TraceIndex[K](
    * @param limit maximum number of items to return
    */
   def list(key: K, endTs: Long, limit: Long): Future[Seq[IndexedTraceId]] = {
-    val startTs: Long = ttl map (dur => endTs - dur.inMicroseconds) getOrElse 0
+    val timestamp: Long = ttl map (dur => endTs - dur.inMicroseconds) getOrElse 0
 
-    client.zRevRangeByScore(encodeKey(key), ZInterval(endTs), ZInterval(startTs), true, Some(Limit(0, limit)))
+    client.zRevRangeByScore(encodeKey(key), ZInterval(endTs), ZInterval(timestamp), true, Some(Limit(0, limit)))
       .map(_.left.get)
       .map(_.asTuples map (tup => IndexedTraceId(tup._1.copy().readLong(), tup._2.toLong)))
   }

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisIndexSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisIndexSpec.scala
@@ -88,7 +88,7 @@ class RedisIndexSpec extends RedisSpecification {
 
     // should find traces by the key and value annotation
     result(redisIndex.getTraceIdsByAnnotation("service", "BAH", Some(ByteBuffer.wrap("BEH".getBytes)), endTs, 1)) should
-      be (Seq(IndexedTraceId(span1.traceId, span1.lastAnnotation.get.timestamp)))
+      be (Seq(IndexedTraceId(span1.traceId, span1.timestamp.get)))
   }
 
   test("not index empty service name") {

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Util.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Util.scala
@@ -92,7 +92,7 @@ object Util {
    */
   def duration(spans: List[Span]): Long = {
     val endTs = spans.flatMap(_.annotations).map(_.timestamp).reduceOption(_ max _)
-    (endTs.getOrElse(0L) - spans.headOption.flatMap(_.startTs).getOrElse(0L))
+    (endTs.getOrElse(0L) - spans.headOption.flatMap(_.timestamp).getOrElse(0L))
   }
 
   /*

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/TraceSummaryTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/TraceSummaryTest.scala
@@ -48,12 +48,11 @@ class TraceSummaryTest extends FunSuite {
     assert(summary.endpoints == List(ep1, ep2, ep3, ep4, ep5))
   }
 
-  test("start, end timestamp and duration") {
+  test("timestamp and duration") {
     val summary = TraceSummary(trace).get
 
-    assert(summary.startTs == 100L)
-    assert(summary.endTs == 500L)
-    assert(summary.durationMicro == 400L)
+    assert(summary.timestamp == 100L)
+    assert(summary.duration == 400L)
   }
 
   test("get span depths from trace") {


### PR DESCRIPTION
This moves existing code around the notion of Span.timestamp,
Span.duration discussed in #807.

The impact from a user POV is minimal. `endTs`, used by the query and UI
formerly looked for the last timestamp in a trace. What this meant is
that if someone clicked search, waited, then clicked search again with
the same `endTs`, an in-flight trace may "disappear" if it has new
activity. Since `endTs` is now based on a stable point (the start), a
trace wouldn't disappear anymore. This impact is so subtle that it is
barely worth discussing.

The primary motivation for this change is to simplify the commodity task
of timestamping and duration stamping spans. This is discussed #807, and
directly supports a new minimal design of local spans (#808).
