### PR TITLE
Converts scala functions Span.timestamp, duration to vals

### DIFF
--- a/zipkin-collector-service/src/test/scala/com/twitter/zipkin/collector/filter/SamplerFilterSpec.scala
+++ b/zipkin-collector-service/src/test/scala/com/twitter/zipkin/collector/filter/SamplerFilterSpec.scala
@@ -25,21 +25,21 @@ import org.scalatest.{FunSuite, Matchers}
 class SamplerFilterSpec extends FunSuite with Matchers with MockitoSugar {
 
   test("let the span pass if debug flag is set") {
-    val span = Span(12345, "methodcall", 666, None, List(), Seq(), Some(true))
+    val span = Span(12345, "methodcall", 666, debug = Some(true))
     val samplerProcessor = new SamplerFilter(NullGlobalSampler)
 
     samplerProcessor(Seq(span)) should be (Seq(span))
   }
 
   test("let the span pass if debug flag false and sampler says yes") {
-    val span = Span(12345, "methodcall", 666, None, List(), Seq(), Some(false))
+    val span = Span(12345, "methodcall", 666, debug = Some(false))
     val samplerProcessor = new SamplerFilter(EverythingGlobalSampler)
 
     samplerProcessor(Seq(span)) should be (Seq(span))
   }
 
   test("not let the span pass if debug flag false and sampler says no") {
-    val span = Span(12345, "methodcall", 666, None, List(), Seq(), Some(false))
+    val span = Span(12345, "methodcall", 666, debug = Some(false))
     val samplerProcessor = new SamplerFilter(NullGlobalSampler)
 
     samplerProcessor(Seq(span)) should be (empty)

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/ApplyTimestampAndDuration.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/ApplyTimestampAndDuration.scala
@@ -1,0 +1,34 @@
+package com.twitter.zipkin.adjuster
+
+import com.twitter.zipkin.common._
+
+/**
+ * This applies timestamp and duration to spans, based on interpretation of
+ * annotations. Spans who already have timestamp and duration set and left
+ * alone.
+ *
+ * After application, spans without a timestamp are filtered out, as they are
+ * not possible to present on a timeline. The only scenario where this is
+ * possible is when instrumentation sends binary annotations ahead of the span
+ * start event, or when a span's start even was lost. Considering this is error
+ * -case or transient, there's no option to control this behavior.
+ */
+object ApplyTimestampAndDuration extends ((List[Span]) => List[Span]) {
+
+  override def apply(spans: List[Span]): List[Span] = spans.map { span =>
+    if (span.timestamp.isDefined && span.duration.isDefined) span else apply(span)
+  }.filter(_.timestamp.nonEmpty).sorted
+
+  def apply(span: Span) = {
+    val sorted = span.annotations.sorted
+    val firstOption = sorted.headOption.map(_.timestamp)
+    val lastOption = sorted.lastOption.map(_.timestamp)
+    span.copy(
+      timestamp = span.timestamp.orElse(firstOption),
+      duration = span.duration.orElse {
+        for (first <- firstOption; last <- lastOption; if (first != last))
+          yield last - first
+      }
+    )
+  }
+}

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/MergeById.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/MergeById.scala
@@ -22,12 +22,6 @@ import scala.collection.mutable
 /**
  * Merge all the spans with the same id. This is used by span stores who store
  * partial spans and need them collated at query time.
- *
- * After merge, spans without a timestamp are filtered out, as they are
- * not possible to present on a timeline. The only scenario where this is
- * possible is when instrumentation sends binary annotations ahead of the span
- * start event, or when a span's start even was lost. Considering this is error
- * -case or transient, there's no option to control this behavior.
  */
 object MergeById extends ((Seq[Span]) => List[Span]) {
 
@@ -43,8 +37,6 @@ object MergeById extends ((Seq[Span]) => List[Span]) {
         case None => spanMap.put(s.id, s)
       }
     })
-    spanMap.values
-      .filter(_.timestamp.nonEmpty)
-      .toList.sorted
+    spanMap.values.toList.sorted
   }
 }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonSpan.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonSpan.scala
@@ -28,6 +28,8 @@ object JsonSpan extends (Span => JsonSpan) {
     s.name.toLowerCase,
     id(s.id),
     s.parentId.map(id(_)),
+    None,
+    None,
     /** If deserialized with jackson, these could be null, as it doesn't look at default values. */
     if (s.annotations == null) List.empty else s.annotations.map(JsonAnnotation.invert).sorted,
     if (s.binaryAnnotations == null) Seq.empty else s.binaryAnnotations.map(JsonBinaryAnnotation.invert),

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/ApplyTimestampAndDurationTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/ApplyTimestampAndDurationTest.scala
@@ -1,0 +1,62 @@
+package com.twitter.zipkin.adjuster
+
+import com.twitter.zipkin.common._
+import org.scalatest.FunSuite
+
+class ApplyTimestampAndDurationTest extends FunSuite {
+
+  test("noop when no annotations") {
+    val span = Span(1, "n", 2, None, None, None)
+
+    val adjusted = ApplyTimestampAndDuration(span)
+    assert(adjusted.timestamp === None)
+    assert(adjusted.duration === None)
+  }
+
+  test("duration is difference between annotation timestamps") {
+    val span = Span(12345, "methodcall", 666, None, None, None, List(
+      Annotation(1, "value1", Some(Endpoint(1, 2, "service"))),
+      Annotation(2, "value2", Some(Endpoint(3, 4, "service"))),
+      Annotation(3, "value3", Some(Endpoint(5, 6, "service")))
+    ))
+
+    val adjusted = ApplyTimestampAndDuration(span)
+    assert(adjusted.timestamp === Some(1))
+    assert(adjusted.duration === Some(2))
+  }
+
+  test("noop when duration already set") {
+    val span = Span(12345, "methodcall", 666, None, Some(83L), Some(11L), List(
+      Annotation(10, "value1", Some(Endpoint(1, 2, "service")))
+    ))
+
+    val adjusted = ApplyTimestampAndDuration(span)
+    assert(adjusted === span)
+  }
+
+  test("duration isn't set when only one annotation") {
+    val span = Span(1, "n", 2, None, None, None, annotations = List(
+      Annotation(1, "value1", Some(Endpoint(1, 2, "service")))
+    ))
+
+    val adjusted = ApplyTimestampAndDuration(span)
+    assert(adjusted.timestamp === Some(1))
+    assert(adjusted.duration === None)
+  }
+
+  test("duration isn't set when only same timestamps") {
+    val span = Span(1, "n", 2, None, None, None, annotations = List(
+      Annotation(1, "value1", Some(Endpoint(1, 2, "service"))),
+      Annotation(1, "value2", Some(Endpoint(1, 2, "service")))
+    ))
+
+    val adjusted = ApplyTimestampAndDuration(span)
+    assert(adjusted.timestamp === Some(1))
+    assert(adjusted.duration === None)
+  }
+
+  /** Missing timestamp means the span cannot be placed on a timeline */
+  test("filters spans without a timestamp") {
+    assert(ApplyTimestampAndDuration(List(Span(12345, "methodcall2", 2))) == List())
+  }
+}

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/CorrectForClockSkewTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/CorrectForClockSkewTest.scala
@@ -46,13 +46,13 @@ class CorrectForClockSkewTest extends FunSuite {
   val skewAnn2 = Annotation(95, Constants.ServerRecv, endpoint2) // skewed
   val skewAnn3 = Annotation(120, Constants.ServerSend, endpoint2) // skewed
   val skewAnn4 = Annotation(135, Constants.ClientRecv, endpoint1)
-  val skewSpan1 = Span(1, "method1", 666, None, List(skewAnn1, skewAnn2, skewAnn3, skewAnn4))
+  val skewSpan1 = Span(1, "method1", 666, None, Some(95L), Some(40L), List(skewAnn1, skewAnn2, skewAnn3, skewAnn4))
 
   val skewAnn5 = Annotation(100, Constants.ClientSend, endpoint2) // skewed
   val skewAnn6 = Annotation(115, Constants.ServerRecv, endpoint3)
   val skewAnn7 = Annotation(120, Constants.ServerSend, endpoint3)
   val skewAnn8 = Annotation(115, Constants.ClientRecv, endpoint2) // skewed
-  val skewSpan2 = Span(1, "method2", 777, Some(666), List(skewAnn5, skewAnn6, skewAnn7, skewAnn8))
+  val skewSpan2 = Span(1, "method2", 777, Some(666L), Some(100L), Some(20L), List(skewAnn5, skewAnn6, skewAnn7, skewAnn8))
 
   val inputTrace = List(skewSpan1, skewSpan2)
 
@@ -73,14 +73,14 @@ class CorrectForClockSkewTest extends FunSuite {
   val expectedAnn2 = Annotation(105, Constants.ServerRecv, endpoint2)
   val expectedAnn3 = Annotation(130, Constants.ServerSend, endpoint2)
   val expectedAnn4 = Annotation(135, Constants.ClientRecv, endpoint1)
-  val expectedSpan1 = Span(1, "method1", 666, None,
+  val expectedSpan1 = Span(1, "method1", 666, None, Some(100L), Some(35L),
     List(expectedAnn1, expectedAnn2, expectedAnn3, expectedAnn4))
 
   val expectedAnn5 = Annotation(110, Constants.ClientSend, endpoint2)
   val expectedAnn6 = Annotation(115, Constants.ServerRecv, endpoint3)
   val expectedAnn7 = Annotation(120, Constants.ServerSend, endpoint3)
   val expectedAnn8 = Annotation(125, Constants.ClientRecv, endpoint2)
-  val expectedSpan2 = Span(1, "method2", 777, Some(666),
+  val expectedSpan2 = Span(1, "method2", 777, Some(666L), Some(110L) ,Some(15L),
     List(expectedAnn5, expectedAnn6, expectedAnn7, expectedAnn8))
 
   val expectedTrace = List(expectedSpan1, expectedSpan2)
@@ -101,7 +101,7 @@ class CorrectForClockSkewTest extends FunSuite {
    */
   val incompleteAnn1 = Annotation(100, Constants.ClientSend, endpoint1)
   val incompleteAnn4 = Annotation(135, Constants.ClientRecv, endpoint1)
-  val incompleteSpan1 = Span(1, "method1", 666, None,
+  val incompleteSpan1 = Span(1, "method1", 666, None, None, None,
     List(incompleteAnn1, incompleteAnn4))
 
   val incompleteTrace = List(expectedSpan1)
@@ -120,12 +120,12 @@ class CorrectForClockSkewTest extends FunSuite {
   val ann6 = Annotation(87, Constants.ClientRecv, epCassie)
   val ann6F = Annotation(86, Constants.ClientRecv, epCassie)
 
-  val span1a = Span(1, "values-from-source", 2209720933601260005L, None, List(ann3, ann6))
-  val span1aFixed = Span(1, "values-from-source", 2209720933601260005L, None, List(ann3F, ann6F))
-  val span1b = Span(1, "values-from-source", 2209720933601260005L, None, List(ann1, ann4))
+  val span1a = Span(1, "values-from-source", 2209720933601260005L, None, None, None, List(ann3, ann6))
+  val span1aFixed = Span(1, "values-from-source", 2209720933601260005L, None, None, None, List(ann3F, ann6F))
+  val span1b = Span(1, "values-from-source", 2209720933601260005L, None, None, None, List(ann1, ann4))
   // the above two spans are part of the same actual span
 
-  val span2 = Span(1, "multiget_slice", -855543208864892776L, Some(2209720933601260005L),
+  val span2 = Span(1, "multiget_slice", -855543208864892776L, Some(2209720933601260005L), None, None,
     List(ann2, ann5))
 
   val realTrace = List(span1a, span1b, span2)
@@ -152,7 +152,7 @@ class CorrectForClockSkewTest extends FunSuite {
     val monorailSr = Annotation(2L, Constants.ServerRecv, epMonorail)
     val monorailSs = Annotation(3L, Constants.ServerSend, epMonorail)
     val unicornCr  = Annotation(4L, Constants.ClientRecv, epTfe)
-    val goodSpan = Span(1, "friendships/create", 12345L, None, List(unicornCs, monorailSr, monorailSs, unicornCr))
+    val goodSpan = Span(1, "friendships/create", 12345L, None, Some(1L), Some(3L), List(unicornCs, monorailSr, monorailSs, unicornCr))
 
     assert(CorrectForClockSkew(List(goodSpan)) === List(goodSpan))
   }
@@ -163,17 +163,17 @@ class CorrectForClockSkewTest extends FunSuite {
 
     val rootSr     = Annotation(1330539326400951L, Constants.ServerRecv, epTfe)
     val rootSs     = Annotation(1330539327264251L, Constants.ServerSend, epTfe)
-    val spanTfe    = Span(1, "post", 7264365917420400007L, None, List(rootSr, rootSs))
+    val spanTfe    = Span(1, "post", 7264365917420400007L, None, Some(rootSr.timestamp), Some(rootSs.timestamp - rootSr.timestamp), List(rootSr, rootSs))
 
     val unicornCs  = Annotation(1330539326401999L, Constants.ClientSend, epTfe)
     val monorailSr = Annotation(1330539325900366L, Constants.ServerRecv, epMonorail)
     val monorailSs = Annotation(1330539326524407L, Constants.ServerSend, epMonorail)
     val unicornCr  = Annotation(1330539327263984L, Constants.ClientRecv, epTfe)
-    val spanMonorailUnicorn = Span(1, "friendships/create", 6379677665629798877L, Some(7264365917420400007L), List(unicornCs, monorailSr, monorailSs, unicornCr))
+    val spanMonorailUnicorn = Span(1, "friendships/create", 6379677665629798877L, Some(7264365917420400007L), Some(monorailSr.timestamp), Some(monorailSs.timestamp - monorailSr.timestamp), List(unicornCs, monorailSr, monorailSs, unicornCr))
 
     val adjustedMonorailSr = Annotation(1330539326520971L, Constants.ServerRecv, epMonorail)
     val adjustedMonorailSs = Annotation(1330539327145012L, Constants.ServerSend, epMonorail)
-    val spanAdjustedMonorail = Span(1, "friendships/create", 6379677665629798877L, Some(7264365917420400007L), List(unicornCs, adjustedMonorailSr, adjustedMonorailSs, unicornCr))
+    val spanAdjustedMonorail = Span(1, "friendships/create", 6379677665629798877L, Some(7264365917420400007L), Some(adjustedMonorailSr.timestamp), Some(adjustedMonorailSs.timestamp - adjustedMonorailSr.timestamp), List(unicornCs, adjustedMonorailSr, adjustedMonorailSs, unicornCr))
 
     val realTrace = List(spanTfe, spanMonorailUnicorn)
     val expected = List(spanTfe, spanAdjustedMonorail)
@@ -191,22 +191,22 @@ class CorrectForClockSkewTest extends FunSuite {
 
     val tfeSr         = Annotation(1330647964054410L, Constants.ServerRecv, epTfe)
     val tfeSs         = Annotation(1330647964057394L, Constants.ServerSend, epTfe)
-    val spanTfe       = Span(1, "get", 583798990668970003L, None, List(tfeSr, tfeSs))
+    val spanTfe       = Span(1, "get", 583798990668970003L, None, Some(tfeSr.timestamp), Some(tfeSs.timestamp - tfeSr.timestamp), List(tfeSr, tfeSs))
 
     val tfeCs         = Annotation(1330647964054881L, Constants.ClientSend, epTfe)
     val passbirdSr    = Annotation(1330647964055250L, Constants.ServerRecv, epPassbird)
     val passbirdSs    = Annotation(1330647964057394L, Constants.ServerSend, epPassbird)
     val tfeCr         = Annotation(1330647964057764L, Constants.ClientRecv, epTfe)
-    val spanPassbird  = Span(1, "get_user_by_auth_token", 7625434200987291951L, Some(583798990668970003L), List(tfeCs, passbirdSr, passbirdSs, tfeCr))
+    val spanPassbird  = Span(1, "get_user_by_auth_token", 7625434200987291951L, Some(583798990668970003L), Some(passbirdSr.timestamp), Some(passbirdSs.timestamp - passbirdSr.timestamp), List(tfeCs, passbirdSr, passbirdSs, tfeCr))
 
     // Gizmoduck server entries are missing
     val passbirdCs    = Annotation(1330647964055324L, Constants.ClientSend, epPassbird)
     val passbirdCr    = Annotation(1330647964057127L, Constants.ClientRecv, epPassbird)
-    val spanGizmoduck = Span(1, "get_by_auth_token", 119310086840195752L, Some(7625434200987291951L),List(passbirdCs, passbirdCr))
+    val spanGizmoduck = Span(1, "get_by_auth_token", 119310086840195752L, Some(7625434200987291951L), Some(passbirdCs.timestamp), Some(passbirdCr.timestamp - passbirdCs.timestamp), List(passbirdCs, passbirdCr))
 
     val gizmoduckCs   = Annotation(1330647963542175L, Constants.ClientSend, epGizmoduck)
     val gizmoduckCr   = Annotation(1330647963542565L, Constants.ClientRecv, epGizmoduck)
-    val spanMemcache  = Span(1, "get", 3983355768376203472L, Some(119310086840195752L), List(gizmoduckCs, gizmoduckCr))
+    val spanMemcache  = Span(1, "get", 3983355768376203472L, Some(119310086840195752L), Some(gizmoduckCs.timestamp), Some(gizmoduckCr.timestamp - gizmoduckCs.timestamp), List(gizmoduckCs, gizmoduckCr))
 
     // Adjusted/created annotations
     val createdGizmoduckSr   = Annotation(1330647964055324L, Constants.ServerRecv, epGizmoduck)
@@ -214,13 +214,13 @@ class CorrectForClockSkewTest extends FunSuite {
     val adjustedGizmoduckCs  = Annotation(1330647964056030L, Constants.ClientSend, epGizmoduck)
     val adjustedGizmoduckCr = Annotation(1330647964056420L, Constants.ClientRecv, epGizmoduck)
 
-    val spanAdjustedGizmoduck = Span(1, "get_by_auth_token", 119310086840195752L, Some(7625434200987291951L), List(passbirdCs, passbirdCr, createdGizmoduckSr, createdGizmoduckSs))
-    val spanAdjustedMemcache = Span(1, "get", 3983355768376203472L, Some(119310086840195752L), List(adjustedGizmoduckCs, adjustedGizmoduckCr))
+    val spanAdjustedGizmoduck = Span(1, "get_by_auth_token", 119310086840195752L, Some(7625434200987291951L),Some(1330647964055324L),Some(1803L), List(passbirdCs, passbirdCr, createdGizmoduckSr, createdGizmoduckSs))
+    val spanAdjustedMemcache = Span(1, "get", 3983355768376203472L, Some(119310086840195752L), Some(1330647964056030L), Some(390L), List(adjustedGizmoduckCs, adjustedGizmoduckCr))
 
     val realTrace = List(spanTfe, spanPassbird, spanGizmoduck, spanMemcache)
     val adjustedTrace = List(spanTfe, spanPassbird, spanAdjustedGizmoduck, spanAdjustedMemcache)
 
-    assert(adjustedTrace === CorrectForClockSkew(realTrace))
+    assert(CorrectForClockSkew(realTrace) === adjustedTrace)
   }
 
   val ep1 = Some(Endpoint(1, 1, "ep1"))
@@ -232,8 +232,8 @@ class CorrectForClockSkewTest extends FunSuite {
     val ss = Annotation(11L, Constants.ServerSend, ep2)
     val cr    = Annotation(4L, Constants.ClientRecv, ep1)
     val cr2    = Annotation(5L, Constants.ClientRecv, ep1)
-    val spanBad   = Span(1, "method", 123L, None, List(cs, sr, ss, cr, cr2))
-    val spanGood   = Span(1, "method", 123L, None, List(cs, sr, ss, cr))
+    val spanBad   = Span(1, "method", 123L, None, Some(1L), Some(10L), List(cs, sr, ss, cr, cr2))
+    val spanGood   = Span(1, "method", 123L, None, Some(1L), Some(10L), List(cs, sr, ss, cr))
 
     val trace1 = List(spanGood)
     assert(trace1 != CorrectForClockSkew(trace1))
@@ -249,7 +249,7 @@ class CorrectForClockSkewTest extends FunSuite {
     val ss = Annotation(11L, Constants.ServerSend, ep2)
     val cr = Annotation(4L, Constants.ClientRecv, ep1)
 
-    val span = Span(1, "method", 123L, None, List(cs, sr, ss, cr))
+    val span = Span(1, "method", 123L, None, Some(1L), Some(10L), List(cs, sr, ss, cr))
 
     val trace1 = List(span)
     assert(trace1 === CorrectForClockSkew(trace1))
@@ -258,7 +258,7 @@ class CorrectForClockSkewTest extends FunSuite {
   test("adjust even if we only have client send") {
     val tfeService = Endpoint(123, 9455, "api.twitter.com-ssl")
 
-    val tfe = Span(142224153997690008L, "get", 142224153997690008L, None, List(
+    val tfe = Span(142224153997690008L, "get", 142224153997690008L, None, Some(60498165L), Some(532935L), List(
       Annotation(60498165L, Constants.ServerRecv, Some(tfeService)),
       Annotation(61031100L, Constants.ServerSend, Some(tfeService))
     ))
@@ -266,7 +266,7 @@ class CorrectForClockSkewTest extends FunSuite {
     val monorailService = Endpoint(456, 8000, "monorail")
     val clusterTwitterweb = Endpoint(123, -13145, "cluster_twitterweb_unicorn")
 
-    val monorail = Span(142224153997690008L, "following/index", 7899774722699781565L, Some(142224153997690008L), List(
+    val monorail = Span(142224153997690008L, "following/index", 7899774722699781565L, Some(142224153997690008L), Some(59501663L), Some(1529181L), List(
       Annotation(59501663L, Constants.ServerRecv, Some(monorailService)),
       Annotation(59934508L, Constants.ServerSend, Some(monorailService)),
       Annotation(60499730L, Constants.ClientSend, Some(clusterTwitterweb)),
@@ -276,7 +276,7 @@ class CorrectForClockSkewTest extends FunSuite {
     val tflockService = Endpoint(456, -14238, "tflock")
     val flockdbEdgesService = Endpoint(789, 6915, "flockdb_edges")
 
-    val tflock = Span(142224153997690008L, "select", 6924056367845423617L, Some(7899774722699781565L), List(
+    val tflock = Span(142224153997690008L, "select", 6924056367845423617L, Some(7899774722699781565L), Some(59541031L), Some(3858L), List(
       Annotation(59541848L, Constants.ClientSend, Some(tflockService)),
       Annotation(59544889L, Constants.ClientRecv, Some(tflockService)),
       Annotation(59541031L, Constants.ServerRecv, Some(flockdbEdgesService)),
@@ -285,7 +285,7 @@ class CorrectForClockSkewTest extends FunSuite {
 
     val flockService = Endpoint(2130706433, 0, "flock")
 
-    val flock = Span(142224153997690008L, "select", 7330066031642813936L, Some(6924056367845423617L), List(
+    val flock = Span(142224153997690008L, "select", 7330066031642813936L, Some(6924056367845423617L), Some(59541299L), Some(1479L), List(
       Annotation(59541299L, Constants.ClientSend, Some(flockService)),
       Annotation(59542778L, Constants.ClientRecv, Some(flockService))
     ))

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/MergeByIdTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/MergeByIdTest.scala
@@ -19,15 +19,10 @@ class MergeByIdTest extends FunSuite {
       Annotation(300, Constants.ClientRecv, Some(Endpoint(123, 123, "service1")))
     )
 
-    val spanToMerge1 = Span(12345, "methodcall2", 2, Some(1), ann1)
-    val spanToMerge2 = Span(12345, "methodcall2", 2, Some(1), ann2)
-    val spanMerged = Span(12345, "methodcall2", 2, Some(1), annMerged)
+    val spanToMerge1 = Span(12345, "methodcall2", 2, Some(1L), None, None, ann1)
+    val spanToMerge2 = Span(12345, "methodcall2", 2, Some(1L), None, None, ann2)
+    val spanMerged = Span(12345, "methodcall2", 2, Some(1L), None, None, annMerged)
 
     assert(MergeById(List(spanToMerge1, spanToMerge2)) == List(spanMerged))
-  }
-
-  /** Missing timestamp means the span cannot be placed on a timeline */
-  test("filters spans without a timestamp") {
-    assert(MergeById(List(Span(12345, "methodcall2", 2))) == List())
   }
 }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTreeEntryTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTreeEntryTest.scala
@@ -36,10 +36,10 @@ class SpanTreeEntryTest extends FunSuite {
   val span3Id = 888L
   val span4Id = 999L
 
-  val span1 = Span(12345, "methodcall1", span1Id, None, annotations1)
-  val span2 = Span(12345, "methodcall2", span2Id, Some(span1Id), annotations2)
-  val span3 = Span(12345, "methodcall2", span3Id, Some(span2Id), annotations3)
-  val span4 = Span(12345, "methodcall2", span4Id, Some(span3Id), annotations4)
+  val span1 = Span(12345, "methodcall1", span1Id, None, None, None, annotations1)
+  val span2 = Span(12345, "methodcall2", span2Id, Some(span1Id), None, None, annotations2)
+  val span3 = Span(12345, "methodcall2", span3Id, Some(span2Id), None, None, annotations3)
+  val span4 = Span(12345, "methodcall2", span4Id, Some(span3Id), None, None, annotations4)
   val span5 = Span(12345, "methodcall4", 1111L, Some(span4Id)) // no annotations
 
   val trace = List(span1, span2, span3, span4)
@@ -54,9 +54,9 @@ class SpanTreeEntryTest extends FunSuite {
 
   test("indexByParentId") {
     val span1 = Span(1, "a", 1)
-    val span2 = Span(1, "b", 2, Some(1))
-    val span3 = Span(1, "c", 3, Some(2))
-    val span4 = Span(1, "d", 4, Some(2))
+    val span2 = Span(1, "b", 2, Some(1L))
+    val span3 = Span(1, "c", 3, Some(2L))
+    val span4 = Span(1, "d", 4, Some(2L))
     val map = new mutable.HashMap[Long, mutable.Set[Span]] with mutable.MultiMap[Long, Span]
     map.addBinding(1, span2)
     map.addBinding(2, span3)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/TraceTest.scala
@@ -1,66 +1,39 @@
 package com.twitter.zipkin.common
 
-import com.twitter.zipkin.Constants
 import org.scalatest.FunSuite
 
 class TraceTest extends FunSuite {
   import com.twitter.zipkin.common.Trace._
 
   test("get duration") {
-    val annotations = List(
-      Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
-      Annotation(200, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
-    val span = Span(12345, "methodcall", 666, None, annotations)
+    val span = Span(12345, "methodcall", 666, None, Some(100), Some(100))
     assert(duration(List(span)) === Some(100))
   }
 
   /** Duration cannot be calculated with a single point. */
   test("get duration empty when an incomplete single span") {
-    val anno = Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1")))
-    val span = Span(12345, "methodcall", 666, None, List(anno))
+    val span = Span(12345, "methodcall", 666, None, Some(100L))
     assert(duration(List(span)) === None)
   }
 
   test("get duration empty when multiple incomplete spans with same timestamp") {
-    val anno = Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1")))
-    val span1 = Span(12345, "methodcall", 666, None, List(anno))
+    val span1 = Span(12345, "methodcall", 666, None, Some(100L))
     val span2 = span1.copy(id = 667)
     assert(duration(List(span1, span2)) === None)
   }
 
   /** Duration is at least the distance between in-flight spans. */
   test("get duration is interval between multiple incomplete annotations") {
-    val anno = Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1")))
-    val span1 = Span(12345, "methodcall", 666, None, List(anno))
-    val span2 = span1.copy(id = 667, annotations = List(anno.copy(timestamp = 150)))
-    val span3 = span1.copy(id = 668, annotations = List(anno.copy(timestamp = 200)))
+    val span1 = Span(12345, "methodcall", 666, None, Some(100L))
+    val span2 = span1.copy(id = 667, timestamp = Some(150L))
+    val span3 = span1.copy(id = 668, timestamp = Some(200L))
     assert(duration(List(span1, span2, span3)) === Some(100))
   }
 
-  test("get duration without root span") {
-    val annotations = List(
-      Annotation(100, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
-      Annotation(200, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
-    val span1 = Span(12345, "methodcall", 666, Some(123), annotations)
-    val annotations2 = List(
-      Annotation(150, Constants.ClientSend, Some(Endpoint(123, 123, "service1"))),
-      Annotation(160, Constants.ClientRecv, Some(Endpoint(123, 123, "service1"))))
-    val span2 = span1.copy(id = 667, annotations = annotations2)
-    assert(duration(List(span1, span2)) === Some(100))
-  }
-
   test("get duration for imbalanced spans") {
-    val ann1 = List(
-      Annotation(0, "Client send", None)
-    )
-    val ann2 = List(
-      Annotation(1, "Server receive", None),
-      Annotation(12, "Server send", None)
-    )
+    val span1 = Span(123, "method_1", 100, None, Some(0))
+    val span2 = Span(123, "method_2", 200, Some(100L), Some(1), Some(12))
 
-    val span1 = Span(123, "method_1", 100, None, ann1)
-    val span2 = Span(123, "method_2", 200, Some(100), ann2)
-
-    assert(duration(List(span1, span2)) === Some(12))
+    assert(duration(List(span1, span2)) === Some(13))
   }
 }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
@@ -17,7 +17,7 @@ class ZipkinJsonTest extends FunSuite with Matchers {
   val query = Endpoint((192 << 24 | 168 << 16 | 1), 9411, "zipkin-query")
 
   test("complete span example") {
-    val s = Span(1, "get", 12345L, None, List(
+    val s = Span(1, "get", 12345L, None, Some(1L), Some(3L), List(
       Annotation(1L, Constants.ClientSend, Some(web.copy(port = 0))),
       Annotation(2L, Constants.ServerRecv, Some(query)),
       Annotation(3L, Constants.ServerSend, Some(query)),
@@ -119,7 +119,7 @@ class ZipkinJsonTest extends FunSuite with Matchers {
   }
 
   test("doesn't serialize absent fields of span") { // like debug or parentId
-    val s = Span(1L, "zipkin-query", 2L, None, List.empty[Annotation], List.empty[BinaryAnnotation])
+    val s = Span(1L, "zipkin-query", 2L)
     assert(mapper.writeValueAsString(s) ==
       """
         |{"traceId":"0000000000000001","name":"zipkin-query","id":"0000000000000002","annotations":[],"binaryAnnotations":[]}

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -27,17 +27,17 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
   val zipkinJdbc = Endpoint(172 << 24 | 17 << 16 | 2, 0, "zipkin-jdbc")
 
   val trace = List(
-    Span(1L, "get", 1L, None, List(
+    Span(1L, "get", 1L, None, Some(today), Some(350), List(
       Annotation(today, Constants.ServerRecv, Some(zipkinWeb)),
       Annotation(today + 350, Constants.ServerSend, Some(zipkinWeb)))),
-    Span(1L, "get", 2L, Some(1L), List(
+    Span(1L, "get", 2L, Some(1L), Some(today + 50), Some(250), List(
       Annotation(today + 50, Constants.ClientSend, Some(zipkinWeb)),
       Annotation(today + 100, Constants.ServerRecv, Some(zipkinQuery.copy(port = 0))),
       Annotation(today + 250, Constants.ServerSend, Some(zipkinQuery.copy(port = 0))),
       Annotation(today + 300, Constants.ClientRecv, Some(zipkinWeb))), List(
       BinaryAnnotation(Constants.ClientAddr, BinaryAnnotationValue(true), Some(zipkinWeb)),
       BinaryAnnotation(Constants.ServerAddr, BinaryAnnotationValue(true), Some(zipkinQuery)))),
-    Span(1L, "query", 3L, Some(2L), List(
+    Span(1L, "query", 3L, Some(2L), Some(today + 150), Some(50), List(
       Annotation(today + 150, Constants.ClientSend, Some(zipkinQuery)),
       Annotation(today + 200, Constants.ClientRecv, Some(zipkinQuery))), List(
       BinaryAnnotation(Constants.ClientAddr, BinaryAnnotationValue(true), Some(zipkinQuery)),
@@ -81,15 +81,15 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
     val three = Endpoint(127 << 24 | 3, 9410, "trace-producer-three")
 
     val trace = List(
-      Span(10L, "get", 10L, None, List(
+      Span(10L, "get", 10L, None, Some(1445136539256150L), Some(1152579L), List(
         Annotation(1445136539256150L, Constants.ServerRecv, Some(one)),
         Annotation(1445136540408729L, Constants.ServerSend, Some(one)))),
-      Span(10L, "get", 20L, Some(10L), List(
+      Span(10L, "get", 20L, Some(10L), Some(1445136539764798L), Some(639337L), List(
         Annotation(1445136539764798L, Constants.ClientSend, Some(one.copy(port = 3001))),
         Annotation(1445136539816432L, Constants.ServerRecv, Some(two)),
         Annotation(1445136540401414L, Constants.ServerSend, Some(two)),
         Annotation(1445136540404135L, Constants.ClientRecv, Some(one.copy(port = 3001))))),
-      Span(10L, "query", 30L, Some(20L), List(
+      Span(10L, "query", 30L, Some(20L), Some(1445136540025751L), Some(371298L), List(
         Annotation(1445136540025751L, Constants.ClientSend, Some(two.copy(port = 3002))),
         Annotation(1445136540072846L, Constants.ServerRecv, Some(three)),
         Annotation(1445136540394644L, Constants.ServerSend, Some(three)),

--- a/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/SpanStoreZipkinTracerTest.scala
+++ b/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/SpanStoreZipkinTracerTest.scala
@@ -24,7 +24,7 @@ class SpanStoreZipkinTracerTest extends JUnitSuite {
     endpoint = finagleEndpoint)
 
   val endpoint = common.Endpoint(172 << 24 | 17 << 16 | 3, 8080, "zipkin-query")
-  val span = common.Span(1L, "get", 1L, None, List(
+  val span = common.Span(1L, "get", 1L, None, Some(123L) ,Some(333L), List(
     Annotation(123, Constants.ClientSend, Some(endpoint)),
     Annotation(456, Constants.ClientRecv, Some(endpoint))),
     Seq.empty, Some(true)

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
@@ -34,39 +34,33 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
 
   val ann1 = Annotation(100, Constants.ClientSend, Some(ep1))
   val ann2 = Annotation(150, Constants.ClientRecv, Some(ep1))
-  val spans1 = List(Span(1, "methodcall", 666, Some(2), List(ann1, ann2)))
-  // duration 50
+  val spans1 = List(Span(1, "methodcall", 666, Some(2), Some(100), Some(50), List(ann1, ann2)))
 
   val ann3 = Annotation(101, Constants.ClientSend, Some(ep2))
   val ann4 = Annotation(501, Constants.ClientRecv, Some(ep2))
-  val spans2 = List(Span(2, "methodcall", 667, None, List(ann3, ann4)))
-  // duration 400
+  val spans2 = List(Span(2, "methodcall", 667, None, Some(101), Some(400), List(ann3, ann4)))
 
   val ann5 = Annotation(99, Constants.ClientSend, Some(ep3))
   val ann6 = Annotation(199, Constants.ClientRecv, Some(ep3))
-  val spans3 = List(Span(3, "methodcall", 668, None, List(ann5, ann6)))
-  // duration 100
+  val spans3 = List(Span(3, "methodcall", 668, None, Some(99), Some(100), List(ann5, ann6)))
 
   // get some server action going on
   val ann7 = Annotation(110, Constants.ServerRecv, Some(ep2))
   val ann8 = Annotation(140, Constants.ServerSend, Some(ep2))
   val spans4 = List(
-    Span(2, "methodcall", 666, Some(2), List(ann1, ann2)),
-    Span(2, "methodcall", 666, Some(2), List(ann7, ann8)))
+    Span(2, "methodcall", 666, Some(2), Some(100), Some(50), List(ann1, ann2)),
+    Span(2, "methodcall", 666, Some(2), Some(110), Some(30), List(ann7, ann8)))
 
   val ann9 = Annotation(60, Constants.ClientSend, Some(ep3))
   val ann10 = Annotation(65, "annotation", Some(ep3))
   val ann11 = Annotation(100, Constants.ClientRecv, Some(ep3))
   val bAnn1 = BinaryAnnotation("annotation", ByteBuffer.wrap("ann".getBytes), AnnotationType.String, Some(ep3))
   val bAnn2 = BinaryAnnotation("binary", ByteBuffer.wrap("ann".getBytes), AnnotationType.Bytes, Some(ep3))
-  val spans5 = List(Span(5, "other-method", 666, Some(2), List(ann9, ann10, ann11), List(bAnn1, bAnn2)))
-  // duration 40
+  val spans5 = List(Span(5, "other-method", 666, Some(2), Some(60), Some(40), List(ann9, ann10, ann11), List(bAnn1, bAnn2)))
 
   val ann13 = Annotation(100, Constants.ClientSend, Some(ep4))
   val ann14 = Annotation(150, Constants.ClientRecv, Some(ep4))
-  val spans6 = List(Span(6, "some-method", 669, Some(2), List(ann13, ann14)))
-  // duration 50
-
+  val spans6 = List(Span(6, "some-method", 669, Some(2), Some(100), Some(50), List(ann13, ann14)))
 
   val allSpans = spans1 ++ spans2 ++ spans3 ++ spans4 ++ spans5 ++ spans6
 

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -22,7 +22,7 @@ class KafkaProcessorSpec extends JUnitSuite {
   import KafkaProcessorSpec.kafkaRule
 
   val topic = Map("integration-test-topic" -> 1)
-  val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)))
+  val validSpan = Span(123, "boo", 456, annotations = List(new Annotation(1, "bah", None)))
   val decoder = new SpanCodec()
   val defaultKafkaTopics = Map("zipkin_kafka" -> 1 )
 
@@ -41,7 +41,7 @@ class KafkaProcessorSpec extends JUnitSuite {
 
   def createMessage(): Array[Byte] = {
     val annotation = Annotation(1, "value", Some(Endpoint(1, 2, "service")))
-    val message = Span(1234, "methodname", 4567, None, List(annotation))
+    val message = Span(1234, "methodname", 4567, annotations = List(annotation))
     val codec = new SpanCodec()
     codec.encode(message)
   }

--- a/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
+++ b/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
@@ -33,7 +33,7 @@ class ScribeSpanReceiverTest extends FunSuite {
   }
   val category = "zipkin"
 
-  val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)))
+  val validSpan = Span(123, "boo", 456, annotations = List(new Annotation(1, "bah", None)))
   val validList = List(LogEntry(category, serializer.toString(validSpan.toThrift)))
 
   val base64 = "CgABAAAAAAAAAHsLAAMAAAADYm9vCgAEAAAAAAAAAcgPAAYMAAAAAQoAAQAAAAAAAAABCwACAAAAA2JhaAAPAAgMAAAAAAIACQAA"

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisStorage.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisStorage.scala
@@ -4,7 +4,7 @@ import com.google.common.base.Charsets._
 import com.twitter.finagle.redis.Client
 import com.twitter.scrooge.{CompactThriftSerializer, ThriftStructSerializer}
 import com.twitter.util.{Duration, Future}
-import com.twitter.zipkin.adjuster.{CorrectForClockSkew, MergeById}
+import com.twitter.zipkin.adjuster.{ApplyTimestampAndDuration, CorrectForClockSkew, MergeById}
 import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.conversions.thrift.{WrappedSpan, ThriftSpan}
 import com.twitter.zipkin.thriftscala
@@ -42,6 +42,7 @@ class RedisStorage(
       .map(_.filterNot(_.isEmpty)
             .map(MergeById)
             .map(CorrectForClockSkew)
+            .map(ApplyTimestampAndDuration)
             .sortBy(_.head)) // sort traces by the first span
 
   private[this] def getSpansByTraceId(traceId: Long): Future[List[Span]] =

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisIndexSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisIndexSpec.scala
@@ -42,17 +42,17 @@ class RedisIndexSpec extends RedisSpecification {
   val ann3 = Annotation(2, "custom", Some(ep))
   val ann4 = Annotation(2, "custom", Some(ep))
 
-  val span1 = Span(123, "methodcall", spanId, None, List(ann1, ann3),
+  val span1 = Span(123, "methodcall", spanId, None, Some(1), Some(1), List(ann1, ann3),
     List(binaryAnnotation("BAH", "BEH")))
-  val span2 = Span(123, "methodcall", spanId, None, List(ann2),
+  val span2 = Span(123, "methodcall", spanId, None, Some(1), None, List(ann2),
     List(binaryAnnotation("BAH2", "BEH2")))
-  val span3 = Span(123, "methodcall", spanId, None, List(ann2, ann3, ann4),
+  val span3 = Span(123, "methodcall", spanId, None, Some(1), None, List(ann2, ann3, ann4),
     List(binaryAnnotation("BAH2", "BEH2")))
 
-  val spanEmptySpanName = Span(123, "", spanId, None, List(ann1, ann2))
+  val spanEmptySpanName = Span(123, "", spanId, None, Some(1), Some(1), List(ann1, ann2))
   val spanEmptyServiceName = Span(123, "spanname", spanId)
 
-  val mergedSpan = Span(123, "methodcall", spanId, None,
+  val mergedSpan = Span(123, "methodcall", spanId, None, Some(1), Some(1),
     List(ann1, ann2), List(binaryAnnotation("BAH2", "BEH2")))
 
   test("index and get span names") {

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSnappyThriftCodec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSnappyThriftCodec.scala
@@ -13,7 +13,7 @@ class RedisSnappyThriftCodecSpec extends RedisSpecification {
     override def codec = thriftscala.Span
   })
 
-  val span = Span(1L, "name", 2L, Option(3L), List.empty, Seq.empty, Some(true)).toThrift
+  val span = Span(1L, "name", 2L, Option(3L), Some(100L), Some(200L), List.empty, Seq.empty, Some(true)).toThrift
 
   test("compress and decompress should yield an equal object") {
     val bytes = thriftCodec.encode(span)

--- a/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/SpanSamplerFilterTest.scala
+++ b/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/SpanSamplerFilterTest.scala
@@ -43,8 +43,8 @@ class SpanSamplerFilterTest extends FunSuite {
 
   test("will not filter debug spans") {
     val spans = Seq(
-      Span(0, "svc", 123L, None, List.empty, Seq.empty, Some(true)),
-      Span(1, "svc", 123L, None, List.empty, Seq.empty, Some(true)),
+      Span(0, "svc", 123L, debug = Some(true)),
+      Span(1, "svc", 123L, debug = Some(true)),
       Span(1, "svc", 123L))
 
     var rcvdSpans = Seq.empty[Span]

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -106,6 +106,8 @@ object thrift {
         s.name.toLowerCase,
         s.id,
         s.parentId,
+        None,
+        None,
         s.annotations match {
           case null => List.empty[Annotation]
           case as => as.map(_.toAnnotation)(breakOut).toList.sorted

--- a/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
+++ b/zipkin-scrooge/src/test/scala/com/twitter/zipkin/adapter/ThriftConversionsTest.scala
@@ -16,13 +16,11 @@
  */
 package com.twitter.zipkin.adapter
 
-import java.nio.ByteBuffer
-
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.conversions.thrift._
-import com.twitter.zipkin.storage.QueryRequest
 import com.twitter.zipkin.thriftscala
 import org.scalatest.FunSuite
+import java.nio.ByteBuffer
 
 class ThriftConversionsTest extends FunSuite {
   test("convert Annotation") {
@@ -65,7 +63,7 @@ class ThriftConversionsTest extends FunSuite {
   test("convert Span") {
     val annotationValue = "NONSENSE"
     val expectedAnnotation = Annotation(1, annotationValue, Some(Endpoint(1, 2, "service")))
-    val expectedSpan = Span(12345, "methodcall", 666, None, List(expectedAnnotation))
+    val expectedSpan = Span(12345, "methodcall", 666, annotations = List(expectedAnnotation))
 
     assert(expectedSpan.toThrift.toSpan === expectedSpan)
 

--- a/zipkin-tracegen/src/main/scala/com/twitter/zipkin/tracegen/TraceGen.scala
+++ b/zipkin-tracegen/src/main/scala/com/twitter/zipkin/tracegen/TraceGen.scala
@@ -61,7 +61,7 @@ class TraceGen(traces: Int, maxDepth: Int) {
     val traceId = rnd.nextLong
     val spans = new ListBuffer[Span]()
     def addSpan(name: String, id: Long, parentId: Option[Long], annos: List[Annotation], binAnnos: List[BinaryAnnotation]) {
-      spans += Span(traceId, name, id, parentId, annos, binAnnos)
+      spans += Span(traceId, name, id, parentId, None, None, annos, binAnnos)
     }
   }
 

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Util.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Util.scala
@@ -37,8 +37,7 @@ object Util {
     TimeUnit.HOURS -> ("hrs", "hr"),
     TimeUnit.MINUTES -> ("min", "min"))
 
-  def durationStr(duration: Long): String =
-    durationStr(Duration.fromMicroseconds(duration))
+  def durationStr(duration: Long): String = durationStr(Duration.fromMicroseconds(duration))
 
   def durationStr(d: Duration): String = {
     var micros = d.inMicroseconds

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/HttpZipkinTracerTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/HttpZipkinTracerTest.scala
@@ -34,10 +34,10 @@ class HttpZipkinTracerTest extends JUnitSuite {
     endpoint = finagleEndpoint)
 
   val endpoint = common.Endpoint(172 << 24 | 17 << 16 | 3, 8080, "zipkin-query")
-  val span = common.Span(1L, "get", 1L, None, List(
+  val span = common.Span(1L, "get", 1L, annotations = List(
     Annotation(123, Constants.ClientSend, Some(endpoint)),
     Annotation(456, Constants.ClientRecv, Some(endpoint))),
-    Seq.empty, Some(true)
+    debug = Some(true)
   )
 
   @Test def sendsValidSpanAndIncrementsOk() {

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/TraceSummaryTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/TraceSummaryTest.scala
@@ -26,10 +26,10 @@ class TraceSummaryTest extends FunSuite {
   val span3Id = 888L
   val span4Id = 999L
 
-  val span1 = Span(12345, "methodcall1", span1Id, None, annotations1)
-  val span2 = Span(12345, "methodcall2", span2Id, Some(span1Id), annotations2)
-  val span3 = Span(12345, "methodcall2", span3Id, Some(span2Id), annotations3)
-  val span4 = Span(12345, "methodcall2", span4Id, Some(span3Id), annotations4)
+  val span1 = Span(12345, "methodcall1", span1Id, None, Some(100), Some(50), annotations1)
+  val span2 = Span(12345, "methodcall2", span2Id, Some(span1Id), Some(200), Some(50), annotations2)
+  val span3 = Span(12345, "methodcall2", span3Id, Some(span2Id), Some(300), Some(50), annotations3)
+  val span4 = Span(12345, "methodcall2", span4Id, Some(span3Id), Some(400), Some(100), annotations4)
   val span5 = Span(12345, "methodcall4", 1111L, Some(span4Id)) // no annotations
 
   val trace = List(span1, span2, span3, span4)
@@ -57,13 +57,13 @@ class TraceSummaryTest extends FunSuite {
 
   test("get span depths from trace") {
     val spanNoneParent = Span(1, "", 100)
-    val spanParent = Span(1, "", 200, Some(100))
+    val spanParent = Span(1, "", 200, Some(100L))
     assert(TraceSummary.toSpanDepths(List(spanParent, spanNoneParent)) === Map(100 -> 1, 200 -> 2))
   }
 
   test("get span depths from trace without real root") {
-    val spanNoParent = Span(1, "", 100, Some(0)) // 0 isn't present!
-    val spanParent = Span(1, "", 200, Some(100))
+    val spanNoParent = Span(1, "", 100, Some(0L)) // 0 isn't present!
+    val spanParent = Span(1, "", 200, Some(100L))
     assert(TraceSummary.toSpanDepths(List(spanParent, spanNoParent)) === Map(100 -> 1, 200 -> 2))
   }
 


### PR DESCRIPTION
Before this change, Span.timestamp and duration were always derived
lazily from annotations. This decouples that logic by converting the
scala methods to vals and populating them with
`ApplyTimestampAndDuration`.

This serves us in at least two ways. First, the implicit association
between annotations and timestamp or duration was tested in various
components. Making these explicit centralizes the responsibility, and
lowers the test burden on other components. Also, we want to formalize
these fields in persisted models in support of duration queries and
local spans (#807). Organizing logic ahead of this work makes the change
to persistence simpler.
