### PR TITLE
Adds minDuration and maxDuration to the query api, implemented by SQL

### DIFF
--- a/zipkin-anormdb/src/main/resources/mysql.sql
+++ b/zipkin-anormdb/src/main/resources/mysql.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS zipkin_spans (
   `name` VARCHAR(255) NOT NULL,
   `parent_id` BIGINT,
   `debug` BIT(1),
-  `start_ts` BIGINT COMMENT 'Used to implement TTL; First Annotation.timestamp() or null'
+  `start_ts` BIGINT COMMENT 'Span.timestamp(): epoch micros used for endTs query and to implement TTL'
+  `s_duration` BIGINT COMMENT 'Span.duration(): micros used for minDuration and maxDuration query'
 ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 
 ALTER TABLE zipkin_spans ADD UNIQUE KEY(`trace_id`, `id`) COMMENT 'ignore insert on duplicate';

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -170,7 +170,8 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
         |  name VARCHAR(255) NOT NULL,
         |  parent_id BIGINT,
         |  debug SMALLINT,
-        |  start_ts BIGINT
+        |  start_ts BIGINT,
+        |  duration BIGINT
         |)
       """.stripMargin).execute()
     SQL(

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
@@ -6,7 +6,7 @@ import java.util.Collections
 import org.cassandraunit.CQLDataLoader
 import org.cassandraunit.dataset.CQLDataSet
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra
-import org.junit.BeforeClass
+import org.junit.{BeforeClass, Ignore}
 import org.twitter.zipkin.storage.cassandra.Repository
 
 object CassandraSpanStoreSpec {
@@ -38,4 +38,8 @@ class CassandraSpanStoreSpec extends SpanStoreSpec {
   }
 
   override def clear = cluster.connect().execute("DROP KEYSPACE IF EXISTS " + keyspace)
+
+  @Ignore override def getTraces_duration() = {
+    // TODO!
+  }
 }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/QueryRequestTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/QueryRequestTest.scala
@@ -17,6 +17,24 @@ class QueryRequestTest extends FunSuite {
     }
   }
 
+  test("minDuration must be positive") {
+    intercept[IllegalArgumentException] {
+      QueryRequest("foo", minDuration = Some(0))
+    }
+  }
+
+  test("minDuration is required when specifying maxDuration") {
+    intercept[IllegalArgumentException] {
+      QueryRequest("foo", maxDuration = Some(34))
+    }
+  }
+
+  test("maxDuration must be positive") {
+    intercept[IllegalArgumentException] {
+      QueryRequest("foo", minDuration = Some(1), maxDuration = Some(0))
+    }
+  }
+
   test("endTs must be positive") {
     intercept[IllegalArgumentException] {
       QueryRequest("foo", endTs = 0)

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/QueryExtractor.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/QueryExtractor.scala
@@ -32,6 +32,8 @@ class QueryExtractor @Inject()(@Flag("zipkin.queryService.limit") defaultQueryLi
   def apply(req: Request): Try[QueryRequest] = Try {
     val serviceName = req.params.get("serviceName").getOrElse("")
     val spanName = req.params.get("spanName").flatMap(n => if (n == "all" || n == "") None else Some(n))
+    val minDuration = req.params.get("minDuration").flatMap(d => if (d.isEmpty) None else Some(d.toLong))
+    val maxDuration = req.params.get("maxDuration").flatMap(d => if (d.isEmpty) None else Some(d.toLong))
     val endTs = req.params.getLong("endTs").getOrElse(Time.now.inMicroseconds)
     val limit = req.params.get("limit").map(_.toInt).getOrElse(defaultQueryLimit)
 
@@ -51,6 +53,6 @@ class QueryExtractor @Inject()(@Flag("zipkin.queryService.limit") defaultQueryLi
     } getOrElse {
       (Set.empty[String], Set.empty[(String, String)])
     }
-    QueryRequest(serviceName, spanName, annotations, binaryAnnotations, endTs, limit)
+    QueryRequest(serviceName, spanName, annotations, binaryAnnotations, minDuration, maxDuration, endTs, limit)
   }
 }

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreSpec.scala
@@ -4,9 +4,12 @@ import com.twitter.app.App
 import com.twitter.util.Await.ready
 import com.twitter.zipkin.redis.RedisSpanStoreFactory
 import com.twitter.zipkin.storage.SpanStoreSpec
+import org.junit.Ignore
 
 class RedisSpanStoreSpec extends SpanStoreSpec {
+
   object RedisStore extends App with RedisSpanStoreFactory
+
   RedisStore.main(Array(
     "-zipkin.storage.redis.host", "127.0.0.1",
     "-zipkin.storage.redis.port", "6379",
@@ -16,5 +19,9 @@ class RedisSpanStoreSpec extends SpanStoreSpec {
 
   override def clear = {
     ready(store.clear())
+  }
+
+  @Ignore override def getTraces_duration() = {
+    // TODO!
   }
 }

--- a/zipkin-web/src/main/resources/templates/v2/index.mustache
+++ b/zipkin-web/src/main/resources/templates/v2/index.mustache
@@ -26,6 +26,11 @@
     </div>
 
     <div class="form-group">
+      <label for="minDuration">Duration in microseconds >=</label>
+      <input class="form-control input-sm" id="minDuration" name="minDuration" type="text" value="{{minDuration}}">
+    </div>
+
+    <div class="form-group">
       <label for="limit">Limit</label>
       <input class="form-control input-sm" id="limit" name="limit" type="text" value="{{limit}}">
     </div>

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -242,7 +242,8 @@ class Handlers(mustacheGenerator: ZipkinMustache, queryExtractor: QueryExtractor
           ("endTs" -> queryExtractor.getTimestampStr(req)),
           ("annotationQuery" -> req.params.get("annotationQuery").getOrElse("")),
           ("spans" -> spanList),
-          ("limit" -> queryExtractor.getLimitStr(req)))
+          ("limit" -> queryExtractor.getLimitStr(req)),
+          ("minDuration" -> req.params.get("minDuration").getOrElse("")))
 
         queryExtractor.getAnnotations(req).foreach( annos =>
           data ++= Map(


### PR DESCRIPTION
This adds minDuration and maxDuration queries that zipkin-web can use to
search for long traces. This is initially supported by the in-memory and
anorm (SQL) span stores.

This adds very basic UI support, which someone better at javascript can
polish up:

<img width="936" alt="screen shot 2015-11-06 at 4 34 56 pm" src="https://cloud.githubusercontent.com/assets/64215/11012242/5930d0d4-84a6-11e5-9fb5-67dbcc45adfb.png">
