### PR TITLE
Introduces LOCAL_COMPONENT("lc") binary annotation and example use-case

### DIFF
--- a/zipkin-collector-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
+++ b/zipkin-collector-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
@@ -29,6 +29,7 @@ class ConfigSpec extends FunSuite with Matchers {
   test("validate collector configs") {
     val configSource = Seq(
       "/collector-dev.scala",
+      "/collector-mysql.scala",
       "/collector-cassandra.scala",
       "/collector-redis.scala"
     ) map { r =>

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/Constants.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/Constants.scala
@@ -32,13 +32,15 @@ object Constants {
   val ServerAddr: String = "sa"
   val WireSend: String = "ws"
   val WireRecv: String = "wr"
+  val LocalComponent: String = "lc"
 
   val CoreClient: Set[String] = Set(ClientSend, ClientSendFragment, ClientRecv, ClientRecvFragment)
   val CoreServer: Set[String] = Set(ServerRecv, ServerRecvFragment, ServerSend, ServerSendFragment)
   val CoreAddress: Set[String] = Set(ClientAddr, ServerAddr)
   val CoreWire: Set[String] = Set(WireSend, WireRecv)
+  val CoreLocal: Set[String] = Set(LocalComponent)
 
-  val CoreAnnotations: Set[String] = CoreClient ++ CoreServer ++ CoreWire
+  val CoreAnnotations: Set[String] = CoreClient ++ CoreServer ++ CoreWire ++ CoreLocal
 
   val CoreAnnotationNames: Map[String, String] = Map(
     ClientSend -> "Client Send",
@@ -52,7 +54,8 @@ object Constants {
     ClientAddr -> "Client Address",
     ServerAddr -> "Server Address",
     WireSend -> "Wire Send",
-    WireRecv -> "Wire Receive"
+    WireRecv -> "Wire Receive",
+    LocalComponent -> "Local Component"
   )
 
   /* 127.0.0.1 */

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -151,8 +151,7 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
   /** Shows that duration queries go against the root span, not the child */
   @Test def getTraces_duration() {
-    // Foreshadowing of local spans https://github.com/openzipkin/zipkin/issues/808
-    val archiver = List(binaryAnnotation("lc", "archiver"))
+    val archiver = List(binaryAnnotation(Constants.LocalComponent, "archiver"))
     val targz = Span(1L, "targz", 1L, None, Some(100L), Some(200L), binaryAnnotations = archiver)
     val tar = Span(1L, "tar", 2L, Some(1L), Some(100L), Some(150L), binaryAnnotations = archiver)
     val gz = Span(1L, "gz", 3L, Some(1L), Some(250L), Some(50L), binaryAnnotations = archiver)

--- a/zipkin-query-service/src/main/scala/com/twitter/zipkin/query/BootstrapTrace.scala
+++ b/zipkin-query-service/src/main/scala/com/twitter/zipkin/query/BootstrapTrace.scala
@@ -1,0 +1,28 @@
+package com.twitter.zipkin.query
+
+import com.twitter.finagle.tracing.{Annotation, DefaultTracer, Record, Trace}
+import com.twitter.util.Time
+import com.twitter.zipkin.Constants
+import scala.collection.mutable.ArrayBuffer
+
+/** This decouples bootstrap tracing from trace initialization. */
+object BootstrapTrace {
+  private val id = Trace.nextId
+  private val records = ArrayBuffer[Record]()
+
+  record(Annotation.ServiceName("zipkin-query"))
+  record(Annotation.BinaryAnnotation(Constants.LocalComponent, "finatra"))
+  record(Annotation.Rpc("bootstrap"))
+  record("init")
+
+  private def record(ann: Annotation): Unit = records += Record(id, Time.now, ann, None)
+
+  def record(message: String): Unit = record(Annotation.Message(message))
+
+  /** records duration and flushes the trace */
+  def complete() = {
+    // TODO: DeadlineSpanMap needs an update to mark complete based on Span.duration
+    record(Annotation.ClientRecv())
+    records.foreach(DefaultTracer.self.record)
+  }
+}

--- a/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
+++ b/zipkin-query-service/src/test/scala/com/twitter/zipkin/config/ConfigSpec.scala
@@ -17,10 +17,8 @@ package com.twitter.zipkin.config
 
 import com.google.common.base.Charsets.UTF_8
 import com.google.common.io.Resources
-import com.twitter.finagle.ListeningServer
-import com.twitter.ostrich.admin.RuntimeEnvironment
 import com.twitter.util.Eval
-import com.twitter.zipkin.builder.Builder
+import com.twitter.zipkin.builder.QueryServiceBuilder
 import org.scalatest.{FunSuite, Matchers}
 
 class ConfigSpec extends FunSuite with Matchers {
@@ -30,6 +28,7 @@ class ConfigSpec extends FunSuite with Matchers {
   test("validate query configs") {
     val configSource = Seq(
       "/query-dev.scala",
+      "/query-mysql.scala",
       "/query-cassandra.scala",
       "/query-redis.scala"
     ) map { r =>
@@ -37,9 +36,8 @@ class ConfigSpec extends FunSuite with Matchers {
     }
 
     for (source <- configSource) {
-      val config = eval[Builder[RuntimeEnvironment => ListeningServer]](source)
-      config should not be(Nil)
-      config.apply()
+      val query = eval[QueryServiceBuilder](source)
+      query should not be(Nil)
     }
   }
 }

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServer.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServer.scala
@@ -92,7 +92,6 @@ class ZipkinQueryServer(spanStore: SpanStore, dependencyStore: DependencyStore) 
 
   override def httpExternalSocketAddress = Option(httpServer).map(_.boundAddress)
 
-  override def waitForServer() {
-    Await.ready(httpServer)
-  }
+  override def waitForServer() = Await.ready(httpServer)
+
 }

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
@@ -107,6 +107,34 @@ const string SERVER_SEND_FRAGMENT = "ssf"
  */
 const string SERVER_RECV_FRAGMENT = "srf"
 
+#***** BinaryAnnotation.key ******
+/**
+ * The value of "lc" is the component or namespace of a local span.
+ *
+ * BinaryAnnotation.host adds service context needed to support queries.
+ *
+ * Local Component("lc") supports three key features: flagging, query by
+ * service and filtering Span.name by namespace.
+ *
+ * While structurally the same, local spans are fundamentally different than
+ * RPC spans in how they should be interpreted. For example, zipkin v1 tools
+ * center on RPC latency and service graphs. Root local-spans are neither
+ * indicative of critical path RPC latency, nor have impact on the shape of a
+ * service graph. By flagging with "lc", tools can special-case local spans.
+ *
+ * Zipkin v1 Spans are unqueryable unless they can be indexed by service name.
+ * The only path to a service name is by (Binary)?Annotation.host.serviceName.
+ * By logging "lc", a local span can be queried even if no other annotations
+ * are logged.
+ *
+ * The value of "lc" is the namespace of Span.name. For example, it might be
+ * "finatra2", for a span named "bootstrap". "lc" allows you to resolves
+ * conflicts for the same Span.name, for example "finatra/bootstrap" vs
+ * "finch/bootstrap". Using local component, you'd search for spans named
+ * "bootstrap" where "lc=finch"
+ */
+const string LOCAL_COMPONENT = "lc"
+
 #***** BinaryAnnotation.key where value = [1] and annotation_type = BOOL ******
 /**
  * Indicates a client address ("ca") in a span. Most likely, there's only one.

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/BootstrapTrace.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/BootstrapTrace.scala
@@ -1,0 +1,29 @@
+package com.twitter.zipkin.web
+
+import com.twitter.finagle.tracing.{Annotation, DefaultTracer, Record, Trace}
+import com.twitter.util.Time
+import com.twitter.zipkin.Constants
+
+import scala.collection.mutable.ArrayBuffer
+
+/** This decouples bootstrap tracing from trace initialization. */
+object BootstrapTrace {
+   private val id = Trace.nextId
+   private val records = ArrayBuffer[Record]()
+ 
+   record(Annotation.ServiceName("zipkin-web"))
+   record(Annotation.BinaryAnnotation(Constants.LocalComponent, "twitter-server"))
+   record(Annotation.Rpc("bootstrap"))
+   record("init")
+ 
+   private def record(ann: Annotation): Unit = records += Record(id, Time.now, ann, None)
+ 
+   def record(message: String): Unit = record(Annotation.Message(message))
+ 
+   /** records duration and flushes the trace */
+   def complete() = {
+     // TODO: DeadlineSpanMap needs an update to mark complete based on Span.duration
+     record(Annotation.ClientRecv())
+     records.foreach(DefaultTracer.self.record)
+   }
+ }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -308,6 +308,8 @@ class Handlers(mustacheGenerator: ZipkinMustache, queryExtractor: QueryExtractor
           val key = ZConstants.CoreAnnotationNames.get(ann.key).get
           val value = ann.host.map { e => s"${e.getHostAddress}:${e.getUnsignedPort}" }.get
           JsonBinaryAnnotation(key, value, None, ann.host.map(JsonEndpoint))
+        case ann if ZConstants.CoreAnnotationNames.contains(ann.key) =>
+          JsonBinaryAnnotation(ann.copy(key = ZConstants.CoreAnnotationNames.get(ann.key).get))
         case ann => JsonBinaryAnnotation(ann)
       }
 


### PR DESCRIPTION
Local spans have been discussed at length, but have never been
formalized. This formalizes how to tag a span as local, including
rationale documentation. To help demonstrate the point, zipkin-web and
zipkin-query use this for bootstrap tracing.

Fixes #808

Here are example local spans from finatra and twitter-server bootstrap:

<img width="810" alt="screen shot 2015-11-07 at 12 34 17 pm" src="https://cloud.githubusercontent.com/assets/64215/11017376/c7aa3b08-8551-11e5-9e7f-38ee2bd7e00a.png">

<img width="810" alt="screen shot 2015-11-07 at 12 35 28 pm" src="https://cloud.githubusercontent.com/assets/64215/11017380/cb6b317a-8551-11e5-9bbb-5e816ed45bf4.png">
