### PR TITLE
Settles on endTs and lookback query parameters

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStore.scala
@@ -25,11 +25,10 @@ abstract class CassandraDependencyStore extends DependencyStore {
 
   def close() = repository.close()
 
-  override def getDependencies(startTs: Option[Long], _endTs: Option[Long] = None) = {
-    val endTs = _endTs.getOrElse(Time.now.inMicroseconds)
+  override def getDependencies(endTs: Long, lookback: Option[Long]) = {
 
     val endEpochDayMillis = floorEpochMicrosToDayMillis(endTs)
-    val startEpochDayMillis = floorEpochMicrosToDayMillis(endTs - MICROSECONDS.convert(1, DAYS))
+    val startEpochDayMillis = floorEpochMicrosToDayMillis(endTs - lookback.getOrElse(endTs))
 
     FutureUtil.toFuture(repository.getDependencies(startEpochDayMillis, endEpochDayMillis))
       .map { dependencies => dependencies.asScala

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -240,6 +240,7 @@ abstract class CassandraSpanStore(
     serviceName: String,
     spanName: Option[String],
     endTs: Long,
+    lookback: Long, // TODO
     limit: Int
   ): Future[Seq[IndexedTraceId]] = {
     QueryGetTraceIdsByNameCounter.incr()
@@ -263,6 +264,7 @@ abstract class CassandraSpanStore(
     annotation: String,
     value: Option[ByteBuffer],
     endTs: Long,
+    lookback: Long, // TODO
     limit: Int
   ): Future[Seq[IndexedTraceId]] = {
     QueryGetTraceIdsByAnnotationCounter.incr()

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
@@ -39,6 +39,10 @@ class CassandraSpanStoreSpec extends SpanStoreSpec {
 
   override def clear = cluster.connect().execute("DROP KEYSPACE IF EXISTS " + keyspace)
 
+  @Ignore override def getTraces_lookback() = {
+    // TODO!
+  }
+
   @Ignore override def getTraces_duration() = {
     // TODO!
   }

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/DependencyStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/DependencyStoreInJava.java
@@ -17,7 +17,7 @@ public class DependencyStoreInJava extends DependencyStore {
     }
 
     @Override
-    public Future<Seq<DependencyLink>> getDependencies(Option<Object> startTs, Option<Object> endTs) {
+    public Future<Seq<DependencyLink>> getDependencies(long endTs, Option<Object> lookback) {
         return null;
     }
 

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/QueryRequestTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/QueryRequestTest.scala
@@ -41,6 +41,12 @@ class QueryRequestTest extends FunSuite {
     }
   }
 
+  test("lookback must be positive") {
+    intercept[IllegalArgumentException] {
+      QueryRequest("foo", lookback = Some(0))
+    }
+  }
+
   test("limit must be positive") {
     intercept[IllegalArgumentException] {
       QueryRequest("foo", limit = 0)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -69,7 +69,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
   @Test def getDependencies() = {
     processDependencies(trace)
 
-    result(store.getDependencies(None, None)) should be(dep.links)
+    result(store.getDependencies(today + 1000)) should be(dep.links)
   }
 
   /**
@@ -97,10 +97,11 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
     )
     processDependencies(trace)
 
+    val traceDuration = Trace.duration(trace).get
     result(store.getDependencies(
-      Some(trace.head.timestamp.get),
-      Some(trace.last.timestamp.get))
-    ).sortBy(_.parent) should be(
+      trace(0).timestamp.get + traceDuration,
+      Some(traceDuration)
+    )).sortBy(_.parent) should be(
       List(
         new DependencyLink("trace-producer-one", "trace-producer-two", 1),
         new DependencyLink("trace-producer-two", "trace-producer-three", 1)
@@ -114,7 +115,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
   @Test def getDependenciesMultiLevel() = {
     processDependencies(trace)
 
-    result(store.getDependencies(None, None)) should be(dep.links)
+    result(store.getDependencies(today + 1000)) should be(dep.links)
   }
 
   @Test def dependencies_loopback {
@@ -126,7 +127,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
 
     processDependencies(traceWithLoopback)
 
-    result(store.getDependencies(None, None)) should be(Dependencies.toLinks(traceWithLoopback))
+    result(store.getDependencies(today + 1000)) should be(Dependencies.toLinks(traceWithLoopback))
   }
 
   /**
@@ -136,31 +137,31 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
   @Test def dependencies_headlessTrace {
     processDependencies(List(trace(1), trace(2)))
 
-    result(store.getDependencies(None, None)) should be(Dependencies.toLinks(List(trace(1), trace(2))))
+    result(store.getDependencies(today + 1000)) should be(Dependencies.toLinks(List(trace(1), trace(2))))
   }
 
 
-  @Test def getDependencies_looksBackOneDay() = {
+  @Test def getDependencies_looksBackIndefinitely() = {
     processDependencies(trace)
 
-    result(store.getDependencies(None, Some(today + day))) should be(dep.links)
+    result(store.getDependencies(today + 1000)) should be(dep.links)
   }
 
   @Test def getDependencies_insideTheInterval() = {
     processDependencies(trace)
 
-    result(store.getDependencies(Some(dep.startTs), Some(dep.endTs))) should be(dep.links)
+    result(store.getDependencies(dep.endTs, Some(dep.endTs - dep.startTs))) should be(dep.links)
   }
 
   @Test def getDependencies_endTimeBeforeData() = {
     processDependencies(trace)
 
-    result(store.getDependencies(None, Some(today - day))) should be(empty)
+    result(store.getDependencies(today - day)) should be(empty)
   }
 
-  @Test def getDependencies_endTimeAfterData() = {
+  @Test def getDependencies_lookbackAfterData() = {
     processDependencies(trace)
 
-    result(store.getDependencies(None, Some(today + 2 * day))) should be(empty)
+    result(store.getDependencies(today + 2 * day, Some(day))) should be(empty)
   }
 }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -262,12 +262,22 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   }
 
   /** Traces whose root span has timestamps before or at endTs are returned */
-  @Test def getTraces_endTs() {
+  @Test def getTraces_endTsAndLookback() {
     result(store(Seq(span1, span3))) // span1's timestamp is 1, span3's timestamp is 2
 
     result(store.getTraces(QueryRequest("service", endTs = 1))) should be(Seq(List(span1)))
     result(store.getTraces(QueryRequest("service", endTs = 2))) should be(Seq(List(span1), List(span3)))
     result(store.getTraces(QueryRequest("service", endTs = 3))) should be(Seq(List(span1), List(span3)))
+  }
+
+  /** Traces whose root span has timestamps between (endTs - lookback) and endTs are returned */
+  @Test def getTraces_lookback() {
+    result(store(Seq(span1, span3))) // span1's timestamp is 1, span3's timestamp is 2
+
+    result(store.getTraces(QueryRequest("service", endTs = 1, lookback = Some(1)))) should be(Seq(List(span1)))
+    result(store.getTraces(QueryRequest("service", endTs = 2, lookback = Some(1)))) should be(Seq(List(span1), List(span3)))
+    result(store.getTraces(QueryRequest("service", endTs = 3, lookback = Some(1)))) should be(Seq(List(span3)))
+    result(store.getTraces(QueryRequest("service", endTs = 3, lookback = Some(2)))) should be(Seq(List(span1), List(span3)))
   }
 
   @Test def getAllServiceNames_emptyServiceName() {

--- a/zipkin-query-service/README.md
+++ b/zipkin-query-service/README.md
@@ -19,6 +19,7 @@ Below are environment variables definitions.
     * `QUERY_PORT`: Listen port for the query thrift api; Defaults to 9411
     * `QUERY_ADMIN_PORT`: Listen port for the ostrich admin http server; Defaults to 9901
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
+    * `QUERY_LOOKBACK`: How many microseconds queries look back from endTs; Defaults to 7 days
     * `SCRIBE_HOST`: Listen host for scribe, where traces will be sent
     * `SCRIBE_PORT`: Listen port for scribe, where traces will be sent
 

--- a/zipkin-query-service/src/main/scala/com/twitter/zipkin/builder/QueryServiceBuilder.scala
+++ b/zipkin-query-service/src/main/scala/com/twitter/zipkin/builder/QueryServiceBuilder.scala
@@ -16,6 +16,7 @@
 package com.twitter.zipkin.builder
 
 import ch.qos.logback.classic.{Logger, Level}
+import com.twitter.conversions.time._
 import com.twitter.finagle.ListeningServer
 import com.twitter.finagle.stats.DefaultStatsReceiver
 import com.twitter.finagle.tracing.{DefaultTracer, NullTracer}
@@ -45,8 +46,10 @@ case class QueryServiceBuilder(override val defaultFinatraHttpPort: String = "0.
       case _ => NullTracer
     }
 
+    val defaultLookback = sys.env.get("QUERY_LOOKBACK").getOrElse(7.days.inMicroseconds.toString)
     nonExitingMain(Array(
-      "-local.doc.root", "/"
+      "-local.doc.root", "/",
+      "-zipkin.queryService.lookback", defaultLookback
     ))
     adminHttpServer
   }

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerTest.scala
@@ -1,0 +1,33 @@
+package com.twitter.zipkin.query
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.http.Request
+import com.twitter.zipkin.storage.{InMemorySpanStore, NullDependencyStore}
+import org.scalatest.{FunSuite, Matchers}
+
+class ZipkinQueryServerTest extends FunSuite with Matchers {
+
+  test("zipkin.queryService.limit override") {
+    val query = new ZipkinQueryServer(new InMemorySpanStore, new NullDependencyStore) {
+      override def postWarmup() = Unit // don't start a server
+      override def waitForServer() = Unit // don't wait for a server
+    }
+    query.nonExitingMain(Array("-zipkin.queryService.limit", "1000"))
+    val queryRequest = query.injector.instance[QueryExtractor].apply(Request("?serviceName=foo")).get
+
+    queryRequest.limit should be(1000)
+    queryRequest.lookback should be(7.days.inMicroseconds)  // default
+  }
+
+  test("zipkin.queryService.lookback override") {
+    val query = new ZipkinQueryServer(new InMemorySpanStore, new NullDependencyStore) {
+      override def postWarmup() = Unit // don't start a server
+      override def waitForServer() = Unit // don't wait for a server
+    }
+    query.nonExitingMain(Array("-zipkin.queryService.lookback", 1.day.inMicroseconds.toString))
+    val queryRequest = query.injector.instance[QueryExtractor].apply(Request("?serviceName=foo")).get
+
+    queryRequest.limit should be(10) // default
+    queryRequest.lookback should be(86400000000L)
+  }
+}

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -36,6 +36,7 @@ class RedisSpanStore(client: Client, ttl: Option[Duration])
     serviceName: String,
     spanName: Option[String],
     endTs: Long,
+    lookback: Long, // TODO
     limit: Int
   ): Future[Seq[IndexedTraceId]] = {
     index.getTraceIdsByName(serviceName, spanName, endTs, limit)
@@ -46,6 +47,7 @@ class RedisSpanStore(client: Client, ttl: Option[Duration])
     annotation: String,
     value: Option[ByteBuffer],
     endTs: Long,
+    lookback: Long, // TODO
     limit: Int
   ): Future[Seq[IndexedTraceId]] = {
     index.getTraceIdsByAnnotation(serviceName, annotation, value, endTs, limit)

--- a/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreSpec.scala
+++ b/zipkin-redis/src/test/scala/com/twitter/zipkin/storage/redis/RedisSpanStoreSpec.scala
@@ -21,6 +21,10 @@ class RedisSpanStoreSpec extends SpanStoreSpec {
     ready(store.clear())
   }
 
+  @Ignore override def getTraces_lookback() = {
+    // TODO!
+  }
+
   @Ignore override def getTraces_duration() = {
     // TODO!
   }

--- a/zipkin-web/src/main/resources/app/js/component_data/dependency.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/dependency.js
@@ -14,8 +14,8 @@ define(
       var services = {};
       var dependencies = {};
 
-      this.getDependency = function (startTs, endTs) {
-        var url = "/api/dependencies?startTs=" + startTs + '&endTs=' + endTs;
+      this.getDependency = function (endTs) {
+        var url = "/api/dependencies?endTs=" + endTs;
         $.ajax(url, {
           type: "GET",
           dataType: "json",
@@ -69,7 +69,7 @@ define(
           }.bind(this));
         });
 
-        this.getDependency(0, Date.now() * 1000);
+        this.getDependency(Date.now() * 1000);
       });
 
       this.getServiceData = function (serviceName, callback) {


### PR DESCRIPTION
This settles on endTs as the only time boundary for queries, with a
configurable lookback of either the flag `zipkin.queryService.lookback`
or when running zipkin-query-service, the env variable `QUERY_LOOKBACK`.

We have two queries that need to support a notion of endTs and lookback:
trace and dependency. By supporting lookback, we allow administrators
control over how much data might be subject to search by default.

In the past, the dependency query documentation said it defaulted to
lookback 24hrs. However, the query passed actually applied to all data,
as 0 was passed as the startTs parameter. This changes the default to
be the same as trace query, 7 days, and overridable.

7 days was chosen as that's the length of the data TTL. We would expect
administrators to override this, for example to 2 days.
