### PR TITLE
Ensures duration queries all spans by service, not just root spans

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -295,7 +295,8 @@ class AnormSpanStore(val db: DB,
       val result:List[(Long, Long)] = SQL(
         """SELECT t1.trace_id, start_ts
           |FROM zipkin_spans t1
-          |WHERE trace_id = id
+          |JOIN zipkin_annotations t2 ON t1.trace_id = t2.trace_id AND t1.id = t2.span_id
+          |WHERE t2.endpoint_service_name = {service_name}
           |AND duration BETWEEN {min_duration} AND {max_duration}
           |AND start_ts BETWEEN {start_ts} AND {end_ts}
           |GROUP BY t1.trace_id

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
@@ -5,16 +5,17 @@ import com.twitter.zipkin.util.Util.checkArgument
 import scala.util.hashing.MurmurHash3
 
 /**
- * @param _serviceName Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]]
+ * @param _serviceName Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]] and constrains
+ *                     all other parameters.
  * @param _spanName When present, only include traces with this [[com.twitter.zipkin.common.Span.name]]
  * @param annotations Include traces whose [[com.twitter.zipkin.common.Span.annotations]] include a value in this set.
  *                    This is an AND condition against the set, as well against [[binaryAnnotations]]
  * @param binaryAnnotations Include traces whose [[com.twitter.zipkin.common.Span.binaryAnnotations]] include a
  *                          String whose key and value are an entry in this set.
  *                          This is an AND condition against the set, as well against [[annotations]]
- * @param minDuration only return traces whose [[com.twitter.zipkin.common.Trace.duration]] is
+ * @param minDuration only return traces whose [[com.twitter.zipkin.common.Span.duration]] is
  *                    greater than or equal to minDuration microseconds.
- * @param maxDuration only return traces whose [[com.twitter.zipkin.common.Trace.duration]] is less
+ * @param maxDuration only return traces whose [[com.twitter.zipkin.common.Span.duration]] is less
  *                    than or equal to maxDuration microseconds. Only valid with [[minDuration]].
  * @param endTs only return traces where all [[com.twitter.zipkin.common.Span.timestamp]] are at
  *              or before this time in epoch microseconds. Defaults to current time.

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/SpanStore.scala
@@ -159,7 +159,6 @@ class InMemorySpanStore extends SpanStore with CollectAnnotationQueries {
     limit: Int
   ): Future[Seq[IndexedTraceId]] = call {
     spansForService(serviceName)
-      .filter(s => s.id == s.traceId) // only root spans
       .filter(_.timestamp.exists(t => t >= (endTs - lookback) && t <= endTs))
       .filter(_.duration.exists(_ >= minDuration))
       .filter(_.duration.exists(_ <= maxDuration.getOrElse(Long.MaxValue)))


### PR DESCRIPTION
Before, min and maxDuration queries applied only to root spans. Since a
call to a service can happen anywhere in the tree, this artifically
limited usefulness. Now, duration queries will apply to any span for a
given service.
