### PR TITLE
Include endpoints from binary annotations in trace summary

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
@@ -56,10 +56,10 @@ case class Span(
   override def compare(that: Span) =
     java.lang.Long.compare(timestamp.getOrElse(0L), that.timestamp.getOrElse(0L))
 
-  def serviceNames: Set[String] = (
-    annotations.flatMap(_.host.map(h => h.serviceName)) ++
-      binaryAnnotations.flatMap(_.host.map(h => h.serviceName))
-    ).toSet
+  def endpoints: Set[Endpoint] =
+    (annotations.flatMap(_.host) ++ binaryAnnotations.flatMap(_.host)).toSet
+
+  def serviceNames: Set[String] = endpoints.map(_.serviceName)
 
   /**
    * Tries to extract the best name of the service in this span. This depends on annotations

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/SpanTest.scala
@@ -19,7 +19,17 @@ package com.twitter.zipkin.common
 import org.scalatest.FunSuite
 
 class SpanTest extends FunSuite {
-
+  val span = Span(12345, "methodcall", 666, None, None, None,
+    List(
+      Annotation(1, "cs", Some(Endpoint(1, 2, "cs"))),
+      Annotation(1, "sr", Some(Endpoint(1, 2, "sr"))),
+      Annotation(1, "ss", Some(Endpoint(1, 2, "ss"))),
+      Annotation(1, "cr", Some(Endpoint(1, 2, "cr")))
+    ),
+    List(
+      BinaryAnnotation("ca", BinaryAnnotationValue(true), Some(Endpoint(1, 2, "ca"))),
+      BinaryAnnotation("sa", BinaryAnnotationValue(true), Some(Endpoint(1, 2, "sa")))
+    ))
   /** Representations should lowercase on the way in */
   test("name cannot be lowercase") {
     intercept[IllegalArgumentException] {
@@ -27,18 +37,12 @@ class SpanTest extends FunSuite {
     }
   }
 
+  test("endpoints include binary annotations") {
+    assert(span.endpoints.map(_.serviceName) === Set("cs", "cr", "ss", "sr", "ca", "sa"))
+  }
+
   test("serviceNames include binary annotations") {
-    assert(Span(12345, "methodcall", 666, None, None, None,
-      List(
-        Annotation(1, "cs", Some(Endpoint(1, 2, "cs"))),
-        Annotation(1, "sr", Some(Endpoint(1, 2, "sr"))),
-        Annotation(1, "ss", Some(Endpoint(1, 2, "ss"))),
-        Annotation(1, "cr", Some(Endpoint(1, 2, "cr")))
-      ),
-      List(
-        BinaryAnnotation("ca", BinaryAnnotationValue(true), Some(Endpoint(1, 2, "ca"))),
-        BinaryAnnotation("sa", BinaryAnnotationValue(true), Some(Endpoint(1, 2, "sa")))
-      )).serviceNames === Set("cs", "cr", "ss", "sr", "ca", "sa"))
+    assert(span.serviceNames === Set("cs", "cr", "ss", "sr", "ca", "sa"))
   }
 
   test("serviceName preference") {

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/TraceSummary.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/TraceSummary.scala
@@ -32,7 +32,7 @@ object TraceSummary {
    */
   def apply(trace: List[Span]): Option[TraceSummary] = {
     val duration = Trace.duration(trace).getOrElse(0L)
-    val endpoints = trace.flatMap(_.annotations).flatMap(_.host).distinct
+    val endpoints = trace.flatMap(_.endpoints).distinct
     for (
       traceId <- trace.headOption.map(_.traceId);
       timestamp <- trace.headOption.flatMap(_.timestamp)


### PR DESCRIPTION
Noticed we were inconsistent about this.
