### PR TITLE
Fixes service name query for spans who only have binary annotations

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -94,7 +94,7 @@ class AnormSpanStore(val db: DB,
             .on("timestamp" -> span.timestamp.getOrElse(System.currentTimeMillis() * 1000)) // fallback if we have no timestamp, yet
             .on("ipv4" -> b.host.map(_.ipv4))
             .on("port" -> b.host.map(_.port))
-            .on("service_name" -> b.host.map(_.serviceName).getOrElse("Unknown service name")) // from Annotation
+            .on("service_name" -> b.serviceName)
             .execute()
         )
       })
@@ -201,7 +201,6 @@ class AnormSpanStore(val db: DB,
             |  SELECT DISTINCT trace_id
             |  FROM zipkin_annotations
             |  WHERE endpoint_service_name = {service_name}
-            |  AND a_type = -1
             |  GROUP BY trace_id)
             |AS t2 ON t1.trace_id = t2.trace_id
             |WHERE (name = {name} OR {name} = '')

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Annotation.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Annotation.scala
@@ -27,7 +27,7 @@ import java.util.Comparator
  */
 case class Annotation(timestamp: Long, value: String, host: Option[Endpoint])
   extends Ordered[Annotation] {
-  def serviceName = host.map(_.serviceName).getOrElse("Unknown service name")
+  def serviceName = host.map(_.serviceName).getOrElse("unknown")
 
   /**
    * @return diff between timestamps of the two annotations.

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/BinaryAnnotation.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/BinaryAnnotation.scala
@@ -24,7 +24,9 @@ case class BinaryAnnotation(
   value: ByteBuffer,
   annotationType: AnnotationType,
   host: Option[Endpoint]
-)
+) {
+  def serviceName = host.map(_.serviceName).getOrElse("unknown")
+}
 
 object BinaryAnnotation {
   def apply[V](key: String, value: BinaryAnnotationValue[V], host: Option[Endpoint]): BinaryAnnotation =

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
@@ -67,13 +67,15 @@ case class Span(
    */
   lazy val serviceName: Option[String] = {
     // Most authoritative is the label of the server's endpoint
-    binaryAnnotations.find(_.key == Constants.ServerAddr).flatMap(_.host).map(_.serviceName) orElse
+    binaryAnnotations.find(_.key == Constants.ServerAddr).map(_.serviceName) orElse
       // Next, the label of any server annotation, logged by an instrumented server
-      serverSideAnnotations.flatMap(_.host).headOption.map(_.serviceName) orElse
+      serverSideAnnotations.headOption.map(_.serviceName) orElse
       // Next is the label of the client's endpoint
-      binaryAnnotations.find(_.key == Constants.ClientAddr).flatMap(_.host).map(_.serviceName) orElse
-      // Finally, the label of any client annotation, logged by an instrumented client
-      clientSideAnnotations.flatMap(_.host).headOption.map(_.serviceName)
+      binaryAnnotations.find(_.key == Constants.ClientAddr).map(_.serviceName) orElse
+      // Next is the label of any client annotation, logged by an instrumented client
+      clientSideAnnotations.headOption.map(_.serviceName) orElse
+      // Finally is the label of the local component's endpoint
+      binaryAnnotations.find(_.key == Constants.LocalComponent).map(_.serviceName)
   }
 
   /**

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -143,6 +143,15 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     result(store.getTraces(QueryRequest("badservice", Some("badmethod")))) should be(empty)
   }
 
+  @Test def getTraces_serviceNameInBinaryAnnotation() {
+    val localTrace = List(Span(1L, "targz", 1L, None, Some(100L), Some(200L),
+      binaryAnnotations = List(BinaryAnnotation(Constants.LocalComponent, "archiver", Some(ep)))))
+
+    result(store(localTrace))
+
+    result(store.getTraces(QueryRequest("service"))) should be(Seq(localTrace))
+  }
+
   /** Shows that duration queries go against the root span, not the child */
   @Test def getTraces_duration() {
     val service1 = Endpoint(127 << 24 | 1, 8080, "service1")


### PR DESCRIPTION
Local spans are permitted to have a single binary annotation. Logic
needed to be adjusted to allow these to be queried by service, as
formerly the service of a binary annotation wasn't consistently
indexed or presented.
