### PR TITLE
Ensures all span stores apply filters to results bound to endTs

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -189,7 +189,7 @@ abstract class CassandraSpanStore(
           .map(MergeById)
           .map(CorrectForClockSkew)
           .map(ApplyTimestampAndDuration)
-          .sortBy(_.head) // CQL doesn't allow order by with an "in" query
+          .sortBy(_.head)(Ordering[Span].reverse) // sort descending by the first span
       }
   }
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
@@ -5,6 +5,12 @@ import com.twitter.zipkin.util.Util.checkArgument
 import scala.util.hashing.MurmurHash3
 
 /**
+ * Invoking this request retrieves traces matching the below filters.
+ *
+ * <p/> Results should be filtered against [[endTs]], subject to [[limit]] and [[_lookback]]. For
+ * example, if endTs is 10:20 today, limit is 10, and lookback is 7 days, traces returned should be
+ * those nearest to 10:20 today, not 10:20 a week ago.
+ *
  * @param _serviceName Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]] and constrains
  *                     all other parameters.
  * @param _spanName When present, only include traces with this [[com.twitter.zipkin.common.Span.name]]

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
@@ -566,36 +566,6 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |[
           |  [
           |    {
-          |      "traceId" : "0000000000000003",
-          |      "name" : "methodcall",
-          |      "id" : "0000000000000003",
-          |      "timestamp" : 99,
-          |      "duration" : 100,
-          |      "annotations" : [
-          |        {
-          |          "timestamp" : 99,
-          |          "value" : "cs",
-          |          "endpoint" : {
-          |            "serviceName" : "service2",
-          |            "ipv4" : "0.0.0.234",
-          |            "port" : 234
-          |          }
-          |        },
-          |        {
-          |          "timestamp" : 199,
-          |          "value" : "cr",
-          |          "endpoint" : {
-          |            "serviceName" : "service2",
-          |            "ipv4" : "0.0.0.234",
-          |            "port" : 234
-          |          }
-          |        }
-          |      ],
-          |      "binaryAnnotations" : [ ]
-          |    }
-          |  ],
-          |  [
-          |    {
           |      "traceId" : "0000000000000002",
           |      "name" : "methodcall",
           |      "id" : "0000000000000002",
@@ -683,6 +653,36 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
           |            "serviceName" : "service1",
           |            "ipv4" : "0.0.0.123",
           |            "port" : 123
+          |          }
+          |        }
+          |      ],
+          |      "binaryAnnotations" : [ ]
+          |    }
+          |  ],
+          |  [
+          |    {
+          |      "traceId" : "0000000000000003",
+          |      "name" : "methodcall",
+          |      "id" : "0000000000000003",
+          |      "timestamp" : 99,
+          |      "duration" : 100,
+          |      "annotations" : [
+          |        {
+          |          "timestamp" : 99,
+          |          "value" : "cs",
+          |          "endpoint" : {
+          |            "serviceName" : "service2",
+          |            "ipv4" : "0.0.0.234",
+          |            "port" : 234
+          |          }
+          |        },
+          |        {
+          |          "timestamp" : 199,
+          |          "value" : "cr",
+          |          "endpoint" : {
+          |            "serviceName" : "service2",
+          |            "ipv4" : "0.0.0.234",
+          |            "port" : 234
           |          }
           |        }
           |      ],

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisStorage.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisStorage.scala
@@ -43,7 +43,7 @@ class RedisStorage(
             .map(MergeById)
             .map(CorrectForClockSkew)
             .map(ApplyTimestampAndDuration)
-            .sortBy(_.head)) // sort traces by the first span
+            .sortBy(_.head)(Ordering[Span].reverse)) // sort descending by the first span
 
   private[this] def getSpansByTraceId(traceId: Long): Future[List[Span]] =
     client.lRange(encodeTraceId(traceId), 0L, -1L) map


### PR DESCRIPTION
Filtered traces are now returned in reverse insertion order. This is
because the primary search interface is a timeline view, looking back
from an end timestamp.

The in-memory and anorm span stores were the only ones applying request
filters against traces at the beginning of (endTs - lookback, endTs) vs
looking back from endTs. This created a poor experience where old traces
returned by default.

This enforces the lookback behavior and clarifies it by ordering traces
descending against endTs, A loose test was clarified to ensure limit
applies this way.

Besides trace ordering, which happens after traces return from the
backend, redis and cassandra implementations are unaffected, as they
already had the intended behavior.

Fixed #826
