### PR TITLE
gzip encodes messages between zipkin-query and zipkin-web

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -71,9 +71,12 @@ trait ZipkinWebFactory { self: App =>
   * we get the host after the [[queryDest]] flag has been parsed.
   */
   lazy val queryClient = new HttpClient(
-    httpService =
-      Http.client.configured(param.Label("zipkin-query")).newClient(queryDest()).toService,
-    defaultHeaders = Map("Host" -> queryDest()),
+    httpService = Http.client.configured(param.Label("zipkin-query"))
+                             .newClient(queryDest()).toService,
+    defaultHeaders = Map(
+      "Host" -> queryDest(),
+      "Accept-Encoding" -> "gzip"
+    ),
     mapper = new FinatraObjectMapper(ZipkinJson)
   )
 


### PR DESCRIPTION
Regardless of thrift vs json, trace data is full of repeated strings. By
accepting gzip encoding, we can dramatically reduce api response size on
the wire. This is particularly helpful as some frameworks impose strict
limits on transport message size.

See #833
