### PR TITLE
added cache control to public css and js

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -12,6 +12,7 @@ import com.twitter.zipkin.common._
 import com.twitter.zipkin.json._
 import com.twitter.zipkin.web.mustache.ZipkinMustache
 import com.twitter.zipkin.{Constants => ZConstants}
+import com.twitter.conversions.time._
 import org.jboss.netty.handler.codec.http.QueryStringEncoder
 import java.io.{File, FileInputStream, InputStream}
 
@@ -57,6 +58,7 @@ class Handlers(mustacheGenerator: ZipkinMustache, queryExtractor: QueryExtractor
 
     def apply(response: Response) {
       response.setContentType(typ)
+      response.cacheControl = 10.minutes
       response.content = Buf.ByteArray.Owned(content)
     }
   }


### PR DESCRIPTION
I'm not scala programmer but looking at this
https://github.com/twitter/finagle/blob/bf4b0ea8b4bb34f4cb98fa6da06723bc58635487/finagle-http/src/test/scala/com/twitter/finagle/http/MessageTest.scala

I think it should work.

The UI is slow. Looking at the cause it is because we have lots of css and js and they are sent everytime.
@adriancole  please run tests xD
