### PR TITLE
Truncates cassandra test data as opposed to dropping the keyspace

### DIFF
--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStoreSpec.scala
@@ -1,35 +1,14 @@
 package com.twitter.zipkin.storage.cassandra
 
-import java.util.Collections
-
-import com.datastax.driver.core.Cluster
 import com.twitter.util.Await._
 import com.twitter.zipkin.common.{Dependencies, Span}
 import com.twitter.zipkin.storage.DependencyStoreSpec
-import org.cassandraunit.CQLDataLoader
-import org.cassandraunit.dataset.CQLDataSet
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra
 import org.junit.BeforeClass
 import org.twitter.zipkin.storage.cassandra.Repository
 
-object CassandraDependencyStoreSpec {
-  val keyspace = "test_zipkin_dependencystore"
-  // Defer shared connection to the cluster
-  lazy val cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(9142).build()
+object CassandraDependencyStoreSpec extends CassandraFixture("test_zipkin_dependencystore") {
 
-  @BeforeClass def cassandra = {
-    startEmbeddedCassandra("cu-cassandra.yaml", "build/embeddedCassandra", 10 * 1000)
-
-    new CQLDataLoader(cluster.connect).load(new CQLDataSet() {
-      override def isKeyspaceDeletion = true
-
-      override def getKeyspaceName = keyspace
-
-      override def isKeyspaceCreation = true
-
-      override def getCQLStatements = Collections.emptyList()
-    })
-  }
+  @BeforeClass override def cassandra = super.cassandra
 }
 
 class CassandraDependencyStoreSpec extends DependencyStoreSpec {
@@ -45,5 +24,5 @@ class CassandraDependencyStoreSpec extends DependencyStoreSpec {
     result(store.storeDependencies(deps))
   }
 
-  override def clear = cluster.connect().execute("DROP KEYSPACE IF EXISTS " + keyspace)
+  override def clear = truncate
 }

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraFixture.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraFixture.scala
@@ -1,0 +1,41 @@
+package com.twitter.zipkin.storage.cassandra
+
+import com.datastax.driver.core.Cluster
+import org.cassandraunit.CQLDataLoader
+import org.cassandraunit.dataset.CQLDataSet
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper._
+import org.twitter.zipkin.storage.cassandra.Repository
+import java.util.Collections
+
+class CassandraFixture(val keyspace: String) {
+  // Defer shared connection to the cluster
+  lazy val cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(9142).build()
+
+  def cassandra = {
+    startEmbeddedCassandra("cu-cassandra.yaml", "build/embeddedCassandra", 10 * 1000)
+
+    new CQLDataLoader(cluster.connect).load(new CQLDataSet() {
+      override def isKeyspaceDeletion = false
+
+      override def getKeyspaceName = keyspace
+
+      override def isKeyspaceCreation = false
+
+      override def getCQLStatements = Collections.emptyList()
+    })
+  }
+
+  def truncate = {
+    new Repository(keyspace, cluster, true) // initialize the repository, which creates the keyspace.
+    val connection = cluster.connect()
+    Seq(
+      "traces",
+      "dependencies",
+      "service_names",
+      "span_names",
+      "service_name_index",
+      "service_span_name_index",
+      "annotations_index"
+    ).foreach(cf => connection.execute("TRUNCATE %s.%s".format(keyspace, cf)))
+  }
+}

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStoreSpec.scala
@@ -1,32 +1,12 @@
 package com.twitter.zipkin.storage.cassandra
 
-import com.datastax.driver.core.Cluster
 import com.twitter.zipkin.storage.SpanStoreSpec
-import java.util.Collections
-import org.cassandraunit.CQLDataLoader
-import org.cassandraunit.dataset.CQLDataSet
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra
 import org.junit.{BeforeClass, Ignore}
 import org.twitter.zipkin.storage.cassandra.Repository
 
-object CassandraSpanStoreSpec {
-  val keyspace = "test_zipkin_spanstore"
-  // Defer shared connection to the cluster
-  lazy val cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(9142).build()
+object CassandraSpanStoreSpec extends CassandraFixture("test_zipkin_spanstore") {
 
-  @BeforeClass def cassandra = {
-    startEmbeddedCassandra("cu-cassandra.yaml", "build/embeddedCassandra", 10 * 1000)
-
-    new CQLDataLoader(cluster.connect).load(new CQLDataSet() {
-      override def isKeyspaceDeletion = true
-
-      override def getKeyspaceName = keyspace
-
-      override def isKeyspaceCreation = true
-
-      override def getCQLStatements = Collections.emptyList()
-    })
-  }
+  @BeforeClass override def cassandra = super.cassandra
 }
 
 class CassandraSpanStoreSpec extends SpanStoreSpec {
@@ -37,7 +17,7 @@ class CassandraSpanStoreSpec extends SpanStoreSpec {
     override lazy val repository = new Repository(keyspace, cluster, true)
   }
 
-  override def clear = cluster.connect().execute("DROP KEYSPACE IF EXISTS " + keyspace)
+  override def clear = truncate
 
   @Ignore override def getTraces_lookback() = {
     // TODO!


### PR DESCRIPTION
Cassandra tests were taking several minutes to complete. @yurishkuro
noticed this was due to redundant keyspace dropping. This changes
behavior to truncate instead.

Fixes #816
