### PR TITLE
Remove constraint that root span's trace id = span id

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormDependencyStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormDependencyStore.scala
@@ -59,7 +59,7 @@ case class AnormDependencyStore(val db: DB,
         }) *).map(r => (r._1, r._2) -> r._3).toMap
 
       parentChild.values.flatMap(identity).flatMap(r => {
-        // parent can be empty if a root span is missing, or the root's span id doesn't eq the trace id
+        // parent can be empty if a root span is missing
         for (
           parent <- traceSpanServiceName.get((r._1, r._2));
           child <- traceSpanServiceName.get((r._1, r._3))

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -304,7 +304,6 @@ abstract class CassandraSpanStore(
       }
   }
 
-  /** Only return traces where root span duration is between minDuration and maxDuration */
   override protected def getTraceIdsByDuration(
     serviceName: String,
     spanName: Option[String],

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
@@ -27,9 +27,8 @@ import com.twitter.zipkin.util.Util._
  * sometimes created directly by application developers to indicate events of interest, such as a
  * cache miss.
  *
- * <p/>The root span is where [[traceId]] = [[id]] and [[parentId]] is empty. The root span is
- * usually the longest interval in the trace, starting with [[timestamp]] and ending with
- * [[timestamp]] + [[duration]].
+ * <p/>The root span is where [[parentId]] is empty; it usually has the longest [[duration]] in the
+ * trace.
  *
  * <p/>Span identifiers are packed into longs, but should be treated opaquely. String encoding is
  * fixed-width lower-hex, to avoid signed interpretation.
@@ -37,9 +36,8 @@ import com.twitter.zipkin.util.Util._
  * @param traceId unique 8-byte identifier for a trace, set on all spans within it.
  * @param name span name in lowercase, rpc method for example. Conventionally, when the span name
  *             isn't known, name = "unknown".
- * @param id unique 8-byte identifier of this span within a trace. If this is the root span,
- *           [[id]] = [[traceId]] and [[parentId]] is absent. A span is uniquely identified in
- *           storage by (trace_id, id).
+ * @param id unique 8-byte identifier of this span within a trace. A span is uniquely
+ *           identified in storage by (trace_id, id).
  * @param parentId the parent's [[id]]; absent if this the root span in a trace.
  * @param timestamp epoch microseconds of the start of this span; absent if this an incomplete span.
  * @param duration measurement in microseconds of the critical path, if known.

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
@@ -40,7 +40,7 @@ trait CollectAnnotationQueries {
     limit: Int
   ): Future[Seq[IndexedTraceId]]
 
-  /** Only return traces where root span duration is between minDuration and maxDuration */
+  /** Only return traces where [[Span.duration]] is between minDuration and maxDuration */
   protected def getTraceIdsByDuration(
     serviceName: String,
     spanName: Option[String],

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
@@ -276,9 +276,8 @@ struct BinaryAnnotation {
  * log statements, and are sometimes created directly by application developers
  * to indicate events of interest, such as a cache miss.
  *
- * The root span is where trace_id = id and parent_id = Nil. The root span is
- * usually the longest interval in the trace, starting with Span.timestamp and
- * ending with Span.timestamp + Span.duration.
+ * The root span is where parent_id = Nil; it usually has the longest duration
+ * in the trace.
  *
  * Span identifiers are packed into i64s, but should be treated opaquely.
  * String encoding is fixed-width lower-hex, to avoid signed interpretation.
@@ -294,9 +293,8 @@ struct Span {
    */
   3: string name,
   /**
-   * Unique 8-byte identifier of this span within a trace. If this is the root
-   * span, id = trace_id and parent_id is absent. A span is uniquely identified
-   * in storage by (trace_id, id).
+   * Unique 8-byte identifier of this span within a trace. A span is uniquely
+   * identified in storage by (trace_id, id).
    */
   4: i64 id,
   /**

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Util.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Util.scala
@@ -85,6 +85,28 @@ object Util {
     spans filter { !_.parentId.flatMap(idSpan.get).isDefined }
   }
 
+  /**
+   * In some cases we don't care if it's the actual root span or just the span
+   * that is closes to the root. For example it could be that we don't yet log spans
+   * from the root service, then we want the one just below that.
+   * FIXME if there are holes in the trace this might not return the correct span
+   */
+  private[web] def getRootMostSpan(spans: List[Span]): Option[Span] = {
+    spans.find(!_.parentId.isDefined) orElse {
+      val idSpan = getIdToSpanMap(spans)
+      spans.headOption map {
+        recursiveGetRootMostSpan(idSpan, _)
+      }
+    }
+  }
+
+  private def recursiveGetRootMostSpan(idSpan: Map[Long, Span], prevSpan: Span): Span = {
+    // parent id shouldn't be none as then we would have returned already
+    val span = for (id <- prevSpan.parentId; s <- idSpan.get(id)) yield
+    recursiveGetRootMostSpan(idSpan, s)
+    span.getOrElse(prevSpan)
+  }
+
   /*
    * Turn the Trace into a map of Span Id -> Span
    */

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/UtilTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/UtilTest.scala
@@ -17,6 +17,7 @@
 package com.twitter.zipkin.web
 
 import com.twitter.conversions.time._
+import com.twitter.zipkin.common.Span
 import org.scalatest.FunSuite
 
 class UtilTest extends FunSuite {
@@ -51,5 +52,41 @@ class UtilTest extends FunSuite {
       // test as Long
       assert(durationStr(t.inMicroseconds) === v)
     }
+  }
+
+  test("get root spans when id = trace id") {
+    val spanNoneParent = Span(100, "", 100)
+    val spanParent = Span(100, "", 200, Some(100L))
+    assert(getRootSpans(List(spanParent, spanNoneParent)) === List(spanNoneParent))
+  }
+
+  test("get root spans when id != trace id") {
+    val spanNoneParent = Span(1, "", 100)
+    val spanParent = Span(1, "", 200, Some(100L))
+    assert(getRootSpans(List(spanParent, spanNoneParent)) === List(spanNoneParent))
+  }
+
+  test("get root spans when parent id not found") {
+    val spanNoneParent = Span(1, "", 100, Some(0L)) // 0 isn't present!
+    val spanParent = Span(1, "", 200, Some(100L))
+    assert(getRootSpans(List(spanParent, spanNoneParent)) === List(spanNoneParent))
+  }
+
+  test("get root most span when id = trace id") {
+    val spanNoneParent = Span(100, "", 100)
+    val spanParent = Span(100, "", 200, Some(100L))
+    assert(getRootMostSpan(List(spanParent, spanNoneParent)) === Some(spanNoneParent))
+  }
+
+  test("get root most span when id != trace id") {
+    val spanNoneParent = Span(1, "", 100)
+    val spanParent = Span(1, "", 200, Some(100L))
+    assert(getRootMostSpan(List(spanParent, spanNoneParent)) === Some(spanNoneParent))
+  }
+
+  test("get root most span when parent id not found") {
+    val spanNoneParent = Span(1, "", 100, Some(0L)) // 0 isn't present!
+    val spanParent = Span(1, "", 200, Some(100L))
+    assert(getRootMostSpan(List(spanParent, spanNoneParent)) === Some(spanNoneParent))
   }
 }


### PR DESCRIPTION
This removes any confusing text which might indicate root span's trace
id must equal its span id.

Fixes #849
