### PR TITLE
Drops untested H2, PostgreSQL drivers; switches MySQL to MariaDB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Sat, 15 Aug 2015 15:15:18 +0000
-version=1.23.4-SNAPSHOT
+version=1.24.0-SNAPSHOT
 group=io.zipkin
 repo=https://github.com/openzipkin/zipkin
 description=A distributed tracing system
@@ -33,5 +33,5 @@ tracegenDest=localhost
 # files are created in the current working directory, query and collector need
 # to start in the same directory.
 #
-# Other values are sqlite-memory, h2-memory, h2-persistent, postgresql, mysql
+# Other values are sqlite-memory (for unit tests) and mysql (available in docker)
 dbEngine=sqlite-persistent

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,15 +26,15 @@ ext {
     // The values are the dependency to be used in the build to support the requested storage system.
     //
     // The default value of dbEngine is sqlite-persistent, defined in gradle.properties
-    // To override, run the build like this: ./gradlew build -PdbEngine=postgresql
+    // To override, run the build like this: ./gradlew build -PdbEngine=sqlite-memory
     anormDriverDependencies = [
             "sqlite-memory": "org.xerial:sqlite-jdbc:3.8.11.2",  // sqlite-jdbc4 isn't out, yet
             "sqlite-persistent": "org.xerial:sqlite-jdbc:3.8.11.2",
-            "h2-memory": "com.h2database:h2:1.4.190",
-            "h2-persistent": "com.h2database:h2:1.4.190",
-            // Don't add EOL versions! http://www.postgresql.org/support/versioning
-            "postgresql": "org.postgresql:postgresql:9.3-1104-jdbc4",
-            "mysql": "mysql:mysql-connector-java:5.1.37"
+            // MySQL connector is GPL, even if it has an OSS exception.
+            // https://www.mysql.com/about/legal/licensing/foss-exception/
+            //
+            // MariaDB has a friendlier license, LGPL, which is less scary in audits.
+            "mysql": "org.mariadb.jdbc:mariadb-java-client:1.3.0"
     ]
 }
 

--- a/zipkin-anormdb/README.md
+++ b/zipkin-anormdb/README.md
@@ -1,7 +1,6 @@
 # zipkin-anormdb
 
 AnormDB is a SQL layer for zipkin span storage.
-See [sql-databases](https://github.com/openzipkin/zipkin/blob/master/doc/sql-databases.db) for details.
 
 ## Service Configuration
 

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
@@ -75,7 +75,7 @@ case class DBConfig(name: String = "sqlite-persistent",
    * Anorm supports any SQL database, so more databases can be added here.
    *
    * The other place the database driver needs to be set is in the project
-   * dependencies in project/Project.scala.
+   * dependencies in `gradle/dependencies.gradle`.
    */
   private val dbmap = Map(
     "sqlite-memory" -> DBInfo(
@@ -90,29 +90,12 @@ case class DBConfig(name: String = "sqlite-persistent",
       location = { dbp: DBParams => "jdbc:sqlite:" + dbp.dbName + ".db" },
       jdbc3 = true
     ),
-    "h2-memory" -> DBInfo(
-      description = "H2 in-memory",
-      driver = "org.h2.Driver",
-      location = { dbp: DBParams => "jdbc:h2:mem:" + dbp.dbName }
-    ),
-    "h2-persistent" -> DBInfo(
-      description = "H2 persistent",
-      driver = "org.h2.Driver",
-      location = { dbp: DBParams => "jdbc:h2:" + dbp.dbName }
-    ),
-    "postgresql" -> DBInfo(
-      description = "PostgreSQL",
-      driver = "org.postgresql.Driver",
-      location = { dbp: DBParams =>
-        "jdbc:postgresql://" + dbp.host + dbp.getPort + "/" + dbp.dbName + "?user=" + dbp.username + "&password=" + dbp.password + "&ssl=" + dbp.ssl
-      }
-    ),
     "mysql" -> DBInfo(
       description = "MySQL",
-      driver = "com.mysql.jdbc.Driver",
+      driver = "org.mariadb.jdbc.Driver",
       location = { dbp: DBParams =>
         // We need to enable auto-reconnect to recover from dropped connections
-        "jdbc:mysql://" + dbp.host + dbp.getPort + "/" + dbp.dbName + "?user=" + dbp.username + "&password=" + dbp.password + "&autoReconnect=true"
+        "jdbc:mariadb://" + dbp.host + dbp.getPort + "/" + dbp.dbName + "?user=" + dbp.username + "&password=" + dbp.password + "&autoReconnect=true"
       }
     )
   )


### PR DESCRIPTION
Zipkin formerly pulled dependencies for H2 and PostgreSQL, eventhough we
don't document, test, or allow their configuration in docker or shell
scripts. This drops H2 and PostgreSQL until such time as there's enough
interest to formally support them.

This also switches the MySQL driver to MariaDB. MySQL connector is GPL,
even if it has an OSS exception.
https://www.mysql.com/about/legal/licensing/foss-exception/

MariaDB has a friendlier license, LGPL, which is less scary in audits.
