### PR TITLE
Changes query endTs and lookback from micros to millis

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormDependencyStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormDependencyStore.scala
@@ -40,8 +40,8 @@ case class AnormDependencyStore(val db: DB,
           |WHERE start_ts BETWEEN {startTs} AND {endTs}
           |AND parent_id is not null
         """.stripMargin)
-        .on("startTs" -> startTs)
-        .on("endTs" -> endTs)
+        .on("startTs" -> startTs * 1000)
+        .on("endTs" -> endTs * 1000)
         .as((long("trace_id") ~ long("parent_id") ~ long("id") map {
           case traceId ~ parentId ~ id => (traceId, parentId, id)
         }) *).groupBy(_._1)

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -213,8 +213,8 @@ class AnormSpanStore(val db: DB,
           "AND (name = {name} OR {name} = '')" + sliceQueryFooter)
           .on("service_name" -> serviceName)
           .on("name" -> spanName.getOrElse(""))
-          .on("start_ts" -> (endTs - lookback))
-          .on("end_ts" -> endTs)
+          .on("start_ts" -> (endTs - lookback) * 1000)
+          .on("end_ts" -> endTs * 1000)
           .on("limit" -> limit)
           .as((long("trace_id") ~ long("start_ts") map flatten) *)
         result map { case (tId, ts) =>
@@ -241,8 +241,8 @@ class AnormSpanStore(val db: DB,
               .on("service_name" -> serviceName)
               .on("annotation" -> annotation)
               .on("value" -> Util.getArrayFromBuffer(bytes))
-              .on("start_ts" -> (endTs - lookback))
-              .on("end_ts" -> endTs)
+              .on("start_ts" -> (endTs - lookback) * 1000)
+              .on("end_ts" -> endTs * 1000)
               .on("limit" -> limit)
               .as((long("trace_id") ~ long("start_ts") map flatten) *)
           }
@@ -254,8 +254,8 @@ class AnormSpanStore(val db: DB,
               """.stripMargin + sliceQueryFooter)
               .on("service_name" -> serviceName)
               .on("annotation" -> annotation)
-              .on("start_ts" -> (endTs - lookback))
-              .on("end_ts" -> endTs)
+              .on("start_ts" -> (endTs - lookback) * 1000)
+              .on("end_ts" -> endTs * 1000)
               .on("limit" -> limit)
               .as((long("trace_id") ~ long("start_ts") map flatten) *)
           }
@@ -288,8 +288,8 @@ class AnormSpanStore(val db: DB,
         .on("service_name" -> serviceName)
         .on("min_duration" -> minDuration)
         .on("max_duration" -> maxDuration.getOrElse(Long.MaxValue))
-        .on("start_ts" -> (endTs - lookback))
-        .on("end_ts" -> endTs)
+        .on("start_ts" -> (endTs - lookback) * 1000)
+        .on("end_ts" -> endTs * 1000)
         .on("limit" -> limit)
         .as((long("trace_id") ~ long("start_ts") map flatten) *)
       result map { case (tId, ts) =>

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -273,8 +273,8 @@ abstract class CassandraSpanStore(
     val traceIdsFuture = FutureUtil.toFuture(spanName match {
       // if we have a span name, look up in the service + span name index
       // if not, look up by service name only
-      case Some(x :String) => repository.getTraceIdsBySpanName(serviceName, x, endTs, lookback, limit)
-      case None => repository.getTraceIdsByServiceName(serviceName, endTs, lookback, limit)
+      case Some(x :String) => repository.getTraceIdsBySpanName(serviceName, x, endTs * 1000, lookback * 1000, limit)
+      case None => repository.getTraceIdsByServiceName(serviceName, endTs * 1000, lookback * 1000, limit)
     })
 
     traceIdsFuture.map { traceIds =>
@@ -296,7 +296,7 @@ abstract class CassandraSpanStore(
 
     FutureUtil.toFuture(
       repository
-        .getTraceIdsByAnnotation(annotationKey(serviceName, annotation, value), endTs, lookback, limit))
+        .getTraceIdsByAnnotation(annotationKey(serviceName, annotation, value), endTs * 1000, lookback * 1000, limit))
       .map { traceIds =>
         traceIds.asScala
           .map { case (traceId, ts) => IndexedTraceId(traceId, timestamp = ts) }
@@ -319,7 +319,7 @@ abstract class CassandraSpanStore(
     FutureUtil.toFuture(
       repository
         .getTraceIdsByDuration(serviceName, spanName getOrElse "", minDuration, maxDuration getOrElse Long.MaxValue,
-          endTs, endTs - lookback, limit))
+          endTs * 1000, (endTs - lookback)  * 1000, limit))
       .map { traceIds =>
       traceIds.asScala
         .map { case (traceId, ts) => IndexedTraceId(traceId, timestamp = ts) }

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStoreSpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraDependencyStoreSpec.scala
@@ -18,7 +18,7 @@ class CassandraDependencyStoreSpec extends DependencyStoreSpec {
   }
 
   override def processDependencies(spans: List[Span]) = {
-    val deps = new Dependencies(spans.head.timestamp.get, spans.last.timestamp.get, Dependencies.toLinks(spans))
+    val deps = new Dependencies(spans.head.timestamp.get / 1000, spans.last.timestamp.get / 1000, Dependencies.toLinks(spans))
     result(store.storeDependencies(deps))
   }
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Dependencies.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Dependencies.scala
@@ -24,7 +24,7 @@ import scala.util.hashing.MurmurHash3
  *
  * @param _parent the calling [[com.twitter.zipkin.common.Endpoint.serviceName]]
  * @param _child the callee's [[com.twitter.zipkin.common.Endpoint.serviceName]]
- * @param callCount calls made during the duration (in microseconds) of this link
+ * @param callCount calls made during the duration (in milliseconds) of this link
  */
 // This is not a case-class as we need to enforce serviceName and spanName as lowercase
 class DependencyLink(_parent: String, _child: String, val callCount: Long) {
@@ -58,8 +58,8 @@ object DependencyLink {
 /**
  * This represents all dependencies across all services over a given time period.
  *
- * @param startTs microseconds from epoch
- * @param endTs microseconds from epoch
+ * @param startTs milliseconds from epoch
+ * @param endTs milliseconds from epoch
  * @param links link information for every dependent service
  */
 case class Dependencies(startTs: Long, endTs: Long, links: Seq[DependencyLink]) {

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
@@ -105,7 +105,7 @@ trait CollectAnnotationQueries {
   }
 
   private[this] def queryResponse(ids: Seq[IndexedTraceId], qr: QueryRequest): Future[Seq[Long]] = {
-    Future.value(ids.filter(_.timestamp <= qr.endTs).slice(0, qr.limit).map(_.traceId))
+    Future.value(ids.filter(_.timestamp <= qr.endTs * 1000).slice(0, qr.limit).map(_.traceId))
   }
 
   private trait SliceQuery

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/DependencyStore.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/DependencyStore.scala
@@ -33,9 +33,9 @@ abstract class DependencyStore extends java.io.Closeable {
    * was 25 hours, the implementation would query against 2 buckets.
    *
    * @param endTs only return links from spans where [[com.twitter.zipkin.common.Span.timestamp]]
-   *              are at or before this time in epoch microseconds.
+   *              are at or before this time in epoch milliseconds.
    * @param lookback only return links from spans where [[com.twitter.zipkin.common.Span.timestamp]]
-   *                 are at or after (endTs - lookback) in microseconds. Defaults to endTs.
+   *                 are at or after (endTs - lookback) in milliseconds. Defaults to endTs.
    * @return dependency links in an interval contained by (endTs - lookback) or
    *         empty if none are found
    */

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/DependenciesTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/DependenciesTest.scala
@@ -16,7 +16,7 @@
  */
 package com.twitter.zipkin.common
 
-import java.util.concurrent.TimeUnit.{HOURS, MICROSECONDS}
+import java.util.concurrent.TimeUnit.{HOURS, MILLISECONDS}
 
 import org.scalatest.{FunSuite, Matchers}
 
@@ -27,8 +27,8 @@ class DependenciesTest extends FunSuite with Matchers {
   val dl3 = DependencyLink("tfe", "mobileweb", 2)
   val dl4 = DependencyLink("tfe", "mobileweb", 4)
 
-  val deps1 = Dependencies(0L, MICROSECONDS.convert(1, HOURS), List(dl1, dl3))
-  val deps2 = Dependencies(MICROSECONDS.convert(1, HOURS), MICROSECONDS.convert(2, HOURS), List(dl2, dl4))
+  val deps1 = Dependencies(0L, MILLISECONDS.convert(1, HOURS), List(dl1, dl3))
+  val deps2 = Dependencies(MILLISECONDS.convert(1, HOURS), MILLISECONDS.convert(2, HOURS), List(dl2, dl4))
 
   test("identity on Dependencies.zero") {
     deps1 + Dependencies.zero should be(deps1)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -29,30 +29,30 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   val ep = Endpoint(127 << 24 | 1, 8080, "service")
 
   val spanId = 456
-  val ann1 = Annotation(1, "cs", Some(ep))
-  val ann2 = Annotation(2, "sr", None)
-  val ann3 = Annotation(10, "custom", Some(ep))
-  val ann4 = Annotation(20, "custom", Some(ep))
-  val ann5 = Annotation(5, "custom", Some(ep))
-  val ann6 = Annotation(6, "custom", Some(ep))
-  val ann7 = Annotation(7, "custom", Some(ep))
-  val ann8 = Annotation(8, "custom", Some(ep))
+  val ann1 = Annotation(1000, "cs", Some(ep))
+  val ann2 = Annotation(2000, "sr", None)
+  val ann3 = Annotation(10000, "custom", Some(ep))
+  val ann4 = Annotation(20000, "custom", Some(ep))
+  val ann5 = Annotation(5000, "custom", Some(ep))
+  val ann6 = Annotation(6000, "custom", Some(ep))
+  val ann7 = Annotation(7000, "custom", Some(ep))
+  val ann8 = Annotation(8000, "custom", Some(ep))
 
-  val span1 = Span(123, "methodcall", spanId, None, Some(1), Some(9), List(ann1, ann3),
+  val span1 = Span(123, "methodcall", spanId, None, Some(1000), Some(9000), List(ann1, ann3),
     List(BinaryAnnotation("BAH", "BEH", Some(ep))))
-  val span2 = Span(456, "methodcall", spanId, None, Some(2), None, List(ann2),
+  val span2 = Span(456, "methodcall", spanId, None, Some(2000), None, List(ann2),
     List(BinaryAnnotation("BAH2", "BEH2", Some(ep))))
-  val span3 = Span(789, "methodcall", spanId, None, Some(2), Some(18), List(ann2, ann3, ann4),
+  val span3 = Span(789, "methodcall", spanId, None, Some(2000), Some(18000), List(ann2, ann3, ann4),
     List(BinaryAnnotation("BAH2", "BEH2", Some(ep))))
-  val span4 = Span(999, "methodcall", spanId, None, Some(6), Some(1), List(ann6, ann7),
+  val span4 = Span(999, "methodcall", spanId, None, Some(6000), Some(1000), List(ann6, ann7),
     List())
-  val span5 = Span(999, "methodcall", spanId, None, Some(5), Some(3), List(ann5, ann8),
+  val span5 = Span(999, "methodcall", spanId, None, Some(5000), Some(3000), List(ann5, ann8),
     List(BinaryAnnotation("BAH2", "BEH2", Some(ep))))
 
-  val spanEmptySpanName = Span(123, "", spanId, None, Some(1), Some(1), List(ann1, ann2))
+  val spanEmptySpanName = Span(123, "", spanId, None, Some(1000), Some(1000), List(ann1, ann2))
   val spanEmptyServiceName = Span(123, "spanname", spanId)
 
-  val mergedSpan = Span(123, "methodcall", spanId, None, Some(1), Some(1),
+  val mergedSpan = Span(123, "methodcall", spanId, None, Some(1000), Some(1000),
     List(ann1, ann2), List(BinaryAnnotation("BAH2", "BEH2", Some(ep))))
 
   @Test def getSpansByTraceIds() {
@@ -178,7 +178,7 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
     result(store(trace1 ::: trace2 ::: trace3))
 
-    val lookback = 12L * 60 * 60 * 1000 * 1000 // 12hrs, instead of 7days
+    val lookback = 12L * 60 * 60 * 1000 // 12hrs, instead of 7days
     val endTs = 1000L // greater than all timestamps above
     val q = QueryRequest("placeholder", lookback = Some(lookback), endTs = endTs)
 
@@ -244,13 +244,14 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   }
 
   @Test def getTraces_multipleAnnotationsBecomeAndFilter() {
-    val foo = Span(1, "call1", 1, None, Some(1), None, List(Annotation(1, "foo", Some(ep))))
+    val foo = Span(1, "call1", 1, None, Some(1000), None, List(Annotation(1000, "foo", Some(ep))))
     // would be foo bar, except lexicographically bar precedes foo
-    val barAndFoo = Span(2, "call2", 2, None, Some(2), None, List(Annotation(2, "bar", Some(ep)), Annotation(2, "foo", Some(ep))))
-    val fooAndBazAndQux = Span(3, "call3", 3, None, Some(3), None, foo.annotations.map(_.copy(timestamp = 3)), List(BinaryAnnotation("baz", "qux", Some(ep))))
-    val barAndFooAndBazAndQux = Span(4, "call4", 4, None, Some(4), None, barAndFoo.annotations.map(_.copy(timestamp = 4)), fooAndBazAndQux.binaryAnnotations)
+    val barAndFoo = Span(2, "call2", 2, None, Some(2000), None, List(Annotation(2000, "bar", Some(ep)), Annotation(2000, "foo", Some(ep))))
+    val fooAndBazAndQux = Span(3, "call3", 3, None, Some(3000), None, foo.annotations.map(_.copy(timestamp = 3000)), List(BinaryAnnotation("baz", "qux", Some(ep))))
+    val barAndFooAndBazAndQux = Span(4, "call4", 4, None, Some(4000), None, barAndFoo.annotations.map(_.copy(timestamp = 4000)), fooAndBazAndQux.binaryAnnotations)
 
     result(store(Seq(foo, barAndFoo, fooAndBazAndQux, barAndFooAndBazAndQux)))
+
     result(store.getTraces(QueryRequest("service", annotations = Set("foo")))) should be(
       Seq(List(barAndFooAndBazAndQux), List(fooAndBazAndQux), List(barAndFoo), List(foo))
     )
@@ -285,14 +286,14 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
   /** limit should apply to traces closest to endTs */
   @Test def getTraces_limit() {
-    result(store(Seq(span1, span3))) // span1's timestamp is 1, span3's timestamp is 2
+    result(store(Seq(span1, span3))) // span1's timestamp is 1000, span3's timestamp is 2000
 
     result(store.getTraces(QueryRequest("service", limit = 1))) should be(Seq(List(span3)))
   }
 
   /** Traces whose root span has timestamps before or at endTs are returned */
   @Test def getTraces_endTsAndLookback() {
-    result(store(Seq(span1, span3))) // span1's timestamp is 1, span3's timestamp is 2
+    result(store(Seq(span1, span3))) // span1's timestamp is 1000, span3's timestamp is 2000
 
     result(store.getTraces(QueryRequest("service", endTs = 1))) should be(Seq(List(span1)))
     result(store.getTraces(QueryRequest("service", endTs = 2))) should be(Seq(List(span3), List(span1)))
@@ -301,7 +302,7 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
   /** Traces whose root span has timestamps between (endTs - lookback) and endTs are returned */
   @Test def getTraces_lookback() {
-    result(store(Seq(span1, span3))) // span1's timestamp is 1, span3's timestamp is 2
+    result(store(Seq(span1, span3))) // span1's timestamp is 1000, span3's timestamp is 2000
 
     result(store.getTraces(QueryRequest("service", endTs = 1, lookback = Some(1)))) should be(Seq(List(span1)))
     result(store.getTraces(QueryRequest("service", endTs = 2, lookback = Some(1)))) should be(Seq(List(span3), List(span1)))
@@ -355,18 +356,18 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     val frontend = Some(Endpoint(192 << 24 | 168 << 16 | 2, 8080, "frontend"))
     val backend = Some(Endpoint(192 << 24 | 168 << 16 | 3, 8080, "backend"))
 
-    val parent = Span(1, "method1", 666, None, Some(95), Some(40), List(
-      Annotation(100, Constants.ClientSend, client),
-      Annotation(95, Constants.ServerRecv, frontend), // before client sends
-      Annotation(120, Constants.ServerSend, frontend), // before client receives
-      Annotation(135, Constants.ClientRecv, client)
+    val parent = Span(1, "method1", 666, None, Some(95000), Some(40000), List(
+      Annotation(100000, Constants.ClientSend, client),
+      Annotation(95000, Constants.ServerRecv, frontend), // before client sends
+      Annotation(120000, Constants.ServerSend, frontend), // before client receives
+      Annotation(135000, Constants.ClientRecv, client)
     ).sorted)
 
-    val child = Span(1, "method2", 777, Some(666L), Some(100), Some(20), List(
-      Annotation(100, Constants.ClientSend, frontend),
-      Annotation(115, Constants.ServerRecv, backend),
-      Annotation(120, Constants.ServerSend, backend),
-      Annotation(115, Constants.ClientRecv, frontend) // before server sent
+    val child = Span(1, "method2", 777, Some(666L), Some(100000), Some(20000), List(
+      Annotation(100000, Constants.ClientSend, frontend),
+      Annotation(115000, Constants.ServerRecv, backend),
+      Annotation(120000, Constants.ServerSend, backend),
+      Annotation(115000, Constants.ClientRecv, frontend) // before server sent
     ))
 
     val skewed = List(parent, child)

--- a/zipkin-query-service/README.md
+++ b/zipkin-query-service/README.md
@@ -19,7 +19,7 @@ Below are environment variables definitions.
     * `QUERY_PORT`: Listen port for the query thrift api; Defaults to 9411
     * `QUERY_ADMIN_PORT`: Listen port for the ostrich admin http server; Defaults to 9901
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
-    * `QUERY_LOOKBACK`: How many microseconds queries look back from endTs; Defaults to 7 days
+    * `QUERY_LOOKBACK`: How many milliseconds queries look back from endTs; Defaults to 7 days
     * `SCRIBE_HOST`: Listen host for scribe, where traces will be sent
     * `SCRIBE_PORT`: Listen port for scribe, where traces will be sent
 

--- a/zipkin-query-service/src/main/scala/com/twitter/zipkin/query/Main.scala
+++ b/zipkin-query-service/src/main/scala/com/twitter/zipkin/query/Main.scala
@@ -40,7 +40,7 @@ object Main {
       .asInstanceOf[Logger].setLevel(Level.toLevel(query.logLevel))
 
     // Note: this is blocking, so nothing after this will be called.
-    val defaultLookback = sys.env.get("QUERY_LOOKBACK").getOrElse(7.days.inMicroseconds.toString)
+    val defaultLookback = sys.env.get("QUERY_LOOKBACK").getOrElse(7.days.inMillis.toString)
     query.nonExitingMain(Array(
       "-local.doc.root", "/",
       "-zipkin.queryService.lookback", defaultLookback

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/QueryExtractor.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/QueryExtractor.scala
@@ -35,7 +35,7 @@ class QueryExtractor @Inject()(@Flag("zipkin.queryService.limit") val defaultLim
     val spanName = req.params.get("spanName").flatMap(n => if (n == "all" || n == "") None else Some(n))
     val minDuration = req.params.get("minDuration").flatMap(d => if (d.isEmpty) None else Some(d.toLong))
     val maxDuration = req.params.get("maxDuration").flatMap(d => if (d.isEmpty) None else Some(d.toLong))
-    val endTs = req.params.getLong("endTs").getOrElse(Time.now.inMicroseconds)
+    val endTs = req.params.getLong("endTs").getOrElse(Time.now.inMillis)
     val lookback = req.params.get("lookback").map(_.toLong).getOrElse(defaultLookback)
     val limit = req.params.get("limit").map(_.toInt).getOrElse(defaultLimit)
 

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServer.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryServer.scala
@@ -39,7 +39,7 @@ class ZipkinQueryServer(spanStore: SpanStore, dependencyStore: DependencyStore) 
   // Bind flags used with javax.Inject
   flag("zipkin.queryService.durationBatchSize", 500, "max number of durations to pull per batch")
   flag("zipkin.queryService.limit", 10, "Default query limit for trace results")
-  flag("zipkin.queryService.lookback", 7.days.inMicroseconds, "Default query lookback for trace results")
+  flag("zipkin.queryService.lookback", 7.days.inMillis, "Default query lookback for trace results, in milliseconds")
   flag("zipkin.queryService.servicesMaxAge", 5*60, "Get services cache TTL")
 
   object StorageModule extends TwitterModule {

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerTest.scala
@@ -16,7 +16,7 @@ class ZipkinQueryServerTest extends FunSuite with Matchers {
     val queryRequest = query.injector.instance[QueryExtractor].apply(Request("?serviceName=foo")).get
 
     queryRequest.limit should be(1000)
-    queryRequest.lookback should be(7.days.inMicroseconds)  // default
+    queryRequest.lookback should be(7.days.inMillis)  // default
   }
 
   test("zipkin.queryService.lookback override") {
@@ -24,10 +24,10 @@ class ZipkinQueryServerTest extends FunSuite with Matchers {
       override def postWarmup() = Unit // don't start a server
       override def waitForServer() = Unit // don't wait for a server
     }
-    query.nonExitingMain(Array("-zipkin.queryService.lookback", 1.day.inMicroseconds.toString))
+    query.nonExitingMain(Array("-zipkin.queryService.lookback", 1.day.inMillis.toString))
     val queryRequest = query.injector.instance[QueryExtractor].apply(Request("?serviceName=foo")).get
 
     queryRequest.limit should be(10) // default
-    queryRequest.lookback should be(86400000000L)
+    queryRequest.lookback should be(86400000L)
   }
 }

--- a/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
+++ b/zipkin-redis/src/main/scala/com/twitter/zipkin/storage/redis/RedisSpanStore.scala
@@ -39,7 +39,7 @@ class RedisSpanStore(client: Client, ttl: Option[Duration])
     lookback: Long,
     limit: Int
   ): Future[Seq[IndexedTraceId]] = {
-    index.getTraceIdsByName(serviceName, spanName, endTs, lookback, limit)
+    index.getTraceIdsByName(serviceName, spanName, endTs * 1000, lookback * 1000, limit)
   }
 
   override def getTraceIdsByAnnotation(
@@ -50,7 +50,7 @@ class RedisSpanStore(client: Client, ttl: Option[Duration])
     lookback: Long,
     limit: Int
   ): Future[Seq[IndexedTraceId]] = {
-    index.getTraceIdsByAnnotation(serviceName, annotation, value, endTs, lookback, limit)
+    index.getTraceIdsByAnnotation(serviceName, annotation, value, endTs * 1000, lookback * 1000, limit)
   }
 
   override def getAllServiceNames() = index.getServiceNames.map(_.toList.sorted)

--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinDependencies.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinDependencies.thrift
@@ -21,16 +21,16 @@ struct DependencyLink {
   /** child service name (callee) */
   2: string child
   # 3: Moments OBSOLETE_duration_moments
-  /** calls made during the duration (in microseconds) of this link */
+  /** calls made during the duration of this link */
   4: i64 callCount
   # histogram?
 }
 
 /* An aggregate representation of services paired with every service they call. */
 struct Dependencies {
-  /** microseconds from epoch */
+  /** milliseconds from epoch */
   1: i64 start_ts
-  /** microseconds from epoch */
+  /** milliseconds from epoch */
   2: i64 end_ts
   3: list<DependencyLink> links
 }

--- a/zipkin-web/src/main/resources/app/js/component_data/dependency.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/dependency.js
@@ -69,7 +69,7 @@ define(
           }.bind(this));
         });
 
-        this.getDependency(Date.now() * 1000);
+        this.getDependency(Date.now());
       });
 
       this.getServiceData = function (serviceName, callback) {

--- a/zipkin-web/src/main/resources/app/js/component_ui/timeStamp.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/timeStamp.js
@@ -24,7 +24,7 @@ define(
       }
 
       this.setTimestamp = function(time) {
-        this.$timestamp.val(time.valueOf() * 1000);
+        this.$timestamp.val(time.valueOf());
       }
 
       this.dateChanged = function (e) {

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
@@ -26,7 +26,7 @@ class QueryExtractor(defaultQueryLimit: Int) {
   }
 
   def getTimestampStr(req: Request): String = {
-    req.params.getLong("endTs").getOrElse(Time.now.inMicroseconds).toString
+    req.params.getLong("endTs").getOrElse(Time.now.inMillis).toString
   }
 
   def getAnnotations(req: Request): Option[(Seq[String], Map[String, String])] =

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
@@ -27,7 +27,7 @@ class QueryExtractorTest extends FunSuite {
   def request(p: (String, String)*) = Request(p: _*)
 
   test("getTimestampStr") {
-    val endTs = Time.now.inMicroseconds.toString
+    val endTs = Time.now.inMillis.toString
     val r = request(
       "serviceName" -> "myService",
       "spanName" -> "mySpan",
@@ -41,7 +41,7 @@ class QueryExtractorTest extends FunSuite {
   test("default getTimestampStr") {
     Time.withCurrentTimeFrozen { tc =>
       val actual = queryExtractor.getTimestampStr(request("serviceName" -> "myService"))
-      assert(actual === Time.now.sinceEpoch.inMicroseconds.toString)
+      assert(actual === Time.now.sinceEpoch.inMillis.toString)
     }
   }
 


### PR DESCRIPTION
Time units of query parameters endTs and lookback are now milliseconds
as opposed to microseconds, the grain of Span and Annotation timestamp.
Milliseconds is a more familiar and supported granularity for query,
index and windowing functions.

This change does not change implementation schema. Span stores who use
custom indexes (like cassandra and redis) probably want to update to use
millis now.

See #857
