### PR TITLE
Stops setting Span.timestamp when there's only one annotation

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/ApplyTimestampAndDuration.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/ApplyTimestampAndDuration.scala
@@ -7,19 +7,27 @@ import com.twitter.zipkin.common._
  * annotations. Spans who already have timestamp and duration set and left
  * alone.
  *
- * After application, spans without a timestamp are filtered out, as they are
- * not possible to present on a timeline. The only scenario where this is
- * possible is when instrumentation sends binary annotations ahead of the span
- * start event, or when a span's start even was lost. Considering this is error
- * -case or transient, there's no option to control this behavior.
+ * <p/>After application, spans without a timestamp are filtered out, as they are
+ * not possible to present on a timeline. This is possible on incomplete spans,
+ * or when a span's start even was lost. Considering this is error-case or
+ * transient, there's no option to control this behavior.
  */
 object ApplyTimestampAndDuration extends ((List[Span]) => List[Span]) {
 
-  override def apply(spans: List[Span]): List[Span] = spans.map { span =>
-    if (span.timestamp.isDefined && span.duration.isDefined) span else apply(span)
-  }.filter(_.timestamp.nonEmpty).sorted
+  override def apply(spans: List[Span]): List[Span] =
+    spans.map(apply).filter(_.timestamp.nonEmpty).sorted
 
-  def apply(span: Span) = {
+  /** Looks at annotations to fill missing [[Span.timestamp]] and [[Span.duration]] */
+  def apply(span: Span): Span = {
+    // Don't overwrite authoritatively set timestamp and duration!
+    if (span.timestamp.isDefined && span.duration.isDefined) {
+      return span
+    }
+    // Only calculate span.timestamp and duration on complete spans. This avoids
+    // persisting an inaccurate timestamp due to a late arriving annotation.
+    if (span.annotations.size < 2) {
+      return span
+    }
     val sorted = span.annotations.sorted
     val firstOption = sorted.headOption.map(_.timestamp)
     val lastOption = sorted.lastOption.map(_.timestamp)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/ApplyTimestampAndDurationTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/ApplyTimestampAndDurationTest.scala
@@ -34,13 +34,18 @@ class ApplyTimestampAndDurationTest extends FunSuite {
     assert(adjusted === span)
   }
 
-  test("duration isn't set when only one annotation") {
+  /**
+   * Spans subject to ApplyTimestampAndDuration are incomplete if they have
+   * only one annotation. Rather than persist an unreliable timestamp, we leave
+   * this alone until there's more data.
+   */
+  test("timestamp and duration are left unset when only one annotation") {
     val span = Span(1, "n", 2, None, None, None, annotations = List(
       Annotation(1, "value1", Some(Endpoint(1, 2, "service")))
     ))
 
     val adjusted = ApplyTimestampAndDuration(span)
-    assert(adjusted.timestamp === Some(1))
+    assert(adjusted.timestamp === None)
     assert(adjusted.duration === None)
   }
 


### PR DESCRIPTION
`ApplyTimestampAndDuration` is a bridge that sets Span.timestamp and
duration until instrumentation can be updated to set that directly.

This implies that this feature is only for legacy spans. We know legacy
spans use zipkin core annotations, which come in pairs. For example,
the smallest legacy span is the root span, which has two annotations:
"sr" and "ss".

We found in practice that `ApplyTimestampAndDuration` set Span.timestamp
to the wrong value, the "ss" of a span. This interferes with clock skew
adjustment logic. `ApplyTimestampAndDuration` should only affect legacy
spans, and most specifically complete ones. This changes the code to
abstain from affecting spans with only one annotation, which avoids the
possibility of accidentally choosing "ss" for Span.timestamp.
