### PR TITLE
Avoid span_duration_index queries asking for data we already know is expired

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -319,7 +319,7 @@ abstract class CassandraSpanStore(
     FutureUtil.toFuture(
       repository
         .getTraceIdsByDuration(serviceName, spanName getOrElse "", minDuration, maxDuration getOrElse Long.MaxValue,
-          endTs * 1000, (endTs - lookback)  * 1000, limit))
+          endTs * 1000, (endTs - lookback)  * 1000, limit, indexTtl.inSeconds))
       .map { traceIds =>
       traceIds.asScala
         .map { case (traceId, ts) => IndexedTraceId(traceId, timestamp = ts) }


### PR DESCRIPTION
Avoid queries going into span_duration_index buckets that we already know are only going to be filled with tombstones,

 by ensuring neither startTs and endTs extend back in time when all data would be TTL's

 ref: https://github.com/openzipkin/zipkin/issues/872
