### PR TITLE
Adjusts SpanStoreSpec to use realistic timestamps

### DIFF
--- a/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
+++ b/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
@@ -762,8 +762,8 @@ public final class Repository implements AutoCloseable {
                                                                    int ttl) {
 
         long oldestData = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(ttl));
-        long safeStartTs = 0 == startTs ? startTs : Math.max(startTs, oldestData);
-        long safeEndTs = 0 == endTs ? endTs : Math.max(endTs, oldestData);
+        long safeStartTs = Math.max(startTs, oldestData);
+        long safeEndTs = Math.max(endTs, oldestData);
         int startBucket = durationIndexBucket(safeStartTs);
         int endBucket = durationIndexBucket(safeEndTs);
         try {

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
@@ -79,7 +79,7 @@ trait CollectAnnotationQueries {
         // TODO: timestamps endTs is the wrong name for all this
         querySlices(sliceQueries, qr.copy(limit = 1)) flatMap { ids =>
           val ts = padTimestamp(ids.flatMap(_.map(_.timestamp)).reduceOption(_ min _).getOrElse(0))
-          querySlices(sliceQueries, qr.copy(endTs = ts)) flatMap { ids =>
+          querySlices(sliceQueries, qr.copy(endTs = ts / 1000)) flatMap { ids =>
             queryResponse(traceIdsIntersect(ids), qr)
           }
         }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -21,6 +21,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
 
   /** Notably, the cassandra implementation has day granularity */
   val day = MILLISECONDS.convert(1, DAYS)
+  // Use real time, as most span-stores have TTL logic which looks back several days.
   val today = Time.now.floor(Duration.fromMilliseconds(day)).inMillis
 
   val zipkinWeb = Endpoint(172 << 24 | 17 << 16 | 3, 8080, "zipkin-web")


### PR DESCRIPTION
SpanStoreSpec was using odd timestamps, which interfere with logic
around lookback and TTL. This uses today floored to midnight, which is
stable and won't go negative, if TTL or lookback is subtracted from it.

See #875
