### PR TITLE
Adds MYSQL_USE_SSL environment variable

### DIFF
--- a/zipkin-anormdb/README.md
+++ b/zipkin-anormdb/README.md
@@ -15,6 +15,7 @@ Currently, only MySQL is configurable through environment variables:
     * `MYSQL_HOST`: Defaults to localhost
     * `MYSQL_TCP_PORT`: Defaults to 3306
     * `MYSQL_MAX_CONNECTIONS`: Maximum concurrent connections, defaults to 10
+    * `MYSQL_USE_SSL`: Requires `javax.net.ssl.trustStore` and `javax.net.ssl.trustStorePassword`, defaults to false.
 
 Example MySQL usage:
 ```bash

--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
@@ -94,8 +94,9 @@ case class DBConfig(name: String = "sqlite-persistent",
       description = "MySQL",
       driver = "org.mariadb.jdbc.Driver",
       location = { dbp: DBParams =>
-        // We need to enable auto-reconnect to recover from dropped connections
-        "jdbc:mariadb://" + dbp.host + dbp.getPort + "/" + dbp.dbName + "?user=" + dbp.username + "&password=" + dbp.password + "&autoReconnect=true"
+        "jdbc:mariadb://" + dbp.host + dbp.getPort + "/" + dbp.dbName + "?user=" + dbp.username + "&password=" + dbp.password +
+          (if (dbp.ssl) "&useSSL=true" else "") +
+          "&autoReconnect=true" // recover from dropped connections
       }
     )
   )

--- a/zipkin-collector-service/config/collector-mysql.scala
+++ b/zipkin-collector-service/config/collector-mysql.scala
@@ -16,7 +16,8 @@ val db = DB(DBConfig(
     sys.env.get("MYSQL_HOST").getOrElse("localhost"),
     sys.env.get("MYSQL_TCP_PORT").map(_.toInt),
     sys.env.get("MYSQL_USER").getOrElse(""),
-    sys.env.get("MYSQL_PASS").getOrElse("")
+    sys.env.get("MYSQL_PASS").getOrElse(""),
+    sys.env.get("MYSQL_USE_SSL").map(_.toBoolean).getOrElse(false)
   ),
   maxConnections = sys.env.get("MYSQL_MAX_CONNECTIONS").map(_.toInt).getOrElse(10)
 ))

--- a/zipkin-query-service/config/query-mysql.scala
+++ b/zipkin-query-service/config/query-mysql.scala
@@ -12,7 +12,8 @@ val db = DB(DBConfig(
     sys.env.get("MYSQL_HOST").getOrElse("localhost"),
     sys.env.get("MYSQL_TCP_PORT").map(_.toInt),
     sys.env.get("MYSQL_USER").getOrElse(""),
-    sys.env.get("MYSQL_PASS").getOrElse("")
+    sys.env.get("MYSQL_PASS").getOrElse(""),
+    sys.env.get("MYSQL_USE_SSL").map(_.toBoolean).getOrElse(false)
   ),
   maxConnections = sys.env.get("MYSQL_MAX_CONNECTIONS").map(_.toInt).getOrElse(10)
 ))


### PR DESCRIPTION
The environment variable `MYSQL_USE_SSL` will append `&useSSL=true` to
the mysql JDBC url.

Note: you will likely need `javax.net.ssl.trustStore` and
`javax.net.ssl.trustStorePassword` JVM arguments. For example, docker
will need updates to allow custom `JAVA_OPTS`.

Fixes #885
