### PR TITLE
Mounts query endpoints on zipkin-web

### DIFF
--- a/zipkin-web/src/main/resources/app/js/component_data/dependency.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/dependency.js
@@ -15,7 +15,7 @@ define(
       var dependencies = {};
 
       this.getDependency = function (endTs) {
-        var url = "/api/dependencies?endTs=" + endTs;
+        var url = "/api/v1/dependencies?endTs=" + endTs;
         $.ajax(url, {
           type: "GET",
           dataType: "json",

--- a/zipkin-web/src/main/resources/app/js/component_data/serviceNames.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/serviceNames.js
@@ -11,7 +11,7 @@ define(
 
     function serviceNames() {
       this.updateServiceNames = function(ev, lastServiceName) {
-        $.ajax("/api/services", {
+        $.ajax("/api/v1/services", {
           type: "GET",
           dataType: "json",
           context: this,

--- a/zipkin-web/src/main/resources/app/js/component_data/spanNames.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/spanNames.js
@@ -11,7 +11,7 @@ define(
 
     function spanNames() {
       this.updateSpanNames = function(ev, serviceName) {
-        $.ajax("/api/spans?serviceName=" + serviceName, {
+        $.ajax("/api/v1/spans?serviceName=" + serviceName, {
           type: "GET",
           dataType: "json",
           context: this,

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -372,6 +372,14 @@ class Handlers(mustacheGenerator: ZipkinMustache, queryExtractor: QueryExtractor
     MustacheRenderer("v2/trace.mustache", data)
   }
 
+  def handleTrace(client: HttpClient): Service[Request, Renderer] =
+    Service.mk[Request, Renderer] { req =>
+      pathTraceId(req.path.split("/").lastOption) map { id =>
+        client.execute(Request(s"/api/v1/trace/$id"))
+          .map(CopyRenderer)
+      } getOrElse NotFound
+    }
+
   def handleTraces(client: HttpClient): Service[Request, Renderer] =
     Service.mk[Request, Renderer] { req =>
       pathTraceId(req.path.split("/").lastOption) map { id =>

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -95,12 +95,16 @@ trait ZipkinWebFactory { self: App =>
     Seq(
       ("/app/", handlePublic(resourceDirs, typesMap, publicRoot)),
       ("/public/", handlePublic(resourceDirs, typesMap, publicRoot)),
+      // In preparation of moving static assets to zipkin-query
+      ("/api/v1/dependencies", handleRoute(queryClient, "/api/v1/dependencies")),
+      ("/api/v1/services", handleRoute(queryClient, "/api/v1/services")),
+      ("/api/v1/spans", handleRoute(queryClient, "/api/v1/spans")),
+      ("/api/v1/trace/:id", handleTrace(queryClient)),
+      ("/api/v1/traces", handleRoute(queryClient, "/api/v1/traces")),
+      // TODO: Once the following are javascript-only, we can move remove zipkin-web
       ("/", addLayout("Index", environment()) andThen handleIndex(queryClient)),
       ("/traces/:id", addLayout("Traces", environment()) andThen handleTraces(queryClient)),
-      ("/dependency", addLayout("Dependency", environment()) andThen handleDependency()),
-      ("/api/spans", handleRoute(queryClient, "/api/v1/spans")),
-      ("/api/services", handleRoute(queryClient, "/api/v1/services")),
-      ("/api/dependencies", handleRoute(queryClient, "/api/v1/dependencies"))
+      ("/dependency", addLayout("Dependency", environment()) andThen handleDependency())
     ).foldLeft(new HttpMuxer) { case (m , (p, handler)) =>
       val path = p.split("/").toList
       val handlePath = path.takeWhile { t => !(t.startsWith(":") || t.startsWith("?:")) }


### PR DESCRIPTION
zipkin-web is due to be removed, once a few pages are migrated off
mustache templates in favor of javascript. This begins that process by
making zipkin-web api compatible with its replacement (zipkin-query).
