### PR TITLE
Reduces customness of zipkin-web by eliminating filesystem args

### DIFF
--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -4,7 +4,6 @@ ext.mainClassName = 'com.twitter.zipkin.web.Main'
 task run(type:JavaExec) {
     main = mainClassName
     classpath = sourceSets.main.runtimeClasspath
-    args "-zipkin.web.resourcesRoot=${projectDir}/src/main/resources"
     workingDir project.buildDir
 }
 

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -53,11 +53,7 @@ trait ZipkinWebFactory { self: App =>
   )
 
   val webServerPort = flag("zipkin.web.port", new InetSocketAddress(8080), "Listening port for the zipkin web frontend")
-
   val webRootUrl = flag("zipkin.web.rootUrl", "http://localhost:8080/", "Url where the service is located")
-  val webCacheResources = flag("zipkin.web.cacheResources", false, "cache static resources and mustache templates")
-  val webResourcesRoot = flag("zipkin.web.resourcesRoot", "zipkin-web/src/main/resources", "on-disk location of resources")
-
   val queryDest = flag("zipkin.web.query.dest", "127.0.0.1:9411", "Location of the query server")
   val queryLimit = flag("zipkin.web.query.limit", 10, "Default query limit for trace results")
   val environment = flag("zipkin.web.environmentName", "", "The name of the environment Zipkin is running in")
@@ -80,7 +76,7 @@ trait ZipkinWebFactory { self: App =>
     mapper = new FinatraObjectMapper(ZipkinJson)
   )
 
-  def newMustacheGenerator = new ZipkinMustache(webResourcesRoot(), webCacheResources())
+  def newMustacheGenerator = new ZipkinMustache()
   def newQueryExtractor = new QueryExtractor(queryLimit())
   def newHandlers = new Handlers(newMustacheGenerator, newQueryExtractor)
 
@@ -91,10 +87,9 @@ trait ZipkinWebFactory { self: App =>
     val handlers = newHandlers
     import handlers._
 
-    val publicRoot = if (webCacheResources()) None else Some(webResourcesRoot())
     Seq(
-      ("/app/", handlePublic(resourceDirs, typesMap, publicRoot)),
-      ("/public/", handlePublic(resourceDirs, typesMap, publicRoot)),
+      ("/app/", handlePublic(resourceDirs, typesMap)),
+      ("/public/", handlePublic(resourceDirs, typesMap)),
       // In preparation of moving static assets to zipkin-query
       ("/api/v1/dependencies", handleRoute(queryClient, "/api/v1/dependencies")),
       ("/api/v1/services", handleRoute(queryClient, "/api/v1/services")),

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/mustache/ZipkinMustache.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/mustache/ZipkinMustache.scala
@@ -1,39 +1,18 @@
 package com.twitter.zipkin.web.mustache
 
-import com.github.mustachejava.DefaultMustacheFactory
 import java.io._
+
+import com.github.mustachejava.DefaultMustacheFactory
 import com.twitter.mustache.ScalaObjectHandler
 
-import collection.JavaConversions.mapAsJavaMap
-
-class ZipkinMustache(templateRoot: String, cache: Boolean) {
-  import java.io.Reader
-  class ZipkinMustacheFactory extends DefaultMustacheFactory() {
-    override def getReader(rn: String): Reader = {
-      // hack to get partials to work properly
-      val name = if (rn.startsWith("public")) rn else "templates/" + rn
-
-      if (cache) super.getReader(name) else {
-        val file = new File(templateRoot, name)
-        new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF8"))
-      }
-    }
-
-    def invalidateCaches() {
-      mustacheCache.clear()
-      templateCache.clear()
-    }
-  }
-  private[this] val mf = new ZipkinMustacheFactory
-  //TODO: why isn't the scala handler coercing maps properly?
-  mf.setObjectHandler(new ScalaObjectHandler)
+class ZipkinMustache() {
+  private[this] val mf = new DefaultMustacheFactory
+  mf.setObjectHandler(new ScalaObjectHandler) // data is a scala map
 
   def render(template: String, data: Map[String, Object]): String = {
-    if (!cache) mf.invalidateCaches()
-
     val mustache = mf.compile(template)
     val output = new StringWriter
-    mustache.execute(output, mapAsJavaMap(data)).flush()
+    mustache.execute(output, data).flush()
     output.toString
   }
 }


### PR DESCRIPTION
Direct references to the filesystem led to custom code and limited
options for handling javascript dependencies.

By removing the flags `zipkin.web.cacheResources` and
`zipkin.web.resourcesRoot`, we have less complexity and the assumption
that the asset directory is mutable. This means we can use bower to
add javascript depedencies at package time, which reduces manual work
maintaining them.

Users who want to override the static assets packaged in zipkin-web will
need to make a custom jar, or override resources by placing replacements
before them in the classpath.

Removing this flag means that during development, you may need to bounce
zipkin-web when you change assets such as mustache templates. Since the
goal is to move off mustache and onto pure javascript, this is
acceptable.

See #760
