### PR TITLE
Backfills quality tests for the collector's sampler

### DIFF
--- a/zipkin-collector-service/src/test/scala/com/twitter/zipkin/collector/sampler/AdjustableGlobalSamplerSpec.scala
+++ b/zipkin-collector-service/src/test/scala/com/twitter/zipkin/collector/sampler/AdjustableGlobalSamplerSpec.scala
@@ -18,28 +18,54 @@ package com.twitter.zipkin.collector.sampler
  */
 
 import com.google.common.util.concurrent.Atomics
+import org.scalactic.Tolerance
 import org.scalatest.{FunSuite, Matchers}
+import java.util.Random
 
-class AdjustableGlobalSamplerSpec extends FunSuite with Matchers {
+class AdjustableGlobalSamplerSpec extends FunSuite with Matchers with Tolerance {
+
+  /**
+   * Zipkin trace ids are random 64bit numbers. This creates a relatively large
+   * input to avoid flaking out due to PRNG nuance.
+   */
+  val traceIds = new Random().longs(100000).toArray
+
+  /** Math.abs(Long.MinValue) returns a negative, coerse to Long.MaxValue */
+  test("most negative number defence") {
+    val sampler = new AdjustableGlobalSampler(Atomics.newReference(0.1f))
+    sampler(Long.MinValue) should be (sampler(Long.MaxValue))
+  }
 
   test("keep 10% of traces") {
-    val sampler = new AdjustableGlobalSampler(Atomics.newReference(0.1f))
+    val sampleRate = 0.1f
+    val sampler = new AdjustableGlobalSampler(Atomics.newReference(sampleRate))
 
-    sampler(Long.MinValue) should be (false)
-    sampler(-1) should be (true)
-    sampler(0) should be (true)
-    sampler(1) should be (true)
-    sampler(Long.MaxValue) should be (false)
+    val passCount = traceIds.filter(sampler(_)).size
+
+    // we expect results to be +- 3% of the target rate
+    val expected = (traceIds.size * sampleRate).toInt
+    val error = (expected * .03).toInt
+
+    passCount should be (expected +- error)
+  }
+
+  /**
+    * The collector needs to apply the same decision to incremental updates in a trace.
+    */
+  test("sample decisions are consistent for the same trace ids") {
+    val sampler1 = new AdjustableGlobalSampler(Atomics.newReference(0.1f))
+    val sampler2 = new AdjustableGlobalSampler(Atomics.newReference(0.1f))
+
+    traceIds.filter(sampler1(_)).size should be(traceIds.filter(sampler2(_)).size)
   }
 
   test("drop all traces") {
     val sampler = new AdjustableGlobalSampler(Atomics.newReference(0f))
 
     sampler(Long.MinValue) should be (false)
-    sampler(Long.MinValue + 1)
-    -5000 to 5000 foreach { i =>
-      sampler(i) should be (false)
-    }
+
+    traceIds.filter(sampler(_)) should be(empty)
+
     sampler(Long.MaxValue) should be (false)
   }
 
@@ -47,9 +73,9 @@ class AdjustableGlobalSamplerSpec extends FunSuite with Matchers {
     val sampler = new AdjustableGlobalSampler(Atomics.newReference(1f))
 
     sampler(Long.MinValue) should be (true)
-    -5000 to 5000 foreach { i =>
-      sampler(i) should be (true)
-    }
+
+    traceIds.filter(sampler(_)) should be(traceIds)
+
     sampler(Long.MinValue) should be (true)
   }
 }


### PR DESCRIPTION
The collector's sampler didn't include tests for achieving its target
rate. This backfills, using realistic ids.
