### PR TITLE
Fixes IOException in jar -x on shadow jars

### DIFF
--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -15,6 +15,10 @@ jar.manifest.attributes 'Main-Class': mainClassName
 tasks.build.dependsOn(shadowJar)
 artifacts.zipkinUpload shadowJar
 
+shadowJar {
+    exclude 'META-INF/LICENSE' // jackson's META-INF/LICENSE conflicts with the directory META-INF/license
+}
+
 dependencies {
     compile "com.twitter:finagle-ostrich4_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:finagle-thriftmux_${scalaInterfaceVersion}:${commonVersions.finagle}"

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -15,6 +15,10 @@ jar.manifest.attributes 'Main-Class': mainClassName
 tasks.build.dependsOn(shadowJar)
 artifacts.zipkinUpload shadowJar
 
+shadowJar {
+    exclude 'META-INF/LICENSE' // jackson's META-INF/LICENSE conflicts with the directory META-INF/license
+}
+
 dependencies {
     compile "com.twitter:finagle-ostrich4_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "com.twitter:finagle-zipkin_${scalaInterfaceVersion}:${commonVersions.finagle}"

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -12,6 +12,10 @@ jar.manifest.attributes 'Main-Class': mainClassName
 tasks.build.dependsOn(shadowJar)
 artifacts.zipkinUpload shadowJar
 
+shadowJar {
+  exclude 'META-INF/LICENSE' // jackson's META-INF/LICENSE conflicts with the directory META-INF/license
+}
+
 dependencies {
     compile project(':zipkin-common')
     compile "com.twitter:twitter-server_${scalaInterfaceVersion}:${commonVersions.twitterServer}"


### PR DESCRIPTION
The shadowJar plugin makes a single file out of all the dependencies of
our services. Occasionally, this leads to file conflicts.

Jackson's META-INF/LICENSE conflicts with the directory META-INF/license

While we can run the shadowJars, you cannot extract them with `jar -x`,
as it ends up with an IOException extracting META-INF/license.

This excludes Jackson's META-INF/LICENSE, until we have a better
solution, ideally with one of the proposals in the shadow jar project.

See https://github.com/johnrengelman/shadow/pull/86
See https://github.com/johnrengelman/shadow/pull/102
