### PR TITLE
Introduces KAFKA_STREAMS to control count of consumer threads

### DIFF
--- a/zipkin-collector-service/config/collector-cassandra.scala
+++ b/zipkin-collector-service/config/collector-cassandra.scala
@@ -50,7 +50,10 @@ val storeBuilder = Store.Builder(
 )
 
 val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
-  KafkaSpanReceiverFactory.factory(_, sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"))
+  KafkaSpanReceiverFactory.factory(_,
+    sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"),
+    sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt
+  )
 )
 
 CollectorServiceBuilder(

--- a/zipkin-collector-service/config/collector-dev.scala
+++ b/zipkin-collector-service/config/collector-dev.scala
@@ -30,7 +30,10 @@ val db = DB()
 
 val storeBuilder = Store.Builder(SpanStoreBuilder(db), DependencyStoreBuilder(db))
 val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
-  KafkaSpanReceiverFactory.factory(_, sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"))
+  KafkaSpanReceiverFactory.factory(_,
+    sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"),
+    sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt
+  )
 )
 
 CollectorServiceBuilder(

--- a/zipkin-collector-service/config/collector-mysql.scala
+++ b/zipkin-collector-service/config/collector-mysql.scala
@@ -27,7 +27,10 @@ val db = DB(DBConfig(
 //   - zipkin-anormdb/src/main/resources/mysql.sql
 val storeBuilder = Store.Builder(SpanStoreBuilder(db), DependencyStoreBuilder(db))
 val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
-  KafkaSpanReceiverFactory.factory(_, sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"))
+  KafkaSpanReceiverFactory.factory(_,
+    sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"),
+    sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt
+  )
 )
 
 CollectorServiceBuilder(

--- a/zipkin-receiver-kafka/README.md
+++ b/zipkin-receiver-kafka/README.md
@@ -9,6 +9,7 @@ It is enabled when the `KAFKA_ZOOKEEPER` environment variable is set. Here are t
 
    * `KAFKA_ZOOKEEPER`: ZooKeeper host string, comma-separated host:port value. no default.
    * `KAFKA_TOPIC`: Defaults to zipkin
+   * `KAFKA_STREAMS`: Count of consumer threads consuming the topic. defaults to 1.
 
 Example usage:
 

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
@@ -17,11 +17,12 @@ object KafkaSpanReceiverFactory {
    *
    * @param zookeeper the zookeeper connect string, ex. 127.0.0.1:2181
    * @param topic  the topic zipkin spans will be consumed from
+   * @param streams the count of consumer threads consuming the topic
    */
-  def factory(zookeeper: String, topic: String) = {
+  def factory(zookeeper: String, topic: String, streams: Int = 1) = {
     object KafkaFactory extends App with KafkaSpanReceiverFactory
     KafkaFactory.kafkaZookeeperConnect.parse(zookeeper)
-    KafkaFactory.kafkaTopics.parse(topic + "=1")
+    KafkaFactory.kafkaTopics.parse(topic + "=" + streams)
     (process: SpanReceiver.Processor) => KafkaFactory.newKafkaSpanReceiver(process)
   }
 }


### PR DESCRIPTION
@prat0318 noticed that collectors always hit the same partition, which
meant throughput didn't increase by adding instances. This uses the
"High Level Consumer" approach, exposing a consumer count, as an attempt
to remedy this situation. For example setting `KAFKA_STREAMS=4` should
result in 4 consumers reading different partitions.

See https://cwiki.apache.org/confluence/display/KAFKA/Consumer+Group+Example
