### PR TITLE
Reverts Kafka client to 0.8.x to avoid broker compatibility issues

### DIFF
--- a/zipkin-receiver-kafka/build.gradle
+++ b/zipkin-receiver-kafka/build.gradle
@@ -1,11 +1,13 @@
 dependencies {
     compile project(':zipkin-collector')
 
-    compile "org.apache.kafka:kafka_${scalaInterfaceVersion}:0.9.0.0"
+    // This is pinned to Kafka 0.8.x client as 0.9.x brokers work with them, but not visa-versa
+    // http://docs.confluent.io/2.0.0/upgrade.html
+    compile "org.apache.kafka:kafka_${scalaInterfaceVersion}:0.8.2.2"
     compile 'org.apache.commons:commons-io:1.3.2'
     compile "com.twitter:scrooge-serializer_${scalaInterfaceVersion}:${commonVersions.scrooge}"
     // kafka's zk uses log4j: route to slf4j
     compile "org.slf4j:log4j-over-slf4j:${commonVersions.slf4j}"
 
-    testCompile 'com.github.charithe:kafka-junit:1.8'
+    testCompile 'com.github.charithe:kafka-junit:1.7' // pinned to 0.8.2.2
 }


### PR DESCRIPTION
As it turns out, the upgrade path of kafka is brokers first, as 0.9
brokers are compatible with 0.8 clients, but not visa-versa. The eager
upgrade I made broke that path.

This materialized as an IllegalArgumentException with no message, so
almost impossible to debug.

This change sticks with 0.8.x clients until we either make a standalone
0.9 kafka collector or re-evaluate when 0.9 adoption is higher.

See https://groups.google.com/d/msg/confluent-platform/r8xox149Vn4/qR9q1QjwBQAJ
