### PR TITLE
Fixes error where Kafka stream processing chokes on malformed data

### DIFF
--- a/zipkin-receiver-kafka/build.gradle
+++ b/zipkin-receiver-kafka/build.gradle
@@ -1,3 +1,5 @@
+test.maxParallelForks = 1
+
 dependencies {
     compile project(':zipkin-collector')
 

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.{TimeUnit, Executors}
 import kafka.consumer.{Consumer, ConsumerConfig, ConsumerConnector}
 import kafka.serializer.{Decoder, StringDecoder}
 
-object KafkaProcessor{
+object KafkaProcessor {
 
   type KafkaDecoder = Decoder[List[ThriftSpan]]
 

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -1,9 +1,11 @@
 package com.twitter.zipkin.receiver.kafka
 
+import java.util.concurrent.LinkedBlockingQueue
+
 import com.github.charithe.kafka.KafkaJunitRule
 import com.twitter.util.{Await, Future, Promise}
 import com.twitter.zipkin.common._
-import com.twitter.zipkin.conversions.thrift.thriftSpanToSpan
+import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
 import kafka.producer._
 import org.junit.{ClassRule, Test}
@@ -21,47 +23,48 @@ class KafkaProcessorSpec extends JUnitSuite {
 
   import KafkaProcessorSpec.kafkaRule
 
-  val topic = Map("integration-test-topic" -> 1)
+  val annotation = Annotation(1, "value", Some(Endpoint(1, 2, "service")))
   // Intentionally leaving timestamp and duration unset, as legacy instrumentation don't set this.
-  val validSpan = Span(123, "boo", 456, annotations = List(new Annotation(1, "bah", None)))
-  val decoder = new SpanCodec()
-  val defaultKafkaTopics = Map("zipkin_kafka" -> 1 )
+  val span = Span(1234, "methodname", 4567, annotations = List(annotation))
+  val codec = new SpanCodec()
 
-  def validateSpan(spans: Seq[ThriftSpan]): Future[Unit] = {
-    assert( 1 == spans.length, "received more spans than sent" )
-    val message = spans.head.toSpan
-    assert(message.traceId == 1234, "traceId mismatch")
-    assert(message.name == "methodname", "method name mismatch")
-    assert(message.id == 4567, "spanId mismatch")
-    message.annotations map { a =>
-      assert(a.value == "value", "annotation name mismatch")
-      assert(a.timestamp == 1, "annotation timestamp mismatch")
-    }
-    Future.Done
-  }
-
-  def createMessage(): Array[Byte] = {
-    val annotation = Annotation(1, "value", Some(Endpoint(1, 2, "service")))
-    // Intentionally leaving timestamp and duration unset, as legacy instrumentation don't set this.
-    val message = Span(1234, "methodname", 4567, annotations = List(annotation))
-    val codec = new SpanCodec()
-    codec.encode(message)
-  }
-
-  @Test def kafkaProcessorTest() {
-    val producer = new Producer[Array[Byte], Array[Byte]](kafkaRule.producerConfigWithDefaultEncoder())
-    val message = createMessage()
-    val data = new KeyedMessage("zipkin_kafka", "any".getBytes, message)
+  @Test def messageWithSingleSpan() {
+    val topic = "single_span"
     val recvdSpan = new Promise[Seq[ThriftSpan]]
 
-    producer.send(data)
+    val service = KafkaProcessor(Map(topic -> 1), kafkaRule.consumerConfig(), { s =>
+      recvdSpan.setValue(s)
+      Future.value(true)
+    }, codec, codec)
+
+    val producer = new Producer[Array[Byte], Array[Byte]](kafkaRule.producerConfigWithDefaultEncoder())
+    producer.send(new KeyedMessage(topic, codec.encode(span)))
     producer.close()
 
-    val service = KafkaProcessor(defaultKafkaTopics, kafkaRule.consumerConfig(), { s =>
-        recvdSpan.setValue(s)
-        Future.value(true)
-      }, new SpanCodec, new SpanCodec)
+    assert(Await.result(recvdSpan) == Seq(span.toThrift))
 
-    validateSpan(Await.result(recvdSpan))
+    Await.result(service.close())
+  }
+
+  @Test def skipsMalformedData() {
+    val topic = "malformed"
+    val recvdSpans = new LinkedBlockingQueue[Seq[ThriftSpan]](3)
+
+    val service = KafkaProcessor(Map(topic -> 1), kafkaRule.consumerConfig(), { s =>
+      recvdSpans.add(s)
+      Future.value(true)
+    }, codec, codec)
+
+    val producer = new Producer[Array[Byte], Array[Byte]](kafkaRule.producerConfigWithDefaultEncoder())
+
+    producer.send(new KeyedMessage(topic, codec.encode(span)))
+    producer.send(new KeyedMessage(topic, "malformed".getBytes()))
+    producer.send(new KeyedMessage(topic, codec.encode(span)))
+    producer.close()
+
+    for (elem <- 1 until 2)
+      assert(recvdSpans.take() == Seq(span.toThrift))
+
+    Await.result(service.close())
   }
 }


### PR DESCRIPTION
`msg.message()` implicitly decodes thrifts via scrooge. We now guard the
operation as decode failures were hanging things.

Fixes #907
