### PR TITLE
Adds constants for common binary annotation keys to http

### DIFF
--- a/doc/src/sphinx/Architecture.rst
+++ b/doc/src/sphinx/Architecture.rst
@@ -54,7 +54,7 @@ The line above will add an annotation with the string attached to the point in t
 when it happened. You can also add a key value annotation. It could look like this:
 
 .. parsed-literal::
-    Trace.recordBinary("http.response.code", "500")
+    Trace.recordBinary("http.status_code", "500")
 
 Ruby Thrift
 -----------

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/BinaryAnnotation.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/BinaryAnnotation.scala
@@ -21,18 +21,18 @@ import com.twitter.io.Charsets.Utf8
 
 /**
  * Binary annotations are tags applied to a Span to give it context. For example, a binary
- * annotation of "http.uri" could the path to a resource in a RPC call.
+ * annotation of "http.path" could the path to a resource in a RPC call.
  *
  * <p/>Binary annotations of type [[AnnotationType.String]] are always queryable, though more a
  * historical implementation detail than a structural concern.
  *
  * <p/>Binary annotations can repeat, and vary on the host. Similar to Annotation, the host
  * indicates who logged the event. This allows you to tell the difference between the client and
- * server side of the same key. For example, the key "http.uri" might be different on the client and
+ * server side of the same key. For example, the key "http.path" might be different on the client and
  * server side due to rewriting, like "/api/v1/myresource" vs "/myresource. Via the host field, you
  * can see the different points of view, which often help in debugging.
  *
- * @param key name used to lookup spans, such as "http.uri" or "finagle.version"
+ * @param key name used to lookup spans, such as "http.path" or "finagle.version"
  * @param value  Serialized thrift bytes, in TBinaryProtocol format, with big endian byte order.
  * @param annotationType The thrift type of value, most often [[AnnotationType.String]].
  * @param host The host that recorded the value with two exceptions. When [[key]] is "ca" or "sa",

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Span.scala
@@ -45,7 +45,7 @@ import com.twitter.zipkin.util.Util._
  *                    statements, annotations are often codes: for example [[Constants.ServerRecv]].
  *                    Annotations are sorted ascending by timestamp.
  * @param binaryAnnotations tags a span with context, usually to support query or aggregation. For
- *                          example, a binary annotation key could be "http.uri".
+ *                          example, a binary annotation key could be "http.path".
  * @param debug true is a request to store this span even if it overrides sampling policy.
  */
 case class Span(

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/ZipkinJsonTest.scala
@@ -23,7 +23,7 @@ class ZipkinJsonTest extends FunSuite with Matchers {
       Annotation(3L, Constants.ServerSend, Some(query)),
       Annotation(4L, Constants.ClientRecv, Some(web.copy(port = 0)))
     ), List(
-      BinaryAnnotation("http.uri", ByteBuffer.wrap("/path".getBytes(UTF_8)), AnnotationType.String, Some(web.copy(port = 0))),
+      BinaryAnnotation("http.path", ByteBuffer.wrap("/path".getBytes(UTF_8)), AnnotationType.String, Some(web.copy(port = 0))),
       BinaryAnnotation(Constants.ClientAddr, ByteBuffer.wrap(Array[Byte](1)), AnnotationType.Bool, Some(web)),
       BinaryAnnotation(Constants.ServerAddr, ByteBuffer.wrap(Array[Byte](1)), AnnotationType.Bool, Some(query))
     ), Some(true))
@@ -72,7 +72,7 @@ class ZipkinJsonTest extends FunSuite with Matchers {
                  |  ],
                  |  "binaryAnnotations": [
                  |    {
-                 |      "key": "http.uri",
+                 |      "key": "http.path",
                  |      "value": "/path",
                  |      "endpoint": {
                  |        "serviceName": "zipkin-web",
@@ -159,10 +159,10 @@ class ZipkinJsonTest extends FunSuite with Matchers {
 
   /** String type can be inferred from the json value */
   test("binary annotation: String doesn't need type") {
-    val a = BinaryAnnotation("http.uri", ByteBuffer.wrap("/path".getBytes(UTF_8)), AnnotationType.String, None)
+    val a = BinaryAnnotation("http.path", ByteBuffer.wrap("/path".getBytes(UTF_8)), AnnotationType.String, None)
     assert(mapper.writeValueAsString(a) ==
       """
-        |{"key":"http.uri","value":"/path"}
+        |{"key":"http.path","value":"/path"}
       """.stripMargin.trim
     )
   }

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/FilteredHttpEntrypointTraceInitializer.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/FilteredHttpEntrypointTraceInitializer.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.http.{Method, Request, Response}
 import com.twitter.finagle.tracing.{DefaultTracer, Trace}
 import com.twitter.finagle.{Filter, ServiceFactory, Stack, param}
 import com.twitter.util.Future
+import com.twitter.zipkin.thriftscala.Constants
 
 /**
  * Hacked variant of the private `com.twitter.finagle.http.codec.HttpServerTraceInitializer`
@@ -35,7 +36,7 @@ object FilteredHttpEntrypointTraceInitializer extends Stack.Module1[param.Tracer
         case -1 => req.uri
         case n => req.uri.substring(0, n)
       }
-      Trace.recordBinary("http.uri", withoutQuery)
+      Trace.recordBinary(Constants.HTTP_PATH, withoutQuery)
       svc(req)
     }
   }

--- a/zipkin-web/src/main/resources/templates/v2/index.mustache
+++ b/zipkin-web/src/main/resources/templates/v2/index.mustache
@@ -41,7 +41,7 @@
     </button>
 
     <div class="clearfix"></div>
-    <input type="text" class="form-control input-sm" id="annotationQuery" name="annotationQuery" value="{{annotationQuery}}" style="width: 100%" placeholder='Annotations Query (e.g. "finagle.timeout", "http.uri=/foo/bar/ and cluster=foo and cache.miss")'>
+    <input type="text" class="form-control input-sm" id="annotationQuery" name="annotationQuery" value="{{annotationQuery}}" style="width: 100%" placeholder='Annotations Query (e.g. "finagle.timeout", "http.path=/foo/bar/ and cluster=foo and cache.miss")'>
   </form>
 {{#queryResults}}
   <div id="trace-filters">

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/FilteredHttpEntrypointTraceInitializer.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/FilteredHttpEntrypointTraceInitializer.scala
@@ -35,7 +35,7 @@ object FilteredHttpEntrypointTraceInitializer extends Stack.Module1[param.Tracer
         case -1 => req.uri
         case n => req.uri.substring(0, n)
       }
-      Trace.recordBinary("http.uri", withoutQuery)
+      Trace.recordBinary("http.path", withoutQuery) // Constants.HTTP_PATH is not yet in finagle
       svc(req)
     }
   }

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
@@ -18,6 +18,7 @@ package com.twitter.zipkin.web
 
 import com.twitter.finagle.http.Request
 import com.twitter.util.Time
+import com.twitter.zipkin.thriftscala.Constants
 import org.scalatest.FunSuite
 
 class QueryExtractorTest extends FunSuite {
@@ -68,24 +69,24 @@ class QueryExtractorTest extends FunSuite {
   test("parse key value annotations") {
     val r = request(
       "serviceName" -> "myService",
-      "annotationQuery" -> "http.responsecode=500")
+      "annotationQuery" -> "http.status_code=500")
     val actual = queryExtractor.getAnnotations(r).get
-    assert(actual._2 === Map("http.responsecode" -> "500"))
+    assert(actual._2 === Map(Constants.HTTP_STATUS_CODE -> "500"))
   }
 
   test("parse key value annotations with slash") {
     val r = request(
       "serviceName" -> "myService",
-      "annotationQuery" -> "http.uri=/sessions")
+      "annotationQuery" -> "http.path=/sessions")
     val actual = queryExtractor.getAnnotations(r).get
-    assert(actual._2 === Map("http.uri" -> "/sessions"))
+    assert(actual._2 === Map(Constants.HTTP_PATH -> "/sessions"))
   }
 
   test("parse key value annotations with equal sign") {
     val r = request(
       "serviceName" -> "myService",
-      "annotationQuery" -> "http.uri=sessions=foo")
+      "annotationQuery" -> "http.path=sessions=foo")
     val actual = queryExtractor.getAnnotations(r).get
-    assert(actual._2 === Map("http.uri" -> "sessions=foo"))
+    assert(actual._2 === Map(Constants.HTTP_PATH -> "sessions=foo"))
   }
 }


### PR DESCRIPTION
Zipkin systems quite often trace http systems. However, the keys used
vary. This makes it hard to effectively query across tracers written by
different people.

This encourages common keys, like "http.path", for http. This doesn't
preclude other conventions or limit the choices. The naming convention
is path-based, which is most similar to former discussions around a
common data model, and the exact naming convention used in Google Cloud
Trace. The keys chosen actually match fields stored by existing tracers.

Most notably, this replaces the convention "http.uri" with "http.path",
as there was an implicit understanding formerly that "http.uri" strips
query parameters.

The migration path to these keys is a one-time problem, as zipkin has no
OR query. Ex. you cannot simultaneously query for either "http.uri" or
"http.path". Here are some scenarios:

Customize collectors to duplicate "http.uri" as "http.path"; tell users
to query for "http.path". This costs more storage temporarily. For
example, this duplication could apply while tracers are being updated.
Once old data expires out, users can reliably search by "http.path". At
that point, the customization could move to just renaming "http.uri" to
"http.path" until all tracers are updated.

Another option is to simply implement the new keys. Apologize to users
who search by "http.uri", that they have to also search by "http.path"
until tracers are updated. This is impactful for the period of the TTL,
so for example, this could be scheduled over a holiday weekend to have
the least impact to users.

See https://groups.google.com/forum/#!topic/distributed-tracing/dnzo02hO8KY
