### PR TITLE
Changes test getDependenciesAllInstrumented to run the query as of 'today', because Cassandra Spark job only saves computed dependencies as-of 'now' floored to a day.

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/Dependencies.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/Dependencies.scala
@@ -20,7 +20,7 @@ import scala.util.hashing.MurmurHash3
 
 /**
  * A representation of the fact that one service calls another. These should be unique across
- * the set of (parent, child)
+ * the set of (parent, child) for a given time period.
  *
  * @param _parent the calling [[com.twitter.zipkin.common.Endpoint.serviceName]]
  * @param _child the callee's [[com.twitter.zipkin.common.Endpoint.serviceName]]

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -121,10 +121,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
     processDependencies(trace)
 
     val traceDuration = Trace.duration(trace).get
-    result(store.getDependencies(
-      (trace(0).timestamp.get + traceDuration) / 1000,
-      Some(traceDuration / 1000)
-    )).sortBy(_.parent) should be(
+    result(store.getDependencies(today + 1000)).sortBy(_.parent) should be(
       List(
         new DependencyLink("trace-producer-one", "trace-producer-two", 1),
         new DependencyLink("trace-producer-two", "trace-producer-three", 1)


### PR DESCRIPTION
Per #912 
