### PR TITLE
Fixes Unhandled Exception of Error parsing binary annotation

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonBinaryAnnotation.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonBinaryAnnotation.scala
@@ -22,12 +22,12 @@ object JsonBinaryAnnotation extends (BinaryAnnotation => JsonBinaryAnnotation) {
   def apply(b: BinaryAnnotation) = {
     val (annotationType: Option[String], value: Any) = try {
       b.annotationType.value match {
-        case Bool.value => (None, if (b.value.get() != 0) true else false)
+        case Bool.value => (None, if (b.value.get(0) != 0) true else false)
         case Bytes.value => (Some("BYTES"), base64.encode(b.value.array(), b.value.position(), b.value.remaining()))
-        case I16.value => (Some("I16"), b.value.getShort)
-        case I32.value => (Some("I32"), b.value.getInt)
-        case I64.value => (Some("I64"), b.value.getLong)
-        case Double.value => (Some("DOUBLE"), b.value.getDouble)
+        case I16.value => (Some("I16"), b.value.getShort(0))
+        case I32.value => (Some("I32"), b.value.getInt(0))
+        case I64.value => (Some("I64"), b.value.getLong(0))
+        case Double.value => (Some("DOUBLE"), b.value.getDouble(0))
         case String.value => (None, new String(b.value.array(), b.value.position(), b.value.remaining(), Utf8))
         case _ => throw new Exception("Unsupported annotation type: %s".format(b))
       }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
@@ -41,6 +41,7 @@ class JsonConversionTest extends FunSuite with Matchers {
     val ann = BinaryAnnotation("key", ByteBuffer.wrap(array), AnnotationType.Bytes, None)
     val convert = JsonBinaryAnnotation(ann)
     assert(convert.value === BaseEncoding.base64().encode(array))
+    assert(ann.value.position() === 0)
     JsonBinaryAnnotation(JsonBinaryAnnotation.invert(convert)) should be(convert)
   }
 
@@ -50,10 +51,12 @@ class JsonConversionTest extends FunSuite with Matchers {
 
     val trueConvert = JsonBinaryAnnotation(trueAnnotation)
     assert(trueConvert.value === true)
+    assert(trueAnnotation.value.position() === 0)
     JsonBinaryAnnotation(JsonBinaryAnnotation.invert(trueConvert)) should be(trueConvert)
 
     val falseConvert = JsonBinaryAnnotation(falseAnnotation)
     assert(falseConvert.value === false)
+    assert(falseAnnotation.value.position() === 0)
     JsonBinaryAnnotation(JsonBinaryAnnotation.invert(falseConvert)) should be(falseConvert)
   }
 
@@ -61,6 +64,7 @@ class JsonConversionTest extends FunSuite with Matchers {
     val ann = BinaryAnnotation("key", ByteBuffer.allocate(2).putShort(0, 5.toShort), AnnotationType.I16, None)
     val convert = JsonBinaryAnnotation(ann)
     assert(convert.value === 5)
+    assert(ann.value.position() === 0)
     JsonBinaryAnnotation(JsonBinaryAnnotation.invert(convert)) should be(convert)
   }
 
@@ -68,6 +72,7 @@ class JsonConversionTest extends FunSuite with Matchers {
     val ann = BinaryAnnotation("key", ByteBuffer.allocate(4).putInt(0, 6), AnnotationType.I32, None)
     val convert = JsonBinaryAnnotation(ann)
     assert(convert.value === 6)
+    assert(ann.value.position() === 0)
     JsonBinaryAnnotation(JsonBinaryAnnotation.invert(convert)) should be(convert)
   }
 
@@ -75,6 +80,7 @@ class JsonConversionTest extends FunSuite with Matchers {
     val ann = BinaryAnnotation("key", ByteBuffer.allocate(8).putLong(0, 99999999999L), AnnotationType.I64, None)
     val convert = JsonBinaryAnnotation(ann)
     assert(convert.value === 99999999999L)
+    assert(ann.value.position() === 0)
     JsonBinaryAnnotation(JsonBinaryAnnotation.invert(convert)) should be(convert)
   }
 
@@ -82,6 +88,7 @@ class JsonConversionTest extends FunSuite with Matchers {
     val ann = BinaryAnnotation("key", ByteBuffer.allocate(8).putDouble(0, 1.3496), AnnotationType.Double, None)
     val convert = JsonBinaryAnnotation(ann)
     assert(convert.value === 1.3496)
+    assert(ann.value.position() === 0)
     JsonBinaryAnnotation(JsonBinaryAnnotation.invert(convert)) should be(convert)
   }
 
@@ -89,6 +96,7 @@ class JsonConversionTest extends FunSuite with Matchers {
     val ann = BinaryAnnotation("key", ByteBuffer.wrap("HELLO!".getBytes), AnnotationType.String, None)
     val convert = JsonBinaryAnnotation(ann)
     assert(convert.value === "HELLO!")
+    assert(ann.value.position() === 0)
     JsonBinaryAnnotation(JsonBinaryAnnotation.invert(convert)) should be(convert)
   }
 


### PR DESCRIPTION
I started to use SERVER_ADDR and I got internal server error of zipkin-query frequently.
Environment: mysql 5.6 (AWS RDS), Zipkin 1.30.x, customized docker-zipkin.

After code reading, I guess JsonBinaryAnnotation.apply uses ByteBuffer incorrectly.
`ByteBuffer.getTYPE` is `relative` method so it has side effect that forwards buffer position.

Usually it will be evaluated only once so actually no error.
However, it fires BufferUnderflowException if evaluated twice by unknown execution path.

So I propose to use `absolute` get method to avoid unintended side effects.
I find similar bugs in another place but not found yet.

One point, `storage/SpanStore.scala: _.binaryAnnotations.exists(ba => ba.key == annotation && ba.value == value.get)` in zipkin-common is suspected.
However, I think it does `ba.value.Equals(value.get)` which `value.get` means dereferrence, not a relative get method so it may be no problem.
But, since ByteBuffer.Equals watches not only contents but also buffer position, it might be effected potentially by this change.

Here is a stacktrace:

```
23:48:35.623 [pool-1-thread-2] ERROR c.t.f.http.response.ResponseBuilder - Unhandled Exception
scala.MatchError: Error parsing binary annotation: BufferUnderflowException() (of class java.lang.String)
        at com.twitter.zipkin.json.JsonBinaryAnnotation$.apply(JsonBinaryAnnotation.scala:23) ~[zipkin-query.jar:na]
        at com.twitter.zipkin.json.JsonBinaryAnnotation$.apply(JsonBinaryAnnotation.scala:18) ~[zipkin-query.jar:na]
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245) ~[zipkin-query.jar:na]
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245) ~[zipkin-query.jar:na]
        at scala.collection.immutable.List.foreach(List.scala:381) ~[zipkin-query.jar:na]
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:245) ~[zipkin-query.jar:na]
        at scala.collection.immutable.List.map(List.scala:285) ~[zipkin-query.jar:na]
        at com.twitter.zipkin.json.JsonSpan$.apply(JsonSpan.scala:31) ~[zipkin-query.jar:na]
        at com.twitter.zipkin.json.JsonSpan$.apply(JsonSpan.scala:22) ~[zipkin-query.jar:na]
        at scala.collection.immutable.List.map(List.scala:277) ~[zipkin-query.jar:na]
        at com.twitter.zipkin.query.ZipkinQueryController$$anonfun$5$$anonfun$apply$2$$anonfun$apply$3.apply(ZipkinQueryController.scala:64) ~[zipkin-query.jar:na]
        at com.twitter.zipkin.query.ZipkinQueryController$$anonfun$5$$anonfun$apply$2$$anonfun$apply$3.apply(ZipkinQueryController.scala:64) ~[zipkin-query.jar:na]
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245) ~[zipkin-query.jar:na]
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245) ~[zipkin-query.jar:na]
        at scala.collection.immutable.List.foreach(List.scala:381) ~[zipkin-query.jar:na]
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:245) ~[zipkin-query.jar:na]
        at scala.collection.immutable.List.map(List.scala:285) ~[zipkin-query.jar:na]
        at com.twitter.zipkin.query.ZipkinQueryController$$anonfun$5$$anonfun$apply$2.apply(ZipkinQueryController.scala:64) ~[zipkin-query.jar:na]
        at com.twitter.zipkin.query.ZipkinQueryController$$anonfun$5$$anonfun$apply$2.apply(ZipkinQueryController.scala:64) ~[zipkin-query.jar:na]
        at com.twitter.util.Future$$anonfun$map$1$$anonfun$apply$6.apply(Future.scala:950) ~[zipkin-query.jar:na]
        at com.twitter.util.Try$.apply(Try.scala:13) ~[zipkin-query.jar:na]
        at com.twitter.util.Future$.apply(Future.scala:97) ~[zipkin-query.jar:na]
        at com.twitter.util.Future$$anonfun$map$1.apply(Future.scala:950) ~[zipkin-query.jar:na]
        at com.twitter.util.Future$$anonfun$map$1.apply(Future.scala:949) ~[zipkin-query.jar:na]
        at com.twitter.util.Promise$Transformer.liftedTree1$1(Promise.scala:112) [zipkin-query.jar:na]
        at com.twitter.util.Promise$Transformer.k(Promise.scala:112) [zipkin-query.jar:na]
        at com.twitter.util.Promise$Transformer.apply(Promise.scala:122) [zipkin-query.jar:na]
        at com.twitter.util.Promise$Transformer.apply(Promise.scala:103) [zipkin-query.jar:na]
        at com.twitter.util.Promise$$anon$1.run(Promise.scala:366) [zipkin-query.jar:na]
        at com.twitter.concurrent.LocalScheduler$Activation.run(Scheduler.scala:178) [zipkin-query.jar:na]
        at com.twitter.concurrent.LocalScheduler$Activation.submit(Scheduler.scala:136) [zipkin-query.jar:na]
        at com.twitter.concurrent.LocalScheduler.submit(Scheduler.scala:207) [zipkin-query.jar:na]
        at com.twitter.concurrent.Scheduler$.submit(Scheduler.scala:92) [zipkin-query.jar:na]
        at com.twitter.util.Promise.runq(Promise.scala:350) [zipkin-query.jar:na]
        at com.twitter.util.Promise.updateIfEmpty(Promise.scala:721) [zipkin-query.jar:na]
        at com.twitter.util.ExecutorServiceFuturePool$$anon$2.run(FuturePool.scala:107) [zipkin-query.jar:na]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_60]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_60]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_60]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_60]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_60]
23:48:35.660 [pool-1-thread-2] INFO  c.t.f.h.filters.AccessLoggingFilter - 172.17.0.252 - - [27/Jan/2016:23:48:35 +0000] "GET /api/v1/traces?limit=10&endTs=1453938510948&serviceName=cmd-api&minDuration=&spanName=all&annotationQuery= HTTP/1.1" 500 36 733 "-"
```
