### PR TITLE
Adds KAFKA_GROUP_ID parameter

### DIFF
--- a/zipkin-collector-service/config/collector-cassandra.scala
+++ b/zipkin-collector-service/config/collector-cassandra.scala
@@ -52,6 +52,7 @@ val storeBuilder = Store.Builder(
 val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
   KafkaSpanReceiverFactory.factory(_,
     sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"),
+    sys.env.get("KAFKA_GROUP_ID").getOrElse("zipkin"),
     sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt
   )
 )

--- a/zipkin-collector-service/config/collector-dev.scala
+++ b/zipkin-collector-service/config/collector-dev.scala
@@ -32,6 +32,7 @@ val storeBuilder = Store.Builder(SpanStoreBuilder(db), DependencyStoreBuilder(db
 val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
   KafkaSpanReceiverFactory.factory(_,
     sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"),
+    sys.env.get("KAFKA_GROUP_ID").getOrElse("zipkin"),
     sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt
   )
 )

--- a/zipkin-collector-service/config/collector-mysql.scala
+++ b/zipkin-collector-service/config/collector-mysql.scala
@@ -29,6 +29,7 @@ val storeBuilder = Store.Builder(SpanStoreBuilder(db), DependencyStoreBuilder(db
 val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
   KafkaSpanReceiverFactory.factory(_,
     sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"),
+    sys.env.get("KAFKA_GROUP_ID").getOrElse("zipkin"),
     sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt
   )
 )

--- a/zipkin-receiver-kafka/README.md
+++ b/zipkin-receiver-kafka/README.md
@@ -9,6 +9,7 @@ It is enabled when the `KAFKA_ZOOKEEPER` environment variable is set. Here are t
 
    * `KAFKA_ZOOKEEPER`: ZooKeeper host string, comma-separated host:port value. no default.
    * `KAFKA_TOPIC`: Defaults to zipkin
+   * `KAFKA_GROUP_ID`: Consumer group this process is consuming on behalf of. Defaults to zipkin
    * `KAFKA_STREAMS`: Count of consumer threads consuming the topic. defaults to 1.
 
 Example usage:

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
@@ -17,11 +17,13 @@ object KafkaSpanReceiverFactory {
    *
    * @param zookeeper the zookeeper connect string, ex. 127.0.0.1:2181
    * @param topic  the topic zipkin spans will be consumed from
+   * @param groupId the consumer group this process is consuming on behalf of.
    * @param streams the count of consumer threads consuming the topic
    */
-  def factory(zookeeper: String, topic: String, streams: Int = 1) = {
+  def factory(zookeeper: String, topic: String, groupId: String = "zipkin", streams: Int = 1) = {
     object KafkaFactory extends App with KafkaSpanReceiverFactory
     KafkaFactory.kafkaZookeeperConnect.parse(zookeeper)
+    KafkaFactory.kafkaGroupId.parse(groupId)
     KafkaFactory.kafkaTopics.parse(topic + "=" + streams)
     (process: SpanReceiver.Processor) => KafkaFactory.newKafkaSpanReceiver(process)
   }


### PR DESCRIPTION
Uses `KAFKA_GROUP_ID` as it matches the kafka property "group.id"

Fixes #933
