### PR TITLE
Fixes alias column handling on mysql

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/util/DBConfig.scala
@@ -96,7 +96,8 @@ case class DBConfig(name: String = "sqlite-persistent",
       location = { dbp: DBParams =>
         "jdbc:mariadb://" + dbp.host + dbp.getPort + "/" + dbp.dbName + "?user=" + dbp.username + "&password=" + dbp.password +
           (if (dbp.ssl) "&useSSL=true" else "") +
-          "&autoReconnect=true" // recover from dropped connections
+          "&autoReconnect=true" + // recover from dropped connections
+          "&useOldAliasMetadataBehavior=true" // workaround for alias column
       }
     )
   )

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/DependencyStoreSpec.scala
@@ -197,7 +197,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
    *       span3: CS SR SS CR: Dependency 1
    */
   @Test def getDependencies_intermediateSpans() = {
-    val trace = ApplyTimestampAndDuration(List(
+    val trace = List(
       Span(20L, "get", 20L,
         annotations = List(
           Annotation(today * 1000, Constants.ServerRecv, Some(zipkinWeb)),
@@ -224,7 +224,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
       binaryAnnotations = List(
         BinaryAnnotation(Constants.ClientAddr, true, Some(zipkinQuery)),
         BinaryAnnotation(Constants.ServerAddr, true, Some(zipkinJdbc))))
-    ))
+    )
 
     processDependencies(trace)
     result(store.getDependencies(today + 1000)) should contain theSameElementsAs(dep.links)
@@ -244,7 +244,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
   @Test def getDependencies_notInstrumentedClientAndServer() = {
     val someClient = Endpoint(172 << 24 | 17 << 16 | 4, 80, "some-client")
 
-    val trace = ApplyTimestampAndDuration(List(
+    val trace = List(
       Span(20L, "get", 20L,
         annotations = List(
           Annotation(today * 1000, Constants.ServerRecv, Some(zipkinWeb)),
@@ -264,7 +264,7 @@ abstract class DependencyStoreSpec extends JUnitSuite with Matchers {
         binaryAnnotations = List(
           BinaryAnnotation(Constants.ClientAddr, true, Some(zipkinQuery)),
           BinaryAnnotation(Constants.ServerAddr, true, Some(zipkinJdbc))))
-    ))
+    )
 
     processDependencies(trace)
     val dep = new Dependencies(today, today + 1000, List(


### PR DESCRIPTION
Since default behavior of mysql driver can't treat alias column with anorm, DependencyStore on mysql returns weird results.
