### PR TITLE
Fix #953: Run webpack before preparing resources for fat jar

### DIFF
--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -59,6 +59,7 @@ task webpack(type: NpmTask) {
 }
 webpack.dependsOn(npmInstall)
 build.dependsOn(webpack)
+processResources.dependsOn(webpack)
 run.dependsOn(webpack)
 
 apply from: "${rootDir}/gradle/verify-licenses.gradle"


### PR DESCRIPTION
Initially I used `shadowJar.dependsOn`, but it turns out that's too late in the build process.

When testing, keep in mind that currently `zipkin-web/src/main/resources/dist` isn't deleted by `zipkin-web:clean`.
