### PR TITLE
Adds CASSANDRA_MAX_CONNECTIONS to control pooled connections per host

### DIFF
--- a/zipkin-cassandra/README.md
+++ b/zipkin-cassandra/README.md
@@ -12,6 +12,7 @@ Here are the Cassandra-specific environment variables:
    * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails. No default
    * `CASSANDRA_CONTACT_POINTS`: Comma separated list of hosts / ip addresses part of Cassandra cluster. Defaults to localhost
    * `CASSANDRA_LOCAL_DC`: Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
+   * `CASSANDRA_MAX_CONNECTIONS`: Max pooled connections per datacenter-local host. Defaults to 8
 
 Example usage:
 

--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -35,6 +35,7 @@ object CassandraSpanStoreDefaults {
   val SpanTtl = 7.days
   val IndexTtl = 3.days
   val MaxTraceCols = 100000
+  val MaxConnections = 8
   val SpanCodec = new ScroogeThriftCodec[ThriftSpan](ThriftSpan)
 }
 

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
@@ -1,7 +1,7 @@
 package com.twitter.zipkin.cassandra
 
-import com.datastax.driver.core.policies.{RoundRobinPolicy, LatencyAwarePolicy, TokenAwarePolicy, DCAwareRoundRobinPolicy}
-import com.datastax.driver.core.{Host, HostDistance, AuthProvider}
+import com.datastax.driver.core.policies.{DCAwareRoundRobinPolicy, LatencyAwarePolicy, RoundRobinPolicy, TokenAwarePolicy}
+import com.datastax.driver.core.{AuthProvider, Host, HostDistance}
 import com.twitter.app.App
 import java.net.InetSocketAddress
 import java.util.Arrays.asList
@@ -141,5 +141,25 @@ class CassandraSpanStoreFactorySpec extends FunSuite with Matchers with MockitoS
     val bar = mock[Host]
     when(bar.getDatacenter).thenReturn("bar")
     policy.distance(bar) should be(HostDistance.IGNORED)
+  }
+
+  test("zipkin.store.cassandra.maxConnections default") {
+    TestFactory.nonExitingMain(Array())
+
+    TestFactory.createClusterBuilder()
+      .getConfiguration()
+      .getPoolingOptions()
+      .getMaxConnectionsPerHost(HostDistance.LOCAL) should be (8)
+  }
+
+  test("zipkin.store.cassandra.maxConnections override") {
+    TestFactory.nonExitingMain(Array(
+      "-zipkin.store.cassandra.maxConnections", "16"
+    ))
+
+    TestFactory.createClusterBuilder()
+      .getConfiguration()
+      .getPoolingOptions()
+      .getMaxConnectionsPerHost(HostDistance.LOCAL) should be (16)
   }
 }

--- a/zipkin-collector-service/config/collector-cassandra.scala
+++ b/zipkin-collector-service/config/collector-cassandra.scala
@@ -41,6 +41,7 @@ if (username.isDefined && password.isDefined) {
 }
 
 sys.env.get("CASSANDRA_LOCAL_DC").foreach(Factory.cassandraLocalDc.parse(_))
+sys.env.get("CASSANDRA_MAX_CONNECTIONS").foreach(Factory.cassandraMaxConnections.parse(_))
 
 val storeBuilder = Store.Builder(
   new Builder[SpanStore]() {

--- a/zipkin-query-service/config/query-cassandra.scala
+++ b/zipkin-query-service/config/query-cassandra.scala
@@ -36,6 +36,7 @@ if (username.isDefined && password.isDefined) {
 }
 
 sys.env.get("CASSANDRA_LOCAL_DC").foreach(Factory.cassandraLocalDc.parse(_))
+sys.env.get("CASSANDRA_MAX_CONNECTIONS").foreach(Factory.cassandraMaxConnections.parse(_))
 
 val spanStore = Factory.newCassandraStore()
 val dependencies = Factory.newCassandraDependencies()


### PR DESCRIPTION
This setting should be used with CASSANDRA_LOCAL_DC, as that indicates
the local datacenter, which CASSANDRA_MAX_CONNECTIONS applies to.

Fixes #956
