### PR TITLE
Prefers client when deriving duration

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/CorrectForClockSkew.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/CorrectForClockSkew.scala
@@ -246,12 +246,6 @@ object CorrectForClockSkew extends ((List[Span]) => List[Span]) {
         }
       ).sorted
 
-      // reset timestamp and duration as if there's skew, these will change.
-      val firstOption = annotations.headOption.map(_.timestamp)
-      val lastOption = annotations.lastOption.map(_.timestamp)
-      val duration = for (first <- firstOption; last <- lastOption; if (first != last))
-        yield last - first
-
       // Local spans may have no annotations, so above calculation may produce None.
       // But if the timestamp is already defined, we just need to adjust it by the skew.
       val lcTimestamp: Option[Long] = span.timestamp.flatMap {
@@ -265,8 +259,7 @@ object CorrectForClockSkew extends ((List[Span]) => List[Span]) {
       }
 
       new SpanTreeEntry(span.copy(
-        timestamp = lcTimestamp orElse firstOption,
-        duration = duration orElse span.duration, // fallback to original if no annotations
+        timestamp = lcTimestamp orElse annotations.headOption.map(_.timestamp),
         annotations = annotations.sorted), spanTree.children)
     }
   }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/CorrectForClockSkewTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/adjuster/CorrectForClockSkewTest.scala
@@ -46,13 +46,13 @@ class CorrectForClockSkewTest extends FunSuite {
   val skewAnn2 = Annotation(95, Constants.ServerRecv, endpoint2) // skewed
   val skewAnn3 = Annotation(120, Constants.ServerSend, endpoint2) // skewed
   val skewAnn4 = Annotation(135, Constants.ClientRecv, endpoint1)
-  val skewSpan1 = Span(1, "method1", 666, None, Some(95L), Some(40L), List(skewAnn1, skewAnn2, skewAnn3, skewAnn4))
+  val skewSpan1 = Span(1, "method1", 666, None, Some(95L), Some(35L), List(skewAnn1, skewAnn2, skewAnn3, skewAnn4))
 
   val skewAnn5 = Annotation(100, Constants.ClientSend, endpoint2) // skewed
   val skewAnn6 = Annotation(115, Constants.ServerRecv, endpoint3)
   val skewAnn7 = Annotation(120, Constants.ServerSend, endpoint3)
   val skewAnn8 = Annotation(115, Constants.ClientRecv, endpoint2) // skewed
-  val skewSpan2 = Span(1, "method2", 777, Some(666L), Some(100L), Some(20L), List(skewAnn5, skewAnn6, skewAnn7, skewAnn8))
+  val skewSpan2 = Span(1, "method2", 777, Some(666L), Some(100L), Some(15L), List(skewAnn5, skewAnn6, skewAnn7, skewAnn8))
 
   val inputTrace = List(skewSpan1, skewSpan2)
 


### PR DESCRIPTION
Previously, the clock skew corrector incorrectly derived duration. This
was inaccurate as the distance between annotations on the span's host is
not subject to skew.

When zipkin spans cross multiple hosts, it is usually due to a client+
server span. By preferring the client's duration, we avoid having to
consider skew when deriving duration from annotations. Regardless, we
only derive duration when it isn't explicitly set.

Fixes #955
