### PR TITLE
bugfix: make sure that the span is wrapped in jquery

### DIFF
--- a/zipkin-web/src/main/resources/app/js/component_ui/trace.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/trace.js
@@ -287,7 +287,9 @@ define(
             $.each(self.parents[id], function(i, pId) { self.spans[pId].openChildren += 1; });
           });
           $.each(self.spansByService, function(svc, spans) {
-            $.each(spans, function(i, $span) { $span.inFilters += 1; });
+            $.each(self.getSpansByService(svc), function(i, $span) {
+              $span.inFilters += 1;
+            });
           });
           self.triggerForAllServices('uiAddServiceNameFilter');
         });


### PR DESCRIPTION
I'm not sure if it's affecting the end user experience in any way, but we get a JavaScript exception that blocks execution when you click the "Expand All" button to show all spans in a trace. (You must open the browser debugger to see it)

Apparently, JavaScript 's weak type system has been ~~abused~~ leveraged. `self.spansByService` is a map from service name to list of span ids (strings), but that list of ids will eventually be converted/lazy-initialised into a list of jquery objects (that wrap the spans' DOM elements). The lazy-initialisation mostly happens inside `getSpansByService`. I think we should refactor the code so that it creates jquery objects up-front. For now, this patch should fix the exception.
