### PR TITLE
Frontend routing

### DIFF
--- a/zipkin-web/package.json
+++ b/zipkin-web/package.json
@@ -13,11 +13,13 @@
     "bootstrap-datepicker": "^1.6.0",
     "bootstrap-sass": "^3.3.6",
     "chosen-npm": "^1.4.2",
+    "crossroads": "^0.12.2",
     "d3": "^3.5.14",
     "flightjs": "^1.5.1",
     "jquery": "^2.2.0",
     "js-cookie": "^2.1.0",
     "moment": "^2.11.1",
+    "query-string": "^3.0.0",
     "timeago": "^1.5.1"
   },
   "devDependencies": {

--- a/zipkin-web/src/main/resources/app/js/component_ui/trace.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/trace.js
@@ -2,10 +2,11 @@
 
 define(
   [
-    'flight'
+    'flight',
+    'query-string'
   ],
 
-  function (flight) {
+  function (flight, queryString) {
 
     return flight.component(trace);
 
@@ -434,7 +435,7 @@ define(
         /*get spans from trace-container-backup*/
         $('#trace-container-backup .span:not(#timeLabel-backup)').each(function() { self.setupSpansBackup($(this)); });
 
-        var serviceName = $.getUrlVar('serviceName');
+        var serviceName = queryString.parse(location.search).serviceName;
         if (serviceName !== undefined)
           this.trigger(document, 'uiAddServiceNameFilter', {value: serviceName});
         else

--- a/zipkin-web/src/main/resources/app/js/main.js
+++ b/zipkin-web/src/main/resources/app/js/main.js
@@ -1,4 +1,10 @@
-'use strict';
+import {compose, registry, advice, logger as withLogging, debug} from 'flight';
+import $ from 'jquery';
+import crossroads from 'crossroads';
+import queryString from 'query-string';
+import initializeDefault from './page/default';
+import initializeTrace from './page/trace';
+import initializeDependency from './page/dependency';
 
 Array.prototype.remove = function(from, to) {
   var rest = this.slice((to || from) + 1 || this.length);
@@ -6,54 +12,10 @@ Array.prototype.remove = function(from, to) {
   return this.push.apply(this, rest);
 };
 
-require(
-  [
-    'flight',
-    'jquery'
-  ],
+debug.enable(true);
+compose.mixin(registry, [advice.withAdvice]);
 
-  function(flight, $) {
-    $.extend({
-      getUrlVars: function(){
-        var vars = [], hash;
-        var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-        for(var i = 0; i < hashes.length; i++)
-        {
-          hash = hashes[i].split('=');
-          vars.push(hash[0]);
-          vars[hash[0]] = hash[1];
-        }
-        return vars;
-      },
-      getUrlVar: function(name) {
-        return $.getUrlVars()[name];
-      }
-    });
-
-    var compose = flight.compose;
-    var registry = flight.registry;
-    var advice = flight.advice;
-    var withLogging = flight.logger;
-    var debug = flight.debug;
-
-    debug.enable(true);
-    compose.mixin(registry, [advice.withAdvice]);
-
-    require(
-      [
-        './page/default',
-        './page/trace',
-        './page/dependency'
-      ],
-      function(
-        initializeDefault,
-        initializeTrace,
-        initializeDependency
-      ) {
-        initializeDefault();
-        initializeTrace();
-        initializeDependency();
-      }
-    );
-  }
-);
+crossroads.addRoute('', initializeDefault);
+crossroads.addRoute('traces/{id}', initializeTrace);
+crossroads.addRoute('dependency', initializeDependency);
+crossroads.parse(window.location.pathname);


### PR DESCRIPTION
Introduce crossroads, a JavaScript URL router. This will let us
perform logic client-side based on which page is served. The first
use-case is to only mount the relevant flight.js components for
which page we are looking at.

query-string is an npm module that parses query strings. We
replace the home-baked jquery plugin with this npm module instead.

main.js is simplified and rewritten to ES6.
