### PR TITLE
Render page title and environment name client-side

### DIFF
--- a/zipkin-web/src/main/resources/app/js/component_ui/environment.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/environment.js
@@ -1,0 +1,6 @@
+import flight from 'flight';
+export const environment = flight.component(function environment() {
+  this.after('initialize', function() {
+    this.$node.text(window.config.environment);
+  });
+});

--- a/zipkin-web/src/main/resources/app/js/page/default.js
+++ b/zipkin-web/src/main/resources/app/js/page/default.js
@@ -5,6 +5,7 @@ define(
     'timeago',
     '../component_data/spanNames',
     '../component_data/serviceNames',
+    '../component_ui/environment',
     '../component_ui/serviceName',
     '../component_ui/spanName',
     '../component_ui/infoPanel',
@@ -20,6 +21,7 @@ define(
     timeago,
     SpanNamesData,
     ServiceNamesData,
+    {environment: EnvironmentUI},
     ServiceNameUI,
     SpanNameUI,
     InfoPanelUI,
@@ -34,8 +36,10 @@ define(
     return initialize;
 
     function initialize() {
+      window.document.title = 'Zipkin - Index';
       SpanNamesData.attachTo(document);
       ServiceNamesData.attachTo(document);
+      EnvironmentUI.attachTo('#environment');
       ServiceNameUI.attachTo('#serviceName');
       SpanNameUI.attachTo('#spanName');
       InfoPanelUI.attachTo('#infoPanel');

--- a/zipkin-web/src/main/resources/app/js/page/dependency.js
+++ b/zipkin-web/src/main/resources/app/js/page/dependency.js
@@ -3,7 +3,9 @@
 define(
   [
     'moment',
+    'query-string',
     '../component_data/dependency',
+    '../component_ui/environment',
     '../component_ui/dependencyGraph',
     '../component_ui/serviceDataModal',
     '../component_ui/timeStamp',
@@ -11,7 +13,9 @@ define(
   ],
 
   function (moment,
+            queryString,
             DependencyData,
+            {environment: EnvironmentUI},
             DependencyGraphUI,
             ServiceDataModal,
             TimeStampUI,
@@ -20,16 +24,13 @@ define(
     return initialize;
 
     function initialize() {
-      // parse query string to set form
-      var params = {}, postBody = location.search.substring(1), regex = /([^&=]+)=([^&]*)/g, m;
-      while (m = regex.exec(postBody)) {
-        params[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
-      }
-      var endTs = params['endTs'] || moment().valueOf();
-      var startTs = params['startTs'] || moment().valueOf() - 7*24*60*60*1000; // set default startTs 7 days ago
-      $('#endTs').val(endTs);
-      $('#startTs').val(startTs);
+      window.document.title = 'Zipkin - Dependency';
 
+      const {startTs, endTs} = queryString.parse(location.search);
+      $('#endTs').val(endTs || moment().valueOf());
+      $('#startTs').val(startTs || moment().valueOf() - 7*24*60*60*1000); // set default startTs 7 days ago;
+
+      EnvironmentUI.attachTo('#environment');
       DependencyData.attachTo('#dependency-container');
       DependencyGraphUI.attachTo('#dependency-container');
       ServiceDataModal.attachTo('#service-data-modal-container');

--- a/zipkin-web/src/main/resources/app/js/page/trace.js
+++ b/zipkin-web/src/main/resources/app/js/page/trace.js
@@ -2,6 +2,7 @@
 
 define(
   [
+    '../component_ui/environment',
     '../component_ui/filterAllServices',
     '../component_ui/fullPageSpinner',
     '../component_ui/serviceFilterSearch',
@@ -11,6 +12,7 @@ define(
   ],
 
   function (
+    {environment: EnvironmentUI},
     FilterAllServicesUI,
     FullPageSpinnerUI,
     ServiceFilterSearchUI,
@@ -22,6 +24,9 @@ define(
     return initialize;
 
     function initialize() {
+      window.document.title = 'Zipkin - Traces';
+
+      EnvironmentUI.attachTo('#environment');
       FilterAllServicesUI.attachTo('#filterAllServices', {totalServices: $('.trace-details.services span').length});
       FullPageSpinnerUI.attachTo('#fullPageSpinner');
       ServiceFilterSearchUI.attachTo('#serviceFilterSearch');

--- a/zipkin-web/src/main/resources/templates/v2/layout.mustache
+++ b/zipkin-web/src/main/resources/templates/v2/layout.mustache
@@ -4,7 +4,7 @@
     <meta charset='utf-8'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
 
-    <title>Zipkin - {{pageTitle}}</title>
+    <title>Zipkin</title>
 
     <meta name='description' content=''>
     <meta name='viewport' content='width=device-width, initial-scale=1'>
@@ -26,9 +26,7 @@
         </div>
         <div class="navbar-right" style="width: 50%">
           <div class="navbar-right" style='padding-left: 15px'>
-            <div class="navbar-brand">
-              <span class='muted'>{{environment}}</span>
-            </div>
+            <p class="navbar-text muted" id="environment"></p>
           </div>
           <form id="traceIdQueryForm" class="form-inline" role="form">
             <div class="navbar-right" style="width: 25%; float: right">
@@ -66,6 +64,7 @@
       </div>
     </div>
 
+    <script src="/config.js"></script>
     <script src="/dist/app.min.js"></script>
   </body>
 </html>

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -43,7 +43,7 @@ class Handlers(mustacheGenerator: ZipkinMustache, queryExtractor: QueryExtractor
   case class ConfigRenderer(config: Map[String, _]) extends Renderer {
     def apply(response: Response) {
       response.contentType = "application/javascript"
-      response.contentString = "window.config = " + ZipkinJson.writeValueAsString(config) + ";"
+      response.contentString = s"window.config = ${ZipkinJson.writeValueAsString(config)};"
     }
   }
 

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -99,9 +99,13 @@ trait ZipkinWebFactory { self: App =>
       ("/api/v1/trace/:id", handleTrace(queryClient)),
       ("/api/v1/traces", handleRoute(queryClient, "/api/v1/traces")),
       // TODO: Once the following are javascript-only, we can move remove zipkin-web
-      ("/", addLayout("Index", environment()) andThen handleIndex(queryClient)),
-      ("/traces/:id", addLayout("Traces", environment()) andThen handleTraces(queryClient)),
-      ("/dependency", addLayout("Dependency", environment()) andThen handleDependency())
+      ("/", addLayout andThen handleIndex(queryClient)),
+      ("/traces/:id", addLayout andThen handleTraces(queryClient)),
+      ("/dependency", addLayout andThen handleDependency()),
+      ("/config.js", handleConfig(Map(
+        "environment" -> environment(),
+        "queryLimit" -> queryLimit()
+      )))
     ).foldLeft(new HttpMuxer) { case (m , (p, handler)) =>
       val path = p.split("/").toList
       val handlePath = path.takeWhile { t => !(t.startsWith(":") || t.startsWith("?:")) }


### PR DESCRIPTION
Add a config.js endpoint that sets relevant zipkin-web
configuration in window.config. (environment name,
default query limit etc)

Moving rendering of title and environment to the client
side means that layout.mustache has no other data to be
injected, so it can act as a pure decorator. (Which helps
us move from server-side rendering to client-side rendering)
