### PR TITLE
Move all mustache rendering to the browser

### DIFF
--- a/zipkin-web/src/main/resources/app/js/component_data/default.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/default.js
@@ -1,0 +1,15 @@
+import {component} from 'flight';
+import $ from 'jquery';
+
+export const DefaultData = component(function defaultData() {
+  this.after('initialize', function() {
+    $.ajax('/modelview' + window.location.pathname + window.location.search, {
+      type: "GET",
+      dataType: "json",
+      context: this,
+      success: function(modelview) {
+        this.trigger('defaultPageModelView', modelview);
+      }
+    });
+  });
+});

--- a/zipkin-web/src/main/resources/app/js/component_data/trace.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/trace.js
@@ -1,0 +1,15 @@
+import {component} from 'flight';
+import $ from 'jquery';
+
+export const TraceData = component(function traceData() {
+  this.after('initialize', function() {
+    $.ajax('/modelview' + window.location.pathname + window.location.search, {
+      type: "GET",
+      dataType: "json",
+      context: this,
+      success: function(modelview) {
+        this.trigger('tracePageModelView', modelview);
+      }
+    });
+  });
+});

--- a/zipkin-web/src/main/resources/app/js/component_ui/traces.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/traces.js
@@ -10,8 +10,6 @@ define(
     flight,
     FilterLabelUI
   ) {
-    FilterLabelUI.attachTo('.service-filter-label');
-
     return flight.component(traces);
 
     function traces() {
@@ -81,6 +79,8 @@ define(
       };
 
       this.after('initialize', function() {
+        FilterLabelUI.attachTo('.service-filter-label');
+
         this.$traces = this.$node.find('.trace');
         this.$traces.each(function() {
           var $this = $(this);

--- a/zipkin-web/src/main/resources/app/js/page/default.js
+++ b/zipkin-web/src/main/resources/app/js/page/default.js
@@ -2,7 +2,9 @@
 
 define(
   [
+    'flight',
     'timeago',
+    '../component_data/default',
     '../component_data/spanNames',
     '../component_data/serviceNames',
     '../component_ui/environment',
@@ -14,11 +16,14 @@ define(
     '../component_ui/traces',
     '../component_ui/timeStamp',
     '../component_ui/backToTop',
-    '../component_ui/goToTrace'
+    '../component_ui/goToTrace',
+    '../../../templates/v2/index.mustache'
   ],
 
   function (
+    {component},
     timeago,
+    {DefaultData},
     SpanNamesData,
     ServiceNamesData,
     {environment: EnvironmentUI},
@@ -30,27 +35,38 @@ define(
     TracesUI,
     TimeStampUI,
     BackToTop,
-    GoToTraceUI
+    GoToTraceUI,
+    defaultTemplate
   ) {
 
-    return initialize;
+    const DefaultPageComponent = component(function DefaultPage() {
+      this.after('initialize', function() {
+        window.document.title = 'Zipkin - Index';
+        DefaultData.attachTo(document);
 
-    function initialize() {
-      window.document.title = 'Zipkin - Index';
-      SpanNamesData.attachTo(document);
-      ServiceNamesData.attachTo(document);
-      EnvironmentUI.attachTo('#environment');
-      ServiceNameUI.attachTo('#serviceName');
-      SpanNameUI.attachTo('#spanName');
-      InfoPanelUI.attachTo('#infoPanel');
-      InfoButtonUI.attachTo('button.info-request');
-      TraceFiltersUI.attachTo('#trace-filters');
-      TracesUI.attachTo('#traces');
-      TimeStampUI.attachTo('#time-stamp');
-      BackToTop.attachTo('#backToTop');
-      GoToTraceUI.attachTo('#traceIdQueryForm');
+        this.on(document, 'defaultPageModelView', function(ev, modelView) {
+          this.$node.html(defaultTemplate(modelView));
 
-      $('.timeago').timeago();
-    }
+          SpanNamesData.attachTo(document);
+          ServiceNamesData.attachTo(document);
+          EnvironmentUI.attachTo('#environment');
+          ServiceNameUI.attachTo('#serviceName');
+          SpanNameUI.attachTo('#spanName');
+          InfoPanelUI.attachTo('#infoPanel');
+          InfoButtonUI.attachTo('button.info-request');
+          TraceFiltersUI.attachTo('#trace-filters');
+          TracesUI.attachTo('#traces');
+          TimeStampUI.attachTo('#time-stamp');
+          BackToTop.attachTo('#backToTop');
+          GoToTraceUI.attachTo('#traceIdQueryForm');
+
+          $('.timeago').timeago();
+        });
+      });
+    });
+
+    return function initializeDefault() {
+      DefaultPageComponent.attachTo('.content');
+    };
   }
 );

--- a/zipkin-web/src/main/resources/app/js/page/dependency.js
+++ b/zipkin-web/src/main/resources/app/js/page/dependency.js
@@ -3,28 +3,34 @@
 define(
   [
     'moment',
+    'jquery',
     'query-string',
     '../component_data/dependency',
     '../component_ui/environment',
     '../component_ui/dependencyGraph',
     '../component_ui/serviceDataModal',
     '../component_ui/timeStamp',
-    '../component_ui/goToDependency'
+    '../component_ui/goToDependency',
+    '../../../templates/v2/dependency.mustache'
   ],
 
   function (moment,
+            $,
             queryString,
             DependencyData,
             {environment: EnvironmentUI},
             DependencyGraphUI,
             ServiceDataModal,
             TimeStampUI,
-            GoToDependencyUI) {
+            GoToDependencyUI,
+            dependenciesTemplate
+  ) {
 
     return initialize;
 
     function initialize() {
       window.document.title = 'Zipkin - Dependency';
+      $('.content').html(dependenciesTemplate());
 
       const {startTs, endTs} = queryString.parse(location.search);
       $('#endTs').val(endTs || moment().valueOf());

--- a/zipkin-web/src/main/resources/app/js/page/trace.js
+++ b/zipkin-web/src/main/resources/app/js/page/trace.js
@@ -2,39 +2,57 @@
 
 define(
   [
+    'flight',
+    '../component_data/trace',
     '../component_ui/environment',
     '../component_ui/filterAllServices',
     '../component_ui/fullPageSpinner',
     '../component_ui/serviceFilterSearch',
     '../component_ui/spanPanel',
     '../component_ui/trace',
-    '../component_ui/zoomOutSpans'
+    '../component_ui/filterLabel',
+    '../component_ui/zoomOutSpans',
+    '../../../templates/v2/trace.mustache'
   ],
 
   function (
+    {component},
+    {TraceData},
     {environment: EnvironmentUI},
     FilterAllServicesUI,
     FullPageSpinnerUI,
     ServiceFilterSearchUI,
     SpanPanelUI,
     TraceUI,
-    ZoomOut
+    FilterLabelUI,
+    ZoomOut,
+    tracetemplate
   ) {
 
-    return initialize;
+    const TracePageComponent = component(function TracePage() {
+      this.after('initialize', function() {
+        window.document.title = 'Zipkin - Traces';
 
-    function initialize() {
-      window.document.title = 'Zipkin - Traces';
+        TraceData.attachTo(document);
+        this.on(document, 'tracePageModelView', function(ev, modelview) {
+          this.$node.html(tracetemplate(modelview));
 
-      EnvironmentUI.attachTo('#environment');
-      FilterAllServicesUI.attachTo('#filterAllServices', {totalServices: $('.trace-details.services span').length});
-      FullPageSpinnerUI.attachTo('#fullPageSpinner');
-      ServiceFilterSearchUI.attachTo('#serviceFilterSearch');
-      SpanPanelUI.attachTo('#spanPanel');
-      TraceUI.attachTo('#trace-container');
-      ZoomOut.attachTo('#zoomOutSpans');
+          EnvironmentUI.attachTo('#environment');
+          FilterAllServicesUI.attachTo('#filterAllServices', {totalServices: $('.trace-details.services span').length});
+          FullPageSpinnerUI.attachTo('#fullPageSpinner');
+          ServiceFilterSearchUI.attachTo('#serviceFilterSearch');
+          SpanPanelUI.attachTo('#spanPanel');
+          TraceUI.attachTo('#trace-container');
+          FilterLabelUI.attachTo('.service-filter-label');
+          ZoomOut.attachTo('#zoomOutSpans');
 
-      $('.annotation:not(.core)').tooltip({placement: 'left'});
+          $('.annotation:not(.core)').tooltip({placement: 'left'});
+        });
+      });
+    });
+
+    return function initializeTrace() {
+      TracePageComponent.attachTo('.content');
     }
   }
 );

--- a/zipkin-web/src/main/resources/templates/v2/layout.mustache
+++ b/zipkin-web/src/main/resources/templates/v2/layout.mustache
@@ -31,7 +31,7 @@
           <form id="traceIdQueryForm" class="form-inline" role="form">
             <div class="navbar-right" style="width: 25%; float: right">
               <div class="row well-sm clearfix">
-                  <input type="text" class="form-control input-sm" id="traceIdQuery" name="traceIdQuery" value="{{traceIdQuery}}" style="width: 100%" placeholder='Go to trace'>
+                  <input type="text" class="form-control input-sm" id="traceIdQuery" name="traceIdQuery" style="width: 100%" placeholder='Go to trace'>
               </div>
             </div>
           </form>
@@ -40,9 +40,7 @@
     </div>
 
     <div class='container'>
-      <div class='content'>
-        {{{body}}}
-      </div>
+      <div class='content'></div>
     </div>
 
     <div id='fullPageSpinner'>

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -99,9 +99,11 @@ trait ZipkinWebFactory { self: App =>
       ("/api/v1/trace/:id", handleTrace(queryClient)),
       ("/api/v1/traces", handleRoute(queryClient, "/api/v1/traces")),
       // TODO: Once the following are javascript-only, we can move remove zipkin-web
-      ("/", addLayout andThen handleIndex(queryClient)),
-      ("/traces/:id", addLayout andThen handleTraces(queryClient)),
-      ("/dependency", addLayout andThen handleDependency()),
+      ("/modelview/", handleIndex(queryClient)),
+      ("/modelview/traces/:id", handleTraces(queryClient)),
+      ("/", serveStaticIndex()),
+      ("/traces/:id", serveStaticIndex()),
+      ("/dependency", serveStaticIndex()),
       ("/config.js", handleConfig(Map(
         "environment" -> environment(),
         "queryLimit" -> queryLimit()

--- a/zipkin-web/webpack.config.js
+++ b/zipkin-web/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
             loader: 'babel?presets[]=es2015'
         }, {
             test: /\.mustache$/,
-            loader: 'mustache?minify'
+            loader: 'mustache'
         }, {
             test: /.scss$/,
             loader: ExtractTextPlugin.extract('style-loader', 'css-loader!sass-loader')


### PR DESCRIPTION
This means the zipkin-web backend is now only
basically a JSON api + delivering static assets.
There's a lot of complexity going on in the
transformation from trace/span JSON data to
data that is fed into mustache templates. These
transformations are still written in Scala, but
hosted at /modelview endpoints. Ideally, they
should be ported to Scala.

Some code had to be moved around - event handlers
must be bound after the HTML is rendered, which now
happens at a later stage than it used to (when it
was server-side rendered).
