### PR TITLE
Rip out parts of modelview for the index page

### DIFF
--- a/zipkin-web/.babelrc
+++ b/zipkin-web/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-object-rest-spread"]
+}

--- a/zipkin-web/package.json
+++ b/zipkin-web/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "babel-core": "^6.4.5",
     "babel-loader": "^6.2.1",
+    "babel-plugin-transform-object-rest-spread": "^6.5.0",
     "babel-preset-es2015": "^6.3.13",
     "css-loader": "^0.23.1",
     "extract-text-webpack-plugin": "^1.0.1",

--- a/zipkin-web/src/main/resources/app/js/page/default.js
+++ b/zipkin-web/src/main/resources/app/js/page/default.js
@@ -4,6 +4,7 @@ define(
   [
     'flight',
     'timeago',
+    'query-string',
     '../component_data/default',
     '../component_data/spanNames',
     '../component_data/serviceNames',
@@ -22,6 +23,7 @@ define(
   function (
     {component},
     timeago,
+    queryString,
     {DefaultData},
     SpanNamesData,
     ServiceNamesData,
@@ -42,8 +44,22 @@ define(
         window.document.title = 'Zipkin - Index';
         DefaultData.attachTo(document);
 
+        const query = queryString.parse(window.location.search);
+
         this.on(document, 'defaultPageModelView', function(ev, modelView) {
-          this.$node.html(defaultTemplate(modelView));
+          const limit = query.limit || window.config.queryLimit;
+          const minDuration = query.minDuration;
+          const endTs = query.endTs || new Date().getTime();
+          const serviceName = query.serviceName || '';
+          const annotationQuery = query.annotationQuery || '';
+          this.$node.html(defaultTemplate({
+            limit,
+            minDuration,
+            endTs,
+            serviceName,
+            annotationQuery,
+            ...modelView
+          }));
 
           SpanNamesData.attachTo(document);
           ServiceNamesData.attachTo(document);

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/QueryExtractor.scala
@@ -29,8 +29,8 @@ class QueryExtractor(defaultQueryLimit: Int) {
     req.params.getLong("endTs").getOrElse(Time.now.inMillis).toString
   }
 
-  def getAnnotations(req: Request): Option[(Seq[String], Map[String, String])] =
-    req.params.get("annotationQuery") map { query =>
+  def getAnnotations(req: Request): (Seq[String], Map[String, String]) = {
+    val query = req.params.getOrElse("annotationQuery", "")
       val anns = mutable.Buffer[String]()
       val binAnns = mutable.Map[String, String]()
 

--- a/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
+++ b/zipkin-web/src/test/scala/com/twitter/zipkin/web/QueryExtractorTest.scala
@@ -61,7 +61,7 @@ class QueryExtractorTest extends FunSuite {
     val r = request(
       "serviceName" -> "myService",
       "annotationQuery" -> "finagle.retry and finagle.timeout")
-    val actual = queryExtractor.getAnnotations(r).get
+    val actual = queryExtractor.getAnnotations(r)
     assert(actual._1.contains("finagle.retry"))
     assert(actual._1.contains("finagle.timeout"))
   }
@@ -70,7 +70,7 @@ class QueryExtractorTest extends FunSuite {
     val r = request(
       "serviceName" -> "myService",
       "annotationQuery" -> "http.status_code=500")
-    val actual = queryExtractor.getAnnotations(r).get
+    val actual = queryExtractor.getAnnotations(r)
     assert(actual._2 === Map(Constants.HTTP_STATUS_CODE -> "500"))
   }
 
@@ -78,7 +78,7 @@ class QueryExtractorTest extends FunSuite {
     val r = request(
       "serviceName" -> "myService",
       "annotationQuery" -> "http.path=/sessions")
-    val actual = queryExtractor.getAnnotations(r).get
+    val actual = queryExtractor.getAnnotations(r)
     assert(actual._2 === Map(Constants.HTTP_PATH -> "/sessions"))
   }
 
@@ -86,7 +86,7 @@ class QueryExtractorTest extends FunSuite {
     val r = request(
       "serviceName" -> "myService",
       "annotationQuery" -> "http.path=sessions=foo")
-    val actual = queryExtractor.getAnnotations(r).get
+    val actual = queryExtractor.getAnnotations(r)
     assert(actual._2 === Map(Constants.HTTP_PATH -> "sessions=foo"))
   }
 }

--- a/zipkin-web/webpack.config.js
+++ b/zipkin-web/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
         loaders: [{
             test: /\.js$/,
             exclude: /node_modules/,
-            loader: 'babel?presets[]=es2015'
+            loader: 'babel'
         }, {
             test: /\.mustache$/,
             loader: 'mustache'


### PR DESCRIPTION
Some of the properties (query string parsing)
were trivial to move to JavaScript.
.babelrc was added to load plugins, namely
the object spread transform plugin, which lets us
use that syntax (like the diff in page/default.js)
