### PR TITLE
Fix UI bug - trace placeholder wasn't shown

### DIFF
--- a/zipkin-web/src/main/resources/app/js/page/default.js
+++ b/zipkin-web/src/main/resources/app/js/page/default.js
@@ -52,12 +52,15 @@ define(
           const endTs = query.endTs || new Date().getTime();
           const serviceName = query.serviceName || '';
           const annotationQuery = query.annotationQuery || '';
+          const queryWasPerformed = serviceName && serviceName.length > 0;
           this.$node.html(defaultTemplate({
             limit,
             minDuration,
             endTs,
             serviceName,
             annotationQuery,
+            queryWasPerformed,
+            count: modelView.traces.length,
             ...modelView
           }));
 

--- a/zipkin-web/src/main/resources/templates/v2/index.mustache
+++ b/zipkin-web/src/main/resources/templates/v2/index.mustache
@@ -35,7 +35,7 @@
     <div class="clearfix"></div>
     <input type="text" class="form-control input-sm" id="annotationQuery" name="annotationQuery" value="{{annotationQuery}}" style="width: 100%" placeholder='Annotations Query (e.g. "finagle.timeout", "http.path=/foo/bar/ and cluster=foo and cache.miss")'>
   </form>
-{{#queryResults}}
+{{#queryWasPerformed}}
   <div id="trace-filters">
     <div class="pull-left">
       <span>
@@ -62,16 +62,16 @@
       <span class='label service-tag-filtered' data-service-name="{{serviceName}}">{{serviceName}}</span>
     </div>
   </div>
-{{/queryResults}}
+{{/queryWasPerformed}}
 </div>
 
 <div class="row">
-{{^queryResults}}
+{{^queryWasPerformed}}
   <div class="alert alert-info" id="help-msg">
     <p>Please select the criteria for your trace lookup.</p>
   </div>
-{{/queryResults}}
-{{#queryResults}}
+{{/queryWasPerformed}}
+{{#queryWasPerformed}}
   <ul id="traces">
   {{#traces}}
     <li class="trace" data-traceId="{{traceId}}" data-duration="{{duration}}" data-timestamp="{{timestamp}}" data-service-percentage="{{servicePercentage}}">
@@ -97,7 +97,7 @@
     </li>
   {{/traces}}
   </ul>
-{{/queryResults}}
+{{/queryWasPerformed}}
 </div>
 
 <!-- help panel for different lookup options -->


### PR DESCRIPTION
After the UI refactoring, a bug in the handling of
queryResults surfaced. This means the "placeholder" that is
shown before you have made any queries was never rendered.

This fix adds a "queryWasPerformed" property that is
computed client-side. The structure of the JSON returned
from the server is also simplified a bit.

@yurishkuro I think this should fix the bug you reported.
