### PR TITLE
Adds /health endpoint to zipkin-query and zipkin-web

### DIFF
--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
@@ -24,6 +24,10 @@ class ZipkinQueryController @Inject()(spanStore: SpanStore,
                                       @Flag("zipkin.queryService.servicesMaxAge") servicesMaxAge: Int,
                                       @Flag("zipkin.queryService.lookback") val defaultLookback: Long) extends Controller {
 
+  get("/health") { request: Request =>
+    "OK\n" // TODO: expose SpanStore.ok? or similar per #994
+  }
+
   post("/api/v1/spans") { request: Request =>
     val spans: Try[List[Span]] = try {
       Success(request.mediaType match {

--- a/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
+++ b/zipkin-query/src/test/scala/com/twitter/zipkin/query/ZipkinQueryServerFeatureTest.scala
@@ -876,4 +876,11 @@ class ZipkinQueryServerFeatureTest extends FeatureTest with MockitoSugar with Be
       andExpect = Ok,
       withJsonBody = "[ ]")
   }
+
+  "health checks OK" in {
+    server.httpGet(
+      path = "/health",
+      andExpect = Ok,
+      withBody = "OK\n")
+  }
 }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -91,6 +91,7 @@ trait ZipkinWebFactory { self: App =>
       ("/public/", handlePublic(resourceDirs, typesMap)),
       ("/dist/", handlePublic(resourceDirs, typesMap)),
       // In preparation of moving static assets to zipkin-query
+      ("/health", handleRoute(queryClient, "/health")),
       ("/api/v1/dependencies", handleRoute(queryClient, "/api/v1/dependencies")),
       ("/api/v1/services", handleRoute(queryClient, "/api/v1/services")),
       ("/api/v1/spans", handleRoute(queryClient, "/api/v1/spans")),


### PR DESCRIPTION
Various platforms have admin instances that expose health, and Twitter's
does so on a different port. By introducing a "/health" endpoint, we can
start a portable conversation about health that doesn't rely on platform
conventions or opening more ports on the firewall. The use case for this
is load balancer health checks and the zipkin javascript UI.

See #994
