### PR TITLE
set the default for dependencies to 1 day of data

### DIFF
--- a/zipkin-web/src/main/resources/app/js/page/dependency.js
+++ b/zipkin-web/src/main/resources/app/js/page/dependency.js
@@ -35,7 +35,7 @@ define(
 
         const {startTs, endTs} = queryString.parse(location.search);
         $('#endTs').val(endTs || moment().valueOf());
-        $('#startTs').val(startTs || moment().valueOf() - 7*24*60*60*1000); // set default startTs 7 days ago;
+        $('#startTs').val(startTs || moment().valueOf() - 1*24*60*60*1000); // set default startTs 1 day ago;
 
         DependencyData.attachTo('#dependency-container');
         DependencyGraphUI.attachTo('#dependency-container');


### PR DESCRIPTION
In our system we had 2.5million annotations in the last week, when we go to the dependency page we need to wait almost 4 minutes to get the result, people think the page does not work.

Leaving the default in the last one day, I hope that will be better for us and also a sane default as at least the page returns faster and users can change the date if they want.
@adriancole  @eirslett 
