### PR TITLE
Speed up npm install in zipkin-web:build

### DIFF
--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -35,9 +35,6 @@ node {
     // Version of node to use.
     version = '5.5.0'
 
-    // Version of npm to use.
-    npmVersion = '3.6.0'
-
     // Base URL for fetching node distributions (change if you have a mirror).
     distBaseUrl = 'https://nodejs.org/dist'
 


### PR DESCRIPTION
As discussed in https://github.com/openzipkin/zipkin/pull/992#issuecomment-186836795, I looked at how to speed up node-related parts of the build. The only big one I found was that we're being hit by https://github.com/srs/gradle-node-plugin/issues/87.

Setting `npmVersion` causes all transitive dependencies to be installed into the root of `node_modules`, which confuses later npm install runs, and ensures that each. and. every. time. tons of dependencies need to be reinstalled. As a side-effect, this change also gets rid of all the "replacing bundled version of ..." warnings.

Keep in mind that once the `node_modules` dir is messed up, it needs to be removed for the speed improvement to take effect, and `zipkin-web:clean` doesn't remove it at the moment.

This change shaves 20 - 30 seconds off a re-build:
- zipkin-web:build
  - before
    - clean build: 2 minutes 8 seconds
    - rebuild: 39 seconds
  - after
    - clean build: 1 minute 58 seconds
    - rebuild: 10 seconds
