### PR TITLE
Render the index/default page completely client-side

### DIFF
--- a/zipkin-web/karma.conf.js
+++ b/zipkin-web/karma.conf.js
@@ -9,8 +9,8 @@ module.exports = function(config) {
     ],
 
     preprocessors: {
-      '*test.js': ['webpack'],
-      '**/*test.js': ['webpack']
+      '*test.js': ['webpack', 'sourcemap'],
+      '**/*test.js': ['webpack', 'sourcemap']
     },
 
     client: {
@@ -20,6 +20,7 @@ module.exports = function(config) {
     browsers: ['PhantomJS'],
 
     webpack: {
+      devtool: 'inline-source-map',
       module: {
         loaders: [{
           test: /\.js$/,
@@ -50,7 +51,8 @@ module.exports = function(config) {
       require('karma-webpack'),
       require('karma-mocha'),
       require('karma-chai'),
-      require('karma-phantomjs-launcher')
+      require('karma-phantomjs-launcher'),
+      require('karma-sourcemap-loader')
     ],
 
     phantomjsLauncher: {

--- a/zipkin-web/package.json
+++ b/zipkin-web/package.json
@@ -20,7 +20,8 @@
     "flightjs": "^1.5.1",
     "jquery": "^2.2.0",
     "js-cookie": "^2.1.0",
-    "moment": "^2.11.1",
+    "lodash": "^4.5.0",
+    "moment": "^2.11.2",
     "query-string": "^3.0.0",
     "timeago": "^1.5.1"
   },

--- a/zipkin-web/package.json
+++ b/zipkin-web/package.json
@@ -39,6 +39,7 @@
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.2.2",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.4.5",
     "mustache-loader": "^0.3.1",

--- a/zipkin-web/package.json
+++ b/zipkin-web/package.json
@@ -31,6 +31,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.5.0",
+    "chai-shallow-deep-almost-equal": "^1.3.0",
     "css-loader": "^0.23.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",

--- a/zipkin-web/src/main/resources/app/js/component_data/default.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/default.js
@@ -1,15 +1,41 @@
 import {component} from 'flight';
 import $ from 'jquery';
+import queryString from 'query-string';
+import chai from 'chai';
+import {traceSummary, traceSummariesToMustache} from '../component_ui/traceSummary'
 
 export const DefaultData = component(function defaultData() {
-  this.after('initialize', function() {
+  function verifyTraceToMustacheTransformation(modelviewJs) {
     $.ajax('/modelview' + window.location.pathname + window.location.search, {
       type: "GET",
       dataType: "json",
       context: this,
-      success: function(modelview) {
-        this.trigger('defaultPageModelView', modelview);
+      success: (modelviewScala) => {
+        chai.config.truncateThreshold = 0;
+        console.log('Comparing Scala output and JavaScript output:');
+        chai.expect(modelviewJs.traces).to.deep.equal(modelviewScala.traces);
+        console.log('Success: The Scala-transformed results and JavaScript-transformed results are equal.');
       }
     });
+  }
+
+  this.after('initialize', function() {
+    const serviceName = queryString.parse(window.location.search).serviceName;
+    if (serviceName) {
+      $.ajax('/api/v1/traces' + window.location.search, {
+        type: 'GET',
+        dataType: 'json',
+        context: this,
+        success: (traces) => {
+          const modelview = {traces: traceSummariesToMustache(serviceName, traces.map(traceSummary)) };
+          this.trigger('defaultPageModelView', modelview);
+          if (serviceName) {
+            verifyTraceToMustacheTransformation(modelview);
+          }
+        }
+      });
+    } else {
+      this.trigger('defaultPageModelView', {traces: []});
+    }
   });
 });

--- a/zipkin-web/src/main/resources/app/js/component_data/default.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/default.js
@@ -2,7 +2,9 @@ import {component} from 'flight';
 import $ from 'jquery';
 import queryString from 'query-string';
 import chai from 'chai';
+import shallowDeepAlmostEqual from 'chai-shallow-deep-almost-equal';
 import {traceSummary, traceSummariesToMustache} from '../component_ui/traceSummary'
+chai.use(shallowDeepAlmostEqual);
 
 export const DefaultData = component(function defaultData() {
   function verifyTraceToMustacheTransformation(modelviewJs) {
@@ -11,9 +13,9 @@ export const DefaultData = component(function defaultData() {
       dataType: "json",
       context: this,
       success: (modelviewScala) => {
-        chai.config.truncateThreshold = 0;
         console.log('Comparing Scala output and JavaScript output:');
-        chai.expect(modelviewJs.traces).to.deep.equal(modelviewScala.traces);
+        chai.expect(modelviewJs.traces).to.shallowDeepAlmostEqual(modelviewScala.traces);
+        chai.expect(modelviewScala.traces).to.shallowDeepAlmostEqual(modelviewJs.traces);
         console.log('Success: The Scala-transformed results and JavaScript-transformed results are equal.');
       }
     });

--- a/zipkin-web/src/main/resources/app/js/component_data/trace.js
+++ b/zipkin-web/src/main/resources/app/js/component_data/trace.js
@@ -1,14 +1,35 @@
 import {component} from 'flight';
 import $ from 'jquery';
+import traceToMustache from '../../js/component_ui/traceToMustache';
+import chai from 'chai';
+import shallowDeepAlmostEqual from 'chai-shallow-deep-almost-equal';
+chai.use(shallowDeepAlmostEqual);
 
 export const TraceData = component(function traceData() {
-  this.after('initialize', function() {
+  this.verifyMustache = function(jsModelview) {
     $.ajax('/modelview' + window.location.pathname + window.location.search, {
       type: "GET",
       dataType: "json",
       context: this,
-      success: function(modelview) {
+      success: (scalaModelview) => {
+        console.log('Scala modelview', scalaModelview);
+        console.log('JavaScript modelview', jsModelview);
+        chai.expect(jsModelview).to.shallowDeepAlmostEqual(scalaModelview);
+        chai.expect(scalaModelview).to.shallowDeepAlmostEqual(jsModelview);
+        console.log('Success: they are equal.');
+      }
+    });
+  };
+
+  this.after('initialize', function() {
+    $.ajax('/api/v1/trace/' + this.attr.traceId, {
+      type: "GET",
+      dataType: "json",
+      context: this,
+      success: (trace) => {
+        const modelview = traceToMustache(trace);
         this.trigger('tracePageModelView', modelview);
+        this.verifyMustache(modelview);
       }
     });
   });

--- a/zipkin-web/src/main/resources/app/js/component_ui/traceConstants.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/traceConstants.js
@@ -1,0 +1,53 @@
+const CLIENT_SEND = 'cs';
+const CLIENT_SEND_FRAGMENT = 'csf';
+const CLIENT_RECEIVE = 'cr';
+const CLIENT_RECEIVE_FRAGMENT = 'crf';
+const SERVER_SEND = 'ss';
+const SERVER_SEND_FRAGMENT = 'ssf';
+const SERVER_RECEIVE = 'sr';
+const SERVER_RECEIVE_FRAGMENT = 'srf';
+const SERVER_ADDR = 'sa';
+const CLIENT_ADDR = 'ca';
+const WIRE_SEND = 'ws';
+const WIRE_RECEIVE = 'wr';
+const LOCAL_COMPONENT = 'lc';
+const CORE_CLIENT = [CLIENT_RECEIVE, CLIENT_RECEIVE_FRAGMENT, CLIENT_SEND, CLIENT_SEND_FRAGMENT];
+const CORE_SERVER = [SERVER_RECEIVE, SERVER_RECEIVE_FRAGMENT, SERVER_SEND, SERVER_SEND_FRAGMENT];
+const CORE_ADDRESS = [CLIENT_ADDR, SERVER_ADDR];
+const CORE_WIRE = [WIRE_SEND, WIRE_RECEIVE];
+const CORE_LOCAL = [LOCAL_COMPONENT];
+const CORE_ANNOTATIONS = [...CORE_CLIENT, ...CORE_SERVER, ...CORE_WIRE, ...CORE_LOCAL];
+export const Constants = {
+  CLIENT_SEND,
+  CLIENT_SEND_FRAGMENT,
+  CLIENT_RECEIVE,
+  CLIENT_RECEIVE_FRAGMENT,
+  SERVER_SEND,
+  SERVER_SEND_FRAGMENT,
+  SERVER_RECEIVE,
+  SERVER_RECEIVE_FRAGMENT,
+  SERVER_ADDR,
+  CLIENT_ADDR,
+  CORE_CLIENT,
+  CORE_SERVER,
+  LOCAL_COMPONENT,
+  CORE_ADDRESS,
+  CORE_WIRE,
+  CORE_LOCAL,
+  CORE_ANNOTATIONS
+};
+
+export let ConstantNames = {};
+ConstantNames[CLIENT_SEND] = 'Client Send';
+ConstantNames[CLIENT_SEND_FRAGMENT] = 'Client Send Fragment';
+ConstantNames[CLIENT_RECEIVE] = 'Client Receive';
+ConstantNames[CLIENT_RECEIVE_FRAGMENT] = 'Client Receive Fragment';
+ConstantNames[SERVER_SEND] = 'Server Send';
+ConstantNames[SERVER_SEND_FRAGMENT] = 'Server Send Fragment';
+ConstantNames[SERVER_RECEIVE] = 'Server Receive';
+ConstantNames[SERVER_RECEIVE_FRAGMENT] = 'Server Receive Fragment';
+ConstantNames[CLIENT_ADDR] = 'Client Address';
+ConstantNames[SERVER_ADDR] = 'Server Address';
+ConstantNames[WIRE_SEND] = 'Wire Send';
+ConstantNames[WIRE_RECEIVE] = 'Wire Receive';
+ConstantNames[LOCAL_COMPONENT] = 'Local Component';

--- a/zipkin-web/src/main/resources/app/js/component_ui/traceSummary.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/traceSummary.js
@@ -184,6 +184,13 @@ export function traceSummariesToMustache(serviceName = null, traceSummaries, utc
         serviceDurations,
         width
       };
-    }).sort((t1, t2) => t1.duration < t2.duration);
+    }).sort((t1, t2) => {
+      const durationComparison = t2.duration - t1.duration;
+      if (durationComparison === 0) {
+        return t1.traceId.localeCompare(t2.traceId);
+      } else {
+        return durationComparison;
+      }
+    });
   }
 }

--- a/zipkin-web/src/main/resources/app/js/component_ui/traceSummary.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/traceSummary.js
@@ -32,7 +32,7 @@ export function traceDuration(spans) {
 }
 
 export function getServiceNames(span) {
-  return _(endpointsForSpan(span)).uniqWith(endpointEquals).map((ep) => ep.serviceName).filter((name) => name != null && name != '').value();
+  return _(endpointsForSpan(span)).map((ep) => ep.serviceName).filter((name) => name != null && name != '').uniq().value();
 }
 
 export function getServiceName(span) {

--- a/zipkin-web/src/main/resources/app/js/component_ui/traceSummary.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/traceSummary.js
@@ -1,0 +1,196 @@
+import _ from 'lodash';
+import moment from 'moment';
+
+const CLIENT_SEND = 'cs';
+const CLIENT_SEND_FRAGMENT = 'csf';
+const CLIENT_RECEIVE = 'cr';
+const CLIENT_RECEIVE_FRAGMENT = 'crf';
+const SERVER_SEND = 'ss';
+const SERVER_SEND_FRAGMENT = 'ssf';
+const SERVER_RECEIVE = 'sr';
+const SERVER_RECEIVE_FRAGMENT = 'srf';
+const SERVER_ADDR = 'sa';
+const CLIENT_ADDR = 'ca';
+const LOCAL_COMPONENT = 'lc';
+const CORE_CLIENT = [CLIENT_RECEIVE, CLIENT_RECEIVE_FRAGMENT, CLIENT_SEND, CLIENT_SEND_FRAGMENT];
+const CORE_SERVER = [SERVER_RECEIVE, SERVER_RECEIVE_FRAGMENT, SERVER_SEND, SERVER_SEND_FRAGMENT];
+export const Constants = {
+  CLIENT_SEND,
+  CLIENT_SEND_FRAGMENT,
+  CLIENT_RECEIVE,
+  CLIENT_RECEIVE_FRAGMENT,
+  SERVER_SEND,
+  SERVER_SEND_FRAGMENT,
+  SERVER_RECEIVE,
+  SERVER_RECEIVE_FRAGMENT,
+  SERVER_ADDR,
+  CLIENT_ADDR,
+  CORE_CLIENT,
+  CORE_SERVER,
+  LOCAL_COMPONENT
+};
+
+function endpointsForSpan(span) {
+  return _.union(
+    span.annotations.map(a => a.endpoint),
+    span.binaryAnnotations.map(a => a.endpoint)
+  ).filter(h => h != null);
+}
+
+// What's the total duration of the spans in this trace?
+function traceDuration(spans) {
+  // turns (timestamp, timestamp + duration) into an ordered list
+  const timestamps = _(spans).flatMap(({timestamp, duration}) => timestamp ?
+    (duration ?
+      [timestamp, timestamp + duration]
+      :
+      [timestamp]
+    )
+    : []
+  ).sort().value();
+
+  if (timestamps.length < 2) {
+    return null;
+  } else {
+    const first = _.head(timestamps);
+    const last = _.last(timestamps);
+    return last - first;
+  }
+}
+
+function getServiceNames(span) {
+  return _(endpointsForSpan(span)).uniqWith(endpointEquals).map((ep) => ep.serviceName).filter((name) => name != null && name != '').value();
+}
+
+export function getServiceName(span) {
+  // Most authoritative is the label of the server's endpoint
+  const annotationFromServerAddr = _(span.binaryAnnotations || []).find((ann) => ann.key === Constants.SERVER_ADDR && ann.endpoint != null && ann.endpoint.serviceName != null && ann.endpoint.serviceName != '');
+  const serviceNameFromServerAddr = annotationFromServerAddr ? annotationFromServerAddr.endpoint.serviceName : null;
+  if (serviceNameFromServerAddr) {
+    return serviceNameFromServerAddr;
+  }
+
+  // Next, the label of any server annotation, logged by an instrumented server
+  const annotationFromServerSideAnnotations = _(span.annotations || []).find((ann) => Constants.CORE_SERVER.indexOf(ann.value) !== -1 && ann.endpoint != null && ann.endpoint.serviceName != null && ann.endpoint.serviceName != '');
+  const serviceNameFromServerSideAnnotation = annotationFromServerSideAnnotations? annotationFromServerSideAnnotations.endpoint.serviceName : null;
+  if (serviceNameFromServerSideAnnotation) {
+    return serviceNameFromServerSideAnnotation;
+  }
+
+  // Next is the label of the client's endpoint
+  const annotationFromClientAddr = _(span.binaryAnnotations || []).find((ann) => ann.key === Constants.CLIENT_ADDR && ann.endpoint != null && ann.endpoint.serviceName != null && ann.endpoint.serviceName != '');
+  const serviceNameFromClientAddr = annotationFromClientAddr? annotationFromClientAddr.endpoint.serviceName : null;
+  if (serviceNameFromClientAddr) {
+    return serviceNameFromClientAddr;
+  }
+
+  // Next is the label of any client annotation, logged by an instrumented client
+  const annotationFromClientSideAnnotations = _(span.annotations || []).find((ann) => Constants.CORE_CLIENT.indexOf(ann.value) !== -1 && ann.endpoint != null && ann.endpoint.serviceName != null && ann.endpoint.serviceName != '');
+  const serviceNameFromClientAnnotation = annotationFromClientSideAnnotations? annotationFromClientSideAnnotations.endpoint.serviceName : null;
+  if (serviceNameFromClientAnnotation) {
+    return serviceNameFromClientAnnotation;
+  }
+
+  // Finally is the label of the local component's endpoint
+  const annotationFromLocalComponent = _(span.binaryAnnotations || []).find((ann) => ann.key === Constants.LOCAL_COMPONENT && ann.endpoint != null && ann.endpoint.serviceName != null && ann.endpoint.serviceName != '');
+  const serviceNameFromLocalComponent = annotationFromLocalComponent? annotationFromLocalComponent.endpoint.serviceName : null;
+  if (serviceNameFromLocalComponent) {
+    return serviceNameFromLocalComponent;
+  }
+
+  return null;
+}
+
+function getSpanTimestamps(spans) {
+  return _(spans).flatMap((span) => getServiceNames(span).map((serviceName) => ({
+    name: serviceName,
+    timestamp: span.timestamp,
+    duration: span.duration
+  }))).value();
+}
+
+function endpointEquals(e1, e2) {
+  return e1.ipv4 === e2.ipv4 && e1.port === e2.port && e1.serviceName === e2.serviceName;
+}
+
+export function traceSummary(spans = []) {
+  if (spans.length === 0 || !spans[0].timestamp) {
+    return null;
+  } else {
+    const duration = traceDuration(spans) || 0;
+    const endpoints = _(spans).flatMap(endpointsForSpan).uniqWith(endpointEquals).value();
+    const traceId = spans[0].traceId;
+    const timestamp = spans[0].timestamp;
+    const spanTimestamps = getSpanTimestamps(spans);
+    return {
+      traceId,
+      timestamp,
+      duration,
+      spanTimestamps,
+      endpoints
+    };
+  }
+}
+
+function totalServiceTime(stamps, acc = 0) {
+  if (stamps.length == 0) {
+    return acc;
+  } else {
+    const ts = _(stamps).minBy((s) => s.timestamp);
+    const [current, next] = _(stamps).partition((t) => t.timestamp >= ts.timestamp && t.timestamp + t.duration <= ts.timestamp + ts.duration).value();
+    const endTs = Math.max(...current.map((t) => t.timestamp + t.duration));
+    return totalServiceTime(next, acc + (endTs - ts.timestamp));
+  }
+}
+
+function formatDate(timestamp, utc) {
+  let m = moment(timestamp / 1000);
+  if (utc) {
+    m = m.utc();
+  }
+  return m.format('MM-DD-YYYYTHH:mm:ss.SSSZZ');
+
+}
+
+export function traceSummariesToMustache(serviceName = null, traceSummaries, utc = false) {
+  if (traceSummaries.length === 0) {
+    return [];
+  } else {
+    const maxDuration = Math.max(...traceSummaries.map((s) => s.duration)) / 1000;
+
+    return traceSummaries.map((t) => {
+      const duration = t.duration / 1000;
+      const groupedTimestamps = _(t.spanTimestamps).groupBy((sts) => sts.name).value();
+      const serviceDurations = _(groupedTimestamps).toPairs().map(([name, sts]) => ({
+        name,
+        count: sts.length,
+        max: parseInt(Math.max(...sts.map(t => t.duration)) / 1000)
+      })).sortBy('name').value();
+
+      let serviceTime;
+      if (!serviceName || !groupedTimestamps[serviceName]) {
+        serviceTime = 0;
+      } else {
+        serviceTime = totalServiceTime(groupedTimestamps[serviceName]);
+      }
+
+      const startTs = formatDate(t.timestamp, utc);
+      const durationStr = (t.duration / 1000).toFixed(3) + 'ms';
+      const servicePercentage = parseInt(parseFloat(serviceTime) / parseFloat(t.duration) * 100);
+      const spanCount = _(groupedTimestamps).values().sumBy((sts) => sts.length);
+      const width = parseInt(parseFloat(duration) / parseFloat(maxDuration) * 100);
+
+      return {
+        traceId: t.traceId,
+        startTs,
+        timestamp: t.timestamp,
+        duration,
+        durationStr,
+        servicePercentage,
+        spanCount,
+        serviceDurations,
+        width
+      };
+    }).sort((t1, t2) => t1.duration < t2.duration);
+  }
+}

--- a/zipkin-web/src/main/resources/app/js/component_ui/traceToMustache.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/traceToMustache.js
@@ -1,0 +1,171 @@
+import _ from 'lodash';
+import {
+  traceSummary,
+  getGroupedTimestamps,
+  getServiceDurations,
+  getServiceNames,
+  getServiceName,
+  mkDurationStr,
+  traceDuration,
+} from './traceSummary';
+import {Constants, ConstantNames} from './traceConstants';
+
+export function getRootSpans(spans) {
+  const ids = spans.map((s) => s.id);
+  return spans.filter((s) => ids.indexOf(s.parentId) === -1);
+}
+
+function compareSpan(s1, s2) {
+  return (s1.timestamp || 0) - (s2.timestamp || 0);
+}
+
+function childrenToList(entry) {
+  const deepChildren = _(entry.children || []).sort((e1, e2) => compareSpan(e1.span, e2.span)).flatMap(childrenToList).value();
+  return [entry.span, ...deepChildren];
+}
+
+function createSpanTreeEntry(span, trace, indexByParentId = null) {
+  if (indexByParentId == null) {
+    indexByParentId = _(trace).filter((span) => span.parentId != null).groupBy((span) => span.parentId).value();
+  }
+  return {
+    span,
+    children: (indexByParentId[span.id] || []).map((s) => createSpanTreeEntry(s, trace, indexByParentId))
+  };
+}
+
+function getRootMostSpan(spans) {
+  const firstWithoutParent = _(spans).find((s) => !s.parentId);
+  if (firstWithoutParent) {
+    return firstWithoutParent;
+  } else {
+    const idToSpanMap = _(spans).groupBy((s) => s.id).mapValues(([s]) => s);
+    return recursiveGetRootMostSpan(idToSpanMap, spans[0]);
+  }
+}
+
+function recursiveGetRootMostSpan(idSpan, prevSpan) {
+  if (prevSpan.parentId && idSpan[prevSpan.parentId]) {
+    return recursiveGetRootMostSpan(idSpan, idSpan[prevSpan.parentId]);
+  } else {
+    return prevSpan;
+  }
+}
+
+function treeDepths(entry, startDepth) {
+  const initial = {};
+  initial[entry.span.id] = startDepth;
+  if (entry.children.length == 0) {
+    return initial;
+  }
+  return _(entry.children || []).reduce((prevMap, child) => {
+    const childDepths = treeDepths(child, startDepth + 1);
+    const newCombined = {
+      ...prevMap,
+      ...childDepths
+    };
+    return newCombined;
+  }, initial);
+}
+
+
+function toSpanDepths(spans) {
+  const rootMost = getRootMostSpan(spans);
+  const entry = createSpanTreeEntry(rootMost, spans);
+  return treeDepths(entry, 1);
+}
+
+export default function traceToMustache(trace) {
+  const summary = traceSummary(trace);
+  const duration = mkDurationStr(summary.duration);
+  const groupedTimestamps = getGroupedTimestamps(summary);
+  const serviceDurations = getServiceDurations(groupedTimestamps);
+  const services = serviceDurations.length || 0;
+  const serviceCounts = _(serviceDurations).sortBy('name').value();
+  const groupByParentId = _(trace).groupBy((s) => s.parentId).value();
+
+  const traceTimestamp = trace[0].timestamp || 0;
+  const spanDepths = toSpanDepths(trace);
+
+  const depth = Math.max(..._.values(spanDepths));
+
+
+  function mkEndpoint({ipv4, port}) {
+    return ipv4 + ':' + port;
+  }
+
+  const spans = _(getRootSpans(trace)).flatMap(
+    (rootSpan) => childrenToList(createSpanTreeEntry(rootSpan, trace))).map((span) => {
+    const spanStartTs = span.timestamp || traceTimestamp;
+    const depth = spanDepths[span.id] || 1;
+    const width = (span.duration || 0) / summary.duration * 100;
+
+    const binaryAnnotations = span.binaryAnnotations.map((a) => {
+      if (Constants.CORE_ADDRESS.indexOf(a.key) !== -1) {
+        return {
+          ...a,
+          value: mkEndpoint(a.endpoint)
+        };
+      } else if (ConstantNames[a.key]) {
+        return {
+          ...a,
+          key: ConstantNames[a.key]
+        };
+      } else {
+        return a;
+      }
+    });
+
+    const localComponentAnnotation = _(span.binaryAnnotations).find((s) => s.key === Constants.LOCAL_COMPONENT);
+    if (localComponentAnnotation && localComponentAnnotation.endpoint) {
+      binaryAnnotations.push({
+        ...localComponentAnnotation,
+        key: ConstantNames[Constants.LOCAL_COMPONENT],
+        value: mkEndpoint(localComponentAnnotation.endpoint)
+      });
+    }
+
+    return {
+      spanId: span.id,
+      parentId: span.parentId || null,
+      spanName: span.name,
+      serviceNames: getServiceNames(span).join(','),
+      serviceName: getServiceName(span) || '',
+      duration: span.duration,
+      durationStr: mkDurationStr(span.duration),
+      left: parseFloat(spanStartTs - traceTimestamp) / parseFloat(summary.duration) * 100,
+      width: width < 0.1 ? 0.1 : width,
+      depth: (depth + 1) * 5,
+      depthClass: (depth - 1) % 6,
+      children: (groupByParentId[span.id] || []).map((s) => s.id).join(','),
+      annotations: span.annotations.map((a) => ({
+        isCore: Constants.CORE_ANNOTATIONS.indexOf(a.value) !== -1,
+        left: (a.timestamp - spanStartTs) / span.duration * 100,
+        endpoint: a.endpoint ? mkEndpoint(a.endpoint) : null,
+        value: ConstantNames[a.value] || a.value,
+        timestamp: a.timestamp,
+        relativeTime: mkDurationStr(a.timestamp - traceTimestamp),
+        serviceName: a.endpoint && a.endpoint.serviceName? a.endpoint.serviceName : null,
+        width: 8
+      })),
+      binaryAnnotations
+    };
+  }).value();
+
+  const totalSpans = spans.length;
+  const timeMarkers = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0].map((p, index) => ({index, time: mkDurationStr(summary.duration * p)}));
+  const timeMarkersBackup = timeMarkers;
+  const spansBackup = spans;
+
+  return {
+    duration,
+    services,
+    depth,
+    totalSpans,
+    serviceCounts,
+    timeMarkers,
+    timeMarkersBackup,
+    spans,
+    spansBackup
+  };
+};

--- a/zipkin-web/src/main/resources/app/js/component_ui/traceToMustache.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/traceToMustache.js
@@ -103,6 +103,7 @@ export default function traceToMustache(trace) {
       if (Constants.CORE_ADDRESS.indexOf(a.key) !== -1) {
         return {
           ...a,
+          key: ConstantNames[a.key],
           value: formatEndpoint(a.endpoint)
         };
       } else if (ConstantNames[a.key]) {

--- a/zipkin-web/src/main/resources/app/js/component_ui/traceToMustache.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/traceToMustache.js
@@ -120,7 +120,7 @@ export default function traceToMustache(trace) {
     if (localComponentAnnotation && localComponentAnnotation.endpoint) {
       binaryAnnotations.push({
         ...localComponentAnnotation,
-        key: ConstantNames[Constants.LOCAL_COMPONENT],
+        key: "Local Address",
         value: formatEndpoint(localComponentAnnotation.endpoint)
       });
     }

--- a/zipkin-web/src/main/resources/app/js/component_ui/traceToMustache.js
+++ b/zipkin-web/src/main/resources/app/js/component_ui/traceToMustache.js
@@ -75,6 +75,10 @@ function toSpanDepths(spans) {
   return treeDepths(entry, 1);
 }
 
+export function formatEndpoint({ipv4, port = 0}) {
+  return ipv4 + ':' + port;
+}
+
 export default function traceToMustache(trace) {
   const summary = traceSummary(trace);
   const duration = mkDurationStr(summary.duration);
@@ -89,11 +93,6 @@ export default function traceToMustache(trace) {
 
   const depth = Math.max(..._.values(spanDepths));
 
-
-  function mkEndpoint({ipv4, port}) {
-    return ipv4 + ':' + port;
-  }
-
   const spans = _(getRootSpans(trace)).flatMap(
     (rootSpan) => childrenToList(createSpanTreeEntry(rootSpan, trace))).map((span) => {
     const spanStartTs = span.timestamp || traceTimestamp;
@@ -104,7 +103,7 @@ export default function traceToMustache(trace) {
       if (Constants.CORE_ADDRESS.indexOf(a.key) !== -1) {
         return {
           ...a,
-          value: mkEndpoint(a.endpoint)
+          value: formatEndpoint(a.endpoint)
         };
       } else if (ConstantNames[a.key]) {
         return {
@@ -121,7 +120,7 @@ export default function traceToMustache(trace) {
       binaryAnnotations.push({
         ...localComponentAnnotation,
         key: ConstantNames[Constants.LOCAL_COMPONENT],
-        value: mkEndpoint(localComponentAnnotation.endpoint)
+        value: formatEndpoint(localComponentAnnotation.endpoint)
       });
     }
 
@@ -141,7 +140,7 @@ export default function traceToMustache(trace) {
       annotations: span.annotations.map((a) => ({
         isCore: Constants.CORE_ANNOTATIONS.indexOf(a.value) !== -1,
         left: (a.timestamp - spanStartTs) / span.duration * 100,
-        endpoint: a.endpoint ? mkEndpoint(a.endpoint) : null,
+        endpoint: a.endpoint ? formatEndpoint(a.endpoint) : null,
         value: ConstantNames[a.value] || a.value,
         timestamp: a.timestamp,
         relativeTime: mkDurationStr(a.timestamp - traceTimestamp),

--- a/zipkin-web/src/main/resources/app/js/page/default.js
+++ b/zipkin-web/src/main/resources/app/js/page/default.js
@@ -43,7 +43,6 @@ define(
       this.after('initialize', function() {
         window.document.title = 'Zipkin - Index';
         this.trigger(document, 'navigate', {route: 'index'});
-        DefaultData.attachTo(document);
 
         const query = queryString.parse(window.location.search);
 
@@ -79,6 +78,8 @@ define(
 
           $('.timeago').timeago();
         });
+
+        DefaultData.attachTo(document);
       });
     });
 

--- a/zipkin-web/src/main/resources/app/js/page/trace.js
+++ b/zipkin-web/src/main/resources/app/js/page/trace.js
@@ -31,7 +31,9 @@ define(
       this.after('initialize', function() {
         window.document.title = 'Zipkin - Traces';
 
-        TraceData.attachTo(document);
+        TraceData.attachTo(document, {
+          traceId: this.attr.traceId
+        });
         this.on(document, 'tracePageModelView', function(ev, modelview) {
           this.$node.html(tracetemplate(modelview));
 
@@ -48,8 +50,10 @@ define(
       });
     });
 
-    return function initializeTrace() {
-      TracePageComponent.attachTo('.content');
+    return function initializeTrace(traceId) {
+      TracePageComponent.attachTo('.content', {
+        traceId
+      });
     }
   }
 );

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
@@ -232,4 +232,43 @@ describe('mkDurationStr', () => {
   it('should format seconds', () => {
     mkDurationStr(2534999).should.equal('2.535s');
   });
+
+  it('should get correct spanCount', () => {
+    const spans = [{
+      traceId: 'd397ce70f5192a8b',
+      name: 'get',
+      id: 'd397ce70f5192a8b',
+      timestamp: 1457160374149000,
+      duration: 2000,
+      annotations: [{
+        timestamp: 1457160374149000,
+        value: 'sr',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      },{
+        timestamp: 1457160374151000,
+        value: 'ss',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      }],
+      binaryAnnotations: [{
+        key: 'http.path',
+        value: '/api/v1/services',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1'}
+      },{
+        key: 'srv/finagle.version',
+        value: '6.33.0',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1'}
+      },{
+        key: 'sa',
+        value: true,
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      },{
+        key: 'ca',
+        value: true,
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 56828}
+      }]
+    }];
+    const summary = traceSummary(spans);
+    const model = traceSummariesToMustache(null, [summary])[0];
+    model.spanCount.should.equal(1);
+  })
 });

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
@@ -3,7 +3,6 @@ import {
   traceSummary,
   getServiceName,
   traceSummariesToMustache,
-  Constants,
   mkDurationStr
 } from '../../js/component_ui/traceSummary';
 import {Constants} from '../../js/component_ui/traceConstants';

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
@@ -214,24 +214,6 @@ describe('traceSummariesToMustache', () => {
     const model = traceSummariesToMustache(null, [summary]);
     model[0].timestamp.should.equal(summary.timestamp);
   });
-});
-
-describe('mkDurationStr', () => {
-  it('should return empty string on zero duration', () => {
-    mkDurationStr(0).should.equal('');
-  });
-
-  it('should format microseconds', () => {
-    mkDurationStr(3).should.equal('3μ');
-  });
-
-  it('should format ms', () => {
-    mkDurationStr(1500).should.equal('1.500ms');
-  });
-
-  it('should format seconds', () => {
-    mkDurationStr(2534999).should.equal('2.535s');
-  });
 
   it('should get correct spanCount', () => {
     const spans = [{
@@ -270,5 +252,63 @@ describe('mkDurationStr', () => {
     const summary = traceSummary(spans);
     const model = traceSummariesToMustache(null, [summary])[0];
     model.spanCount.should.equal(1);
+  });
+
+  it('should order traces by duration and tie-break using trace id', () => {
+    const traceId1 = "9ed44141f679130b";
+    const traceId2 = "6ff1c14161f7bde1";
+    const traceId3 = "1234561234561234";
+    const summary1 = traceSummary([{
+      "traceId":traceId1,
+      "name":"get",
+      "id":"6ff1c14161f7bde1",
+      "timestamp":1457186441657000,
+      "duration":4000,
+      "annotations": [], "binaryAnnotations": []}]);
+    const summary2 = traceSummary([{
+      "traceId":traceId2,
+      "name":"get",
+      "id":"9ed44141f679130b",
+      "timestamp":1457186568026000,
+      "duration":4000,
+      "annotations":[],
+      "binaryAnnotations": []
+    }]);
+    const summary3 = traceSummary([{
+      "traceId":traceId3,
+      "name":"get",
+      "id":"6677567324735",
+      "timestamp":1457186568027000,
+      "duration":3000,
+      "annotations":[],
+      "binaryAnnotations": []
+    }]);
+
+    const model = traceSummariesToMustache(null, [summary1, summary2, summary3]);
+    model[0].traceId.should.equal(traceId2);
+    model[1].traceId.should.equal(traceId1);
+    model[2].traceId.should.equal(traceId3);
+  });
+
+  it('should tie-break a sort on duration using trace id', () => {
+
+  });
+});
+
+describe('mkDurationStr', () => {
+  it('should return empty string on zero duration', () => {
+    mkDurationStr(0).should.equal('');
+  });
+
+  it('should format microseconds', () => {
+    mkDurationStr(3).should.equal('3μ');
+  });
+
+  it('should format ms', () => {
+    mkDurationStr(1500).should.equal('1.500ms');
+  });
+
+  it('should format seconds', () => {
+    mkDurationStr(2534999).should.equal('2.535s');
   });
 });

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
@@ -270,5 +270,5 @@ describe('mkDurationStr', () => {
     const summary = traceSummary(spans);
     const model = traceSummariesToMustache(null, [summary])[0];
     model.spanCount.should.equal(1);
-  })
+  });
 });

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
@@ -1,0 +1,235 @@
+import {
+  Span,
+  traceSummary,
+  getServiceName,
+  traceSummariesToMustache,
+  Constants
+} from '../../js/component_ui/traceSummary';
+
+chai.config.truncateThreshold = 0;
+
+function endpoint(ipv4, port, serviceName) {
+  return {ipv4, port, serviceName};
+}
+
+function annotation(timestamp, value, endpoint) {
+  return {timestamp, value, endpoint};
+}
+
+function span(traceId, name, id, parentId = null, timestamp = null, duration = null, annotations = [], binaryAnnotations = [], debug = false) {
+  return {
+    traceId,
+    name,
+    id,
+    parentId,
+    timestamp,
+    duration,
+    annotations,
+    binaryAnnotations,
+    debug
+  };
+}
+
+const ep1 = endpoint(123, 123, 'service1');
+const ep2 = endpoint(456, 456, 'service2');
+const ep3 = endpoint(666, 666, 'service2');
+const ep4 = endpoint(777, 777, 'service3');
+const ep5 = endpoint(888, 888, 'service3');
+
+describe('traceSummary', () => {
+  const annotations1 = [
+    annotation(100, Constants.CLIENT_SEND, ep1),
+    annotation(150, Constants.CLIENT_RECEIVE, ep1)
+  ];
+  const annotations2 = [
+    annotation(200, Constants.CLIENT_SEND, ep2),
+    annotation(250, Constants.CLIENT_RECEIVE, ep2)
+  ];
+  const annotations3 = [
+    annotation(300, Constants.CLIENT_SEND, ep2),
+    annotation(350, Constants.CLIENT_RECEIVE, ep3)
+  ];
+  const annotations4 = [
+    annotation(400, Constants.CLIENT_SEND, ep4),
+    annotation(500, Constants.CLIENT_RECEIVE, ep5)
+  ];
+
+  const span1Id = '666';
+  const span2Id = '777';
+  const span3Id = '888';
+  const span4Id = '999';
+  const span5Id = '1111';
+
+  const span1 = span(12345, 'methodcall1', span1Id, null, 100, 50, annotations1);
+  const span2 = span(12345, 'methodcall2', span2Id, span1Id, 200, 50, annotations2);
+  const span3 = span(12345, 'methodcall2', span3Id, span2Id, 300, 50, annotations3);
+  const span4 = span(12345, 'methodcall2', span4Id, span3Id, 400, 100, annotations4);
+  const span5 = span(12345, 'methodcall4', span5Id, span4Id);
+
+  const trace = [span1, span2, span3, span4];
+
+  it('should return null when no spans exist', () => {
+    expect(traceSummary([])).to.equal(null);
+  });
+
+  it('should return null when no annotations are present', () => {
+    expect(traceSummary([span5])).to.equal(null);
+  });
+
+  it('dedupes duplicate endpoints', () => {
+    const summary = traceSummary(trace);
+    summary.endpoints.should.eql([ep1, ep2, ep3, ep4, ep5]);
+  });
+
+  it('calculates timestamp and duration', () => {
+    const summary = traceSummary(trace);
+    summary.timestamp.should.equal(100);
+    summary.duration.should.equal(400);
+  });
+});
+
+describe('get service name of a span', () => {
+  it('should get service name from server addr', () => {
+    const span = {
+      binaryAnnotations: [{
+        key: Constants.SERVER_ADDR,
+        value: 'something',
+        endpoint: {
+          serviceName: 'user-service'
+        }
+      }]
+    };
+    getServiceName(span).should.equal('user-service');
+  });
+
+  it('should get service name from some server annotation', () => {
+    const span = {
+      binaryAnnotations: [],
+      annotations: [{
+        value: Constants.SERVER_RECEIVE_FRAGMENT,
+        endpoint: {
+          serviceName: 'test-service'
+        }
+      }]
+    };
+    getServiceName(span).should.equal('test-service');
+  });
+
+  it('should get service name from client addr', () => {
+    const span = {
+      binaryAnnotations: [{
+        key: Constants.CLIENT_ADDR,
+        value: 'something',
+        endpoint: {
+          serviceName: 'my-service'
+        }
+      }]
+    };
+    getServiceName(span).should.equal('my-service');
+  });
+
+  it('should get service name from client annotation', () => {
+    const span = {
+      annotations: [{
+        value: Constants.CLIENT_SEND,
+        endpoint: {
+          serviceName: 'abc-service'
+        }
+      }]
+    };
+    getServiceName(span).should.equal('abc-service');
+  });
+
+  it('should get service name from local component annotation', () => {
+    const span = {
+      binaryAnnotations: [{
+        key: Constants.LOCAL_COMPONENT,
+        value: 'something',
+        endpoint: {
+          serviceName: 'localservice'
+        }
+      }]
+    };
+    getServiceName(span).should.equal('localservice');
+  });
+});
+
+describe('traceSummariesToMustache', () => {
+  const start = 1456447911000000;
+  const summary = {
+    traceId: 'cafedead',
+    timestamp: start,
+    duration: 20000,
+    spanTimestamps: [{
+      name: 'A',
+      timestamp: start,
+      duration: 10000
+    }, {
+      name: 'B',
+      timestamp: start + 1000,
+      duration: 20000
+    }, {
+      name: 'B',
+      timestamp: start + 1000,
+      duration: 15000
+    }],
+    endpoints: [ep1, ep2]
+  };
+
+  it('should return empty list for empty list', () => {
+    traceSummariesToMustache(null, []).should.eql([]);
+  });
+
+  it('should convert duration from micros to millis', () => {
+    const model = traceSummariesToMustache(null, [{duration: 3000}]);
+    model[0].duration.should.equal(3);
+  });
+
+  it('should get service durations', () => {
+    const model = traceSummariesToMustache(null, [summary]);
+    model[0].serviceDurations.should.eql([{
+      name: 'A',
+      count: 1,
+      max: 10
+    }, {
+      name: 'B',
+      count: 2,
+      max: 20
+    }]);
+  });
+
+  it('should pass on the trace id', () => {
+    const model = traceSummariesToMustache('A', [summary]);
+    model[0].traceId.should.equal(summary.traceId);
+  });
+
+  it('should get service percentage', () => {
+    const model = traceSummariesToMustache('A', [summary]);
+    model[0].servicePercentage.should.equal(50);
+  });
+
+  it('should get span count', () => {
+    const model = traceSummariesToMustache(null, [summary]);
+    model[0].spanCount.should.equal(3);
+  });
+
+  it('should format start time', () => {
+    const model = traceSummariesToMustache(null, [summary], true);
+    model[0].startTs.should.equal('02-26-2016T00:51:51.000+0000');
+  });
+
+  it('should format duration', () => {
+    const model = traceSummariesToMustache(null, [summary]);
+    model[0].durationStr.should.equal('20.000ms');
+  });
+
+  it('should calculate the width in percent', () => {
+    const model = traceSummariesToMustache(null, [summary]);
+    model[0].width.should.equal(100);
+  });
+
+  it('should pass on timestamp', () => {
+    const model = traceSummariesToMustache(null, [summary]);
+    model[0].timestamp.should.equal(summary.timestamp);
+  });
+});

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceSummary.test.js
@@ -3,32 +3,15 @@ import {
   traceSummary,
   getServiceName,
   traceSummariesToMustache,
-  Constants
+  Constants,
+  mkDurationStr
 } from '../../js/component_ui/traceSummary';
+import {Constants} from '../../js/component_ui/traceConstants';
+import {endpoint, annotation, span} from './traceTestHelpers';
 
 chai.config.truncateThreshold = 0;
 
-function endpoint(ipv4, port, serviceName) {
-  return {ipv4, port, serviceName};
-}
 
-function annotation(timestamp, value, endpoint) {
-  return {timestamp, value, endpoint};
-}
-
-function span(traceId, name, id, parentId = null, timestamp = null, duration = null, annotations = [], binaryAnnotations = [], debug = false) {
-  return {
-    traceId,
-    name,
-    id,
-    parentId,
-    timestamp,
-    duration,
-    annotations,
-    binaryAnnotations,
-    debug
-  };
-}
 
 const ep1 = endpoint(123, 123, 'service1');
 const ep2 = endpoint(456, 456, 'service2');
@@ -231,5 +214,23 @@ describe('traceSummariesToMustache', () => {
   it('should pass on timestamp', () => {
     const model = traceSummariesToMustache(null, [summary]);
     model[0].timestamp.should.equal(summary.timestamp);
+  });
+});
+
+describe('mkDurationStr', () => {
+  it('should return empty string on zero duration', () => {
+    mkDurationStr(0).should.equal('');
+  });
+
+  it('should format microseconds', () => {
+    mkDurationStr(3).should.equal('3μ');
+  });
+
+  it('should format ms', () => {
+    mkDurationStr(1500).should.equal('1.500ms');
+  });
+
+  it('should format seconds', () => {
+    mkDurationStr(2534999).should.equal('2.535s');
   });
 });

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceTestHelpers.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceTestHelpers.js
@@ -1,0 +1,21 @@
+export function endpoint(ipv4, port, serviceName) {
+  return {ipv4, port, serviceName};
+}
+
+export function annotation(timestamp, value, endpoint) {
+  return {timestamp, value, endpoint};
+}
+
+export function span(traceId, name, id, parentId = null, timestamp = null, duration = null, annotations = [], binaryAnnotations = [], debug = false) {
+  return {
+    traceId,
+    name,
+    id,
+    parentId,
+    timestamp,
+    duration,
+    annotations,
+    binaryAnnotations,
+    debug
+  };
+}

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceToMustache.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceToMustache.test.js
@@ -69,33 +69,6 @@ describe('traceToMustache', () => {
       max: 0
     }]);
   });
-});
-
-describe('get root spans', () => {
-  it('should find root spans in a trace', () => {
-    const trace = [{
-      parentId: null, // root span (no parent)
-      id: 1
-    }, {
-      parentId: 1,
-      id: 2
-    }, {
-      parentId: 3, // root span (no parent with this id)
-      id: 4
-    }, {
-      parentId: 4,
-      id: 5
-    }];
-
-    const rootSpans = getRootSpans(trace);
-    rootSpans.should.eql([{
-      parentId: null,
-      id: 1
-    }, {
-      parentId: 3,
-      id: 4
-    }]);
-  });
 
   it('should show human-readable annotation name', () => {
     const trace = [{
@@ -123,6 +96,33 @@ describe('get root spans', () => {
     span.annotations[0].value.should.equal('Server Receive');
     span.annotations[1].value.should.equal('Server Send');
     span.binaryAnnotations[0].key.should.equal('Server Address');
+  });
+});
+
+describe('get root spans', () => {
+  it('should find root spans in a trace', () => {
+    const trace = [{
+      parentId: null, // root span (no parent)
+      id: 1
+    }, {
+      parentId: 1,
+      id: 2
+    }, {
+      parentId: 3, // root span (no parent with this id)
+      id: 4
+    }, {
+      parentId: 4,
+      id: 5
+    }];
+
+    const rootSpans = getRootSpans(trace);
+    rootSpans.should.eql([{
+      parentId: null,
+      id: 1
+    }, {
+      parentId: 3,
+      id: 4
+    }]);
   });
 });
 

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceToMustache.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceToMustache.test.js
@@ -60,11 +60,11 @@ describe('traceToMustache', () => {
       max: 0
     }, {
       name: 'service2',
-      count: 3,
+      count: 2,
       max: 0
     }, {
       name: 'service3',
-      count: 2,
+      count: 1,
       max: 0
     }]);
   });

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceToMustache.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceToMustache.test.js
@@ -1,5 +1,9 @@
 import {Constants} from '../../js/component_ui/traceConstants';
-import traceToMustache, {getRootSpans} from '../../js/component_ui/traceToMustache';
+import traceToMustache,
+  {
+    getRootSpans,
+    formatEndpoint
+  } from '../../js/component_ui/traceToMustache';
 import {endpoint, annotation, span} from './traceTestHelpers';
 
 const ep1 = endpoint(123, 123, 'service1');
@@ -90,5 +94,15 @@ describe('get root spans', () => {
       parentId: 3,
       id: 4
     }]);
+  });
+});
+
+describe('formatEndpoint', () => {
+  it('should format ip and port', () => {
+    formatEndpoint({ipv4: '150.151.152.153', port: 5000}).should.equal('150.151.152.153:5000');
+  });
+
+  it('should use 0 as default port', () => {
+    formatEndpoint({ipv4: '150.151.152.153'}).should.equal('150.151.152.153:0');
   });
 });

--- a/zipkin-web/src/main/resources/app/test/component_ui/traceToMustache.test.js
+++ b/zipkin-web/src/main/resources/app/test/component_ui/traceToMustache.test.js
@@ -4,6 +4,7 @@ import traceToMustache,
     getRootSpans,
     formatEndpoint
   } from '../../js/component_ui/traceToMustache';
+import {traceSummary} from '../../js/component_ui/traceSummary';
 import {endpoint, annotation, span} from './traceTestHelpers';
 
 const ep1 = endpoint(123, 123, 'service1');
@@ -94,6 +95,34 @@ describe('get root spans', () => {
       parentId: 3,
       id: 4
     }]);
+  });
+
+  it('should show human-readable annotation name', () => {
+    const trace = [{
+      traceId:  '2480ccca8df0fca5',
+      name: 'get',
+      id: '2480ccca8df0fca5',
+      timestamp: 1457186385375000,
+      duration: 333000,
+      annotations: [{
+        timestamp: 1457186385375000,
+        value: 'sr',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      },{
+        timestamp: 1457186385708000,
+        value: 'ss',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      }],
+      binaryAnnotations: [{
+        key: 'sa',
+        value: true,
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      }]
+    }];
+    const {spans: [span]} = traceToMustache(trace);
+    span.annotations[0].value.should.equal('Server Receive');
+    span.annotations[1].value.should.equal('Server Send');
+    span.binaryAnnotations[0].key.should.equal('Server Address');
   });
 });
 

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -178,7 +178,7 @@ class Handlers(queryExtractor: QueryExtractor) {
 
       val serviceDurations = groupedSpanTimestamps.map { case (n, sts) =>
         MustacheServiceDuration(n, sts.length, sts.map(_.duration).max / 1000)
-      }.toSeq
+      }.toSeq.sortWith((d1, d2) => d1.name.compareTo(d2.name) < 0)
 
       val serviceTime = for {
         name <- serviceName
@@ -214,9 +214,7 @@ class Handlers(queryExtractor: QueryExtractor) {
       for (traces <- tracesCall) yield {
         val (annotations, binaryAnnotations) = queryExtractor.getAnnotations(req)
         val data = Map(
-          "traces" -> traceSummaryToMustache(serviceName, traces),
-          "annotations" -> annotations,
-          "binaryAnnotations" -> binaryAnnotations
+          "traces" -> traceSummaryToMustache(serviceName, traces)
         )
         JsonRenderer(data)
       }

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -15,8 +15,6 @@ import com.twitter.conversions.time._
 import org.jboss.netty.handler.codec.http.QueryStringEncoder
 import java.io.InputStream
 
-import sun.net.www.http.HttpClient
-
 import scala.annotation.tailrec
 
 class Handlers(queryExtractor: QueryExtractor) {

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -196,7 +196,7 @@ class Handlers(queryExtractor: QueryExtractor) {
         serviceDurations,
         ((duration.toFloat / maxDuration) * 100).toInt
       )
-    }.sortBy((_.duration, _.traceId)).reverse
+    }.sortBy(t => (t.duration, t.traceId)).reverse
   }
 
   def handleIndex(client: HttpClient): Service[Request, Renderer] =

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -196,7 +196,7 @@ class Handlers(queryExtractor: QueryExtractor) {
         serviceDurations,
         ((duration.toFloat / maxDuration) * 100).toInt
       )
-    }.sortBy(_.duration).reverse
+    }.sortBy((_.duration, _.traceId)).reverse
   }
 
   def handleIndex(client: HttpClient): Service[Request, Renderer] =


### PR DESCRIPTION
> The default page used to leverage a /modelview endpoint
> on the Scala server to generate a model to pass into its
> Mustache template. The logic from that /modelview endpoint
> is now ported to JavaScript, so that all the pre-rendering
> business logic happens on the client side.
> 
> Since this is a high-risk change, the /modelview endpoint
> still exists on the server. Every time we request a page,
> the UI will actually fetch a processed version from that
> endpoint as well, and compare the Scala version with
> the JavaScript version. The idea is that we can compare
> outputs of the two, and if there's a difference, we can
> assume that's a bug in the JavaScript port.
> The endpoint, and the UI logic to compare implementations,
> will soon be removed, after testing.

Please don't merge this PR yet - I really need people to test
this change manually!

It would be great if you can checkout this branch, start
zipkin-web and look at a few trace summaries. (Not traces,
but the list of trace summaries/search results on the front
page).
In the browser debugger, there's a console.log thing that
logs whether the JavaScript implementation gives the same
result as the Scala implementation, given the same input.

I would love to hear if anybody experiences a situation where
the two implementations produce different output - and in
that case, what the input was.

If you've tried running zipkin-web with this change, and you
found no bugs, be sure to +1 the PR. Whenever we're sure
that most bugs are cleared out, I'll update with another commit
that removes the automatic scala-vs-javascript-comparison
on every page load.
