### PR TITLE
Fleshes out log message when cassandra spans are missing timestamp

### DIFF
--- a/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
+++ b/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/Repository.java
@@ -253,9 +253,9 @@ public final class Repository implements AutoCloseable {
 
         try {
             if (0 == timestamp && metadata.get("traces.compaction.class").contains("DateTieredCompactionStrategy")) {
-                LOG.warn("span with no first or last timestamp. "
-                        + "if this happens a lot consider switching back to SizeTieredCompactionStrategy for "
-                        + KEYSPACE + ".traces");
+                LOG.warn("Span {} in trace {} had no timestamp. "
+                        + "If this happens a lot consider switching back to SizeTieredCompactionStrategy for "
+                        + "{}.traces", spanName, traceId, KEYSPACE);
             }
 
             BoundStatement bound = insertSpan.bind()


### PR DESCRIPTION
Before, the log message about spans missing a timestamp had no context.
This made it hard to narrow down instrumentation that might be
responsible. In this change, the span's name and trace id are logged.

Ex. `Span 456_473519988_1241441653 in trace 123 had no timestamp...`

Fixes #1010
