### PR TITLE
Update RELEASE.md: don't need to manually sync to Maven Central anymore

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,14 +22,6 @@
 
    ![Release details](travis/flow.png)
 
-1. **Sync to Maven Central**
-
-   Publishing to Maven Central currently happens by manually pushing the "Sync" button on
-   [Bintray](https://bintray.com/openzipkin/maven/zipkin#central) after the release has finished.
-   This is required because automated sync requires a synchronous call to the Bintray API for
-   publishing the just released version, and that consistently times out (PR [#82](https://github.com/bintray/gradle-bintray-plugin/pull/82)
-   in [`zipkin-gradle-plugin`](https://github.com/bintray/gradle-bintray-plugin/) may help with that).
-
 1. **Publish `docker-zipkin`**
 
    Refer to [docker-zipkin/RELEASE.md](https://github.com/openzipkin/docker-zipkin/blob/master/RELEASE.md).


### PR DESCRIPTION
#813 made that go away, it's way past time to make the documentation reflect that.
