### PR TITLE
Span should get children IDs

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -260,6 +260,7 @@ class Handlers(queryExtractor: QueryExtractor) {
     val traceDuration = Trace.duration(trace).getOrElse(0L)
     val spanDepths = TraceSummary.toSpanDepths(trace)
     val spanMap = getIdToSpanMap(trace)
+    val byParentId = trace.filter(_.parentId.isDefined).groupBy(_.parentId.get)
 
     val spans = for {
       rootSpan <- getRootSpans(trace)
@@ -293,7 +294,7 @@ class Handlers(queryExtractor: QueryExtractor) {
         "width" -> (if (width < 0.1) 0.1 else width),
         "depth" -> (depth + 1) * 5,
         "depthClass" -> (depth - 1) % 6,
-        "children" -> spanMap.get(span.id).map(s => SpanId(s.id).toString).mkString(","),
+        "children" -> byParentId.getOrElse(span.id, Nil).map(s => SpanId(s.id).toString).mkString(","),
         "annotations" -> span.annotations.map { a =>
           Map(
             "isCore" -> ZConstants.CoreAnnotations.contains(a.value),


### PR DESCRIPTION
It looks like there was a bug in renderTrace, probably an oversight after a refactoring.
In the web UI, (the data/modelview prepared for trace rendering) every span has a list of
children/child span IDs. This list only contained a single element the ID of the span itself.
I'm sure the intention is to get the actual list of children.

It looks like this may have fixed #999, at least in some cases.
