### PR TITLE
Changes default cassandra load balancing policy to dc-aware round-robin

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactory.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactory.scala
@@ -18,7 +18,7 @@ package com.twitter.zipkin.cassandra
 import java.net.InetSocketAddress
 
 import com.datastax.driver.core.{HostDistance, PoolingOptions, Cluster}
-import com.datastax.driver.core.policies.{RoundRobinPolicy, DCAwareRoundRobinPolicy, LatencyAwarePolicy, TokenAwarePolicy}
+import com.datastax.driver.core.policies.{DCAwareRoundRobinPolicy, LatencyAwarePolicy, TokenAwarePolicy}
 import com.google.common.net.HostAndPort
 import com.twitter.app.App
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
@@ -72,7 +72,7 @@ trait CassandraSpanStoreFactory {self: App =>
       if (cassandraLocalDc.isDefined)
         DCAwareRoundRobinPolicy.builder().withLocalDc(cassandraLocalDc()).build()
       else
-        new RoundRobinPolicy()
+        DCAwareRoundRobinPolicy.builder().build()
     ).build()))
     builder.withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(
       HostDistance.LOCAL, cassandraMaxConnections()


### PR DESCRIPTION
Before, the default cassandra load balancing policy was to consider all
datacenters local. This could lead to high latency when storing or
receiving spans. This changes the default policy to be datacenter aware.

The impact is that the first host's datacenter will be chosen as the
local one, and any hosts that aren't in that datacenter will be ignored.

As before, the local datacenter can be pinned via `CASSANDRA_LOCAL_DC`.
