### PR TITLE
Upgrade shadowjar plugin to 1.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.2'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1"
         classpath 'com.moowork.gradle:gradle-node-plugin:0.11'
     }


### PR DESCRIPTION
Version 1.2.2 fails with Gradle 2.11, as discussed in https://github.com/johnrengelman/shadow/issues/187, upgrading doesn't break anything (AFAICT) and saves some future pain.

Reproduced by running `gradle` instead of `./gradlew`, see exception below.

```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/abesto/playground/zipkin/zipkin-collector-service/build.gradle' line: 1

* What went wrong:
A problem occurred evaluating project ':zipkin-collector-service'.
> Failed to apply plugin [class 'com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin']
   > Could not create task of type 'ShadowJar'.
```
