### PR TITLE
Supports viewing raw traces via GET /api/v1/trace/:id?raw

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/AnormSpanStore.scala
@@ -104,7 +104,13 @@ class AnormSpanStore(val db: DB,
     }
   }
 
-  override def getTracesByIds(traceIds: Seq[Long]): Future[Seq[List[Span]]] = db.inNewThreadWithRecoverableRetry {
+  override def getTracesByIds(traceIds: Seq[Long]) = getSpansByTraceIds(traceIds).map(
+    _.map(CorrectForClockSkew)
+     .map(ApplyTimestampAndDuration)
+     .sortBy(_.head)(Ordering[Span].reverse) // sort descending by the first span
+  )
+
+  override def getSpansByTraceIds(traceIds: Seq[Long]): Future[Seq[Seq[Span]]] = db.inNewThreadWithRecoverableRetry {
     implicit val (conn, borrowTime) = borrowConn()
     try {
       val traceIdsString:String = traceIds.mkString(",")
@@ -174,12 +180,7 @@ class AnormSpanStore(val db: DB,
           Span(span.traceId, span.spanName, span.spanId, span.parentId, span.timestamp, span.duration, spanAnnos, spanBinAnnos, span.debug)
         }
       }
-      // Redundant sort as List.groupBy loses order of values
-      results.groupBy(_.traceId)
-        .values.toList
-        .map(CorrectForClockSkew)
-        .map(ApplyTimestampAndDuration)
-        .sortBy(_.head)(Ordering[Span].reverse) // sort descending by the first span
+      results.groupBy(_.traceId).values.toSeq
     } finally {
       returnConn(conn, borrowTime, "getSpansByTraceIds")
     }

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/CorrectForClockSkew.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/adjuster/CorrectForClockSkew.scala
@@ -25,15 +25,15 @@ import scala.collection.{Map, breakOut}
  * Adjusts Spans timestamps so that each child happens after their parents.
  * This is to counteract clock skew on servers, we want the Trace to happen in order.
  */
-object CorrectForClockSkew extends ((List[Span]) => List[Span]) {
+object CorrectForClockSkew extends ((Seq[Span]) => List[Span]) {
 
-  override def apply(spans: List[Span]): List[Span] = {
+  override def apply(spans: Seq[Span]): List[Span] = {
     spans.find(!_.parentId.isDefined) match {
       case Some(s) => {
         val tree = SpanTreeEntry.create(s, spans)
         adjust(tree, None).toList
       }
-      case None => spans
+      case None => spans.toList
     }
   }
 

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/common/SpanTreeEntry.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/common/SpanTreeEntry.scala
@@ -26,7 +26,7 @@ object SpanTreeEntry {
   /**
    * Get the spans of this trace in a tree form. SpanTreeEntry wraps a Span and its children.
    */
-  def create(span: Span, spans: List[Span]): SpanTreeEntry = { // apply would collide on generics
+  def create(span: Span, spans: Seq[Span]): SpanTreeEntry = { // apply would collide on generics
     create(span, indexByParentId(spans))
   }
 
@@ -40,7 +40,7 @@ object SpanTreeEntry {
   /*
    * Turn the Trace into a map of Span Id -> One or more children Spans
    */
-  private[common] def indexByParentId(spans: List[Span]): mutable.MultiMap[Long, Span] = {
+  private[common] def indexByParentId(spans: Seq[Span]): mutable.MultiMap[Long, Span] = {
     val map = new mutable.HashMap[Long, mutable.Set[Span]] with mutable.MultiMap[Long, Span]
     for ( s <- spans; pId <- s.parentId ) map.addBinding(pId, s)
     map

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
@@ -23,6 +23,11 @@ public class SpanStoreInJava extends SpanStore {
     }
 
     @Override
+    public Future<Seq<Seq<Span>>> getSpansByTraceIds(Seq<Object> traceIds) {
+        return null;
+    }
+
+    @Override
     public Future<Seq<String>> getAllServiceNames() {
         return null;
     }


### PR DESCRIPTION
When troubleshooting instrumentation, we sometimes need to hop to the
database to see what the collector stored (which is closer to what the
instrumentation sent).

In some cases, we are hunting down "clock skew" problems, and sometimes
that's a red herring. Some times we are looking to see if applications
are sending the same span multiple times. The reason we have to go to
the database is we can't quite tell if query-time adjustment logic is
helping or hurting.

This introduces a new query flag "raw" to the get trace endpoint. When
specified, no query time adjustments are made after data is returned
from the backend.
