### PR TITLE
Reverts default Cassandra host policy to RoundRobin

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactory.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactory.scala
@@ -18,7 +18,7 @@ package com.twitter.zipkin.cassandra
 import java.net.InetSocketAddress
 
 import com.datastax.driver.core.{HostDistance, PoolingOptions, Cluster}
-import com.datastax.driver.core.policies.{DCAwareRoundRobinPolicy, LatencyAwarePolicy, TokenAwarePolicy}
+import com.datastax.driver.core.policies.{RoundRobinPolicy, DCAwareRoundRobinPolicy, LatencyAwarePolicy, TokenAwarePolicy}
 import com.google.common.net.HostAndPort
 import com.twitter.app.App
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
@@ -72,7 +72,7 @@ trait CassandraSpanStoreFactory {self: App =>
       if (cassandraLocalDc.isDefined)
         DCAwareRoundRobinPolicy.builder().withLocalDc(cassandraLocalDc()).build()
       else
-        DCAwareRoundRobinPolicy.builder().build()
+        new RoundRobinPolicy() // This can select remote, but LatencyAwarePolicy will prefer local
     ).build()))
     builder.withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(
       HostDistance.LOCAL, cassandraMaxConnections()


### PR DESCRIPTION
When changing loadbalancer policy, we didn't consider a scenario brought
up by @michaelsembwever:

`DCAwareRoundRobinPolicy` will by default prefer the first contact node's
datacenter. If that node happens to be in a remote datacenter, latency
will be high, and the `LatencyAwarePolicy` cannot correct it (since
local nodes will be filtered out).

The previous logic is better because eventhough `RoundRobinPolicy` can
select a remote datacenter, it also selects local ones: the
`LatencyAwarePolicy` will eventually correct to choose only the local
ones.

This reverts commit 813f94d2fc2040c9296fb13075080c5d0c07cf19.

See https://github.com/openzipkin/zipkin-java/pull/92/files#r55933918
