### PR TITLE
[zipkin-ui] Change nomenclature of tasks calling npm

### DIFF
--- a/zipkin-ui/build.gradle
+++ b/zipkin-ui/build.gradle
@@ -31,14 +31,14 @@ node {
     nodeModulesDir = file("${project.projectDir}")
 }
 
-task webpack(type: NpmTask) {
+task npmBuild(type: NpmTask) {
     args = ['run-script', 'build']
     dependsOn npmInstall
 }
-processResources.dependsOn(webpack)
+processResources.dependsOn(npmBuild)
 
-task karma(type: NpmTask) {
+task npmTest(type: NpmTask) {
     args = ['run-script', 'test']
-    dependsOn webpack
+    dependsOn npmBuild
 }
-check.dependsOn karma
+check.dependsOn npmTest


### PR DESCRIPTION
The current naming implies knowledge of the implementation of the npm tasks it's calling. I expect in the far future we'll replace karma with another test runner, and forget to change the name of the task, leading to confusion and inconsistency.

(Even so there's still some coupling between webpack and Gradle in the name of the "dist" dir, but if the npm build output dir changes, this will automatically break. If it doesn't need an update, this will be just fine)
