### PR TITLE
Load configuration from /config.json

### DIFF
--- a/zipkin-ui/js/component_ui/environment.js
+++ b/zipkin-ui/js/component_ui/environment.js
@@ -1,8 +1,7 @@
 import flight from 'flightjs';
-import config from '../config';
 
 export default flight.component(function environmentUI() {
   this.after('initialize', function() {
-    this.$node.text(config('environment'));
+    this.$node.text(this.attr.config('environment'));
   });
 });

--- a/zipkin-ui/js/config.js
+++ b/zipkin-ui/js/config.js
@@ -1,11 +1,15 @@
+import $ from 'jquery';
+
 const defaults = {
+  environment: '',
   queryLimit: 15
 };
 
-export default function(key) {
-  if (!window.config) {
-    return defaults[key];
-  } else {
-    return window.config[key] || defaults[key];
-  }
+export default function loadConfig() {
+  return $.ajax('/config.json', {
+    type: 'GET',
+    dataType: 'json'
+  }).then(data => function config(key) {
+    return data[key] || defaults[key];
+  });
 }

--- a/zipkin-ui/js/main.js
+++ b/zipkin-ui/js/main.js
@@ -4,13 +4,16 @@ import initializeDefault from './page/default';
 import initializeTrace from './page/trace';
 import initializeDependency from './page/dependency';
 import CommonUI from './page/common';
+import loadConfig from './config';
 
-debug.enable(true);
-compose.mixin(registry, [advice.withAdvice]);
+loadConfig().then(config => {
+  debug.enable(true);
+  compose.mixin(registry, [advice.withAdvice]);
 
-CommonUI.attachTo(window.document.body);
+  CommonUI.attachTo(window.document.body, {config});
 
-crossroads.addRoute('', initializeDefault);
-crossroads.addRoute('traces/{id}', initializeTrace);
-crossroads.addRoute('dependency', initializeDependency);
-crossroads.parse(window.location.pathname);
+  crossroads.addRoute('', () => initializeDefault(config));
+  crossroads.addRoute('traces/{id}', traceId => initializeTrace(traceId, config));
+  crossroads.addRoute('dependency', () => initializeDependency(config));
+  crossroads.parse(window.location.pathname);
+});

--- a/zipkin-ui/js/page/common.js
+++ b/zipkin-ui/js/page/common.js
@@ -7,6 +7,6 @@ export default component(function CommonUI() {
   this.after('initialize', function() {
     this.$node.html(layoutTemplate());
     NavbarUI.attachTo('#navbar');
-    EnvironmentUI.attachTo('#environment');
+    EnvironmentUI.attachTo('#environment', {config: this.attr.config});
   });
 });

--- a/zipkin-ui/js/page/default.js
+++ b/zipkin-ui/js/page/default.js
@@ -15,7 +15,6 @@ import TimeStampUI from '../component_ui/timeStamp';
 import BackToTop from '../component_ui/backToTop';
 import GoToTraceUI from '../component_ui/goToTrace';
 import {defaultTemplate} from '../templates';
-import config from '../config';
 
 const DefaultPageComponent = component(function DefaultPage() {
   this.after('initialize', function() {
@@ -25,7 +24,7 @@ const DefaultPageComponent = component(function DefaultPage() {
     const query = queryString.parse(window.location.search);
 
     this.on(document, 'defaultPageModelView', function(ev, modelView) {
-      const limit = query.limit || config('queryLimit');
+      const limit = query.limit || this.attr.config('queryLimit');
       const minDuration = query.minDuration;
       const endTs = query.endTs || new Date().getTime();
       const serviceName = query.serviceName || '';
@@ -61,6 +60,6 @@ const DefaultPageComponent = component(function DefaultPage() {
   });
 });
 
-export default function initializeDefault() {
-  DefaultPageComponent.attachTo('.content');
+export default function initializeDefault(config) {
+  DefaultPageComponent.attachTo('.content', {config});
 }

--- a/zipkin-ui/js/page/dependency.js
+++ b/zipkin-ui/js/page/dependency.js
@@ -30,6 +30,6 @@ const DependencyPageComponent = component(function DependencyPage() {
   });
 });
 
-export default function initializeDependencies() {
-  DependencyPageComponent.attachTo('.content');
+export default function initializeDependencies(config) {
+  DependencyPageComponent.attachTo('.content', {config});
 }

--- a/zipkin-ui/js/page/trace.js
+++ b/zipkin-ui/js/page/trace.js
@@ -35,8 +35,9 @@ const TracePageComponent = component(function TracePage() {
   });
 });
 
-export default function initializeTrace(traceId) {
+export default function initializeTrace(traceId, config) {
   TracePageComponent.attachTo('.content', {
-    traceId
+    traceId,
+    config
   });
 }

--- a/zipkin-ui/static/index.html
+++ b/zipkin-ui/static/index.html
@@ -6,7 +6,6 @@
     <link href="/app.min.css" rel="stylesheet">
 </head>
 <body>
-<script src="/config.js"></script>
 <script src="/app.min.js"></script>
 </body>
 </html>

--- a/zipkin-ui/webpack.config.js
+++ b/zipkin-ui/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
             loader: 'mustache'
         }, {
             test: /.scss$/,
-            loader: ExtractTextPlugin.extract('style-loader', 'css-loader!sass-loader')
+            loader: ExtractTextPlugin.extract('style-loader', 'css-loader?sourceMap!sass-loader?sourceMap')
         }, {
             test: /\.woff2?$|\.ttf$|\.eot$|\.svg|\.png$/,
             loader: 'file'
@@ -30,6 +30,7 @@ module.exports = {
         filename: 'app.min.js',
         publicPath: '/'
     },
+    devtool: 'source-map',
     plugins: [
         new webpack.ProvidePlugin({
             $: "jquery",

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -34,8 +34,9 @@ class Handlers {
 
   case class ConfigRenderer(config: Map[String, _]) extends Renderer {
     def apply(response: Response) {
-      response.contentType = "application/javascript"
-      response.contentString = s"window.config = ${ZipkinJson.writeValueAsString(config)};"
+      response.contentType = "application/json"
+      response.cacheControl = 10.minutes
+      response.contentString = ZipkinJson.writeValueAsString(config)
     }
   }
 

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -85,7 +85,7 @@ trait ZipkinWebFactory { self: App =>
       ("/api/v1/spans", handleRoute(queryClient, "/api/v1/spans")),
       ("/api/v1/trace/:id", handleTrace(queryClient)),
       ("/api/v1/traces", handleRoute(queryClient, "/api/v1/traces")),
-      ("/config.js", handleConfig(Map(
+      ("/config.json", handleConfig(Map(
         "environment" -> environment(),
         "queryLimit" -> queryLimit()
       )))


### PR DESCRIPTION
Renames the /config.js endpoint. Returns json
instead of setting window.config. This is more
flexible, but also somewhat more involved, since
we have to load configuration asynchronously
from the client code.

Also adds source map generation for js and css
(easier debugging)
