### PR TITLE
Put assets in /static/ directory inside the zipkin-ui jar

### DIFF
--- a/zipkin-ui/build.gradle
+++ b/zipkin-ui/build.gradle
@@ -5,7 +5,6 @@ artifacts.zipkinUpload jar
 sourceSets {
     main {
         resources {
-            srcDir 'static'
             srcDir 'dist'
         }
     }

--- a/zipkin-ui/static/static-loader.js
+++ b/zipkin-ui/static/static-loader.js
@@ -1,0 +1,1 @@
+require('file?name=[name].[ext]!./index.html');

--- a/zipkin-ui/webpack.config.js
+++ b/zipkin-ui/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
     entry: [
         __dirname + '/js/main.js',
         __dirname + '/css/style-loader.js',
+        __dirname + '/static/static-loader.js'
     ],
     resolve: {
         modulesDirectories: ['node_modules']
@@ -26,7 +27,7 @@ module.exports = {
         }]
     },
     output: {
-        path: __dirname + '/dist',
+        path: __dirname + '/dist/static',
         filename: 'app.min.js',
         publicPath: '/'
     },


### PR DESCRIPTION
This makes it easier to use from Spring boot.
Somebody else needs to take it from here; I can't figure out how to make zipkin-web work with the new directory layout...

Fixes #1031.
