### PR TITLE
Removes ostrich dependency from zipkin-query-service

### DIFF
--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -20,7 +20,7 @@ shadowJar {
 }
 
 dependencies {
-    compile "com.twitter:finagle-ostrich4_${scalaInterfaceVersion}:${commonVersions.finagle}"
+    compile "com.twitter:util-eval_${scalaInterfaceVersion}:${commonVersions.twitterUtil}"
     compile "com.twitter:finagle-zipkin_${scalaInterfaceVersion}:${commonVersions.finagle}"
     compile "ch.qos.logback:logback-core:${commonVersions.logback}"
     compile "ch.qos.logback:logback-classic:${commonVersions.logback}"

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -33,10 +33,6 @@ import com.twitter.zipkin.json.ZipkinJson
 import org.slf4j.LoggerFactory
 
 trait ZipkinWebFactory { self: App =>
-  private[this] val resourceDirs = Set(
-    "/"
-  )
-
   private[this] val typesMap = Map(
     "css" -> "text/css",
     "png" -> "image/png",


### PR DESCRIPTION
Ostrich was used to parse the '-f' argument in `zipkin-query-service`.
However, it also brought in a '/static/' directory of resources that
will clash with `zipkin-ui` static content. This parses `-f` manually,
and removes the dep.

Fixes #1036
