### PR TITLE
zipkin-web: Serve from /static/ following #1035

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -96,6 +96,13 @@ class Handlers {
     new Service[Request, Renderer] {
       private[this] var rendererCache = Map.empty[String, Future[Renderer]]
 
+      /**
+        * Resolves the resource to return for the path requested by the browser
+        * @param path The path requested by the browser. Always starts with `/`
+        * @return The URL of the file referenced by the path if it has an extension (ie. contains a dot), `static/index.html`
+        *         otherwise (we use the same HTML to serve all the pages, the page generation logic is in JS based on
+        *         `window.location`). Returns `None` if the requested file doesn't exist.
+        */
       private[this] def getResource(path: String): Option[URL] =
         Option(getClass.getResource(path match {
           case _ if path.split("/").last.contains(".") => s"/static$path"

--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Main.scala
@@ -77,8 +77,7 @@ trait ZipkinWebFactory { self: App =>
     import handlers._
 
     Seq(
-      ("/", handlePublic(Set("/"), typesMap)),
-      // In preparation of moving static assets to zipkin-query
+      ("/", handlePublic(typesMap)),
       ("/health", handleRoute(queryClient, "/health")),
       ("/api/v1/dependencies", handleRoute(queryClient, "/api/v1/dependencies")),
       ("/api/v1/services", handleRoute(queryClient, "/api/v1/services")),


### PR DESCRIPTION
This change also revamps the way resources are resolved.

The old logic was "find the static resource, and if you can't, then serve index.html".

The new logic is "if the request is a file (through heuristic 'it has an extension'), serve it. otherwise serve index.html"

This makes the intention cleaner, and gives us 404 where a 404 is needed instead of the contents of index.html
