### PR TITLE
Fix: zipkin-web resource resolver blew up on empty path

### DIFF
--- a/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
+++ b/zipkin-web/src/main/scala/com/twitter/zipkin/web/Handlers.scala
@@ -106,7 +106,7 @@ class Handlers {
         */
       private[this] def getResource(path: String): Option[URL] =
         Option(getClass.getResource(path match {
-          case _ if path.split("/").last.contains(".") => s"/static$path"
+          case _ if path.split("/").lastOption.exists(_.contains(".")) => s"/static$path"
           case default => "/static/index.html"
         }))
 


### PR DESCRIPTION
The problem was introduced in #1039, no idea why it worked initially.

The exception was:

```
next on empty iterator


scala.collection.Iterator$$anon$2.next(Iterator.scala:39)
scala.collection.Iterator$$anon$2.next(Iterator.scala:37)
scala.collection.IndexedSeqLike$Elements.next(IndexedSeqLike.scala:63)
scala.collection.IterableLike$class.head(IterableLike.scala:107)
scala.collection.mutable.ArrayOps$ofRef.scala$collection$IndexedSeqOptimized$$super$head(ArrayOps.scala:186)
scala.collection.IndexedSeqOptimized$class.head(IndexedSeqOptimized.scala:126)
scala.collection.mutable.ArrayOps$ofRef.head(ArrayOps.scala:186)
scala.collection.TraversableLike$class.last(TraversableLike.scala:459)
scala.collection.mutable.ArrayOps$ofRef.scala$collection$IndexedSeqOptimized$$super$last(ArrayOps.scala:186)
scala.collection.IndexedSeqOptimized$class.last(IndexedSeqOptimized.scala:132)
scala.collection.mutable.ArrayOps$ofRef.last(ArrayOps.scala:186)
com.twitter.zipkin.web.Handlers$$anon$1.com$twitter$zipkin$web$Handlers$$anon$$getResource(Handlers.scala:109)
...
```
