### PR TITLE
Allows receiver-kafka to consume JSON encoded spans

### DIFF
--- a/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/builder/CollectorServiceBuilder.scala
+++ b/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/builder/CollectorServiceBuilder.scala
@@ -24,9 +24,9 @@ import com.twitter.zipkin.builder.Builder
 import com.twitter.zipkin.collector.filter.{SamplerFilter, ServiceStatsFilter}
 import com.twitter.zipkin.collector.sampler.AdjustableGlobalSampler
 import com.twitter.zipkin.collector.{SpanReceiver, ZipkinCollector}
+import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.receiver.scribe.ScribeReceiver
 import com.twitter.zipkin.storage.Store
-import com.twitter.zipkin.thriftscala._
 import org.slf4j.LoggerFactory
 import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicReference
@@ -61,10 +61,8 @@ case class CollectorServiceBuilder[T](
 
     val sampler = new SamplerFilter(new AdjustableGlobalSampler(sampleRate))
 
-    import com.twitter.zipkin.conversions.thrift._
-
     val process = (spans: Seq[Span]) =>
-      store.spanStore.apply(ServiceStatsFilter(sampler(spans.map(_.toSpan))))
+      store.spanStore.apply(ServiceStatsFilter(sampler(spans)))
 
     val stats = serverBuilder.statsReceiver
     val impl = new ScribeReceiver(scribeCategories, process, stats)

--- a/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/SpanReceiver.scala
+++ b/zipkin-collector/src/main/scala/com/twitter/zipkin/collector/SpanReceiver.scala
@@ -16,7 +16,7 @@
 package com.twitter.zipkin.collector
 
 import com.twitter.util.{Closable, CloseAwaitably, Future}
-import com.twitter.zipkin.thriftscala.Span
+import com.twitter.zipkin.common.Span
 
 /**
  * SpanReceivers are nothing special. They need only allow us to Await on them

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
@@ -1,6 +1,6 @@
 package com.twitter.zipkin.receiver.kafka
 
-import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
+import com.twitter.zipkin.common.Span
 import com.twitter.util.{Closable, CloseAwaitably, FuturePool, Future, Time}
 import java.util.concurrent.{TimeUnit, Executors}
 import kafka.consumer.{Consumer, ConsumerConfig, ConsumerConnector}
@@ -8,14 +8,14 @@ import kafka.serializer.{Decoder, StringDecoder}
 
 object KafkaProcessor {
 
-  type KafkaDecoder = Decoder[List[ThriftSpan]]
+  type KafkaDecoder = Decoder[List[Span]]
 
   val defaultKeyDecoder = new StringDecoder()
 
   def apply[T](
     topics:Map[String, Int],
     config: ConsumerConfig,
-    process: Seq[ThriftSpan] => Future[Unit],
+    process: Seq[Span] => Future[Unit],
     keyDecoder: Decoder[T],
     valueDecoder: KafkaDecoder
   ): KafkaProcessor[T] = new KafkaProcessor(topics, config, process, keyDecoder, valueDecoder)
@@ -24,7 +24,7 @@ object KafkaProcessor {
 class KafkaProcessor[T](
   topics: Map[String, Int],
   config: ConsumerConfig,
-  process: Seq[ThriftSpan] => Future[Unit],
+  process: Seq[Span] => Future[Unit],
   keyDecoder: Decoder[T],
   valueDecoder: KafkaProcessor.KafkaDecoder
 ) extends Closable with CloseAwaitably {

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
@@ -6,7 +6,7 @@ import com.twitter.app.App
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.util.{Closable, Future, Time}
 import com.twitter.zipkin.collector.SpanReceiver
-import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
+import com.twitter.zipkin.common.Span
 import kafka.consumer.ConsumerConfig
 import kafka.serializer.Decoder
 
@@ -47,9 +47,9 @@ trait KafkaSpanReceiverFactory { self: App =>
   val kafkaAutoOffset = flag("zipkin.kafka.zk.autooffset", defaultKafkaAutoOffset, "kafka zk auto offset [smallest|largest]")
 
   def newKafkaSpanReceiver[T](
-    process: Seq[ThriftSpan] => Future[Unit],
+    process: Seq[Span] => Future[Unit],
     stats: StatsReceiver = DefaultStatsReceiver.scope("KafkaSpanReceiver"),
-    keyDecoder: Decoder[T] = KafkaProcessor.defaultKeyDecoder,
+    keyDecoder: Decoder[String] = KafkaProcessor.defaultKeyDecoder,
     valueDecoder: KafkaProcessor.KafkaDecoder = new SpanDecoder()
   ): SpanReceiver = new SpanReceiver {
 

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/SpanDecoder.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/SpanDecoder.scala
@@ -1,21 +1,32 @@
 package com.twitter.zipkin.receiver.kafka
 
+import com.fasterxml.jackson.core.`type`.TypeReference
 import com.twitter.scrooge.TArrayByteTransport
 import com.twitter.zipkin.conversions.thrift
+import com.twitter.zipkin.json.{JsonSpan, ZipkinJson}
 import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
 import org.apache.thrift.protocol.{TBinaryProtocol, TType}
 
 class SpanDecoder extends KafkaProcessor.KafkaDecoder {
 
-  // Given the thrift encoding is TBinaryProtocol..
+  val jsonSpansReader = ZipkinJson.readerFor(new TypeReference[List[JsonSpan]] {})
+
+  // In TBinaryProtocol encoding, the first byte is the TType, in a range 0-16
+  // .. If the first byte isn't in that range, it isn't a thrift.
+  //
+  // When byte(0) == '[' (91), assume it is a list of json-encoded spans
+  //
+  // When byte(0) <= 16, assume it is a TBinaryProtocol-encoded thrift
   // .. When serializing a Span (Struct), the first byte will be the type of a field
-  // .. When serializing a List[ThriftSpan], the first byte is the member type, TType.STRUCT
-  // Span has no STRUCT fields: we assume that if the first byte is TType.STRUCT is a list.
+  // .. When serializing a List[ThriftSpan], the first byte is the member type, TType.STRUCT(12)
+  // .. As ThriftSpan has no STRUCT fields: so, if the first byte is TType.STRUCT(12), it is a list.
   def fromBytes(bytes: Array[Byte]) =
-    if (bytes(0) == TType.STRUCT) {
-      thrift.thriftListToThriftSpans(bytes)
+    if (bytes(0) == '[') {
+      jsonSpansReader.readValue[List[JsonSpan]](bytes).map(JsonSpan.invert)
+    } else if (bytes(0) == TType.STRUCT) {
+      thrift.thriftListToSpans(bytes)
     } else {
       val proto = new TBinaryProtocol(TArrayByteTransport(bytes))
-      List(ThriftSpan.decode(proto))
+      List(thrift.thriftSpanToSpan(ThriftSpan.decode(proto)).toSpan)
     }
 }

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -3,11 +3,10 @@ package com.twitter.zipkin.receiver.kafka
 import java.util.concurrent.LinkedBlockingQueue
 
 import com.github.charithe.kafka.KafkaJunitRule
-import com.twitter.io.Buf
 import com.twitter.util.{Await, Future, Promise}
 import com.twitter.zipkin.common._
 import com.twitter.zipkin.conversions.thrift._
-import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
+import com.twitter.zipkin.json.{JsonSpan, ZipkinJson}
 import kafka.producer._
 import org.apache.thrift.protocol.{TType, TList, TBinaryProtocol}
 import org.apache.thrift.transport.TMemoryBuffer
@@ -31,9 +30,9 @@ class KafkaProcessorSpec extends JUnitSuite {
   val span = Span(1234, "methodname", 4567, annotations = List(annotation))
   val codec = new SpanDecoder()
 
-  @Test def messageWithSingleSpan() {
-    val topic = "single_span"
-    val recvdSpan = new Promise[Seq[ThriftSpan]]
+  @Test def messageWithSingleSpan_thrift() {
+    val topic = "single_span_thrift"
+    val recvdSpan = new Promise[Seq[Span]]
 
     val service = KafkaProcessor(Map(topic -> 1), kafkaRule.consumerConfig(), { s =>
       recvdSpan.setValue(s)
@@ -41,17 +40,17 @@ class KafkaProcessorSpec extends JUnitSuite {
     }, codec, codec)
 
     val producer = new Producer[Array[Byte], Array[Byte]](kafkaRule.producerConfigWithDefaultEncoder())
-    producer.send(new KeyedMessage(topic, encode(span)))
+    producer.send(new KeyedMessage(topic, encodeThrift(span)))
     producer.close()
 
-    assert(Await.result(recvdSpan) == Seq(span.toThrift))
+    assert(Await.result(recvdSpan) == Seq(span))
 
     Await.result(service.close())
   }
 
-  @Test def messageWithMultipleSpans() {
-    val topic = "multiple_spans"
-    val recvdSpan = new Promise[Seq[ThriftSpan]]
+  @Test def messageWithMultipleSpans_thrift() {
+    val topic = "multiple_spans_thrift"
+    val recvdSpan = new Promise[Seq[Span]]
 
     val service = KafkaProcessor(Map(topic -> 1), kafkaRule.consumerConfig(), { s =>
       recvdSpan.setValue(s)
@@ -59,18 +58,37 @@ class KafkaProcessorSpec extends JUnitSuite {
     }, codec, codec)
 
     val producer = new Producer[Array[Byte], Array[Byte]](kafkaRule.producerConfigWithDefaultEncoder())
-    producer.send(new KeyedMessage(topic, encode(Seq(span, span)))) // 2 spans in one message
+    producer.send(new KeyedMessage(topic, encodeThrift(Seq(span, span)))) // 2 spans in one message
     producer.close()
 
     // make sure we decoded both spans from the same message
-    assert(Await.result(recvdSpan) == Seq(span.toThrift, span.toThrift))
+    assert(Await.result(recvdSpan) == Seq(span, span))
+
+    Await.result(service.close())
+  }
+
+  @Test def messageWithMultipleSpans_json() {
+    val topic = "multiple_spans_json"
+    val recvdSpan = new Promise[Seq[Span]]
+
+    val service = KafkaProcessor(Map(topic -> 1), kafkaRule.consumerConfig(), { s =>
+      recvdSpan.setValue(s)
+      Future.value(true)
+    }, codec, codec)
+
+    val producer = new Producer[Array[Byte], Array[Byte]](kafkaRule.producerConfigWithDefaultEncoder())
+    producer.send(new KeyedMessage(topic, encodeJson(Seq(span, span)))) // 2 spans in one message
+    producer.close()
+
+    // make sure we decoded both spans from the same message
+    assert(Await.result(recvdSpan) == Seq(span, span))
 
     Await.result(service.close())
   }
 
   @Test def skipsMalformedData() {
     val topic = "malformed"
-    val recvdSpans = new LinkedBlockingQueue[Seq[ThriftSpan]](3)
+    val recvdSpans = new LinkedBlockingQueue[Seq[Span]](3)
 
     val service = KafkaProcessor(Map(topic -> 1), kafkaRule.consumerConfig(), { s =>
       recvdSpans.add(s)
@@ -79,18 +97,19 @@ class KafkaProcessorSpec extends JUnitSuite {
 
     val producer = new Producer[Array[Byte], Array[Byte]](kafkaRule.producerConfigWithDefaultEncoder())
 
-    producer.send(new KeyedMessage(topic, encode(span)))
+    producer.send(new KeyedMessage(topic, encodeThrift(span)))
+    producer.send(new KeyedMessage(topic, "[\"='".getBytes())) // screwed up json
     producer.send(new KeyedMessage(topic, "malformed".getBytes()))
-    producer.send(new KeyedMessage(topic, encode(span)))
+    producer.send(new KeyedMessage(topic, encodeThrift(span)))
     producer.close()
 
     for (elem <- 1 until 2)
-      assert(recvdSpans.take() == Seq(span.toThrift))
+      assert(recvdSpans.take() == Seq(span))
 
     Await.result(service.close())
   }
 
-  def encode(span: Span) = {
+  def encodeThrift(span: Span) = {
     val transport = new TMemoryBuffer(0)
     val oproto = new TBinaryProtocol(transport)
     val tspan = spanToThriftSpan(span)
@@ -98,7 +117,7 @@ class KafkaProcessorSpec extends JUnitSuite {
     transport.getArray()
   }
 
-  def encode(spans: Seq[Span]) = {
+  def encodeThrift(spans: Seq[Span]) = {
     // serialize all spans as a thrift list
     val transport = new TMemoryBuffer(0)
     val oproto = new TBinaryProtocol(transport)
@@ -106,5 +125,10 @@ class KafkaProcessorSpec extends JUnitSuite {
     spans.map(spanToThriftSpan).foreach(_.toThrift.write(oproto))
     oproto.writeListEnd()
     transport.getArray()
+  }
+
+  def encodeJson(spans: Seq[Span]) = {
+    // serialize all spans as a json list
+    ZipkinJson.writer().writeValueAsBytes(spans.map(JsonSpan))
   }
 }

--- a/zipkin-receiver-scribe/src/main/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiver.scala
+++ b/zipkin-receiver-scribe/src/main/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiver.scala
@@ -22,6 +22,8 @@ import com.twitter.logging.Logger
 import com.twitter.scrooge.BinaryThriftStructSerializer
 import com.twitter.util.{Base64StringEncoder, Future, NonFatal, Return, Throw, Time}
 import com.twitter.zipkin.collector.{QueueFullException, SpanReceiver}
+import com.twitter.zipkin.common.Span
+import com.twitter.zipkin.conversions.thrift
 import com.twitter.zipkin.thriftscala.{LogEntry, ResultCode, Scribe, Span => ThriftSpan}
 import java.net.InetSocketAddress
 import java.util.concurrent.CancellationException
@@ -83,8 +85,8 @@ class ScribeReceiver(
     (cat, messagesStats.scope("perCategory").counter(cat))
   }.toMap
 
-  private[this] def entryToSpan(entry: LogEntry): Option[ThriftSpan] = try {
-    Some(deserializer.fromString(entry.message))
+  private[this] def entryToSpan(entry: LogEntry): Option[Span] = try {
+    Some(thrift.thriftSpanToSpan(deserializer.fromString(entry.message)).toSpan)
   } catch {
     case e: Exception => {
       // scribe doesn't have any ResultCode.ERROR or similar

--- a/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
+++ b/zipkin-receiver-scribe/src/test/scala/com/twitter/zipkin/receiver/scribe/ScribeSpanReceiverTest.scala
@@ -40,14 +40,14 @@ class ScribeSpanReceiverTest extends FunSuite {
   val base64 = "CgABAAAAAAAAAHsLAAMAAAADYm9vCgAEAAAAAAAAAcgPAAYMAAAAAQoAAQAAAAAAAAABCwACAAAAA2JhaAAPAAgMAAAAAAIACQAA"
 
   test("processes entries") {
-    var recvdSpan: Option[Seq[ThriftSpan]] = None
+    var recvdSpan: Option[Seq[Span]] = None
     val receiver = new ScribeReceiver(Set(category), { s =>
       recvdSpan = Some(s)
       Future.Done
     })
     assert(Await.result(receiver.log(Seq(validList.head, validList.head))) === ResultCode.Ok)
     assert(!recvdSpan.isEmpty)
-    assert(recvdSpan.get.map(_.toSpan) === Seq(validSpan, validSpan))
+    assert(recvdSpan.get === Seq(validSpan, validSpan))
   }
 
   test("ok when scribe client cancels their request") {
@@ -96,7 +96,7 @@ class ScribeSpanReceiverTest extends FunSuite {
   }
 
   test("ignores bad categories") {
-    var recvdSpan: Option[ThriftSpan] = None
+    var recvdSpan: Option[Span] = None
     val receiver = new ScribeReceiver(Set("othercat"), { s =>
       recvdSpan = Some(s.head)
       Future.Done
@@ -106,7 +106,7 @@ class ScribeSpanReceiverTest extends FunSuite {
   }
 
   test("ignores bad messages") {
-    var recvdSpan: Option[ThriftSpan] = None
+    var recvdSpan: Option[Span] = None
     val receiver = new ScribeReceiver(Set(category), { s =>
       recvdSpan = Some(s.head)
       Future.Done

--- a/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
+++ b/zipkin-scrooge/src/main/scala/com/twitter/zipkin/conversions/thrift.scala
@@ -132,22 +132,19 @@ object thrift {
   implicit def spanToThriftSpan(s: Span) = new ThriftSpan(s)
   implicit def thriftSpanToSpan(s: thriftscala.Span) = new WrappedSpan(s)
 
-  def thriftListToThriftSpans(bytes: Array[Byte]) = {
+  def thriftListToSpans(bytes: Array[Byte])  = {
     val proto = new TBinaryProtocol(TArrayByteTransport(bytes))
     val _list = proto.readListBegin()
     if (_list.size > 10000) {
       throw new IllegalArgumentException(_list.size + " > 10000: possibly malformed thrift")
     }
-    val result = new ArrayBuffer[thriftscala.Span](_list.size)
+    val result = new ArrayBuffer[Span](_list.size)
     for (i <- 1 to _list.size) {
-      result += thriftscala.Span.decode(proto)
+      result += thriftSpanToSpan(thriftscala.Span.decode(proto)).toSpan
     }
     proto.readListEnd()
     result.toList
   }
-
-  def thriftListToSpans(bytes: Array[Byte]) =
-    thriftListToThriftSpans(bytes).map(thriftSpanToSpan(_).toSpan)
 
   class WrappedDependencyLink(dl: DependencyLink) {
     lazy val toThrift = thriftscala.DependencyLink(dl.parent, dl.child, dl.callCount)


### PR DESCRIPTION
By allowing JSON encoded span lists as Kafka message values, we enable
users to send the same payload as they can over the http transport. It
also allows a very easy debug story, such as sending test spans via CLI.

This implementation peeks at the first byte in the Kafka message, and
attempts to decode json, if it is a '[', or decimal 91. When using
TBinaryProtocol (thrift) encoding, we know that the first byte will be
the Type, which is decimal <=16, so there's no risk of clash.

Fixes #1037
