### PR TITLE
Adds CASSANDRA_KEYSPACE, _SPAN_TTL and _INDEX_TTL variables

### DIFF
--- a/zipkin-cassandra/README.md
+++ b/zipkin-cassandra/README.md
@@ -8,11 +8,14 @@
 
 Here are the Cassandra-specific environment variables:
 
+   * `CASSANDRA_KEYSPACE`: The keyspace to use. Defaults to "zipkin".
    * `CASSANDRA_ENSURE_SCHEMA`: Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema-cql3.txt. Defaults to true
    * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails. No default
    * `CASSANDRA_CONTACT_POINTS`: Comma separated list of hosts / ip addresses part of Cassandra cluster. Defaults to localhost
    * `CASSANDRA_LOCAL_DC`: Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
    * `CASSANDRA_MAX_CONNECTIONS`: Max pooled connections per datacenter-local host. Defaults to 8
+   * `CASSANDRA_SPAN_TTL`: Time-to-live in seconds for span data. Defaults to 604800 (7 days)
+   * `CASSANDRA_INDEX_TTL`: Time-to-live in seconds for index data. Defaults to 259200 (3 days)
 
 Example usage:
 

--- a/zipkin-collector-service/config/collector-cassandra.scala
+++ b/zipkin-collector-service/config/collector-cassandra.scala
@@ -16,6 +16,7 @@
 
 import com.google.common.util.concurrent.Atomics
 import com.twitter.app.App
+import com.twitter.conversions.time._
 import com.twitter.zipkin.builder.Builder
 import com.twitter.zipkin.cassandra.CassandraSpanStoreFactory
 import com.twitter.zipkin.collector.builder.{CollectorServiceBuilder, ZipkinServerBuilder}
@@ -29,8 +30,11 @@ val sampleRate = sys.env.get("COLLECTOR_SAMPLE_RATE").getOrElse("1.0").toFloat
 
 object Factory extends App with CassandraSpanStoreFactory
 
+Factory.keyspace.parse(sys.env.get("CASSANDRA_KEYSPACE").getOrElse("zipkin"))
 Factory.ensureSchema.parse(sys.env.get("CASSANDRA_ENSURE_SCHEMA").getOrElse("true"))
 Factory.cassandraDest.parse(sys.env.get("CASSANDRA_CONTACT_POINTS").getOrElse("localhost"))
+Factory.cassandraSpanTtl.parse(sys.env.get("CASSANDRA_SPAN_TTL").map(_.+(".seconds")).getOrElse(7.days.toString))
+Factory.cassandraIndexTtl.parse(sys.env.get("CASSANDRA_INDEX_TTL").map(_.+(".seconds")).getOrElse(3.days.toString))
 
 val username = sys.env.get("CASSANDRA_USERNAME")
 val password = sys.env.get("CASSANDRA_PASSWORD")

--- a/zipkin-query-service/config/query-cassandra.scala
+++ b/zipkin-query-service/config/query-cassandra.scala
@@ -15,6 +15,7 @@
  */
 
 import com.twitter.app.App
+import com.twitter.conversions.time._
 import com.twitter.zipkin.builder.QueryServiceBuilder
 import com.twitter.zipkin.cassandra.CassandraSpanStoreFactory
 
@@ -24,8 +25,11 @@ val logLevel = sys.env.get("QUERY_LOG_LEVEL").getOrElse("INFO")
 
 object Factory extends App with CassandraSpanStoreFactory
 
+Factory.keyspace.parse(sys.env.get("CASSANDRA_KEYSPACE").getOrElse("zipkin"))
 Factory.ensureSchema.parse(sys.env.get("CASSANDRA_ENSURE_SCHEMA").getOrElse("true"))
 Factory.cassandraDest.parse(sys.env.get("CASSANDRA_CONTACT_POINTS").getOrElse("localhost"))
+Factory.cassandraSpanTtl.parse(sys.env.get("CASSANDRA_SPAN_TTL").map(_.+(".seconds")).getOrElse(7.days.toString))
+Factory.cassandraIndexTtl.parse(sys.env.get("CASSANDRA_INDEX_TTL").map(_.+(".seconds")).getOrElse(3.days.toString))
 
 val username = sys.env.get("CASSANDRA_USERNAME")
 val password = sys.env.get("CASSANDRA_PASSWORD")


### PR DESCRIPTION
This adds some missing variables that are widely useful for Cassandra:
- `CASSANDRA_KEYSPACE`: The keyspace to use. Defaults to "zipkin".
- `CASSANDRA_SPAN_TTL`: Time-to-live in seconds for span data. Defaults to 604800 (7 days)
- `CASSANDRA_INDEX_TTL`: Time-to-live in seconds for index data. Defaults to 259200 (3 days)

These are supported for both the collector and the query processes.

Fixes #1053
