### PR TITLE
Filters undefined duration when calculating totalServiceTime

### DIFF
--- a/zipkin-ui/js/component_ui/traceSummary.js
+++ b/zipkin-ui/js/component_ui/traceSummary.js
@@ -147,12 +147,15 @@ export function traceSummary(spans = []) {
   }
 }
 
-function totalServiceTime(stamps, acc = 0) {
-  if (stamps.length === 0) {
+export function totalServiceTime(stamps, acc = 0) {
+  // This is a recursive function that performs arithmetic on duration
+  // If duration is undefined, it will infinitely recurse. Filter out that case
+  const filtered = stamps.filter((s) => s.duration);
+  if (filtered.length === 0) {
     return acc;
   } else {
-    const ts = _(stamps).minBy((s) => s.timestamp);
-    const [current, next] = _(stamps)
+    const ts = _(filtered).minBy((s) => s.timestamp);
+    const [current, next] = _(filtered)
         .partition((t) =>
           t.timestamp >= ts.timestamp
           && t.timestamp + t.duration <= ts.timestamp + ts.duration)

--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -2,7 +2,8 @@ import {
   traceSummary,
   getServiceName,
   traceSummariesToMustache,
-  mkDurationStr
+  mkDurationStr,
+  totalServiceTime
 } from '../../js/component_ui/traceSummary';
 import {Constants} from '../../js/component_ui/traceConstants';
 import {endpoint, annotation, span} from './traceTestHelpers';
@@ -308,5 +309,29 @@ describe('mkDurationStr', () => {
 
   it('should format seconds', () => {
     mkDurationStr(2534999).should.equal('2.535s');
+  });
+});
+
+describe('totalServiceTime', () => {
+  const time1 = {name: 'service', timestamp: 1456447911000000, duration: 1000};
+  const time2 = {name: 'service', timestamp: 1456447912000000, duration: 2000};
+  const time3 = {name: 'service', timestamp: 1456447913000000, duration: 3000};
+
+  it('should return zero on empty input', () => {
+    totalServiceTime([]).should.equal(0);
+  });
+
+  it('should return duration on single input', () => {
+    totalServiceTime([time1]).should.equal(time1.duration);
+  });
+
+  it('should sum on multiple inputs', () => {
+    totalServiceTime([time1, time2, time3]).should.equal(6000);
+  });
+
+  it('shouldnt infinitely recurse when duration is undefined', () => {
+    // when json form of span is missing the duration key
+    const undefinedDuration = {name: 'zipkin-web', timestamp: time1.timestamp, duration: undefined};
+    totalServiceTime([time1, time2, time3, undefinedDuration]).should.equal(6000);
   });
 });


### PR DESCRIPTION
The zipkin api is supposed to return Span.timestamp and Span.duration.
There's a test `getSpansByTraceIds_doesntPerformQueryTimeAdjustment`,
which was added recently, which should insure that this is set.

Until all span store tests update to running this test, notably
zipkin-java, we'll need to guard as opposed to recursing indefinitely.

Fixes #1056
