### PR TITLE
[zipkin-ui] Add hash to filename of app[.min].{js,css}[.map]

### DIFF
--- a/zipkin-ui/webpack.config.js
+++ b/zipkin-ui/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
     },
     output: {
         path: __dirname + '/build/resources/main/zipkin-ui/',
-        filename: 'app.min.js',
+        filename: 'app-[hash].min.js',
         publicPath: '/'
     },
     devtool: 'source-map',
@@ -37,7 +37,7 @@ module.exports = {
             $: "jquery",
             jQuery: "jquery"
         }),
-        new ExtractTextPlugin("app.min.css", {allChunks: true}),
+        new ExtractTextPlugin("app-[hash].min.css", {allChunks: true}),
         new HtmlWebpackPlugin()
     ],
     devServer: {


### PR DESCRIPTION
The inside of the .jar list looks like this after the change:

```
META-INF/
META-INF/MANIFEST.MF
zipkin-ui/
zipkin-ui/448c34a56d699c29117adc64c43affeb.woff2
zipkin-ui/614fad616d014daf5367e068505cad35.png
zipkin-ui/89889688147bd7575d6327160d64e760.svg
zipkin-ui/8b55a822e72b8fd5e2ee069236f2d797.png
zipkin-ui/app-8f28873f153b2b06e7ab.min.css
zipkin-ui/app-8f28873f153b2b06e7ab.min.css.map
zipkin-ui/app-8f28873f153b2b06e7ab.min.js
zipkin-ui/app-8f28873f153b2b06e7ab.min.js.map
zipkin-ui/e18bbf611f2a2e43afc071aa2f4e1512.ttf
zipkin-ui/f4769f9bdb7466be65088239c12046d1.eot
zipkin-ui/fa2772327f55d8198301fdb8bcfc8158.woff
zipkin-ui/index.html
```
