### PR TITLE
Adds start time element to the trace search screen, matching /dependency

### DIFF
--- a/zipkin-ui/js/component_data/default.js
+++ b/zipkin-ui/js/component_data/default.js
@@ -3,11 +3,24 @@ import $ from 'jquery';
 import queryString from 'query-string';
 import {traceSummary, traceSummariesToMustache} from '../component_ui/traceSummary';
 
+export function convertToApiQuery(windowLocationSearch) {
+  const query = queryString.parse(windowLocationSearch);
+  // zipkin's api looks back from endTs
+  if (query.startTs) {
+    if (query.endTs > query.startTs) {
+      query.lookback = String(query.endTs - query.startTs);
+    }
+    delete query.startTs;
+  }
+  return query;
+}
+
 export default component(function DefaultData() {
   this.after('initialize', function() {
-    const serviceName = queryString.parse(window.location.search).serviceName;
+    const query = convertToApiQuery(window.location.search);
+    const serviceName = query.serviceName;
     if (serviceName) {
-      $.ajax(`/api/v1/traces${window.location.search}`, {
+      $.ajax(`/api/v1/traces?${queryString.stringify(query)}`, {
         type: 'GET',
         dataType: 'json',
         success: traces => {

--- a/zipkin-ui/js/config.js
+++ b/zipkin-ui/js/config.js
@@ -2,7 +2,8 @@ import $ from 'jquery';
 
 const defaults = {
   environment: '',
-  queryLimit: 15
+  queryLimit: 15,
+  defaultLookback: 24 * 60 * 60 * 1000 // 24 hours
 };
 
 export default function loadConfig() {

--- a/zipkin-ui/js/page/default.js
+++ b/zipkin-ui/js/page/default.js
@@ -27,12 +27,14 @@ const DefaultPageComponent = component(function DefaultPage() {
       const limit = query.limit || this.attr.config('queryLimit');
       const minDuration = query.minDuration;
       const endTs = query.endTs || new Date().getTime();
+      const startTs = query.startTs || (endTs - this.attr.config('defaultLookback'));
       const serviceName = query.serviceName || '';
       const annotationQuery = query.annotationQuery || '';
       const queryWasPerformed = serviceName && serviceName.length > 0;
       this.$node.html(defaultTemplate({
         limit,
         minDuration,
+        startTs,
         endTs,
         serviceName,
         annotationQuery,
@@ -49,7 +51,8 @@ const DefaultPageComponent = component(function DefaultPage() {
       InfoButtonUI.attachTo('button.info-request');
       TraceFiltersUI.attachTo('#trace-filters');
       TracesUI.attachTo('#traces');
-      TimeStampUI.attachTo('#time-stamp');
+      TimeStampUI.attachTo('#end-ts');
+      TimeStampUI.attachTo('#start-ts');
       BackToTop.attachTo('#backToTop');
       GoToTraceUI.attachTo('#traceIdQueryForm');
 

--- a/zipkin-ui/js/page/dependency.js
+++ b/zipkin-ui/js/page/dependency.js
@@ -18,8 +18,7 @@ const DependencyPageComponent = component(function DependencyPage() {
 
     const {startTs, endTs} = queryString.parse(location.search);
     $('#endTs').val(endTs || moment().valueOf());
-    const defaultStartTs = 24 * 60 * 60 * 1000; // set default startTs 1 day ago;
-    $('#startTs').val(startTs || moment().valueOf() - defaultStartTs);
+    $('#startTs').val(startTs || moment().valueOf() - this.attr.config('defaultLookback'));
 
     DependencyData.attachTo('#dependency-container');
     DependencyGraphUI.attachTo('#dependency-container');

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -10,7 +10,14 @@
       </select>
     </div>
 
-    <div id="time-stamp" class="form-group">
+    <div id="start-ts" class="form-group">
+      <label for="timeStamp">Start time</label>
+      <input class="form-control input-sm date-input" type="text">
+      <input class="form-control input-sm time-input" type="text">
+      <input class="timestamp-value" id="startTs" name="startTs" type="hidden" value="{{startTs}}">
+    </div>
+
+    <div id="end-ts" class="form-group">
       <label for="timeStamp">End time</label>
       <input class="form-control input-sm date-input" type="text">
       <input class="form-control input-sm time-input" type="text">

--- a/zipkin-ui/test/component_data/default.test.js
+++ b/zipkin-ui/test/component_data/default.test.js
@@ -1,0 +1,28 @@
+import {convertToApiQuery} from '../../js/component_data/default';
+
+describe('convertToApiQuery', () => {
+  const should = require('chai').should();
+
+  it('should not require startTs', () => {
+    const parsed = convertToApiQuery('?endTs=1459169770000');
+
+    parsed.endTs.should.equal('1459169770000');
+    should.not.exist(parsed.lookback);
+    should.not.exist(parsed.startTs);
+  });
+
+  it('should replace startTs with lookback', () => {
+    const parsed = convertToApiQuery('?startTs=1459169760000&endTs=1459169770000');
+
+    parsed.endTs.should.equal('1459169770000');
+    parsed.lookback.should.equal('10000');
+    should.not.exist(parsed.startTs);
+  });
+
+  it('should not add negative lookback', () => {
+    const parsed = convertToApiQuery('?endTs=1459169760000&startTs=1459169770000');
+
+    should.not.exist(parsed.lookback);
+    should.not.exist(parsed.startTs);
+  });
+});


### PR DESCRIPTION
This adds the same start time element from /dependency to the main trace
search screen.

This also switches both /dependency and the trace search screen to read
the config property `defaultLookback`.

Fixes #1065 #1063

<img width="914" alt="screen shot 2016-03-28 at 10 17 43 pm" src="https://cloud.githubusercontent.com/assets/64215/14079935/3574bf94-f534-11e5-82ae-1ea1d329c36c.png">
