### PR TITLE
Fix #1074: Don't distribute non-shadow jar for *-service

### DIFF
--- a/zipkin-collector-service/build.gradle
+++ b/zipkin-collector-service/build.gradle
@@ -14,6 +14,7 @@ jar.manifest.attributes 'Main-Class': mainClassName
 
 tasks.build.dependsOn(shadowJar)
 artifacts.zipkinUpload shadowJar
+configurations.zipkinUpload.artifacts.removeAll { it.archiveTask.is jar }
 
 shadowJar {
     exclude 'META-INF/LICENSE' // jackson's META-INF/LICENSE conflicts with the directory META-INF/license

--- a/zipkin-query-service/build.gradle
+++ b/zipkin-query-service/build.gradle
@@ -14,6 +14,7 @@ jar.manifest.attributes 'Main-Class': mainClassName
 
 tasks.build.dependsOn(shadowJar)
 artifacts.zipkinUpload shadowJar
+configurations.zipkinUpload.artifacts.removeAll { it.archiveTask.is jar }
 
 shadowJar {
     exclude 'META-INF/LICENSE' // jackson's META-INF/LICENSE conflicts with the directory META-INF/license

--- a/zipkin-web/build.gradle
+++ b/zipkin-web/build.gradle
@@ -12,6 +12,7 @@ jar.manifest.attributes 'Main-Class': mainClassName
 
 tasks.build.dependsOn(shadowJar)
 artifacts.zipkinUpload shadowJar
+configurations.zipkinUpload.artifacts.removeAll { it.archiveTask.is jar }
 
 shadowJar {
   exclude 'META-INF/LICENSE' // jackson's META-INF/LICENSE conflicts with the directory META-INF/license


### PR DESCRIPTION
Not totally sure this will work, but the only (easy) way to check is to ask Travis to run it.
