### PR TITLE
Coerses null-value binary annotation to empty

### DIFF
--- a/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
+++ b/zipkin-anormdb/src/main/scala/com/twitter/zipkin/storage/anormdb/DB.scala
@@ -225,7 +225,7 @@ case class DB(dbconfig: DBConfig = new DBConfig()) {
    * Implicitly convert an Anorm row to a byte array.
    */
   def rowToByteArray: Column[Array[Byte]] = {
-    Column.nonNull[Array[Byte]] { (value, meta) =>
+    Column.nonNull1[Array[Byte]] { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       valueToByteArrayOption(value) match {
         case Some(bytes) => Right(bytes)

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonBinaryAnnotation.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/json/JsonBinaryAnnotation.scala
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.common.base.CaseFormat.{UPPER_CAMEL, UPPER_UNDERSCORE}
 import com.google.common.io.BaseEncoding
 import com.twitter.io.Charsets.Utf8
-import com.twitter.zipkin.common._
 import com.twitter.zipkin.common.AnnotationType._
+import com.twitter.zipkin.common._
 
 case class JsonBinaryAnnotation(key: String,
                                 value: Any,
@@ -28,7 +28,7 @@ object JsonBinaryAnnotation extends (BinaryAnnotation => JsonBinaryAnnotation) {
         case I32.value => (Some("I32"), b.value.getInt(0))
         case I64.value => (Some("I64"), b.value.getLong(0))
         case Double.value => (Some("DOUBLE"), b.value.getDouble(0))
-        case String.value => (None, new String(b.value.array(), b.value.position(), b.value.remaining(), Utf8))
+        case String.value => (None, if (b.value == null) "" else new String(b.value.array(), b.value.position(), b.value.remaining(), Utf8))
         case _ => throw new Exception("Unsupported annotation type: %s".format(b))
       }
     } catch {

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/json/JsonConversionTest.scala
@@ -100,6 +100,13 @@ class JsonConversionTest extends FunSuite with Matchers {
     JsonBinaryAnnotation(JsonBinaryAnnotation.invert(convert)) should be(convert)
   }
 
+  test("string with null value coerses to empty") {
+    val ann = BinaryAnnotation("key", null, AnnotationType.String, None)
+    val convert = JsonBinaryAnnotation(ann)
+    assert(convert.value === "")
+    JsonBinaryAnnotation(JsonBinaryAnnotation.invert(convert)) should be(convert)
+  }
+
   test("boolean's annotation type is implicit") {
     val unqualified = JsonBinaryAnnotation("key", true, None, None)
     val qualified = JsonBinaryAnnotation("key", true, Some("BOOL"), None)

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -266,6 +266,21 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     )
   }
 
+  /** Make sure empty binary annotation values don't crash */
+  @Test def getTraces_binaryAnnotationWithEmptyValue() {
+    val span = Span(1, "call1", 1, None, Some((today + 1) * 1000), None, binaryAnnotations =
+      List(BinaryAnnotation("empty", "", Some(ep))))
+
+    result(store(Seq(span)))
+
+    result(store.getTraces(QueryRequest("service"))) should be(
+      Seq(List(span))
+    )
+    result(store.getTracesByIds(List(1L))) should be(
+      Seq(List(span))
+    )
+  }
+
   /**
    * It is expected that [[com.twitter.zipkin.storage.SpanStore.apply]] will
    * receive the same span id multiple times with different annotations. At


### PR DESCRIPTION
Rather than blowing up, this coerses a binary annotation with null to
empty string. While this is invalid, but we shouldn't blow up.

Fixes #1073
