### PR TITLE
Fixes crash when storage isn't available at bootstrap

### DIFF
--- a/zipkin-query-service/src/main/scala/com/twitter/zipkin/builder/QueryServiceBuilder.scala
+++ b/zipkin-query-service/src/main/scala/com/twitter/zipkin/builder/QueryServiceBuilder.scala
@@ -44,6 +44,11 @@ case class QueryServiceBuilder(override val defaultFinatraHttpPort: String = "0.
 
   override def postWarmup() {
     super.postWarmup()
-    BootstrapTrace.complete()
+    try {
+      BootstrapTrace.complete()
+    } catch {
+      case e => log.warning("Unable to trace bootstrap due to %s(%s)"
+        .format(e.getClass.getSimpleName, if (e.getMessage == null) "" else e.getMessage))
+    }
   }
 }


### PR DESCRIPTION
Self-tracing during Finatra bootstrap when cassandra was down caused the
process to crash. This makes it a log warning instead.

``` bash
16:29:18.435 [main] WARN  c.t.z.builder.QueryServiceBuilder - Unable to trace bootstrap due to NoHostAvailableException(All host(s) tried for query failed (tried: localhost/127.0.0.1:9042 (com.datastax.driver.core.TransportException: [localhost/127.0.0.1:9042] Cannot connect)))
```

Note: api calls will fail w/ HTTP 500 until storage is available.

Fixes #1007
Fixes https://github.com/openzipkin/docker-zipkin/issues/74
