### PR TITLE
Squashes remaining missing parent bugs in the trace detail screen

### DIFF
--- a/zipkin-ui/test/component_ui/trace.test.js
+++ b/zipkin-ui/test/component_ui/trace.test.js
@@ -1,67 +1,183 @@
-import {showSpans} from '../../js/component_ui/trace';
-import {traceDetailSpan, spanToShow} from './traceTestHelpers';
+import {showSpans, hideSpans} from '../../js/component_ui/trace';
+import {traceDetailSpan} from './traceTestHelpers';
 
 describe('showSpans', () => {
   it('expands and highlights span to show', () => {
-    const spans = {'0000000000000001': traceDetailSpan()};
+    const span = traceDetailSpan('0000000000000001');
+    const spans = {'0000000000000001': span};
     const parents = {'0000000000000001': []};
     const children = {'0000000000000001': []};
-    const spansToShow = {0: spanToShow('0000000000000001')};
+    const selected = {0: span};
 
-    showSpans(spans, parents, children, spansToShow);
+    showSpans(spans, parents, children, selected);
 
-    spansToShow[0].shownText.should.contain('-');
-    spansToShow[0].expanded.should.equal(true);
-    spansToShow[0].showClasses.should.contain('highlight');
+    span.expanderText.should.contain('-');
+    span.expanded.should.equal(true);
+    [...span.classes].should.contain('highlight');
   });
 
-  it('sets open parents and children coherently', () => {
+  it('sets shown, open parents and children based on selected spans', () => {
+    const span1 = traceDetailSpan('0000000000000001');
+    const span2 = traceDetailSpan('0000000000000002');
+    const span3 = traceDetailSpan('0000000000000003');
+    const span4 = traceDetailSpan('0000000000000004');
     const spans = {
-      '0000000000000001': traceDetailSpan(),
-      '0000000000000002': traceDetailSpan(),
-      '0000000000000003': traceDetailSpan()
+      '0000000000000001': span1,
+      '0000000000000002': span2,
+      '0000000000000003': span3,
+      '0000000000000004': span4
     };
     const parents = {
       '0000000000000001': [],
       '0000000000000002': ['0000000000000001'],
-      '0000000000000003': ['0000000000000001']
+      '0000000000000003': ['0000000000000001'],
+      '0000000000000004': ['0000000000000003']
     };
     const children = {
       '0000000000000001': ['0000000000000002', '0000000000000003'],
       '0000000000000002': [],
-      '0000000000000003': []
+      '0000000000000003': ['0000000000000004'],
+      '0000000000000004': []
     };
-    const spansToShow = {
-      0: spanToShow('0000000000000001'),
-      1: spanToShow('0000000000000002'),
-      2: spanToShow('0000000000000003'),
-    };
+    const selected = {0: span3};
 
-    showSpans(spans, parents, children, spansToShow);
+    showSpans(spans, parents, children, selected);
 
-    spans['0000000000000001'].shown.should.equal(true);
-    spans['0000000000000001'].openParents.should.equal(0);
-    spans['0000000000000001'].openChildren.should.equal(2);
+    span1.shown.should.equal(true); // because a child was selected
+    span1.openParents.should.equal(0);
+    span1.openChildren.should.equal(1); // because only span3 was selected
 
-    spans['0000000000000002'].shown.should.equal(true);
-    spans['0000000000000002'].openParents.should.equal(1);
-    spans['0000000000000002'].openChildren.should.equal(0);
+    span2.shown.should.equal(false);
 
-    spans['0000000000000003'].shown.should.equal(true);
-    spans['0000000000000003'].openParents.should.equal(1);
-    spans['0000000000000003'].openChildren.should.equal(0);
+    span3.shown.should.equal(true);
+    span3.openParents.should.equal(0);
+    span3.openChildren.should.equal(0);
+
+    span4.shown.should.equal(true);
+    span4.openParents.should.equal(1); // because its parent was selected
+    span4.openChildren.should.equal(0);
   });
 
   it('works when root-most span parent is missing', () => {
-    const spans = {'0000000000000001': traceDetailSpan()};
+    const span = traceDetailSpan('0000000000000001');
+    const spans = {'0000000000000001': span};
     const parents = {'0000000000000001': ['0000000000000000']};
     const children = {'0000000000000001': []};
-    const spansToShow = {0: spanToShow('0000000000000001')};
+    const selected = {0: span};
 
-    showSpans(spans, parents, children, spansToShow);
+    showSpans(spans, parents, children, selected);
 
-    spans['0000000000000001'].shown.should.equal(false);
-    spans['0000000000000001'].openParents.should.equal(0);
-    spans['0000000000000001'].openChildren.should.equal(0);
+    span.shown.should.equal(true);
+    span.openParents.should.equal(0);
+    span.openChildren.should.equal(0);
+  });
+});
+
+describe('hideSpans', () => {
+  it('collapses and removes highlight', () => {
+    const span = traceDetailSpan('0000000000000001');
+    const spans = {'0000000000000001': span};
+    const parents = {'0000000000000001': []};
+    const children = {'0000000000000001': []};
+    const selected = {0: span};
+
+    showSpans(spans, parents, children, selected);
+    hideSpans(spans, parents, children, selected);
+
+    span.expanderText.should.contain('+');
+    span.expanded.should.equal(false);
+    [...span.classes].should.not.contain('highlight');
+  });
+
+  it('sets hidden, open parents and children based on selected spans', () => {
+    const span1 = traceDetailSpan('0000000000000001');
+    const span2 = traceDetailSpan('0000000000000002');
+    const span3 = traceDetailSpan('0000000000000003');
+    const span4 = traceDetailSpan('0000000000000004');
+    const spans = {
+      '0000000000000001': span1,
+      '0000000000000002': span2,
+      '0000000000000003': span3,
+      '0000000000000004': span4
+    };
+    const parents = {
+      '0000000000000001': [],
+      '0000000000000002': ['0000000000000001'],
+      '0000000000000003': ['0000000000000001'],
+      '0000000000000004': ['0000000000000003']
+    };
+    const children = {
+      '0000000000000001': ['0000000000000002', '0000000000000003'],
+      '0000000000000002': [],
+      '0000000000000003': ['0000000000000004'],
+      '0000000000000004': []
+    };
+    const selected = {0: span3};
+
+    showSpans(spans, parents, children, selected);
+    hideSpans(spans, parents, children, selected);
+
+    span1.hidden.should.equal(true);
+    span1.openParents.should.equal(0);
+    span1.openChildren.should.equal(0);
+
+    span2.hidden.should.equal(false);
+
+    span3.hidden.should.equal(true);
+    span3.openParents.should.equal(0);
+    span3.openChildren.should.equal(0);
+
+    span4.hidden.should.equal(true);
+    span4.openParents.should.equal(0);
+    span4.openChildren.should.equal(0);
+  });
+
+  it('doesnt hide parents when childrenOnly', () => {
+    const span1 = traceDetailSpan('0000000000000001');
+    const span2 = traceDetailSpan('0000000000000002');
+    const span3 = traceDetailSpan('0000000000000003');
+    const span4 = traceDetailSpan('0000000000000004');
+    const spans = {
+      '0000000000000001': span1,
+      '0000000000000002': span2,
+      '0000000000000003': span3,
+      '0000000000000004': span4
+    };
+    const parents = {
+      '0000000000000001': [],
+      '0000000000000002': ['0000000000000001'],
+      '0000000000000003': ['0000000000000001'],
+      '0000000000000004': ['0000000000000003']
+    };
+    const children = {
+      '0000000000000001': ['0000000000000002', '0000000000000003'],
+      '0000000000000002': [],
+      '0000000000000003': ['0000000000000004'],
+      '0000000000000004': []
+    };
+    const selected = {0: span3};
+
+    showSpans(spans, parents, children, selected);
+    hideSpans(spans, parents, children, selected, true);
+
+    span1.hidden.should.equal(false);
+    span2.hidden.should.equal(false);
+    span3.hidden.should.equal(false);
+    span4.hidden.should.equal(true);
+  });
+
+  it('works when root-most span parent is missing', () => {
+    const span = traceDetailSpan('0000000000000001');
+    const spans = {'0000000000000001': span};
+    const parents = {'0000000000000001': ['0000000000000000']};
+    const children = {'0000000000000001': []};
+    const selected = {0: span};
+
+    showSpans(spans, parents, children, selected);
+    hideSpans(spans, parents, children, selected);
+
+    span.hidden.should.equal(true);
+    span.openParents.should.equal(0);
+    span.openChildren.should.equal(0);
   });
 });

--- a/zipkin-ui/test/component_ui/traceTestHelpers.js
+++ b/zipkin-ui/test/component_ui/traceTestHelpers.js
@@ -28,27 +28,23 @@ export function span(traceId,
   };
 }
 
-export function traceDetailSpan() {
-  return {
-    openParents: 0,
-    openChildren: 0,
-    shown: false,
-    show() {this.shown = true;}
-  };
-}
-
-export function spanToShow(id) {
-  const shownText = [];
-  const showClasses = [];
+export function traceDetailSpan(id) {
+  const expanderText = [];
+  const classes = new Set();
   return {
     id,
     inFilters: 0,
-    shownText,
+    openParents: 0,
+    openChildren: 0,
+    shown: false,
+    show() {this.shown = true;},
+    hidden: false,
+    hide() {this.hidden = true;},
+    expanderText,
     expanded: false,
-    $expander: {text: t => shownText.push(t)},
-    showClasses,
-    show() {
-      return {addClass: c => showClasses.push(c)};
-    }
+    $expander: {text: t => expanderText.push(t)},
+    classes,
+    addClass: c => classes.add(c),
+    removeClass: c => classes.delete(c)
   };
 }


### PR DESCRIPTION
We previously fixed missing parent bugs but there were two more cases
they could occur.
- Removes redundant logic when all spans are selected (vs by service)
- Fixes collapse, which had the same missing parent bug

Fixes #1092
