### PR TITLE
Heavily guards AdaptiveSampleRate, as close wasn't safe to call

### DIFF
--- a/zipkin-sampler/src/main/scala/com/twitter/zipkin/sampler/AdaptiveSampler.scala
+++ b/zipkin-sampler/src/main/scala/com/twitter/zipkin/sampler/AdaptiveSampler.scala
@@ -29,8 +29,6 @@ import com.twitter.io.Charsets
 import com.twitter.util._
 import com.twitter.zipkin.common.Span
 
-import scala.collection.JavaConversions
-
 /**
  * The adaptive sampler optimizes sampling towards a global rate. This state
  * is maintained in ZooKeeper.

--- a/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/AdaptiveSamplerTest.scala
+++ b/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/AdaptiveSamplerTest.scala
@@ -1,6 +1,7 @@
 package com.twitter.zipkin.sampler
 
 import java.util.Random
+import java.util.concurrent.atomic.{AtomicLong, AtomicInteger}
 
 import com.twitter.app.App
 import com.twitter.finagle.Service
@@ -31,6 +32,10 @@ class AdaptiveSamplerTest extends JUnitSuite with Tolerance {
     result(sampler.apply(hundredSpans, Service.mk(spanStore)))
 
     assert(spanStore.spans.size === (90 +- 10)) // TODO: see if there's a way to tighten this up!
+  }
+
+  @Test def closeOnBadServerDoesntHang() {
+    new AdaptiveSampleRate(new AtomicLong(), new AtomicInteger(), "127.0.0.1:8800").close()
   }
 
   @Test def ignoresBadRateReadFromZookeeper() {


### PR DESCRIPTION
There's a lot of leaky resources hidden inside `AdaptiveSampleRate`. This fortifies `close()` as calling it would hang in a loop like this:

```
Apr 21, 2016 9:19:49 AM com.twitter.common.zookeeper.Group$ActiveMembership$1 get
WARNING: Temporary error cancelling membership: /election/member_0000000000
org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss for /election/member_0000000000
    at org.apache.zookeeper.KeeperException.create(KeeperException.java:99)
    at org.apache.zookeeper.KeeperException.create(KeeperException.java:51)
    at org.apache.zookeeper.ZooKeeper.delete(ZooKeeper.java:873)
    at com.twitter.common.zookeeper.Group$ActiveMembership$1.get(Group.java:370)
    at com.twitter.common.zookeeper.Group$ActiveMembership$1.get(Group.java:367)
    at com.twitter.common.util.BackoffHelper$1.get(BackoffHelper.java:109)
    at com.twitter.common.util.BackoffHelper$1.get(BackoffHelper.java:107)
    at com.twitter.common.util.BackoffHelper.doUntilResult(BackoffHelper.java:127)
    at com.twitter.common.util.BackoffHelper.doUntilSuccess(BackoffHelper.java:107)
    at com.twitter.common.zookeeper.Group$ActiveMembership.cancel(Group.java:367)
    at com.twitter.common.zookeeper.CandidateImpl$4$1.execute(CandidateImpl.java:157)
    at com.twitter.zipkin.sampler.ZKClient$$anon$4$$anonfun$close$1.apply$mcV$sp(ZKClient.scala:296)
    at com.twitter.zipkin.sampler.ZKClient$$anon$4$$anonfun$close$1.apply(ZKClient.scala:294)
    at com.twitter.zipkin.sampler.ZKClient$$anon$4$$anonfun$close$1.apply(ZKClient.scala:294)
    at com.twitter.util.Try$.apply(Try.scala:13)
    at com.twitter.util.ExecutorServiceFuturePool$$anon$2.run(FuturePool.scala:107)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```
