### PR TITLE
Fixes bug where adaptive rate was basing decisions on local store rate

### DIFF
--- a/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/AdaptiveSampleRateTest.scala
+++ b/zipkin-sampler/src/test/scala/com/twitter/zipkin/sampler/AdaptiveSampleRateTest.scala
@@ -20,10 +20,10 @@ import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.util.{MockTimer, Time, Var}
 import org.scalatest.FunSuite
 
-class StoreRateCheckTest extends FunSuite {
-  test("fails when the request rate is non-positive") {
+class AdaptiveSampleRateTest extends FunSuite {
+  test("fails when the target store rate is non-positive") {
     val rate = Var(1)
-    val check = new StoreRateCheck[Unit](rate)
+    val check = new TargetStoreRateCheck[Unit](rate)
     assert(check(Some(())).isDefined)
 
     rate.update(0)
@@ -60,8 +60,8 @@ class StoreRateCheckTest extends FunSuite {
   }
 
   test("fail unless enough outliers are encountered") {
-    val rate = Var(10)
-    val check = new OutlierCheck(rate, 2, 0.1)
+    val targetRate = Var(10)
+    val check = new OutlierCheck(targetRate, 2, 0.1)
 
     assert(check(Some(Seq())).isEmpty)
     assert(check(Some(Seq(10, 10, 10))).isEmpty)


### PR DESCRIPTION
The adaptive sampler has a thread that sets a new rate when it sees
outliers compared against a target (target is the amount of requests
the storage layer is capable of).

This logic had a bug where it compared outliers against the local
storage rate of the leader, not the target rate.

In normal case, if there were 10 balanced nodes, with a target rate of
10k spans/second, each node could write 1k spans/second. Since the input
to span collectors is a percentage, not a budget, the adaptive sampler
needs to re-calculate the sampling percentage based on how much
collectors are writing. Ex, if they are writing more, the percentage
would need to be lowered to drop enough spans to meet a target rate. If
they are writing less, the percentage could be raised to not
unnecessarily drop spans.

The outlier check compares the aggregate rate of all collectors against
a target: its `Seq[Int]` input is a sequence of `memberVals.sum`

The algorith is.. if a count of aggregate rate measurements went up or
down beyond a threshold (15%), a new rate could be calculated.

For example, if the target was 10k, a count of inputs <8.5k or >11.5k
would lead to a new rate.

If you substitute a local node here, you'll notice that this would fire
much more often. For example, if the target was 10k, a specific member
would be writing at 1k. If so, inputs <850 or >1150 would fire a
calculation. <850 is impossible as the local member is writing above
that. >1150 would happen any time there's more than 1 node. In other
words, it would fire always.

While non-critical (firing more is better than firing less), this small
bug caused busy work and made the outlier check almost useless.
