### PR TITLE
Quote parameterized path in HTTP_PATH documentation.

### DIFF
--- a/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
+++ b/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift
@@ -131,7 +131,7 @@ const string HTTP_METHOD = "http.method"
  * of distinct URIs less. For example, one can query for the same resource, regardless of signing
  * parameters encoded in the query line. This does not reduce cardinality to a HTTP single route.
  * For example, it is common to express a route as an http URI template like
- * /resource/{resource_id}. In systems where only equals queries are available, searching for
+ * "/resource/{resource_id}". In systems where only equals queries are available, searching for
  * http/path=/resource won't match if the actual request was /resource/abcd-ff.
  *
  * Historical note: This was commonly expressed as "http.uri" in zipkin, eventhough it was most


### PR DESCRIPTION
The combination of / and { seem to trip up thrift compiler 0.9.1. I haven't tried on 0.9.3 and assume it works since this is checked in, but it's a very minor change to add support for older compilers for users that are stuck with them.
