### PR TITLE
Excludes scala dependencies from zipkin-cassandra-core

### DIFF
--- a/zipkin-cassandra-core/build.gradle
+++ b/zipkin-cassandra-core/build.gradle
@@ -7,3 +7,8 @@ repositories {
 dependencies {
     compile(group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.0.0')
 }
+
+// Strip out scala deps inherited from the base project
+install.repositories.mavenInstaller.pom*.whenConfigured {pom ->
+    pom.dependencies.removeAll {dep -> dep.groupId != 'com.datastax.cassandra'}
+}

--- a/zipkin-ui/build.gradle
+++ b/zipkin-ui/build.gradle
@@ -38,6 +38,7 @@ task npmLint(type: NpmTask) {
 }
 check.dependsOn npmLint
 
+// Strip out scala deps inherited from the base project
 install.repositories.mavenInstaller.pom*.whenConfigured {pom ->
     pom.dependencies.clear()
 }


### PR DESCRIPTION
Those using zipkin-cassandra-core don't need scala deps. Those deps
clash with things like 2.10 compiled Kafka. This removes the scala
deps.

However, they still appear in the pom after `./mvnw clean install`

I'm not sure why...

```
$  ./gradlew :zipkin-cassandra-core:dependencyInsight --dependency org.scala-lang
:zipkin-cassandra-core:dependencyInsight
No dependencies matching given input were found in configuration ':zipkin-cassandra-core:compile'

BUILD SUCCESSFUL

$ grep scala $HOME/.m2/repository/io/zipkin/zipkin-cassandra-core/1.39.7-SNAPSHOT/zipkin-cassandra-core-1.39.7-SNAPSHOT.pom
      <groupId>org.scala-lang</groupId>
      <artifactId>scala-library</artifactId>
```
