### PR TITLE
Updates to Datastax Cassandra Driver 3.0

### DIFF
--- a/zipkin-cassandra-core/build.gradle
+++ b/zipkin-cassandra-core/build.gradle
@@ -5,11 +5,5 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '2.1.10'){
-        exclude group: 'com.github.jnr', module: 'jnr-posix'
-    }
-    // above is packaged with 3.0.27, which is licensed under CPL; 3.0.29 is licensed under EPL
-    compile group: 'com.github.jnr', name: 'jnr-posix', version: '3.0.29'
-    testCompile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', classifier: 'tests', version: '2.1.10'
-    testCompile group: 'org.apache.commons', name: 'commons-exec', version: '1.3'
+    compile(group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.0.0')
 }

--- a/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/ZipkinRetryPolicy.java
+++ b/zipkin-cassandra-core/src/main/java/org/twitter/zipkin/storage/cassandra/ZipkinRetryPolicy.java
@@ -1,11 +1,12 @@
 
 package org.twitter.zipkin.storage.cassandra;
 
+import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.WriteType;
+import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.policies.RetryPolicy;
-import com.datastax.driver.core.policies.RetryPolicy.RetryDecision;
 
 public final class ZipkinRetryPolicy implements RetryPolicy {
 
@@ -26,5 +27,21 @@ public final class ZipkinRetryPolicy implements RetryPolicy {
     @Override
     public RetryDecision onUnavailable(Statement statement, ConsistencyLevel cl, int requiredReplica, int aliveReplica, int nbRetry) {
         return RetryDecision.retry(ConsistencyLevel.ONE);
+    }
+
+    @Override
+    public RetryDecision onRequestError(Statement statement, ConsistencyLevel cl,
+        DriverException e, int nbRetry) {
+        return RetryDecision.tryNextHost(ConsistencyLevel.ONE);
+    }
+
+    @Override
+    public void init(Cluster cluster) {
+        // nothing to do
+    }
+
+    @Override
+    public void close() {
+        // nothing to do
     }
 }

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/cassandra/CassandraSpanStoreFactorySpec.scala
@@ -87,7 +87,7 @@ class CassandraSpanStoreFactorySpec extends FunSuite with Matchers with MockitoS
                          .getConfiguration()
                          .getProtocolOptions()
                          .getAuthProvider()
-                         .newAuthenticator(new InetSocketAddress("localhost", 8080))
+                         .newAuthenticator(new InetSocketAddress("localhost", 8080), null)
                          .initialResponse()
     authProvider should be(SASLhandshake)
   }


### PR DESCRIPTION
By updating to Datastax Driver 3, we still support Cassandra 2.2+, but
also 3.0.

Tested against Cassandra 2.2, 3.0 and 3.5

See #952
