### PR TITLE
Adds kafka property to control fetch.message.max.bytes

### DIFF
--- a/zipkin-collector-service/config/collector-cassandra.scala
+++ b/zipkin-collector-service/config/collector-cassandra.scala
@@ -60,7 +60,8 @@ val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
   KafkaSpanReceiverFactory.factory(_,
     sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"),
     sys.env.get("KAFKA_GROUP_ID").getOrElse("zipkin"),
-    sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt
+    sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt,
+    sys.env.get("KAFKA_MAX_MESSAGE_SIZE").map(_.toInt).getOrElse(1024 * 1024)
   )
 )
 

--- a/zipkin-collector-service/config/collector-dev.scala
+++ b/zipkin-collector-service/config/collector-dev.scala
@@ -33,7 +33,8 @@ val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
   KafkaSpanReceiverFactory.factory(_,
     sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"),
     sys.env.get("KAFKA_GROUP_ID").getOrElse("zipkin"),
-    sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt
+    sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt,
+    sys.env.get("KAFKA_MAX_MESSAGE_SIZE").map(_.toInt).getOrElse(1024 * 1024)
   )
 )
 

--- a/zipkin-collector-service/config/collector-mysql.scala
+++ b/zipkin-collector-service/config/collector-mysql.scala
@@ -30,7 +30,8 @@ val kafkaReceiver = sys.env.get("KAFKA_ZOOKEEPER").map(
   KafkaSpanReceiverFactory.factory(_,
     sys.env.get("KAFKA_TOPIC").getOrElse("zipkin"),
     sys.env.get("KAFKA_GROUP_ID").getOrElse("zipkin"),
-    sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt
+    sys.env.get("KAFKA_STREAMS").getOrElse("1").toInt,
+    sys.env.get("KAFKA_MAX_MESSAGE_SIZE").map(_.toInt).getOrElse(1024 * 1024)
   )
 )
 

--- a/zipkin-receiver-kafka/README.md
+++ b/zipkin-receiver-kafka/README.md
@@ -13,6 +13,7 @@ It is enabled when the `KAFKA_ZOOKEEPER` environment variable is set. Here are t
    * `KAFKA_TOPIC`: Defaults to zipkin
    * `KAFKA_GROUP_ID`: Consumer group this process is consuming on behalf of. Defaults to zipkin
    * `KAFKA_STREAMS`: Count of consumer threads consuming the topic. defaults to 1.
+   * `KAFKA_MAX_MESSAGE_SIZE`: Maximum size of a message containing spans in bytes. Defaults to 1 MiB
 
 Example usage:
 


### PR DESCRIPTION
This adds `KAFKA_MAX_MESSAGE_SIZE` -> `fetch.message.max.bytes`

Fixes #1101
