### PR TITLE
Updates to Datastax Cassandra Driver 3.0.1

### DIFF
--- a/zipkin-cassandra-core/build.gradle
+++ b/zipkin-cassandra-core/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.0.0')
+    compile(group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.0.1')
 }
 
 // Strip out scala deps inherited from the base project


### PR DESCRIPTION
Mostly bugfixes, but there are some improvements inside

https://github.com/datastax/java-driver/tree/3.0.1/changelog
