### PR TITLE
Display service name when showing addresses in the span detail element

### DIFF
--- a/zipkin-ui/js/component_ui/traceToMustache.js
+++ b/zipkin-ui/js/component_ui/traceToMustache.js
@@ -79,7 +79,10 @@ function toSpanDepths(spans) {
   return treeDepths(entry, 1);
 }
 
-export function formatEndpoint({ipv4, port = 0}) {
+export function formatEndpoint({ipv4, port = 0, serviceName = ''}) {
+  if (serviceName) {
+    return `${ipv4}:${port} (${serviceName})`;
+  }
   return `${ipv4}:${port}`;
 }
 

--- a/zipkin-ui/js/component_ui/traceToMustache.js
+++ b/zipkin-ui/js/component_ui/traceToMustache.js
@@ -153,7 +153,6 @@ export default function traceToMustache(trace) {
           value: ConstantNames[a.value] || a.value,
           timestamp: a.timestamp,
           relativeTime: mkDurationStr(a.timestamp - traceTimestamp),
-          serviceName: a.endpoint && a.endpoint.serviceName ? a.endpoint.serviceName : null,
           width: 8
         })),
         binaryAnnotations

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -104,15 +104,13 @@
           <thead><tr>
             <th>Date Time</th>
             <th>Relative Time</th>
-            <th>Service</th>
             <th>Annotation</th>
-            <th>Host</th>
+            <th>Address</th>
           </tr></thead>
           <tbody>
             <tr>
               <td data-key='timestamp' class="local-datetime"></td>
               <td data-key='relativeTime'></td>
-              <td data-key='serviceName'></td>
               <td data-key='value'></td>
               <td data-key='endpoint'></td>
             </tr>

--- a/zipkin-ui/test/component_ui/traceToMustache.test.js
+++ b/zipkin-ui/test/component_ui/traceToMustache.test.js
@@ -133,4 +133,16 @@ describe('formatEndpoint', () => {
   it('should use 0 as default port', () => {
     formatEndpoint({ipv4: '150.151.152.153'}).should.equal('150.151.152.153:0');
   });
+
+  it('should put service name in parenthesis', () => {
+    formatEndpoint({ipv4: '150.151.152.153', port: 9042, serviceName: 'cassandra'}).should.equal(
+      '150.151.152.153:9042 (cassandra)'
+    );
+  });
+
+  it('should not show empty service name', () => {
+    formatEndpoint({ipv4: '150.151.152.153', port: 9042, serviceName: ''}).should.equal(
+      '150.151.152.153:9042'
+    );
+  });
 });


### PR DESCRIPTION
Example screenshot:
![image](https://cloud.githubusercontent.com/assets/3523016/15262008/b0932ef0-192d-11e6-9c11-c5a1f570e745.png)

Why: when a request comes from or goes to uninstrumented service, the instrumented part may log CA/SA annotations that include not only the peer IP address, but also the service name. However, the current UI, while it has a special handing for CA/SA annotations, does not display the service name.
