### PR TITLE
Show errors

### DIFF
--- a/zipkin-ui/css/main.scss
+++ b/zipkin-ui/css/main.scss
@@ -39,6 +39,10 @@ body {
   cursor: pointer;
 }
 
+#errorPanel {
+  display: none;
+}
+
 #fullPageSpinner {
   display: none;
   position: absolute;

--- a/zipkin-ui/js/component_data/default.js
+++ b/zipkin-ui/js/component_data/default.js
@@ -1,4 +1,5 @@
 import {component} from 'flightjs';
+import {errToStr} from '../../js/component_ui/error';
 import $ from 'jquery';
 import queryString from 'query-string';
 import {traceSummary, traceSummariesToMustache} from '../component_ui/traceSummary';
@@ -22,13 +23,15 @@ export default component(function DefaultData() {
     if (serviceName) {
       $.ajax(`/api/v1/traces?${queryString.stringify(query)}`, {
         type: 'GET',
-        dataType: 'json',
-        success: traces => {
-          const modelview = {
-            traces: traceSummariesToMustache(serviceName, traces.map(traceSummary))
-          };
-          this.trigger('defaultPageModelView', modelview);
-        }
+        dataType: 'json'
+      }).done(traces => {
+        const modelview = {
+          traces: traceSummariesToMustache(serviceName, traces.map(traceSummary))
+        };
+        this.trigger('defaultPageModelView', modelview);
+      }).fail(e => {
+        this.trigger('defaultPageModelView', {traces: [],
+                                              queryError: errToStr(e)});
       });
     } else {
       this.trigger('defaultPageModelView', {traces: []});

--- a/zipkin-ui/js/component_data/serviceNames.js
+++ b/zipkin-ui/js/component_data/serviceNames.js
@@ -1,14 +1,16 @@
 import {component} from 'flightjs';
+import {getError} from '../../js/component_ui/error';
 import $ from 'jquery';
 
 export default component(function serviceNames() {
   this.updateServiceNames = function(ev, lastServiceName) {
     $.ajax('/api/v1/services', {
       type: 'GET',
-      dataType: 'json',
-      success: names => {
-        this.trigger('dataServiceNames', {names, lastServiceName});
-      }
+      dataType: 'json'
+    }).done(names => {
+      this.trigger('dataServiceNames', {names, lastServiceName});
+    }).fail(e => {
+      this.trigger('uiServerError', getError('cannot load service names', e));
     });
   };
 

--- a/zipkin-ui/js/component_data/spanNames.js
+++ b/zipkin-ui/js/component_data/spanNames.js
@@ -1,14 +1,16 @@
 import {component} from 'flightjs';
+import {getError} from '../../js/component_ui/error';
 import $ from 'jquery';
 
 export default component(function spanNames() {
   this.updateSpanNames = function(ev, serviceName) {
     $.ajax(`/api/v1/spans?serviceName=${serviceName}`, {
       type: 'GET',
-      dataType: 'json',
-      success: spans => {
-        this.trigger('dataSpanNames', {spans});
-      }
+      dataType: 'json'
+    }).done(spans => {
+      this.trigger('dataSpanNames', {spans});
+    }).fail(e => {
+      this.trigger('uiServerError', getError('cannot load span names', e));
     });
   };
 

--- a/zipkin-ui/js/component_data/trace.js
+++ b/zipkin-ui/js/component_data/trace.js
@@ -1,16 +1,19 @@
 import {component} from 'flightjs';
 import $ from 'jquery';
+import {getError} from '../../js/component_ui/error';
 import traceToMustache from '../../js/component_ui/traceToMustache';
 
 export default component(function TraceData() {
   this.after('initialize', function() {
     $.ajax(`/api/v1/trace/${this.attr.traceId}`, {
       type: 'GET',
-      dataType: 'json',
-      success: trace => {
-        const modelview = traceToMustache(trace);
-        this.trigger('tracePageModelView', {modelview, trace});
-      }
+      dataType: 'json'
+    }).done(trace => {
+      const modelview = traceToMustache(trace);
+      this.trigger('tracePageModelView', {modelview, trace});
+    }).fail(e => {
+      this.trigger('uiServerError',
+                   getError(`Cannot load trace ${this.attr.traceId}`, e));
     });
   });
 });

--- a/zipkin-ui/js/component_ui/error.js
+++ b/zipkin-ui/js/component_ui/error.js
@@ -1,0 +1,25 @@
+import {component} from 'flightjs';
+import $ from 'jquery';
+
+export default component(function ErrorUI() {
+  this.after('initialize', function() {
+    this.on(document, 'uiServerError', function(evt, e) {
+      this.$node.append($('<div></div>').text(`ERROR: ${e.desc}: ${e.message}`));
+      this.$node.show();
+    });
+  });
+});
+
+// converts an jqXhr error to a string
+export function errToStr(e) {
+  return e.responseJSON ? e.responseJSON.message : `server error (${e.statusText})`;
+}
+
+// transforms an ajax error into something that is passed to
+// trigger('uiServerError')
+export function getError(desc, e) {
+  return {
+    desc,
+    message: errToStr(e)
+  };
+}

--- a/zipkin-ui/js/main.js
+++ b/zipkin-ui/js/main.js
@@ -5,6 +5,7 @@ import initializeTrace from './page/trace';
 import initializeDependency from './page/dependency';
 import CommonUI from './page/common';
 import loadConfig from './config';
+import {errToStr} from './component_ui/error';
 
 loadConfig().then(config => {
   debug.enable(true);
@@ -16,4 +17,8 @@ loadConfig().then(config => {
   crossroads.addRoute('traces/{id}', traceId => initializeTrace(traceId, config));
   crossroads.addRoute('dependency', () => initializeDependency(config));
   crossroads.parse(window.location.pathname);
+}, e => {
+  // TODO: better error message, but this is better than a blank screen...
+  const err = errToStr(e);
+  document.write(`Error loading config.json: ${err}`);
 });

--- a/zipkin-ui/js/page/common.js
+++ b/zipkin-ui/js/page/common.js
@@ -1,5 +1,6 @@
 import {component} from 'flightjs';
 import EnvironmentUI from '../component_ui/environment';
+import ErrorUI from '../component_ui/error';
 import NavbarUI from '../component_ui/navbar';
 import {layoutTemplate} from '../templates';
 import GoToTraceUI from '../component_ui/goToTrace';
@@ -8,6 +9,7 @@ export default component(function CommonUI() {
   this.after('initialize', function() {
     this.$node.html(layoutTemplate());
     NavbarUI.attachTo('#navbar');
+    ErrorUI.attachTo('#errorPanel');
     EnvironmentUI.attachTo('#environment', {config: this.attr.config});
     GoToTraceUI.attachTo('#traceIdQueryForm');
   });

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -73,6 +73,11 @@
 </div>
 
 <div class="row">
+{{#queryError}}
+  <div class="alert alert-danger" id="query-error-msg">
+    <p>Error executing query: {{ queryError }}</p>
+  </div>
+{{/queryError}}
 {{^queryWasPerformed}}
   <div class="alert alert-info" id="help-msg">
     <p>Please select the criteria for your trace lookup.</p>

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -26,6 +26,9 @@
       </div>
     </div>
 
+    <div id="errorPanel" class="alert alert-danger">
+    </div>
+
     <div class='container'>
       <div class='content'></div>
     </div>


### PR DESCRIPTION
(Includes #1124 because of potential merge conflicts)

This is 3 separate pieces that have 3 commits associated with them:
- Show an error when config.json isn't present
- Provide mechanisms to show errors if one of the ajax calls loading data fails
- Show the user an error when a query fails (this uses a separate mechanism to ensure that it's placed in a semantically meaningful way... a query that fails is something like `foo==bar`)
