### PR TITLE
Expose prometheus compatible metrics on /prometheus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,12 @@
 
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-autoconfigure-metrics-prometheus</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-guava</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/zipkin-autoconfigure/metrics-prometheus/README.md
+++ b/zipkin-autoconfigure/metrics-prometheus/README.md
@@ -1,0 +1,18 @@
+# Prometheus Metrics
+
+Exposes [Spring Actuator metrics](http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html)
+on `/prometheus` using the Prometheus exposition [text format version 0.0.4](https://prometheus.io/docs/instrumenting/exposition_formats/).
+
+All metrics defaults to the `gauge` type, unless a known format is specified by a prefix in the metric name. Currently the only two detected types are `gauge_` and `counter_`.
+
+## Scrape configuration example
+
+```yaml
+  - job_name: 'zipkin'
+    scrape_interval: 5s
+    metrics_path: '/prometheus'
+    static_configs:
+      - targets: ['localhost:9411']
+
+```
+

--- a/zipkin-autoconfigure/metrics-prometheus/pom.xml
+++ b/zipkin-autoconfigure/metrics-prometheus/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>zipkin-autoconfigure</artifactId>
+        <groupId>io.zipkin.java</groupId>
+        <version>1.1.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>zipkin-autoconfigure-metrics-prometheus</artifactId>
+    <name>Auto Configuration: Prometheus Metrics</name>
+
+    <properties>
+        <main.basedir>${project.basedir}/../..</main.basedir>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Import dependency management from Spring Boot -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/metrics/PrometheusMetricsAutoConfiguration.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/metrics/PrometheusMetricsAutoConfiguration.java
@@ -33,10 +33,10 @@ public class PrometheusMetricsAutoConfiguration {
     private static final Pattern SANITIZE_PREFIX_PATTERN = Pattern.compile("^[^a-zA-Z_]");
     private static final Pattern SANITIZE_BODY_PATTERN = Pattern.compile("[^a-zA-Z0-9_]");
 
-    private Collection<PublicMetrics> publicMetrics;
+    private final Collection<PublicMetrics> publicMetrics;
 
     @Autowired
-    public PrometheusMetricsAutoConfiguration(final Collection<PublicMetrics> publicMetrics) {
+    public PrometheusMetricsAutoConfiguration(Collection<PublicMetrics> publicMetrics) {
         this.publicMetrics = publicMetrics;
     }
 

--- a/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/metrics/PrometheusMetricsAutoConfiguration.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/metrics/PrometheusMetricsAutoConfiguration.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.autoconfigure.metrics;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.PublicMetrics;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+@RestController
+@RequestMapping("/prometheus")
+public class PrometheusMetricsAutoConfiguration {
+
+    private static final Pattern SANITIZE_PREFIX_PATTERN = Pattern.compile("^[^a-zA-Z_]");
+    private static final Pattern SANITIZE_BODY_PATTERN = Pattern.compile("[^a-zA-Z0-9_]");
+
+    private Collection<PublicMetrics> publicMetrics;
+
+    @Autowired
+    public PrometheusMetricsAutoConfiguration(final Collection<PublicMetrics> publicMetrics) {
+        this.publicMetrics = publicMetrics;
+    }
+
+    private static String sanitizeMetricName(String metricName) {
+        return SANITIZE_BODY_PATTERN.matcher(
+                SANITIZE_PREFIX_PATTERN.matcher(metricName).replaceFirst("_")
+        ).replaceAll("_");
+    }
+
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity<String> prometheusMetrics() {
+        StringBuilder sb = new StringBuilder();
+
+        for (PublicMetrics publicMetrics : this.publicMetrics) {
+            for (Metric<?> metric : publicMetrics.metrics()) {
+                final String sanitizedName = sanitizeMetricName(metric.getName());
+                final String type = typeForName(sanitizedName);
+                final String metricName = metricName(sanitizedName, type);
+                double value = metric.getValue().doubleValue();
+
+                sb.append(String.format("#TYPE %s %s\n", metricName, type));
+                sb.append(String.format("#HELP %s %s\n", metricName, metricName));
+                sb.append(String.format("%s %s\n", metricName, prometheusDouble(value)));
+            }
+        }
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("text/plain; version=0.0.4; charset=utf-8"))
+                .body(sb.toString());
+
+    }
+
+    private String prometheusDouble(double value) {
+        if (value == Double.POSITIVE_INFINITY) {
+            return "+Inf";
+        } else if (value == Double.NEGATIVE_INFINITY) {
+            return "-Inf";
+        } else {
+            return String.valueOf(value);
+        }
+    }
+
+    private String metricName(String name, String type) {
+        switch (type) {
+            case "counter":
+                return name.replaceFirst("^counter_", "");
+            case "gauge":
+                return name.replaceFirst("^gauge_", "");
+            default:
+                return name;
+        }
+    }
+
+    private String typeForName(String name) {
+        if (name.startsWith("gauge")) {
+            return "gauge";
+        }
+        if (name.startsWith("counter")) {
+            return "counter";
+        }
+
+        return "gauge";
+    }
+}

--- a/zipkin-autoconfigure/metrics-prometheus/src/main/resources/META-INF/spring.factories
+++ b/zipkin-autoconfigure/metrics-prometheus/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+zipkin.autoconfigure.metrics.PrometheusMetricsAutoConfiguration

--- a/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/metrics/PrometheusMetricsAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/metrics/PrometheusMetricsAutoConfigurationTest.java
@@ -28,8 +28,8 @@ public class PrometheusMetricsAutoConfigurationTest {
 
     @Test
     public void correctHttpResponse() throws Exception {
-        final PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("mem.free", 1024));
-        final ResponseEntity<String> response = responseForMetrics(publicMetrics);
+        PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("mem.free", 1024));
+        ResponseEntity<String> response = responseForMetrics(publicMetrics);
 
         assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
         assertThat(response.getHeaders().getContentType().toString(),
@@ -39,10 +39,10 @@ public class PrometheusMetricsAutoConfigurationTest {
     @Test
     public void defaultsToGauge() throws Exception {
 
-        final PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("mem.free", 1024));
-        final ResponseEntity<String> response = responseForMetrics(publicMetrics);
+        PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("mem.free", 1024));
+        ResponseEntity<String> response = responseForMetrics(publicMetrics);
 
-        final String body = response.getBody();
+        String body = response.getBody();
 
         assertThat(body, equalTo(
                 "#TYPE mem_free gauge\n" +
@@ -53,10 +53,10 @@ public class PrometheusMetricsAutoConfigurationTest {
     @Test
     public void detectsCounters() throws Exception {
 
-        final PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("counter_mem.free", 1024));
-        final ResponseEntity<String> response = responseForMetrics(publicMetrics);
+        PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("counter_mem.free", 1024));
+        ResponseEntity<String> response = responseForMetrics(publicMetrics);
 
-        final String body = response.getBody();
+        String body = response.getBody();
 
         assertThat(body, equalTo(
                 "#TYPE mem_free counter\n" +
@@ -67,10 +67,10 @@ public class PrometheusMetricsAutoConfigurationTest {
     @Test
     public void detectsGauges() throws Exception {
 
-        final PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("gauge_mem.free", 1024));
-        final ResponseEntity<String> response = responseForMetrics(publicMetrics);
+        PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("gauge_mem.free", 1024));
+        ResponseEntity<String> response = responseForMetrics(publicMetrics);
 
-        final String body = response.getBody();
+        String body = response.getBody();
 
         assertThat(body, equalTo(
                 "#TYPE mem_free gauge\n" +
@@ -80,7 +80,7 @@ public class PrometheusMetricsAutoConfigurationTest {
 
 
     private ResponseEntity<String> responseForMetrics(PublicMetrics publicMetrics) {
-        final PrometheusMetricsAutoConfiguration pmc = new PrometheusMetricsAutoConfiguration(Collections.singleton(publicMetrics));
+        PrometheusMetricsAutoConfiguration pmc = new PrometheusMetricsAutoConfiguration(Collections.singleton(publicMetrics));
 
         return pmc.prometheusMetrics();
     }

--- a/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/metrics/PrometheusMetricsAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/metrics/PrometheusMetricsAutoConfigurationTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.metrics;
+
+import org.junit.Test;
+import org.springframework.boot.actuate.endpoint.PublicMetrics;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class PrometheusMetricsAutoConfigurationTest {
+
+    @Test
+    public void correctHttpResponse() throws Exception {
+        final PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("mem.free", 1024));
+        final ResponseEntity<String> response = responseForMetrics(publicMetrics);
+
+        assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
+        assertThat(response.getHeaders().getContentType().toString(),
+                equalTo("text/plain;version=0.0.4;charset=utf-8"));
+    }
+
+    @Test
+    public void defaultsToGauge() throws Exception {
+
+        final PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("mem.free", 1024));
+        final ResponseEntity<String> response = responseForMetrics(publicMetrics);
+
+        final String body = response.getBody();
+
+        assertThat(body, equalTo(
+                "#TYPE mem_free gauge\n" +
+                        "#HELP mem_free mem_free\n" +
+                        "mem_free 1024.0\n"));
+    }
+
+    @Test
+    public void detectsCounters() throws Exception {
+
+        final PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("counter_mem.free", 1024));
+        final ResponseEntity<String> response = responseForMetrics(publicMetrics);
+
+        final String body = response.getBody();
+
+        assertThat(body, equalTo(
+                "#TYPE mem_free counter\n" +
+                        "#HELP mem_free mem_free\n" +
+                        "mem_free 1024.0\n"));
+    }
+
+    @Test
+    public void detectsGauges() throws Exception {
+
+        final PublicMetrics publicMetrics = () -> Collections.singleton(new Metric<Number>("gauge_mem.free", 1024));
+        final ResponseEntity<String> response = responseForMetrics(publicMetrics);
+
+        final String body = response.getBody();
+
+        assertThat(body, equalTo(
+                "#TYPE mem_free gauge\n" +
+                        "#HELP mem_free mem_free\n" +
+                        "mem_free 1024.0\n"));
+    }
+
+
+    private ResponseEntity<String> responseForMetrics(PublicMetrics publicMetrics) {
+        final PrometheusMetricsAutoConfiguration pmc = new PrometheusMetricsAutoConfiguration(Collections.singleton(publicMetrics));
+
+        return pmc.prometheusMetrics();
+    }
+}

--- a/zipkin-autoconfigure/pom.xml
+++ b/zipkin-autoconfigure/pom.xml
@@ -38,6 +38,7 @@
     <module>storage-cassandra</module>
     <module>storage-elasticsearch</module>
     <module>storage-mysql</module>
+    <module>metrics-prometheus</module>
   </modules>
 
   <dependencies>

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -64,6 +64,7 @@ public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
 
   @Autowired
   ZipkinUiProperties ui;
+
   @Value("classpath:zipkin-ui/index.html")
   Resource indexHtml;
 

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -40,6 +40,9 @@ $ java -jar ./zipkin-server/target/zipkin-server-*exec.jar --logging.level.zipki
 
 Metrics are exported to the path `/metrics` and extend [defaults reported by spring-boot](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html).
 
+Metrics are also exported to the path `/prometheus` if the `zipkin-autoconfigure-metrics-prometheus` is available in the classpath.
+See the prometheus metrics [README](../zipkin-autoconfigure/metrics-prometheus/README.md) for more information.
+
 ### Collector
 
 Collector metrics are broken down by transport. The following are exported to the "/metrics" endpoint:

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -112,6 +112,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Prometheus metrics -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-autoconfigure-metrics-prometheus</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Trace api controller activity with Brave -->
     <dependency>
       <groupId>io.zipkin.brave</groupId>


### PR DESCRIPTION
We run Zipkin in several kubernetes clusters and thus we need a sane way of collecting the metrics.
As Prometheus has all the built-in support for dealing with the moving parts of Kubernetes, it seems
like a rational choice.

This PR exposes Spring Actuator metrics on `/prometheus`
using the 0.0.4 version of their text format specified
here https://prometheus.io/docs/instrumenting/exposition_formats/.

Not crazy about the path, but adding new controllers into /metrics/\* seems like more complexity than needed.
