### PR TITLE
Highlight spans with errors

### DIFF
--- a/zipkin-ui/css/trace.css
+++ b/zipkin-ui/css/trace.css
@@ -125,6 +125,11 @@
   display: none;
 }
 
+#trace-container .span .duration .annotation[data-value="error"] {
+  border: solid 1px #ff0000;
+  background: #ff0000;
+}
+
 #trace-container .span .duration .tooltip {
   white-space: normal;
 }
@@ -135,6 +140,28 @@
 #trace-container .span.depth-3 .duration { background: rgba(66, 146, 198, 0.60); }
 #trace-container .span.depth-4 .duration { background: rgba(66, 146, 198, 0.80); }
 #trace-container .span.depth-5 .duration { background: rgba(66, 146, 198, 1); }
+
+#trace-container .span[data-error-type="transient"] .handle .service-name {
+  background: #8a6d3b;
+}
+
+#trace-container .span[data-error-type="transient"].depth-0 .duration { background: rgba(230, 215, 140, 0.1); }
+#trace-container .span[data-error-type="transient"].depth-1 .duration { background: rgba(230, 215, 140, 0.20); }
+#trace-container .span[data-error-type="transient"].depth-2 .duration { background: rgba(230, 215, 140, 0.40); }
+#trace-container .span[data-error-type="transient"].depth-3 .duration { background: rgba(230, 215, 140, 0.60); }
+#trace-container .span[data-error-type="transient"].depth-4 .duration { background: rgba(230, 215, 140, 0.80); }
+#trace-container .span[data-error-type="transient"].depth-5 .duration { background: rgba(230, 215, 140, 1); }
+
+#trace-container .span[data-error-type="critical"] .handle .service-name {
+  background: #a94442;
+}
+
+#trace-container .span[data-error-type="critical"].depth-0 .duration { background: rgba(230, 162, 161, 0.1); }
+#trace-container .span[data-error-type="critical"].depth-1 .duration { background: rgba(230, 162, 161, 0.20); }
+#trace-container .span[data-error-type="critical"].depth-2 .duration { background: rgba(230, 162, 161, 0.40); }
+#trace-container .span[data-error-type="critical"].depth-3 .duration { background: rgba(230, 162, 161, 0.60); }
+#trace-container .span[data-error-type="critical"].depth-4 .duration { background: rgba(230, 162, 161, 0.80); }
+#trace-container .span[data-error-type="critical"].depth-5 .duration { background: rgba(230, 162, 161, 1); }
 
 #trace-controls form {
   margin-bottom: 10px;
@@ -149,6 +176,16 @@
 
 #trace-controls .nav-pills .badge {
   background: #428bca;
+}
+
+#spanPanel tr.anno-error-transient {
+  color: #8a6d3b;
+  background: #fcf8e3;
+}
+
+#spanPanel tr.anno-error-critical {
+  color: #a94442;
+  background: #f2dede;
 }
 
 #spanPanel #binaryAnnotations td.value {

--- a/zipkin-ui/css/traces.css
+++ b/zipkin-ui/css/traces.css
@@ -106,6 +106,22 @@
   background-color: #0084B4;
 }
 
+#traces li.trace-error-transient .bar-graphic {
+  background-color: #fcf8e3;;
+}
+
+#traces li.trace-error-transient:hover .bar-graphic {
+  background-color: #8a6d3b;
+}
+
+#traces li.trace-error-critical .bar-graphic {
+  background-color: #f2dede;
+}
+
+#traces li.trace-error-critical:hover .bar-graphic {
+  background-color: #a94442;
+}
+
 #traces li .bar-label {
   position: relative;
   margin-left: 6px;
@@ -124,6 +140,24 @@
 #traces li:hover .bar-label {
   color: #FFF;
   background-color: rgba(0,132,180,.35);
+}
+
+#traces li.trace-error-transient .bar-label {
+  color: #8a6d3b;
+}
+
+#traces li.trace-error-transient:hover .bar-label {
+  color: #FFF;
+  background-color: rgba(138,109,59,.35);
+}
+
+#traces li.trace-error-critical .bar-label {
+  color: #a94442;
+}
+
+#traces li.trace-error-critical:hover .bar-label {
+  color: #FFF;
+  background-color: rgba(169,68,66,.35);
 }
 
 #traces li div span.label {

--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -1,5 +1,6 @@
 import {component} from 'flightjs';
 import $ from 'jquery';
+import {Constants} from './traceConstants';
 
 export default component(function spanPanel() {
   this.$annotationTemplate = null;
@@ -16,6 +17,9 @@ export default component(function spanPanel() {
     const $annoBody = this.$node.find('#annotations tbody').text('');
     $.each(span.annotations, (i, anno) => {
       const $row = self.$annotationTemplate.clone();
+      if (anno.value === Constants.ERROR) {
+        $row.addClass('anno-error-transient');
+      }
       $row.find('td').each(function() {
         const $this = $(this);
         $this.text(anno[$this.data('key')]);
@@ -32,6 +36,9 @@ export default component(function spanPanel() {
     const $binAnnoBody = this.$node.find('#binaryAnnotations tbody').text('');
     $.each(span.binaryAnnotations, (i, anno) => {
       const $row = self.$binaryAnnotationTemplate.clone();
+      if (anno.key === Constants.ERROR) {
+        $row.addClass('anno-error-critical');
+      }
       $row.find('td').each(function() {
         const $this = $(this);
         const maybeObject = anno[$this.data('key')];

--- a/zipkin-ui/js/component_ui/traceConstants.js
+++ b/zipkin-ui/js/component_ui/traceConstants.js
@@ -10,6 +10,7 @@ const SERVER_ADDR = 'sa';
 const CLIENT_ADDR = 'ca';
 const WIRE_SEND = 'ws';
 const WIRE_RECEIVE = 'wr';
+const ERROR = 'error';
 const LOCAL_COMPONENT = 'lc';
 const CORE_CLIENT = [CLIENT_RECEIVE, CLIENT_RECEIVE_FRAGMENT, CLIENT_SEND, CLIENT_SEND_FRAGMENT];
 const CORE_SERVER = [SERVER_RECEIVE, SERVER_RECEIVE_FRAGMENT, SERVER_SEND, SERVER_SEND_FRAGMENT];
@@ -30,6 +31,7 @@ export const Constants = {
   CLIENT_ADDR,
   CORE_CLIENT,
   CORE_SERVER,
+  ERROR,
   LOCAL_COMPONENT,
   CORE_ADDRESS,
   CORE_WIRE,
@@ -51,3 +53,4 @@ ConstantNames[SERVER_ADDR] = 'Server Address';
 ConstantNames[WIRE_SEND] = 'Wire Send';
 ConstantNames[WIRE_RECEIVE] = 'Wire Receive';
 ConstantNames[LOCAL_COMPONENT] = 'Local Component';
+// Don't add ERROR to ConstantNames -- css coloring depends on constant name 'error'

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -86,7 +86,7 @@
 {{#queryWasPerformed}}
   <ul id="traces">
   {{#traces}}
-    <li class="trace" data-traceId="{{traceId}}" data-duration="{{duration}}" data-timestamp="{{timestamp}}" data-service-percentage="{{servicePercentage}}">
+    <li class="trace {{infoClass}}" data-traceId="{{traceId}}" data-duration="{{duration}}" data-timestamp="{{timestamp}}" data-service-percentage="{{servicePercentage}}">
       <a href="/traces/{{traceId}}?serviceName={{serviceName}}">
         <div class="bar-block">
           <span class="bar-graphic" style="width:{{width}}%;"></span>

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -50,6 +50,7 @@
     data-duration-str='{{durationStr}}'
     data-duration='{{duration}}'
     data-children='{{children}}'
+    data-error-type='{{errorType}}'
   >
     <div class='handle'>
       <div class='service-name' style='margin-left: {{depth}}px'>

--- a/zipkin-ui/test/component_ui/traceTestHelpers.js
+++ b/zipkin-ui/test/component_ui/traceTestHelpers.js
@@ -6,6 +6,10 @@ export function annotation(timestamp, value, ep) {
   return {timestamp, value, endpoint: ep};
 }
 
+export function binaryAnnotation(key, value, ep) {
+  return {key, value, endpoint: ep};
+}
+
 export function span(traceId,
                      name,
                      id,


### PR DESCRIPTION
- Annotations: value must be 'error'
- Binary annotations: key must be 'error'
- Fixes #1140 

Here's three screenshots that illustrate the changes:

Traces view (top is transient, bottom is critical):
![traces](https://cloud.githubusercontent.com/assets/567900/16543254/88b323de-4099-11e6-8b7c-eca266a5ce74.png)

Trace view (spans are critical, normal, critical + error annotation, transient):
![trace](https://cloud.githubusercontent.com/assets/567900/16543257/8fdc06f8-4099-11e6-9ba5-580c0eafc0d3.png)

Trace modal:
![trace-modal](https://cloud.githubusercontent.com/assets/567900/16543258/976f442a-4099-11e6-8d6f-4dbd0131c622.png)

And the JSON to duplicate:

```
[
    {
        "annotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "timestamp": 1466977002899000,
                "value": "sr"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "timestamp": 1466977002908000,
                "value": "ss"
            }
        ],
        "binaryAnnotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "key": "http.status_code",
                "value": "500"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "key": "http.url",
                "value": "/error"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "key": "error",
                "value": "You done messed up son"
            }
        ],
        "duration": 9000,
        "id": "8e5b31230ccb7f42",
        "name": "get",
        "timestamp": 1466977002899000,
        "traceId": "8e5b31230ccb7f42"
    },
    {
        "annotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "timestamp": 1466977002899000,
                "value": "sr"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "timestamp": 1466977002908000,
                "value": "ss"
            }
        ],
        "binaryAnnotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "key": "http.status_code",
                "value": "500"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "key": "http.url",
                "value": "/error"
            }
        ],
        "duration": 9000,
        "id": "8e5b31230ccb7e30",
        "parentId": "8e5b31230ccb7f42",
        "name": "getit",
        "timestamp": 1466977002899000,
        "traceId": "8e5b31230ccb7f42"
    },
    {
        "annotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "timestamp": 1466977002899000,
                "value": "sr"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "timestamp": 1466977002908000,
                "value": "ss"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "timestamp": 1466977002907000,
                "value": "error"
            }
        ],
        "binaryAnnotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "key": "http.status_code",
                "value": "500"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "key": "http.url",
                "value": "/error"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server"
                },
                "key": "error",
                "value": "You done messed up son"
            }
        ],
        "duration": 9000,
        "id": "8e5b31230ccb7e43",
        "parentId": "8e5b31230ccb7e30",
        "name": "gettt",
        "timestamp": 1466977002899000,
        "traceId": "8e5b31230ccb7f42"
    },
    {
        "annotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "timestamp": 1466977002899000,
                "value": "sr"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "timestamp": 1466977002908000,
                "value": "ss"
            },{
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "timestamp": 1466977002907000,
                "value": "error"
            }
        ],
        "binaryAnnotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "key": "http.status_code",
                "value": "500"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "key": "http.url",
                "value": "/error"
            }
        ],
        "duration": 19000,
        "id": "8e5b31230ccb7e53",
        "parentId": "8e5b31230ccb7e43",
        "name": "geterdone",
        "timestamp": 1466977002899000,
        "traceId": "8e5b31230ccb7f42"
    },
    {
        "annotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "timestamp": 1466977002899000,
                "value": "sr"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "timestamp": 1466977002908000,
                "value": "ss"
            },{
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "timestamp": 1466977002907000,
                "value": "error"
            }
        ],
        "binaryAnnotations": [
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "key": "http.status_code",
                "value": "500"
            },
            {
                "endpoint": {
                    "ipv4": "10.24.23.10",
                    "port": 9411,
                    "serviceName": "zipkin-server2"
                },
                "key": "http.url",
                "value": "/error"
            }
        ],
        "duration": 19000,
        "id": "8e5b31230ccb7e99",
        "name": "is-transient",
        "timestamp": 1466977002899000,
        "traceId": "8e5b31230ccb7e99"
    }
]
```
