### PR TITLE
Adds properties that affect Elasticsearch index scalability

### DIFF
--- a/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -20,21 +20,16 @@ import zipkin.storage.elasticsearch.ElasticsearchStorage;
 
 @ConfigurationProperties("zipkin.storage.elasticsearch")
 public class ZipkinElasticsearchStorageProperties {
-  /**
-   * The elasticsearch cluster to connect to, defaults to "elasticsearch".
-   */
+  /** @see ElasticsearchStorage.Builder#cluster(String) */
   private String cluster = "elasticsearch";
-
-  /**
-   * A list of elasticsearch hostnodes to connect to, in host:port format. The port should be the
-   * transport port, not the http port. Defaults to "localhost:9300".
-   */
+  /** @see ElasticsearchStorage.Builder#hosts(List) */
   private List<String> hosts = Collections.singletonList("localhost:9300");
-
-  /**
-   * The index prefix to use when generating daily index names. Defaults to zipkin.
-   */
+  /** @see ElasticsearchStorage.Builder#index(String) */
   private String index = "zipkin";
+  /** @see ElasticsearchStorage.Builder#indexShards(int) */
+  private int indexShards = 5;
+  /** @see ElasticsearchStorage.Builder#indexReplicas(int) */
+  private int indexReplicas = 1;
 
   public String getCluster() {
     return cluster;
@@ -63,10 +58,28 @@ public class ZipkinElasticsearchStorageProperties {
     return this;
   }
 
+  public int getIndexShards() {
+    return indexShards;
+  }
+
+  public void setIndexShards(int indexShards) {
+    this.indexShards = indexShards;
+  }
+
+  public int getIndexReplicas() {
+    return indexReplicas;
+  }
+
+  public void setIndexReplicas(int indexReplicas) {
+    this.indexReplicas = indexReplicas;
+  }
+
   public ElasticsearchStorage.Builder toBuilder() {
     return ElasticsearchStorage.builder()
         .cluster(cluster)
         .hosts(hosts)
-        .index(index);
+        .index(index)
+        .indexShards(indexShards)
+        .indexReplicas(indexReplicas);
   }
 }

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -136,7 +136,17 @@ The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
                   remaining nodes in the cluster. It is recommended to set this to all the master
                   nodes of the cluster.
     * `ES_INDEX`: The index prefix to use when generating daily index names. Defaults to zipkin.
-
+    * `ES_INDEX_SHARDS`: The number of shards to split the index into. Each shard and its replicas
+                         are assigned to a machine in the cluster. Increasing the number of shards
+                         and machines in the cluster will improve read and write performance. Number
+                         of shards cannot be changed for existing indices, but new daily indices
+                         will pick up changes to the setting. Defaults to 5.
+    * `ES_INDEX_REPLICAS`: The number of replica copies of each shard in the index. Each shard and
+                           its replicas are assigned to a machine in the cluster. Increasing the
+                           number of replicas and machines in the cluster will improve read
+                           performance, but not write performance. Number of replicas can be changed
+                           for existing indices. Defaults to 1. It is highly discouraged to set this
+                           to 0 as it would mean a machine failure results in data loss.
 Example usage:
 
 ```bash

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -49,6 +49,8 @@ zipkin:
       cluster: ${ES_CLUSTER:elasticsearch}
       hosts: ${ES_HOSTS:localhost:9300}
       index: ${ES_INDEX:zipkin}
+      index-shards: ${ES_INDEX_SHARDS:5}
+      index-replicas: ${ES_INDEX_REPLICAS:1}
     mysql:
       host: ${MYSQL_HOST:localhost}
       port: ${MYSQL_TCP_PORT:3306}

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchStorage.java
@@ -48,6 +48,8 @@ public final class ElasticsearchStorage
     String cluster = "elasticsearch";
     List<String> hosts = Collections.singletonList("localhost:9300");
     String index = "zipkin";
+    int indexShards = 5;
+    int indexReplicas = 1;
 
     /**
      * The elasticsearch cluster to connect to, defaults to "elasticsearch".
@@ -71,6 +73,33 @@ public final class ElasticsearchStorage
      */
     public Builder index(String index) {
       this.index = checkNotNull(index, "index");
+      return this;
+    }
+
+    /**
+     * The number of shards to split the index into. Each shard and its replicas are assigned to a
+     * machine in the cluster. Increasing the number of shards and machines in the cluster will
+     * improve read and write performance. Number of shards cannot be changed for existing indices,
+     * but new daily indices will pick up changes to the setting. Defaults to 5.
+     *
+     * <p>Corresponds to <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html">index.number_of_shards</a>
+     */
+    public Builder indexShards(int indexShards) {
+      this.indexShards = indexShards;
+      return this;
+    }
+
+    /**
+     * The number of replica copies of each shard in the index. Each shard and its replicas are
+     * assigned to a machine in the cluster. Increasing the number of replicas and machines in the
+     * cluster will improve read performance, but not write performance. Number of replicas can be
+     * changed for existing indices. Defaults to 1. It is highly discouraged to set this to 0 as it
+     * would mean a machine failure results in data loss.
+     *
+     * <p>Corresponds to <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html">index.number_of_replicas</a>
+     */
+    public Builder indexReplicas(int indexReplicas) {
+      this.indexReplicas = indexReplicas;
       return this;
     }
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
@@ -33,7 +33,7 @@ import zipkin.internal.LazyCloseable;
 final class LazyClient extends LazyCloseable<Client> {
   private final String clusterName;
   private final List<String> hosts;
-  private final String indexTemplate;
+  final String indexTemplate;
 
   LazyClient(ElasticsearchStorage.Builder builder) {
     this.clusterName = builder.cluster;
@@ -42,7 +42,9 @@ final class LazyClient extends LazyCloseable<Client> {
       this.indexTemplate = Resources.toString(
           Resources.getResource("zipkin/storage/elasticsearch/zipkin_template.json"),
           StandardCharsets.UTF_8)
-          .replace("${__INDEX__}", builder.index);
+          .replace("${__INDEX__}", builder.index)
+          .replace("${__NUMBER_OF_SHARDS__}", String.valueOf(builder.indexShards))
+          .replace("${__NUMBER_OF_REPLICAS__}", String.valueOf(builder.indexReplicas));
     } catch (IOException e) {
       throw new AssertionError("Error reading jar resource, shouldn't happen.", e);
     }

--- a/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
+++ b/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
@@ -1,6 +1,8 @@
 {
   "template": "${__INDEX__}-*",
   "settings": {
+    "index.number_of_shards": ${__NUMBER_OF_SHARDS__},
+    "index.number_of_replicas": ${__NUMBER_OF_REPLICAS__},
     "index.requests.cache.enable": true,
     "analysis": {
       "analyzer": {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/LazyClientTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/LazyClientTest.java
@@ -29,4 +29,24 @@ public class LazyClientTest {
     assertThat(lazyClient)
         .hasToString("{\"clusterName\": \"cluster\", \"hosts\": [\"host1\", \"host2\"]}");
   }
+
+  @Test
+  public void defaultShardAndReplicaCount() {
+    LazyClient lazyClient = new LazyClient(new ElasticsearchStorage.Builder());
+
+    assertThat(lazyClient.indexTemplate)
+        .contains("    \"index.number_of_shards\": 5,\n"
+            + "    \"index.number_of_replicas\": 1,");
+  }
+
+  @Test
+  public void overrideShardAndReplicaCount() {
+    LazyClient lazyClient = new LazyClient(new ElasticsearchStorage.Builder()
+        .indexShards(30)
+        .indexReplicas(0));
+
+    assertThat(lazyClient.indexTemplate)
+        .contains("    \"index.number_of_shards\": 30,\n"
+            + "    \"index.number_of_replicas\": 0,");
+  }
 }


### PR DESCRIPTION
This adds the following properties, which help control the scalability
of Zipkin's index in Elasticsearch.

```
* `ES_INDEX_SHARDS`: The number of shards to split the index into. Each shard and its replicas
                     are assigned to a machine in the cluster. Increasing the number of shards
                     and machines in the cluster will improve read and write performance. Number
                     of shards cannot be changed for existing indices, but new daily indices
                     will pick up changes to the setting. Defaults to 5.
* `ES_INDEX_REPLICAS`: The number of replica copies of each shard in the index. Each shard and
                       its replicas are assigned to a machine in the cluster. Increasing the
                       number of replicas and machines in the cluster will improve read
                       performance, but not write performance. Number of replicas can be changed
                       for existing indices. Defaults to 1. It is highly discouraged to set this
                       to 0 as it would mean a machine failure results in data loss.
```
