### PR TITLE
Fixes NPE when ES aggregations don't exist yet

### DIFF
--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -64,5 +64,12 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
@@ -307,6 +307,9 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
     INSTANCE;
 
     @Override public List<String> apply(SearchResponse response) {
+      if (response.getAggregations() == null) {
+        return Collections.emptyList();
+      }
       Terms namesAgg = response.getAggregations().get("name_agg");
       if (namesAgg == null) {
         return Collections.emptyList();

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ConvertSpanNameResponseTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ConvertSpanNameResponseTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import zipkin.storage.elasticsearch.ElasticsearchSpanStore.ConvertSpanNameResponse;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConvertSpanNameResponseTest {
+
+  @Rule
+  public MockitoRule mocks = MockitoJUnit.rule();
+
+  @Mock
+  private SearchResponse response;
+
+  @Mock
+  private Aggregations aggregations;
+
+  @Test
+  public void emptyWhenAggregatesAreNull() {
+    assertThat(ConvertSpanNameResponse.INSTANCE.apply(response))
+        .isEmpty();
+  }
+
+  @Test
+  public void emptyWhenMissingNameAgg() {
+    when(response.getAggregations()).thenReturn(aggregations);
+
+    assertThat(ConvertSpanNameResponse.INSTANCE.apply(response))
+        .isEmpty();
+  }
+
+  @Test
+  public void namesAggBucketKeysAreSpanNames() {
+    when(response.getAggregations()).thenReturn(aggregations);
+    Terms terms = mock(Terms.class);
+    when(aggregations.get("name_agg")).thenReturn(terms);
+    Terms.Bucket bucket = mock(Terms.Bucket.class);
+    when(terms.getBuckets()).thenReturn(asList(bucket));
+    when(bucket.getKeyAsString()).thenReturn("service");
+
+    assertThat(ConvertSpanNameResponse.INSTANCE.apply(response))
+        .containsExactly("service");
+  }
+}


### PR DESCRIPTION
Reported by @liangman

```
2016-06-28 10:58:14.976 ERROR 44212 --- [nio-9431-exec-3] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.NullPointerException] with root cause

java.lang.NullPointerException: null
    at zipkin.storage.elasticsearch.ElasticsearchSpanStore$ConvertSpanNameResponse.apply(ElasticsearchSpanStore.java:310) ~[zipkin-storage-elasticsearch-1.1.6-SNAPSHOT.jar!/:na]
    at zipkin.storage.elasticsearch.ElasticsearchSpanStore$ConvertSpanNameResponse.apply(ElasticsearchSpanStore.java:306) ~[zipkin-storage-elasticsearch-1.1.6-SNAPSHOT.jar!/:na]
    at com.google.common.util.concurrent.Futures$2.apply(Futures.java:760) ~[guava-18.0.jar!/:na]
    at com.google.common.util.concurrent.Futures$ChainingListenableFuture.run(Futures.java:906) ~[guava-18.0.jar!/:na]
    at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:457) ~[guava-18.0.jar!/:na]
    at com.google.common.util.concurrent.ExecutionList.executeListener(ExecutionList.java:156) ~[guava-18.0.jar!/:na]
    at com.google.common.util.concurrent.ExecutionList.execute(ExecutionList.java:145) ~[guava-18.0.jar!/:na]
    at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:185) ~[guava-18.0.jar!/:na]
    at com.google.common.util.concurrent.SettableFuture.set(SettableFuture.java:53) ~[guava-18.0.jar!/:na]
    at zipkin.storage.elasticsearch.ElasticFutures$1.onResponse(ElasticFutures.java:27) ~[zipkin-storage-elasticsearch-1.1.6-SNAPSHOT.jar!/:na]
    at org.elasticsearch.action.support.ThreadedActionListener$1.doRun(ThreadedActionListener.java:89) ~[elasticsearch-2.3.3.jar!/:2.3.3]
    at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[elasticsearch-2.3.3.jar!/:2.3.3]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_73]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_73]
    at java.lang.Thread.run(Thread.java:745) [na:1.8.0_73]
```
