### PR TITLE
Coerces Span.timestamp to null when zero

### DIFF
--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -251,7 +251,7 @@ public final class Span implements Comparable<Span> {
 
     /** @see Span#timestamp */
     public Builder timestamp(@Nullable Long timestamp) {
-      this.timestamp = timestamp;
+      this.timestamp = timestamp != null && timestamp == 0 ? null : timestamp;
       return this;
     }
 

--- a/zipkin/src/test/java/zipkin/SpanTest.java
+++ b/zipkin/src/test/java/zipkin/SpanTest.java
@@ -128,4 +128,18 @@ public class SpanTest {
     assertThat(span.binaryAnnotations)
         .containsExactly(baz, foo);
   }
+
+  /** Catches common error when zero is passed instead of null for a timestamp */
+  @Test
+  public void coercesTimestampZeroToNull() {
+    Span span = Span.builder()
+        .traceId(1L)
+        .name("GET")
+        .id(1L)
+        .timestamp(0L)
+        .build();
+
+    assertThat(span.timestamp)
+        .isNull();
+  }
 }


### PR DESCRIPTION
At the expense of making it impossible to represent a span that started in the first microsecond of Jan 1, 1970, we gain index fidelity by working around a common programming mistake.
