### PR TITLE
Replaces hand-written query logging with DataStax QueryLogger

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -28,7 +28,7 @@ $ java -jar ./zipkin-server/target/zipkin-server-*exec.jar
 
 ## Logging
 
-By default, zipkin writes log messages to the console at INFO level and above. You can adjust categories using the `--logging.level.XXX` parameter, or by adjusting [yaml configuration](src/main/resources/zipkin-server.yml).
+By default, zipkin writes log messages to the console at INFO level and above. You can adjust categories using the `--logging.level.XXX` parameter, a `-Dlogging.level.XXX` system property, or by adjusting [yaml configuration](src/main/resources/zipkin-server.yml).
 
 For example, if you want to enable debug logging for all zipkin categories, you can start the server like so:
 
@@ -97,7 +97,7 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 
 ### Cassandra Storage
-Zipkin's [Cassandra storage component](https://github.com/openzipkin/zipkin/tree/master/zipkin-storage/cassandra)
+Zipkin's [Cassandra storage component](../zipkin-storage/cassandra)
 supports version 2.2+ and applies when `STORAGE_TYPE` is set to `cassandra`:
 
     * `CASSANDRA_KEYSPACE`: The keyspace to use. Defaults to "zipkin".
@@ -110,9 +110,8 @@ supports version 2.2+ and applies when `STORAGE_TYPE` is set to `cassandra`:
 Example usage:
 
 ```bash
-$ STORAGE_TYPE=cassandra CASSANDRA_CONTACT_POINTS=host1,host2 java -jar ./zipkin-server/target/zipkin-server-*exec.jar
+$ STORAGE_TYPE=cassandra java -jar ./zipkin-server/target/zipkin-server-*exec.jar --logging.level.com.datastax.driver.core.QueryLogger=trace
 ```
-
 ### MySQL Storage
 The following apply when `STORAGE_TYPE` is set to `mysql`:
 

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -96,7 +96,7 @@ logging:
     com.facebook.swift.service.ThriftServiceProcessor: 'OFF'
 #     # investigate /api/v1/dependencies
 #     zipkin.internal.DependencyLinker: 'DEBUG'
-#     # log cassandra calls
-#     zipkin.storage.cassandra: 'DEBUG'
+#     # log cassandra queries (DEBUG is without values)
+#     com.datastax.driver.core.QueryLogger: 'TRACE'
 #     # log cassandra trace propagation
 #     com.datastax.driver.core.Message: 'TRACE'

--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -10,6 +10,12 @@ The CQL schema is the same as [zipkin-scala](https://github.com/openzipkin/zipki
 `zipkin.storage.cassandra.CassandraStorage.Builder` includes defaults that will
 operate against a local Cassandra installation.
 
+## Logging
+Queries are logged to the category "com.datastax.driver.core.QueryLogger" when debug or trace is
+enabled via SLF4J. Trace level includes bound values.
+
+See [Logging Query Latencies](http://docs.datastax.com/en/developer/java-driver/2.1/supplemental/manual/logging/#logging-query-latencies) for more details.
+
 ## Testing this component
 This module conditionally runs integration tests against a local Cassandra instance.
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraDependenciesWriter.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraDependenciesWriter.java
@@ -17,22 +17,17 @@ import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.datastax.driver.core.utils.Bytes;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import zipkin.DependencyLink;
 import zipkin.internal.Dependencies;
 import zipkin.internal.Util;
 
 final class CassandraDependenciesWriter {
-  private static final Logger LOG = LoggerFactory.getLogger(CassandraDependenciesWriter.class);
-
   private final PreparedStatement insertDependencies;
   private final Session session;
 
@@ -57,19 +52,9 @@ final class CassandraDependenciesWriter {
           .setTimestamp("day", startFlooredToDay)
           .setBytes("dependencies", dependencies);
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(debugInsertDependencies(startFlooredToDay, dependencies));
-      }
       return session.executeAsync(bound);
     } catch (RuntimeException ex) {
-      LOG.error("failed " + debugInsertDependencies(startFlooredToDay, dependencies), ex);
       return Futures.immediateFailedFuture(ex);
     }
-  }
-
-  private String debugInsertDependencies(Date startFlooredToDay, ByteBuffer dependencies) {
-    return insertDependencies.getQueryString()
-        .replace(":day", CassandraUtil.iso8601(startFlooredToDay.getTime() * 1000))
-        .replace(":dependencies", Bytes.toHexString(dependencies));
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
@@ -33,7 +33,10 @@ import static zipkin.internal.Util.checkNotNull;
 /**
  * CQL3 implementation of zipkin storage.
  *
- * <p>This uses zipkin-cassandra-core which packages "/cassandra-schema-cql3.txt"
+ * <p>Queries are logged to the category "com.datastax.driver.core.QueryLogger" when debug or trace
+ * is enabled via SLF4J. Trace level includes bound values.
+ *
+ * <p>Schema is installed by default from "/cassandra-schema-cql3.txt"
  */
 public final class CassandraStorage
     extends LazyGuavaStorageComponent<CassandraSpanStore, CassandraSpanConsumer> {

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/SessionFactory.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/SessionFactory.java
@@ -16,6 +16,7 @@ package zipkin.storage.cassandra;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.PoolingOptions;
+import com.datastax.driver.core.QueryLogger;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.LatencyAwarePolicy;
@@ -48,6 +49,7 @@ public interface SessionFactory {
       Closer closer = Closer.create();
       try {
         Cluster cluster = closer.register(buildCluster(cassandra));
+        cluster.register(new QueryLogger.Builder().build());
         if (cassandra.ensureSchema) {
           Session session = closer.register(cluster.connect());
           Schema.ensureExists(cassandra.keyspace, session);

--- a/zipkin-storage/cassandra/src/test/resources/logback.xml
+++ b/zipkin-storage/cassandra/src/test/resources/logback.xml
@@ -9,7 +9,7 @@
   </appender>
 
   <!-- Note: this will dump a large amount of data in the logs -->
-  <!--<logger name="zipkin.cassandra" level="DEBUG" />-->
+  <!--<logger name="com.datastax.driver.core.QueryLogger" level="TRACE" />-->
 
   <root level="info">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Hand-written query logging has resulted in bugs and also clutters the
codebase. This change replaces that with DataStax QueryLogger, which is
enabled when the category "com.datastax.driver.core.QueryLogger" is at
debug or trace level. Trace level includes bound values.

Ex.

``` bash
$ STORAGE_TYPE=cassandra java -jar zipkin-server/target/zipkin-server-*-exec.jar  --logging.level.zipkin=debug --logging.level.com.datastax.driver.core.QueryLogger=trace
--snip--
2016-06-30 15:28:05.742 TRACE 27669 --- [r2-nio-worker-1] c.d.driver.core.QueryLogger.NORMAL       : [cluster2] [localhost/127.0.0.1:9042] Query completed normally, took 10 ms: [4 bound values] INSERT INTO annotations_index (annotation,bucket,ts,trace_id) VALUES (:annotation,:bucket,:ts,:trace_id); [annotation:0x7a69706b696e2d7365727665723a4170706c69636174696f... [truncated output], bucket:9, ts:1467271680225, trace_id:3814895566661605459]
```

See [Logging Query Latencies](http://docs.datastax.com/en/developer/java-driver/2.1/supplemental/manual/logging/#logging-query-latencies) for more details.
Fixes https://github.com/openzipkin/zipkin-java/issues/190
