### PR TITLE
Extracts DeduplicatingExecutor, preventing redundant Cassandra indexing

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
@@ -212,6 +212,7 @@ public final class CassandraStorage
 
   /** Truncates all the column families, or throws on any failure. */
   @VisibleForTesting void clear() {
+    guavaSpanConsumer().clear();
     List<ListenableFuture<?>> futures = new LinkedList<>();
     for (String cf : ImmutableList.of(
         "traces",

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/DeduplicatingExecutor.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/DeduplicatingExecutor.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.Session;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static zipkin.internal.Util.checkNotNull;
+
+/**
+ * This reduces load on cassandra by preventing semantically equivalent requests from being invoked,
+ * subject to a local TTL.
+ *
+ * <p>Ex. If you want to test that you don't repeatedly send bad data, you could send a 400 back.
+ *
+ * <pre>{@code
+ * ttl = 60 * 1000; // 1 minute
+ * deduper = new DeduplicatingExecutor(session, ttl);
+ *
+ * // the result of the first execution against "foo" is returned to other callers
+ * // until it expires a minute later.
+ * deduper.maybeExecute(bound, "foo");
+ * deduper.maybeExecute(bound, "foo");
+ * }</pre>
+ */
+class DeduplicatingExecutor { // not final for testing
+
+  private final Session session;
+  private final LoadingCache<BoundStatementKey, ListenableFuture<?>> cache;
+
+  /**
+   * @param session which conditionally executes bound statements
+   * @param ttl how long the results of statements are remembered, in milliseconds.
+   */
+  DeduplicatingExecutor(Session session, long ttl) {
+    this.session = session;
+    this.cache = CacheBuilder.newBuilder()
+        .expireAfterWrite(ttl, TimeUnit.MILLISECONDS)
+        .ticker(new Ticker() {
+          @Override public long read() {
+            return nanoTime();
+          }
+        })
+        .build(new CacheLoader<BoundStatementKey, ListenableFuture<?>>() {
+          @Override public ListenableFuture<?> load(final BoundStatementKey key) {
+            ListenableFuture<?> result = executeAsync(key.statement);
+            // Adds a guard that invalidates the future if in error state.
+            Futures.addCallback(result, new FutureCallback<Object>() {
+
+              @Override public void onSuccess(Object result) {
+              }
+
+              @Override public void onFailure(Throwable t) {
+                cache.invalidate(key);
+              }
+            });
+            return result;
+          }
+        });
+  }
+
+  /**
+   * Upon success, the statement's result will be remembered and returned for all subsequent
+   * executions with the same key, subject to a local TTL.
+   *
+   * <p>The results of failed statements are forgotten based on the supplied key.
+   *
+   * @param statement what to conditionally execute
+   * @param key determines equivalence of the bound statement
+   * @return future of work initiated by this or a previous request
+   */
+  ListenableFuture<?> maybeExecuteAsync(BoundStatement statement, Object key) {
+    BoundStatementKey cacheKey = new BoundStatementKey(statement, key);
+    try {
+      ListenableFuture<?> result = cache.get(new BoundStatementKey(statement, key));
+      // A future could be constructed directly (i.e. immediate future), get the value to
+      // see if it was exceptional. If so, the catch block will invalidate that key.
+      if (result.isDone()) result.get();
+      return result;
+    } catch (UncheckedExecutionException | ExecutionException e) {
+      cache.invalidate(cacheKey);
+      return Futures.immediateFailedFuture(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError();
+    }
+  }
+
+  // visible for testing, since nanoTime is weird and can return negative
+  long nanoTime() {
+    return System.nanoTime();
+  }
+
+  @VisibleForTesting ListenableFuture<?> executeAsync(BoundStatement statement) {
+    return session.executeAsync(statement);
+  }
+
+  @VisibleForTesting void clear() {
+    cache.invalidateAll();
+  }
+
+  /** Used to hold a reference to the last statement executed, but without using it in hashCode */
+  static final class BoundStatementKey {
+    final BoundStatement statement;
+    final Object key;
+
+    BoundStatementKey(BoundStatement statement, Object key) {
+      this.statement = checkNotNull(statement, "statement");
+      this.key = checkNotNull(key, "key");
+    }
+
+    @Override
+    public String toString() {
+      return "(" + key + ", " + statement + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) return true;
+      if (o instanceof BoundStatementKey) {
+        return this.key.equals(((BoundStatementKey) o).key);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return key.hashCode();
+    }
+  }
+}

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
@@ -20,11 +20,6 @@ import zipkin.internal.LazyCloseable;
 enum CassandraTestGraph {
   INSTANCE;
 
-  static {
-    // Ensure the repository's local cache of service names expire quickly
-    System.setProperty("zipkin.store.cassandra.internal.writtenNamesTtl", "1");
-  }
-
   final LazyCloseable<CassandraStorage> storage = new LazyCloseable<CassandraStorage>() {
     AssumptionViolatedException ex = null;
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaTestGraph.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaTestGraph.java
@@ -23,11 +23,6 @@ import zipkin.internal.LazyCloseable;
 enum CassandraWithOriginalSchemaTestGraph {
   INSTANCE;
 
-  static {
-    // Ensure the repository's local cache of service names expire quickly
-    System.setProperty("zipkin.store.cassandra.internal.writtenNamesTtl", "1");
-  }
-
   final LazyCloseable<CassandraStorage> storage = new LazyCloseable<CassandraStorage>() {
     AssumptionViolatedException ex = null;
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/DeduplicatingExecutorTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/DeduplicatingExecutorTest.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.Reflection;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.junit.Test;
+
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.mockito.Mockito.mock;
+
+public class DeduplicatingExecutorTest {
+  TestDeduplicatingExecutor executor = TestDeduplicatingExecutor.create(Futures::immediateFuture);
+
+  BoundStatement first = mock(BoundStatement.class);
+  BoundStatement next = mock(BoundStatement.class);
+
+  @Test
+  public void expiresWhenTtlPasses() throws Exception {
+    executor.nanoTime = 0;
+
+    assertThat(executor.maybeExecuteAsync(first, "foo").get())
+        .isEqualTo(first);
+
+    // same result for the foo
+    assertThat(executor.maybeExecuteAsync(next, "foo").get())
+        .isEqualTo(first);
+
+    executor.nanoTime = TimeUnit.MILLISECONDS.toNanos(500);
+
+    // still, same result for the foo
+    assertThat(executor.maybeExecuteAsync(next, "foo").get())
+        .isEqualTo(first);
+
+    // add a key for the element that happened after "foo"
+    assertThat(executor.maybeExecuteAsync(next, "bar").get())
+        .isEqualTo(next);
+
+    // A second after the first call, we should try again
+    executor.nanoTime = TimeUnit.SECONDS.toNanos(1);
+
+    // first key refreshes
+    assertThat(executor.maybeExecuteAsync(next, "foo").get())
+        .isEqualTo(next);
+
+    // second key still caching
+    assertThat(executor.maybeExecuteAsync(first, "bar").get())
+        .isEqualTo(next);
+  }
+
+  @Test
+  public void exceptionArentCached_immediateFuture() throws Exception {
+    executor = TestDeduplicatingExecutor.create(s -> {
+      if (s == first) return Futures.immediateFailedFuture(new IllegalArgumentException());
+      return Futures.immediateFuture(s);
+    });
+    exceptionsArentCached();
+  }
+
+  @Test
+  public void exceptionArentCached_deferredFuture() throws Exception {
+    ListeningExecutorService exec = listeningDecorator(Executors.newSingleThreadExecutor());
+    try {
+      executor = TestDeduplicatingExecutor.create(s -> {
+        if (s == first) {
+          return exec.submit(() -> {
+            Thread.sleep(50);
+            throw new IllegalArgumentException();
+          });
+        }
+        return Futures.immediateFuture(s);
+      });
+      exceptionsArentCached();
+    } finally {
+      exec.shutdownNow();
+    }
+  }
+
+  @Test
+  public void exceptionArentCached_creatingFuture() throws Exception {
+    executor = TestDeduplicatingExecutor.create(s -> {
+      if (s == first) throw new IllegalArgumentException();
+      return Futures.immediateFuture(s);
+    });
+    exceptionsArentCached();
+  }
+
+  private void exceptionsArentCached() throws Exception {
+    executor.nanoTime = 0;
+
+    // Intentionally not dereferencing the future. We need to ensure that dropped failed
+    // futures still purge!
+    ListenableFuture<?> firstFuture = executor.maybeExecuteAsync(first, "foo");
+
+    Thread.sleep(100); // wait a bit for the future to execute and cache to purge the entry
+
+    // doesn't cache exception
+    assertThat(executor.maybeExecuteAsync(next, "foo").get())
+        .isEqualTo(next);
+
+    // sanity check the first future actually failed
+    try {
+      firstFuture.get();
+      failBecauseExceptionWasNotThrown(ExecutionException.class);
+    } catch (ExecutionException e) {
+      assertThat(e).hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  /**
+   * This shows that any number of threads perform a computation only once.
+   */
+  @Test(timeout = 2000L) // 1000 for the selects + expiration (which is 1 second)
+  public void multithreaded() throws Exception {
+    Session session = CassandraTestGraph.INSTANCE.storage.get().session();
+    DeduplicatingExecutor executor =
+        new DeduplicatingExecutor(session, TimeUnit.SECONDS.toMillis(1L));
+    PreparedStatement now = session.prepare("SELECT now() FROM system.local");
+
+    int loopCount = 1000;
+    CountDownLatch latch = new CountDownLatch(loopCount);
+    ExecutorService exec = Executors.newFixedThreadPool(10);
+
+    Collection<ListenableFuture<?>> futures = new ConcurrentLinkedDeque<>();
+    for (int i = 0; i < loopCount; i++) {
+      exec.execute(() -> {
+        futures.add(executor.maybeExecuteAsync(now.bind(), "foo"));
+        futures.add(executor.maybeExecuteAsync(now.bind(), "bar"));
+        latch.countDown();
+      });
+    }
+    latch.await();
+
+    List<Object> results = Futures.allAsList(futures).get();
+
+    assertThat(ImmutableSet.copyOf(results)).hasSize(2);
+
+    // expire the result
+    Thread.sleep(1000L);
+
+    // Sanity check: we don't memoize after we should have expired.
+    assertThat(executor.maybeExecuteAsync(now.bind(), "foo").get())
+        .isNotEqualTo(results.get(0));
+    assertThat(executor.maybeExecuteAsync(now.bind(), "bar").get())
+        .isNotEqualTo(results.get(1));
+  }
+
+  @Test
+  public void expiresWhenTtlPasses_initiallyNegative() throws Exception {
+    executor.nanoTime = -TimeUnit.SECONDS.toNanos(1);
+
+    assertThat(executor.maybeExecuteAsync(first, "foo").get())
+        .isEqualTo(first);
+    assertThat(executor.maybeExecuteAsync(next, "foo").get())
+        .isEqualTo(first);
+
+    // A second after the first call, we should try again
+    executor.nanoTime = 0;
+
+    assertThat(executor.maybeExecuteAsync(next, "foo").get())
+        .isEqualTo(next);
+  }
+
+  static class TestDeduplicatingExecutor extends DeduplicatingExecutor {
+    static TestDeduplicatingExecutor create(Function<BoundStatement, ListenableFuture<?>> callee) {
+      return new TestDeduplicatingExecutor(callee);
+    }
+
+    final Function<BoundStatement, ListenableFuture<?>> delegate;
+    long nanoTime;
+
+    protected TestDeduplicatingExecutor(Function<BoundStatement, ListenableFuture<?>> delegate) {
+      super(fakeSession(delegate), TimeUnit.SECONDS.toMillis(1L));
+      this.delegate = delegate;
+    }
+
+    @Override long nanoTime() {
+      return nanoTime;
+    }
+
+    @Override ListenableFuture<?> executeAsync(BoundStatement statement) {
+      return delegate.apply(statement);
+    }
+  }
+
+  static Session fakeSession(final Function<BoundStatement, ListenableFuture<?>> delegate) {
+    return Reflection.newProxy(Session.class, (proxy, method, args) -> {
+      assert method.getName().equals("executeAsync") && args[0] instanceof BoundStatement;
+      return delegate.apply((BoundStatement) args[0]);
+    });
+  }
+}


### PR DESCRIPTION
The previous code had a mechanism to reduce writes to two indexes:
`service_name_index` and `service_span_name_index`. This mechanism would
prevent writing the same names multiple times. However, it is only
effective on a per-thread basis (as names were stored in thread locals).

In practice, this code is invoked at collection, and collectors have
many request threads per transport. By changing to a shared loading
cache, we can extend the deduplication to all threads. By extracting a
class to do this, we can test the edge cases and make it available for
future work, such as the other indexes.

See #1142
