### PR TITLE
Resurrects index skipping on core annotations in Cassandra

### DIFF
--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraUtilTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import org.junit.Test;
+import zipkin.Constants;
+import zipkin.Span;
+import zipkin.TestObjects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CassandraUtilTest {
+
+  @Test
+  public void annotationKeys_skipsCoreAndAddressAnnotations() throws Exception {
+    Span span = TestObjects.TRACE.get(1);
+
+    assertThat(span.annotations)
+        .extracting(a -> a.value)
+        .matches(Constants.CORE_ANNOTATIONS::containsAll);
+
+    assertThat(span.binaryAnnotations)
+        .extracting(b -> b.key)
+        .containsOnly(Constants.SERVER_ADDR, Constants.CLIENT_ADDR);
+
+    assertThat(CassandraUtil.annotationKeys(span))
+        .isEmpty();
+  }
+}

--- a/zipkin/src/main/java/zipkin/Constants.java
+++ b/zipkin/src/main/java/zipkin/Constants.java
@@ -13,7 +13,13 @@
  */
 package zipkin;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import zipkin.storage.QueryRequest;
+
 public final class Constants {
+
   /**
    * The client sent ("cs") a request to a server. There is only one send per span. For example, if
    * there's a transport error, each attempt can be logged as a {@link #WIRE_SEND} annotation.
@@ -167,6 +173,17 @@ public final class Constants {
    * fails to a different server ip or port.
    */
   public static final String SERVER_ADDR = "sa";
+
+  /**
+   * Zipkin's core annotations indicate when a client or server operation began or ended.
+   *
+   * <p>These annotations are used to derive span timestamps and durations or highlight common
+   * latency explaining events. However, they aren't intuitive as {@link QueryRequest storage
+   * queries}, so needn't be indexed.
+   */
+  public static final List<String> CORE_ANNOTATIONS = Collections.unmodifiableList(
+      Arrays.asList(CLIENT_SEND, CLIENT_RECV, SERVER_SEND, SERVER_RECV, WIRE_SEND, WIRE_RECV,
+          CLIENT_SEND_FRAGMENT, CLIENT_RECV_FRAGMENT, SERVER_SEND_FRAGMENT, SERVER_RECV_FRAGMENT));
 
   private Constants() {
   }

--- a/zipkin/src/main/java/zipkin/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin/storage/QueryRequest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import zipkin.Span;
 import zipkin.internal.Nullable;
 
+import static zipkin.Constants.CORE_ANNOTATIONS;
 import static zipkin.internal.Util.checkArgument;
 
 /**
@@ -134,6 +135,8 @@ public final class QueryRequest {
     this.annotations = annotations;
     for (String annotation : annotations) {
       checkArgument(!annotation.isEmpty(), "annotation was empty");
+      checkArgument(!CORE_ANNOTATIONS.contains(annotation),
+          "queries cannot be refined by core annotations: %s", annotation);
     }
     this.binaryAnnotations = binaryAnnotations;
     for (Map.Entry<String, String> entry : binaryAnnotations.entrySet()) {

--- a/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
@@ -17,9 +17,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import zipkin.Constants;
-import zipkin.TraceKeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.TraceKeys.HTTP_METHOD;
 
 public class QueryRequestTest {
   @Rule
@@ -53,6 +53,18 @@ public class QueryRequestTest {
     thrown.expectMessage("annotation was empty");
 
     QueryRequest.builder().serviceName("foo").addAnnotation("").build();
+  }
+
+  /**
+   * Particularly in the case of cassandra, indexing boundary annotations isn't fruitful work, and
+   * not helpful to users. Nevertheless we should ensure an unlikely caller gets an exception.
+   */
+  @Test
+  public void annotationCantBeCore() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("queries cannot be refined by core annotations: sr");
+
+    QueryRequest.builder().serviceName("foo").addAnnotation(Constants.SERVER_RECV).build();
   }
 
   @Test
@@ -95,7 +107,7 @@ public class QueryRequestTest {
         QueryRequest.builder().serviceName("security-service").parseAnnotationQuery(annotationQuery).build();
 
     assertThat(request.binaryAnnotations)
-        .containsEntry(TraceKeys.HTTP_METHOD, "GET")
+        .containsEntry(HTTP_METHOD, "GET")
         .hasSize(1);
     assertThat(request.annotations)
         .containsExactly(Constants.ERROR);
@@ -115,7 +127,7 @@ public class QueryRequestTest {
         QueryRequest.builder().serviceName("security-service").parseAnnotationQuery(annotationQuery).build();
 
     assertThat(request.annotations)
-        .containsExactly(TraceKeys.HTTP_METHOD);
+        .containsExactly(HTTP_METHOD);
   }
 
   @Test


### PR DESCRIPTION
In the old scala implementation, we used to skip "core annotations" when
performing api queries, and we skipped them on custom indexes like Redis
or Cassandra. Skipping very common annotations like "cs" results in a
lot less storage operations, without affecting meaningful user queries.
