### PR TITLE
Adds error-prone checks to the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,10 @@
     <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
+
+    <!-- Catch common Java mistakes as compile-time errors -->
+    <plexus-compiler-javac-errorprone.version>2.8</plexus-compiler-javac-errorprone.version>
+    <errorprone.version>2.0.9</errorprone.version>
   </properties>
 
   <name>Zipkin (Parent)</name>
@@ -414,6 +418,23 @@
             </configuration>
           </execution>
         </executions>
+        <configuration>
+          <compilerId>javac-with-errorprone</compilerId>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <showWarnings>true</showWarnings>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+            <version>${plexus-compiler-javac-errorprone.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <version>${errorprone.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>

--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
@@ -112,6 +112,7 @@ public class ZipkinCassandraStorageProperties {
   /**
    * @deprecated See {@link CassandraStorage.Builder#indexTtl(int)}
    */
+  @Deprecated
   public void setIndexTtl(int indexTtl) {
     this.indexTtl = indexTtl;
   }

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaTestGraph.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaTestGraph.java
@@ -15,10 +15,11 @@ package zipkin.storage.cassandra;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
-import org.assertj.core.api.exception.RuntimeIOException;
 import org.junit.AssumptionViolatedException;
 import zipkin.Component.CheckResult;
 import zipkin.internal.LazyCloseable;
+
+import static zipkin.storage.cassandra.SessionFactory.Default.buildCluster;
 
 enum CassandraWithOriginalSchemaTestGraph {
   INSTANCE;
@@ -33,7 +34,7 @@ enum CassandraWithOriginalSchemaTestGraph {
           .keyspace("test_zipkin_original").build();
 
       // Install the old schema
-      try (Cluster cluster = new SessionFactory.Default().buildCluster(result);
+      try (Cluster cluster = buildCluster(result);
            Session session = cluster.newSession()) {
         Schema.applyCqlFile(result.keyspace, session, "/cassandra-schema-cql3-original.txt");
       } catch (RuntimeException e) {

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/EnsureSchemaTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/EnsureSchemaTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.storage.cassandra.SessionFactory.Default.buildCluster;
 
 public class EnsureSchemaTest {
 
@@ -34,8 +35,7 @@ public class EnsureSchemaTest {
   public TestName name = new TestName();
 
   @BeforeClass public static void checkCassandraIsUp() {
-    try (Cluster cluster = new SessionFactory.Default().buildCluster(
-        CassandraStorage.builder().build());
+    try (Cluster cluster = buildCluster(CassandraStorage.builder().build());
          Session session = cluster.newSession()) {
       session.execute("SELECT now() FROM system.local");
     } catch (RuntimeException e) {
@@ -51,8 +51,7 @@ public class EnsureSchemaTest {
   @Before
   public void connectAndDropKeyspace() {
     keyspace = name.getMethodName().toLowerCase();
-    cluster = closer.register(new SessionFactory.Default()
-        .buildCluster(CassandraStorage.builder().keyspace(keyspace).build()));
+    cluster = closer.register(buildCluster(CassandraStorage.builder().keyspace(keyspace).build()));
     session = closer.register(cluster.newSession());
     session.execute("DROP KEYSPACE IF EXISTS " + keyspace);
     assertThat(session.getCluster().getMetadata().getKeyspace(keyspace)).isNull();

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/SessionFactoryTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/SessionFactoryTest.java
@@ -31,25 +31,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static zipkin.storage.cassandra.SessionFactory.Default.buildCluster;
+import static zipkin.storage.cassandra.SessionFactory.Default.parseContactPoints;
 
 public class SessionFactoryTest {
-  SessionFactory.Default session = new SessionFactory.Default();
 
   @Test
   public void contactPoints_defaultsToLocalhost() {
-    assertThat(session.parseContactPoints(CassandraStorage.builder().build()))
+    assertThat(parseContactPoints(CassandraStorage.builder().build()))
         .containsExactly(new InetSocketAddress("127.0.0.1", 9042));
   }
 
   @Test
   public void contactPoints_defaultsToPort9042() {
-    assertThat(session.parseContactPoints(CassandraStorage.builder().contactPoints("1.1.1.1").build()))
+    assertThat(parseContactPoints(CassandraStorage.builder().contactPoints("1.1.1.1").build()))
         .containsExactly(new InetSocketAddress("1.1.1.1", 9042));
   }
 
   @Test
   public void contactPoints_defaultsToPort9042_multi() {
-    assertThat(session.parseContactPoints(
+    assertThat(parseContactPoints(
         CassandraStorage.builder().contactPoints("1.1.1.1:9143,2.2.2.2").build()))
         .containsExactly(
             new InetSocketAddress("1.1.1.1", 9143),
@@ -59,7 +59,7 @@ public class SessionFactoryTest {
 
   @Test
   public void contactPoints_hostAndPort() {
-    assertThat(session.parseContactPoints(CassandraStorage.builder().contactPoints("1.1.1.1:9142").build()))
+    assertThat(parseContactPoints(CassandraStorage.builder().contactPoints("1.1.1.1:9142").build()))
         .containsExactly(new InetSocketAddress("1.1.1.1", 9142));
   }
 

--- a/zipkin/src/main/java/zipkin/internal/Dependencies.java
+++ b/zipkin/src/main/java/zipkin/internal/Dependencies.java
@@ -113,11 +113,11 @@ public final class Dependencies {
         field = Field.read(bytes);
         if (field.type == TYPE_STOP) break;
 
-        if (field.equals(START_TS)) {
+        if (field.isEqualTo(START_TS)) {
           startTs = bytes.getLong();
-        } else if (field.equals(END_TS)) {
+        } else if (field.isEqualTo(END_TS)) {
           endTs = bytes.getLong();
-        } else if (field.equals(LINKS)) {
+        } else if (field.isEqualTo(LINKS)) {
           links = DEPENDENCY_LINKS_ADAPTER.read(bytes);
         } else {
           skip(bytes, field.type);

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -172,6 +172,8 @@ public final class JsonCodec implements Codec {
           return result.value(string.getBytes(UTF_8)).build();
         case BYTES:
           return result.value(ByteString.decodeBase64(string).toByteArray()).build();
+        default:
+          break;
       }
       Buffer buffer = new Buffer();
       switch (type) {

--- a/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
@@ -120,11 +120,11 @@ public final class ThriftCodec implements Codec {
         field = Field.read(bytes);
         if (field.type == TYPE_STOP) break;
 
-        if (field.equals(IPV4)) {
+        if (field.isEqualTo(IPV4)) {
           result.ipv4(bytes.getInt());
-        } else if (field.equals(PORT)) {
+        } else if (field.isEqualTo(PORT)) {
           result.port(bytes.getShort());
-        } else if (field.equals(SERVICE_NAME)) {
+        } else if (field.isEqualTo(SERVICE_NAME)) {
           result.serviceName(readUtf8(bytes));
         } else {
           skip(bytes, field.type);
@@ -162,11 +162,11 @@ public final class ThriftCodec implements Codec {
         field = Field.read(bytes);
         if (field.type == TYPE_STOP) break;
 
-        if (field.equals(TIMESTAMP)) {
+        if (field.isEqualTo(TIMESTAMP)) {
           result.timestamp(bytes.getLong());
-        } else if (field.equals(VALUE)) {
+        } else if (field.isEqualTo(VALUE)) {
           result.value(readUtf8(bytes));
-        } else if (field.equals(ENDPOINT)) {
+        } else if (field.isEqualTo(ENDPOINT)) {
           result.endpoint(ENDPOINT_ADAPTER.read(bytes));
         } else {
           skip(bytes, field.type);
@@ -209,13 +209,13 @@ public final class ThriftCodec implements Codec {
         field = Field.read(bytes);
         if (field.type == TYPE_STOP) break;
 
-        if (field.equals(KEY)) {
+        if (field.isEqualTo(KEY)) {
           result.key(readUtf8(bytes));
-        } else if (field.equals(VALUE)) {
+        } else if (field.isEqualTo(VALUE)) {
           result.value(readByteArray(bytes));
-        } else if (field.equals(TYPE)) {
+        } else if (field.isEqualTo(TYPE)) {
           result.type(BinaryAnnotation.Type.fromValue(bytes.getInt()));
-        } else if (field.equals(ENDPOINT)) {
+        } else if (field.isEqualTo(ENDPOINT)) {
           result.endpoint(ENDPOINT_ADAPTER.read(bytes));
         } else {
           skip(bytes, field.type);
@@ -269,23 +269,23 @@ public final class ThriftCodec implements Codec {
         field = Field.read(bytes);
         if (field.type == TYPE_STOP) break;
 
-        if (field.equals(TRACE_ID)) {
+        if (field.isEqualTo(TRACE_ID)) {
           result.traceId(bytes.getLong());
-        } else if (field.equals(NAME)) {
+        } else if (field.isEqualTo(NAME)) {
           result.name(readUtf8(bytes));
-        } else if (field.equals(ID)) {
+        } else if (field.isEqualTo(ID)) {
           result.id(bytes.getLong());
-        } else if (field.equals(PARENT_ID)) {
+        } else if (field.isEqualTo(PARENT_ID)) {
           result.parentId(bytes.getLong());
-        } else if (field.equals(ANNOTATIONS)) {
+        } else if (field.isEqualTo(ANNOTATIONS)) {
           result.annotations(ANNOTATIONS_ADAPTER.read(bytes));
-        } else if (field.equals(BINARY_ANNOTATIONS)) {
+        } else if (field.isEqualTo(BINARY_ANNOTATIONS)) {
           result.binaryAnnotations(BINARY_ANNOTATIONS_ADAPTER.read(bytes));
-        } else if (field.equals(DEBUG)) {
+        } else if (field.isEqualTo(DEBUG)) {
           result.debug(bytes.get() == 1);
-        } else if (field.equals(TIMESTAMP)) {
+        } else if (field.isEqualTo(TIMESTAMP)) {
           result.timestamp(bytes.getLong());
-        } else if (field.equals(DURATION)) {
+        } else if (field.isEqualTo(DURATION)) {
           result.duration(bytes.getLong());
         } else {
           skip(bytes, field.type);
@@ -360,11 +360,11 @@ public final class ThriftCodec implements Codec {
         field = Field.read(bytes);
         if (field.type == TYPE_STOP) break;
 
-        if (field.equals(PARENT)) {
+        if (field.isEqualTo(PARENT)) {
           result.parent(readUtf8(bytes));
-        } else if (field.equals(CHILD)) {
+        } else if (field.isEqualTo(CHILD)) {
           result.child(readUtf8(bytes));
-        } else if (field.equals(CALL_COUNT)) {
+        } else if (field.isEqualTo(CALL_COUNT)) {
           result.callCount(bytes.getLong());
         } else {
           skip(bytes, field.type);
@@ -506,7 +506,7 @@ public final class ThriftCodec implements Codec {
       return new Field(type, type == TYPE_STOP ? TYPE_STOP : bytes.getShort());
     }
 
-    boolean equals(Field that) {
+    boolean isEqualTo(Field that) {
       return this.type == that.type && this.id == that.id;
     }
   }


### PR DESCRIPTION
error-prone is a tool that catches common problems at compile time. For
example, it can figure out if you wrote equals incorrectly, or didn't
use a volatile when double-checking a value.

Non-critical concerns print out as warnings in the compiler log.

See http://errorprone.info/
