### PR TITLE
Re-adds tests for query precision

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <junit.version>4.12</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <assertj.version>3.5.1</assertj.version>
+    <hamcrest.version>1.3</hamcrest.version>
     <okhttp.version>3.3.1</okhttp.version>
 
     <animal-sniffer-maven-plugin.version>1.15</animal-sniffer-maven-plugin.version>

--- a/zipkin-guava/pom.xml
+++ b/zipkin-guava/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -60,6 +60,12 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
@@ -57,6 +57,15 @@ public final class CassandraStorage
     String username;
     String password;
     int maxTraceCols = 100000;
+    /**
+     * Used to avoid hot spots when writing indexes used to query by service name or annotation.
+     *
+     * <p>This controls the amount of buckets, or partitions writes to {@code service_name_index}
+     * and {@code annotations_index}. This must be the same for all query servers, and has
+     * historically always been 10.
+     *
+     * See https://github.com/openzipkin/zipkin/issues/623 for further explanation
+     */
     int bucketCount = 10;
     int spanTtl = (int) TimeUnit.DAYS.toSeconds(7);
     int indexTtl = (int) TimeUnit.DAYS.toSeconds(3);

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetEncoder;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ import zipkin.Span;
 import zipkin.storage.QueryRequest;
 
 import static zipkin.internal.Util.UTF_8;
+import static zipkin.internal.Util.checkArgument;
 import static zipkin.internal.Util.sortedList;
 
 final class CassandraUtil {
@@ -89,6 +91,10 @@ final class CassandraUtil {
   }
 
   static List<String> annotationKeys(QueryRequest request) {
+    if (request.annotations.isEmpty() && request.binaryAnnotations.isEmpty()) {
+      return Collections.emptyList();
+    }
+    checkArgument(request.serviceName != null, "serviceName needed with annotation query");
     Set<String> annotationKeys = new LinkedHashSet<>();
     for (String a : request.annotations) { // doesn't include CORE_ANNOTATIONS
       annotationKeys.add(request.serviceName + ":" + a);

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaSpanStoreTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaSpanStoreTest.java
@@ -13,20 +13,9 @@
  */
 package zipkin.storage.cassandra;
 
-import zipkin.storage.SpanStoreTest;
-
-public class CassandraWithOriginalSchemaSpanStoreTest extends SpanStoreTest {
-  private final CassandraStorage storage;
+public class CassandraWithOriginalSchemaSpanStoreTest extends CassandraSpanStoreTest {
 
   public CassandraWithOriginalSchemaSpanStoreTest() {
-    this.storage = CassandraWithOriginalSchemaTestGraph.INSTANCE.storage.get();
-  }
-
-  @Override protected CassandraStorage storage() {
-    return storage;
-  }
-
-  @Override public void clear() {
-    storage.clear();
+    super(CassandraWithOriginalSchemaTestGraph.INSTANCE.storage.get());
   }
 }

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zipkin/src/test/java/zipkin/TestObjects.java
+++ b/zipkin/src/test/java/zipkin/TestObjects.java
@@ -80,8 +80,10 @@ public final class TestObjects {
   /** Reuse a builder as it is significantly slows tests to create 100000 of these! */
   static Span.Builder spanBuilder() {
     Endpoint e = Endpoint.create("service", 127 << 24 | 1, 8080);
-    Annotation ann = Annotation.create(System.currentTimeMillis() * 1000, SERVER_RECV, e);
-    return Span.builder().name("get").addAnnotation(ann);
+    Annotation sr = Annotation.create(System.currentTimeMillis() * 1000, SERVER_RECV, e);
+    Annotation ss = Annotation.create(sr.timestamp + 1000, SERVER_SEND, e);
+    BinaryAnnotation ba = BinaryAnnotation.create(TraceKeys.HTTP_METHOD, "GET", e);
+    return Span.builder().name("get").addAnnotation(sr).addAnnotation(ss).addBinaryAnnotation(ba);
   }
 
   /**

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -14,6 +14,7 @@
 package zipkin.storage;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.GregorianCalendar;
@@ -276,6 +277,34 @@ public abstract class SpanStoreTest {
 
     assertThat(store().getTraces(QueryRequest.builder().serviceName("service").build()))
         .containsExactly(asList(localTrace));
+  }
+
+  /**
+   * Formerly, a bug was present where cassandra didn't index more than bucket count traces per
+   * millisecond. This stores a lot of spans to ensure indexes work under high-traffic scenarios.
+   */
+  @Test
+  public void getTraces_manyTraces() {
+    int traceCount = 1000;
+    Span span = TestObjects.LOTS_OF_SPANS[0];
+    BinaryAnnotation b = span.binaryAnnotations.get(0);
+
+    accept(Arrays.copyOfRange(TestObjects.LOTS_OF_SPANS, 0, traceCount));
+
+    assertThat(store().getTraces(new QueryRequest.Builder().limit(traceCount).build()))
+        .hasSize(traceCount);
+
+    QueryRequest.Builder builder =
+        QueryRequest.builder().limit(traceCount).serviceName(b.endpoint.serviceName);
+
+    assertThat(store().getTraces(builder.build()))
+        .hasSize(traceCount);
+
+    assertThat(store().getTraces(builder.spanName(span.name).build()))
+        .hasSize(traceCount);
+
+    assertThat(store().getTraces(builder.addBinaryAnnotation(b.key, new String(b.value)).build()))
+        .hasSize(traceCount);
   }
 
   /** Shows that duration queries go against the root span, not the child */


### PR DESCRIPTION
This adds everything for 0d51d90a8859450f704e13faea3dee320e4bb080
except the actual schema change. The latter will be re-introduced in
a short while.
