### PR TITLE
Adds cassandra index optimization

### DIFF
--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
@@ -28,6 +28,10 @@ public class ZipkinCassandraStorageProperties {
   private String password;
   private int spanTtl = (int) TimeUnit.DAYS.toSeconds(7);
   private int indexTtl = (int) TimeUnit.DAYS.toSeconds(3);
+  /** See {@link CassandraStorage.Builder#indexCacheMax(int)} */
+  private int indexCacheMax = 100000;
+  /** See {@link CassandraStorage.Builder#indexCacheTtl(int)} */
+  private int indexCacheTtl = 60;
 
   public String getKeyspace() {
     return keyspace;
@@ -117,6 +121,22 @@ public class ZipkinCassandraStorageProperties {
     this.indexTtl = indexTtl;
   }
 
+  public int getIndexCacheMax() {
+    return indexCacheMax;
+  }
+
+  public void setIndexCacheMax(int indexCacheMax) {
+    this.indexCacheMax = indexCacheMax;
+  }
+
+  public int getIndexCacheTtl() {
+    return indexCacheTtl;
+  }
+
+  public void setIndexCacheTtl(int indexCacheTtl) {
+    this.indexCacheTtl = indexCacheTtl;
+  }
+
   public CassandraStorage.Builder toBuilder() {
     return CassandraStorage.builder()
         .keyspace(keyspace)
@@ -127,6 +147,8 @@ public class ZipkinCassandraStorageProperties {
         .username(username)
         .password(password)
         .spanTtl(spanTtl)
-        .indexTtl(indexTtl);
+        .indexTtl(indexTtl)
+        .indexCacheMax(indexCacheMax)
+        .indexCacheTtl(indexCacheTtl);
   }
 }

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -105,9 +105,14 @@ supports version 2.2+ and applies when `STORAGE_TYPE` is set to `cassandra`:
     * `CASSANDRA_KEYSPACE`: The keyspace to use. Defaults to "zipkin".
     * `CASSANDRA_CONTACT_POINTS`: Comma separated list of hosts / ip addresses part of Cassandra cluster. Defaults to localhost
     * `CASSANDRA_LOCAL_DC`: Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
-    * `CASSANDRA_MAX_CONNECTIONS`: Max pooled connections per datacenter-local host. Defaults to 8
     * `CASSANDRA_ENSURE_SCHEMA`: Ensuring cassandra has the latest schema. If enabled tries to execute scripts in the classpath prefixed with `cassandra-schema-cql3`. Defaults to true
     * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails. No default
+
+The following are tuning parameters which may not concern all users:
+
+    * `CASSANDRA_MAX_CONNECTIONS`: Max pooled connections per datacenter-local host. Defaults to 8
+    * `CASSANDRA_INDEX_CACHE_MAX`: Maximum trace index metadata entries to cache. Zero disables caching. Defaults to 100000.
+    * `CASSANDRA_INDEX_CACHE_TTL`: How many seconds to cache index metadata about a trace. Defaults to 60.
 
 Example usage:
 

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -45,6 +45,10 @@ zipkin:
       span-ttl: ${CASSANDRA_SPAN_TTL:604800}
       # 3 days in seconds
       index-ttl: ${CASSANDRA_INDEX_TTL:259200}
+      # the maximum trace index metadata entries to cache
+      index-cache-max: ${CASSANDRA_INDEX_CACHE_MAX:100000}
+      # how long to cache index metadata about a trace. 1 minute in seconds
+      index-cache-ttl: ${CASSANDRA_INDEX_CACHE_TTL:60}
     elasticsearch:
       cluster: ${ES_CLUSTER:elasticsearch}
       hosts: ${ES_HOSTS:localhost:9300}

--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -5,8 +5,6 @@ This CQL-based Cassandra 2.2+ storage component includes a `GuavaSpanStore` and 
 
 The implementation uses the [Datastax Java Driver 3.x](https://github.com/datastax/java-driver).
 
-The CQL schema is the same as [zipkin-scala](https://github.com/openzipkin/zipkin/tree/master/zipkin-cassandra).
-
 `zipkin.storage.cassandra.CassandraStorage.Builder` includes defaults that will
 operate against a local Cassandra installation.
 
@@ -14,11 +12,15 @@ operate against a local Cassandra installation.
 Queries are logged to the category "com.datastax.driver.core.QueryLogger" when debug or trace is
 enabled via SLF4J. Trace level includes bound values.
 
-See [Logging Query Latencies](http://docs.datastax.com/en/developer/java-driver/2.1/supplemental/manual/logging/#logging-query-latencies) for more details.
+See [Logging Query Latencies](http://docs.datastax.com/en/developer/java-driver/3.0/supplemental/manual/logging/#logging-query-latencies) for more details.
 
 ## Performance notes
 
 Redundant requests to store service or span names are ignored for an hour to reduce load.
+
+Indexing of traces are optimized by default. This reduces writes to Cassandra at the cost of memory
+needed to cache state. This cache is tunable based on your typical trace duration and span count.
+See [CassandraStorage](src/main/java/zipkin/storage/cassandra/CassandraStorage.java) for details.
 
 ## Testing this component
 This module conditionally runs integration tests against a local Cassandra instance.

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -68,6 +68,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-guava</artifactId>
+      <version>3.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
@@ -69,7 +69,7 @@ final class CassandraUtil {
    * @see QueryRequest#annotations
    * @see QueryRequest#binaryAnnotations
    */
-  static List<String> annotationKeys(Span span) {
+  static Set<String> annotationKeys(Span span) {
     Set<String> annotationKeys = new LinkedHashSet<>();
     for (Annotation a : span.annotations) {
       // don't index core annotations as they aren't queryable
@@ -87,7 +87,7 @@ final class CassandraUtil {
         annotationKeys.add(b.endpoint.serviceName + ":" + b.key + ":" + new String(b.value, UTF_8));
       }
     }
-    return sortedList(annotationKeys);
+    return annotationKeys;
   }
 
   static List<String> annotationKeys(QueryRequest request) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CompositeIndexer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CompositeIndexer.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import com.datastax.driver.core.Session;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheBuilderSpec;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import zipkin.Span;
+import zipkin.internal.Nullable;
+import zipkin.internal.Pair;
+
+final class CompositeIndexer {
+
+  private final Set<Indexer> indexers;
+  // Shared across all threads as updates can come from any thread.
+  // Shared for all indexes to make data management easier (ex. maximumSize)
+  private final ConcurrentMap<PartitionKeyToTraceId, Pair<Long>> sharedState;
+
+  CompositeIndexer(Session session, CacheBuilderSpec spec, int bucketCount,
+      @Nullable Integer indexTtl) {
+    this.sharedState = spec == null ? null :
+        CacheBuilder.from(spec).<PartitionKeyToTraceId, Pair<Long>>build().asMap();
+    Indexer.Factory factory = new Indexer.Factory(session, indexTtl, sharedState);
+    this.indexers = ImmutableSet.of(
+        factory.create(new InsertTraceIdByServiceName(bucketCount)),
+        factory.create(new InsertTraceIdBySpanName()),
+        factory.create(new InsertTraceIdByAnnotation(bucketCount))
+    );
+  }
+
+  ImmutableSet<ListenableFuture<?>> index(List<Span> spans) {
+    ImmutableSet.Builder<ListenableFuture<?>> result = ImmutableSet.builder();
+    for (Indexer optimizer : indexers) {
+      result.addAll(optimizer.index(spans));
+    }
+    return result.build();
+  }
+
+  public void clear() {
+    sharedState.clear();
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Indexer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Indexer.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSetMultimap.Builder;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin.Span;
+import zipkin.internal.Nullable;
+import zipkin.internal.Pair;
+import zipkin.storage.QueryRequest;
+
+import static com.google.common.base.CaseFormat.LOWER_HYPHEN;
+import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+import static zipkin.storage.cassandra.CassandraUtil.bindWithName;
+
+/**
+ * Inserts index rows into Cassandra according to {@link IndexSupport} of a table. This skips
+ * entries that don't improve results based on {@link QueryRequest#endTs} and {@link
+ * QueryRequest#lookback}. For example, it doesn't insert rows that only vary on timestamp and exist
+ * between timestamps of existing rows.
+ */
+final class Indexer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Indexer.class);
+  private final PreparedStatement prepared;
+  private final TimestampCodec timestampCodec;
+  private final String boundName;
+  private final IndexSupport index;
+  @Nullable
+  private final Integer indexTtl;
+  private final Session session;
+  /**
+   * Shared across all threads, as updates to indexes can come from any thread. Null disables
+   * optimization.
+   */
+  @Nullable
+  private final ConcurrentMap<PartitionKeyToTraceId, Pair<Long>> sharedState;
+
+  Indexer(Session session, @Nullable Integer indexTtl,
+      @Nullable ConcurrentMap<PartitionKeyToTraceId, Pair<Long>> sharedState, IndexSupport index) {
+    this.index = index;
+    this.boundName = UPPER_CAMEL.to(LOWER_HYPHEN, index.getClass().getSimpleName());
+    Insert insert = index.declarePartitionKey(QueryBuilder.insertInto(index.table())
+        .value("ts", QueryBuilder.bindMarker("ts"))
+        .value("trace_id", QueryBuilder.bindMarker("trace_id")));
+    if (indexTtl != null) {
+      insert.using(QueryBuilder.ttl(QueryBuilder.bindMarker("ttl_")));
+    }
+    this.prepared = session.prepare(insert);
+    this.indexTtl = indexTtl;
+    this.session = session;
+    this.timestampCodec = new TimestampCodec(session);
+    this.sharedState = sharedState;
+  }
+
+  ImmutableSet<ListenableFuture<?>> index(List<Span> spans) {
+    // First parse each span into partition keys used to support query requests
+    Builder<PartitionKeyToTraceId, Long> parsed = ImmutableSetMultimap.builder();
+    for (Span span : spans) {
+      if (span.timestamp == null) continue;
+      for (String partitionKey : index.partitionKeys(span)) {
+        parsed.put(new PartitionKeyToTraceId(index.table(), partitionKey, span.traceId),
+            1000 * (span.timestamp / 1000)); // index precision is millis
+      }
+    }
+
+    // The parsed results may include inserts that already occur, or are redundant as they don't
+    // impact QueryRequest.endTs or QueryRequest.loopback. For example, a parsed timestamp could
+    // be between timestamps of rows that already exist for a particular trace.
+    ImmutableSetMultimap<PartitionKeyToTraceId, Long> maybeInsert = parsed.build();
+
+    ImmutableSetMultimap<PartitionKeyToTraceId, Long> toInsert;
+    if (sharedState == null) { // special-case when caching is disabled.
+      toInsert = maybeInsert;
+    } else {
+      // Optimized results will be smaller when the input includes traces with local spans, or when
+      // other threads indexed the same trace.
+      toInsert = entriesThatIncreaseGap(sharedState, maybeInsert);
+
+      if (maybeInsert.size() > toInsert.size() && LOG.isDebugEnabled()) {
+        int delta = maybeInsert.size() - toInsert.size();
+        LOG.debug("optimized out {}/{} inserts into {}", delta, maybeInsert.size(), index.table());
+      }
+    }
+
+    // For each entry, insert a new row in the index table asynchronously
+    ImmutableSet.Builder<ListenableFuture<?>> result = ImmutableSet.builder();
+    for (Map.Entry<PartitionKeyToTraceId, Long> entry : toInsert.entries()) {
+      BoundStatement bound = bindWithName(prepared, boundName)
+          .setLong("trace_id", entry.getKey().traceId)
+          .setBytesUnsafe("ts", timestampCodec.serialize(entry.getValue()));
+      if (indexTtl != null) {
+        bound.setInt("ttl_", indexTtl);
+      }
+      index.bindPartitionKey(bound, entry.getKey().partitionKey);
+      result.add(session.executeAsync(bound));
+    }
+    return result.build();
+  }
+
+  @VisibleForTesting
+  static ImmutableSetMultimap<PartitionKeyToTraceId, Long> entriesThatIncreaseGap(
+      ConcurrentMap<PartitionKeyToTraceId, Pair<Long>> sharedState,
+      ImmutableSetMultimap<PartitionKeyToTraceId, Long> updates) {
+    ImmutableSet.Builder<PartitionKeyToTraceId> toUpdate = ImmutableSet.builder();
+
+    // Enter a loop that affects shared state when an update widens the time interval for a key.
+    for (Map.Entry<PartitionKeyToTraceId, Long> input : updates.entries()) {
+      PartitionKeyToTraceId key = input.getKey();
+      long timestamp = input.getValue();
+      for (; ; ) {
+        Pair<Long> oldRange = sharedState.get(key);
+        if (oldRange == null) {
+          // Initial state is where this key has a single timestamp.
+          oldRange = sharedState.putIfAbsent(key, Pair.create(timestamp, timestamp));
+
+          // If there was no previous value, we need to update the index
+          if (oldRange == null) {
+            toUpdate.add(key);
+            break;
+          }
+        }
+
+        long first = timestamp < oldRange._1 ? timestamp : oldRange._1;
+        long last = timestamp > oldRange._2 ? timestamp : oldRange._2;
+
+        Pair<Long> newRange = Pair.create(first, last);
+        if (oldRange.equals(newRange)) {
+          break; // the current timestamp is contained
+        } else if (sharedState.replace(key, oldRange, newRange)) {
+          toUpdate.add(key); // The range was extended
+          break;
+        }
+      }
+    }
+
+    // When the loop completes, we'll know one of our updates widened the interval of a trace, if
+    // it is the first or last timestamp. By ignoring those between an existing interval, we can
+    // end up with less Cassandra writes.
+    Builder<PartitionKeyToTraceId, Long> result = ImmutableSetMultimap.builder();
+    for (PartitionKeyToTraceId needsUpdate : toUpdate.build()) {
+      Pair<Long> firstLast = sharedState.get(needsUpdate);
+      if (updates.containsEntry(needsUpdate, firstLast._1)) result.put(needsUpdate, firstLast._1);
+      if (updates.containsEntry(needsUpdate, firstLast._2)) result.put(needsUpdate, firstLast._2);
+    }
+    return result.build();
+  }
+
+  interface IndexSupport {
+
+    String table();
+
+    Insert declarePartitionKey(Insert insert);
+
+    BoundStatement bindPartitionKey(BoundStatement bound, String partitionKey);
+
+    Set<String> partitionKeys(Span span);
+  }
+
+  static class Factory {
+
+    private final Session session;
+    private final Integer indexTtl;
+    private final ConcurrentMap<PartitionKeyToTraceId, Pair<Long>> sharedState;
+
+    public Factory(Session session, @Nullable Integer indexTtl,
+        @Nullable ConcurrentMap<PartitionKeyToTraceId, Pair<Long>> sharedState) {
+      this.session = session;
+      this.indexTtl = indexTtl;
+      this.sharedState = sharedState;
+    }
+
+    Indexer create(IndexSupport index) {
+      return new Indexer(session, indexTtl, sharedState, index);
+    }
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/InsertTraceIdByAnnotation.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/InsertTraceIdByAnnotation.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import java.nio.charset.CharacterCodingException;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import zipkin.Span;
+
+import static zipkin.storage.cassandra.CassandraUtil.annotationKeys;
+import static zipkin.storage.cassandra.CassandraUtil.toByteBuffer;
+
+// QueryRequest.annotations/binaryAnnotations
+final class InsertTraceIdByAnnotation implements Indexer.IndexSupport {
+  private static final ThreadLocalRandom RAND = ThreadLocalRandom.current();
+  private final int bucketCount;
+
+  InsertTraceIdByAnnotation(int bucketCount) {
+    this.bucketCount = bucketCount;
+  }
+
+  @Override public String table() {
+    return Tables.ANNOTATIONS_INDEX;
+  }
+
+  @Override public Insert declarePartitionKey(Insert insert) {
+    return insert.value("annotation", QueryBuilder.bindMarker("annotation"))
+        .value("bucket", QueryBuilder.bindMarker("bucket"));
+  }
+
+  @Override
+  public BoundStatement bindPartitionKey(BoundStatement bound, String partitionKey) {
+    try {
+      return bound.setInt("bucket", RAND.nextInt(bucketCount))
+          .setBytes("annotation", toByteBuffer(partitionKey));
+    } catch (CharacterCodingException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  @Override
+  public Set<String> partitionKeys(Span span) {
+    return annotationKeys(span);
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/InsertTraceIdByServiceName.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/InsertTraceIdByServiceName.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import zipkin.Span;
+
+// QueryRequest.serviceName
+final class InsertTraceIdByServiceName implements Indexer.IndexSupport {
+  private static final ThreadLocalRandom RAND = ThreadLocalRandom.current();
+
+  private final int bucketCount;
+
+  InsertTraceIdByServiceName(int bucketCount) {
+    this.bucketCount = bucketCount;
+  }
+
+  @Override public String table() {
+    return Tables.SERVICE_NAME_INDEX;
+  }
+
+  @Override public Insert declarePartitionKey(Insert insert) {
+    return insert.value("service_name", QueryBuilder.bindMarker("service_name"))
+        .value("bucket", QueryBuilder.bindMarker("bucket"));
+  }
+
+  @Override
+  public BoundStatement bindPartitionKey(BoundStatement bound, String partitionKey) {
+    return bound.setInt("bucket", RAND.nextInt(bucketCount))
+        .setString("service_name", partitionKey);
+  }
+
+  @Override
+  public Set<String> partitionKeys(Span span) {
+    return span.serviceNames();
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/InsertTraceIdBySpanName.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/InsertTraceIdBySpanName.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.Set;
+import zipkin.Span;
+
+// QueryRequest.spanName
+final class InsertTraceIdBySpanName implements Indexer.IndexSupport {
+
+  @Override public String table() {
+    return Tables.SERVICE_SPAN_NAME_INDEX;
+  }
+
+  @Override public Insert declarePartitionKey(Insert insert) {
+    return insert.value("service_span_name", QueryBuilder.bindMarker("service_span_name"));
+  }
+
+  @Override
+  public BoundStatement bindPartitionKey(BoundStatement bound, String partitionKey) {
+    return bound.setString("service_span_name", partitionKey);
+  }
+
+  @Override
+  public Set<String> partitionKeys(Span span) {
+    if (span.name.isEmpty()) return Collections.emptySet();
+
+    ImmutableSet.Builder<String> result = ImmutableSet.builder();
+    for (String serviceName : span.serviceNames()) {
+      result.add(serviceName + "." + span.name);
+    }
+    return result.build();
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/PartitionKeyToTraceId.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/PartitionKeyToTraceId.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import zipkin.internal.Util;
+
+final class PartitionKeyToTraceId {
+
+  final String table;
+  final String partitionKey; // ends up as a partition key, ignoring bucketing
+  final long traceId; // clustering key
+
+  PartitionKeyToTraceId(String table, String partitionKey, long traceId) {
+    this.table = table;
+    this.partitionKey = partitionKey;
+    this.traceId = traceId;
+  }
+
+  @Override public String toString() {
+    return "(" + table + "," + partitionKey + "," + Util.toLowerHex(traceId) + ")";
+  }
+
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (o instanceof PartitionKeyToTraceId) {
+      PartitionKeyToTraceId that = (PartitionKeyToTraceId) o;
+      return this.table.equals(that.table)
+          && this.partitionKey.equals(that.partitionKey)
+          && this.traceId == that.traceId;
+    }
+    return false;
+  }
+
+  @Override public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= table.hashCode();
+    h *= 1000003;
+    h ^= partitionKey.hashCode();
+    h *= 1000003;
+    h ^= (traceId >>> 32) ^ traceId;
+    return h;
+  }
+}

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanConsumerTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.Constants;
+import zipkin.Span;
+import zipkin.TestObjects;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CassandraSpanConsumerTest {
+
+  private final CassandraStorage storage;
+
+  public CassandraSpanConsumerTest() {
+    this.storage = CassandraTestGraph.INSTANCE.storage.get();
+  }
+
+  @Before
+  public void clear() {
+    storage.clear();
+  }
+
+  /**
+   * Core/Boundary annotations like "sr" aren't queryable, and don't add value to users. Address
+   * annotations, like "sa", don't have string values, so are similarly not queryable. Skipping
+   * indexing of such annotations dramatically reduces the load on cassandra and size of indexes.
+   */
+  @Test
+  public void doesntIndexCoreOrNonStringAnnotations() {
+    Span span = TestObjects.TRACE.get(1);
+
+    assertThat(span.annotations)
+        .extracting(a -> a.value)
+        .matches(Constants.CORE_ANNOTATIONS::containsAll);
+
+    assertThat(span.binaryAnnotations)
+        .extracting(b -> b.key)
+        .containsOnly(Constants.SERVER_ADDR, Constants.CLIENT_ADDR);
+
+    accept(span);
+
+    assertThat(rowCount(Tables.ANNOTATIONS_INDEX)).isZero();
+  }
+
+  /**
+   * {@link Span#duration} == 0 is likely to be a mistake, and coerces to null. It is not helpful to
+   * index rows who have no duration.
+   */
+  @Test
+  public void doesntIndexSpansMissingDuration() {
+    Span span = Span.builder().traceId(1L).id(1L).name("get").duration(0L).build();
+
+    accept(span);
+
+    assertThat(rowCount(Tables.SPAN_DURATION_INDEX)).isZero();
+  }
+
+  /**
+   * Simulates a trace with a step pattern, where each span starts a millisecond after the prior
+   * one. The consumer code optimizes index inserts to only represent the interval represented by
+   * the trace as opposed to each individual timestamp.
+   */
+  @Test
+  public void skipsRedundantIndexingInATrace() {
+    Span[] trace = new Span[101];
+    trace[0] = TestObjects.TRACE.get(0);
+
+    IntStream.range(0, 100).forEach(i -> {
+      Span s = TestObjects.TRACE.get(1);
+      trace[i + 1] = s.toBuilder()
+          .id(s.id + i)
+          .timestamp(s.timestamp + i * 1000) // all peer span timestamps happen a millisecond later
+          .annotations(s.annotations.stream()
+              .map(a -> Annotation.create(a.timestamp + i * 1000, a.value, a.endpoint))
+              .collect(toList()))
+          .build();
+    });
+
+    accept(trace);
+    assertThat(rowCount(Tables.SERVICE_SPAN_NAME_INDEX)).isEqualTo(4L);
+    assertThat(rowCount(Tables.SERVICE_NAME_INDEX)).isEqualTo(4L);
+
+    // sanity check base case
+    clear();
+
+    CassandraSpanConsumer withoutOptimization = new CassandraSpanConsumer(
+        storage.session(),
+        storage.bucketCount,
+        storage.spanTtl,
+        storage.indexTtl,
+        null /** Disables optimization, just like CassandraStorage.indexCacheMax = 0 would */
+    );
+    Futures.getUnchecked(withoutOptimization.accept(ImmutableList.copyOf(trace)));
+    assertThat(rowCount(Tables.SERVICE_SPAN_NAME_INDEX)).isEqualTo(201L);
+    assertThat(rowCount(Tables.SERVICE_NAME_INDEX)).isEqualTo(201L);
+  }
+
+  void accept(Span... spans) {
+    Futures.getUnchecked(storage.computeGuavaSpanConsumer().accept(ImmutableList.copyOf(spans)));
+  }
+
+  long rowCount(String table) {
+    return storage.session().execute("SELECT COUNT(*) from " + table).one().getLong(0);
+  }
+}

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
@@ -16,7 +16,6 @@ package zipkin.storage.cassandra;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import zipkin.Constants;
 import zipkin.Span;
 import zipkin.TestObjects;
 import zipkin.internal.ApplyTimestampAndDuration;
@@ -44,43 +43,6 @@ public class CassandraSpanStoreTest extends SpanStoreTest {
 
   @Override public void clear() {
     storage.clear();
-  }
-
-  /**
-   * Core/Boundary annotations like "sr" aren't queryable, and don't add value to users. Address
-   * annotations, like "sa", don't have string values, so are similarly not queryable. Skipping
-   * indexing of such annotations dramatically reduces the load on cassandra and size of indexes.
-   */
-  @Test
-  public void doesntIndexCoreOrNonStringAnnotations() {
-    Span span = TestObjects.TRACE.get(1);
-
-    assertThat(span.annotations)
-        .extracting(a -> a.value)
-        .matches(Constants.CORE_ANNOTATIONS::containsAll);
-
-    assertThat(span.binaryAnnotations)
-        .extracting(b -> b.key)
-        .containsOnly(Constants.SERVER_ADDR, Constants.CLIENT_ADDR);
-
-    accept(span);
-
-    assertThat(storage.session().execute("SELECT * from " + Tables.ANNOTATIONS_INDEX))
-        .isEmpty();
-  }
-
-  /**
-   * {@link Span#duration} == 0 is likely to be a mistake, and coerces to null. It is not helpful to
-   * index rows who have no duration.
-   */
-  @Test
-  public void doesntIndexSpansMissingDuration() {
-    Span span = Span.builder().traceId(1L).id(1L).name("GET").duration(0L).build();
-
-    accept(span);
-
-    assertThat(storage.session().execute("SELECT * from " + Tables.SPAN_DURATION_INDEX))
-        .isEmpty();
   }
 
   /** Cassandra indexing is performed separately, allowing the raw span to be stored unaltered. */

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/IndexerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/IndexerTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Maps;
+import java.util.concurrent.ConcurrentMap;
+import org.junit.Test;
+import zipkin.internal.Pair;
+
+import static org.assertj.guava.api.Assertions.assertThat;
+import static zipkin.storage.cassandra.Tables.SERVICE_NAME_INDEX;
+import static zipkin.storage.cassandra.Tables.SERVICE_SPAN_NAME_INDEX;
+
+public class IndexerTest {
+
+  @Test
+  public void entriesThatIncreaseGap_filtersEntriesWithinTraceInterval() throws Exception {
+    ConcurrentMap<PartitionKeyToTraceId, Pair<Long>> sharedState = Maps.newConcurrentMap();
+
+    ImmutableSetMultimap<PartitionKeyToTraceId, Long> parsed = // intentionally shuffled
+        ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800050L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800150L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800050L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 21), 1467676800150L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800125L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 21), 1467676800125L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800110L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "db", 20), 1467676800150L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800000L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800025L)
+            .build();
+
+    assertThat(Indexer.entriesThatIncreaseGap(sharedState, parsed)).hasSameEntriesAs(
+        ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800050L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800150L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 21), 1467676800125L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 21), 1467676800150L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "db", 20), 1467676800150L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800000L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800050L)
+            .build()
+    );
+  }
+
+  /**
+   * Most partition keys will not clash, as they are delimited differently. For example, spans index
+   * partition keys are delimited with dots, and annotations with colons.
+   *
+   * <p>This tests an edge case, where a delimiter exists in a service name.
+   */
+  @Test
+  public void entriesThatIncreaseGap_treatsIndexesSeparately() throws Exception {
+    ConcurrentMap<PartitionKeyToTraceId, Pair<Long>> sharedState = Maps.newConcurrentMap();
+
+    // If indexes were not implemented properly, the span index app.foo would be mistaken as the
+    // first service index
+    ImmutableSetMultimap<PartitionKeyToTraceId, Long> parsed =
+        ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800050L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800110L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800125L)
+            .put(new PartitionKeyToTraceId(SERVICE_SPAN_NAME_INDEX, "app.foo", 20), 1467676800000L)
+            .build();
+
+    assertThat(Indexer.entriesThatIncreaseGap(sharedState, parsed)).hasSameEntriesAs(
+        ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800050L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800125L)
+            .put(new PartitionKeyToTraceId(SERVICE_SPAN_NAME_INDEX, "app.foo", 20), 1467676800000L)
+            .build()
+    );
+  }
+}

--- a/zipkin-storage/cassandra/src/test/resources/logback.xml
+++ b/zipkin-storage/cassandra/src/test/resources/logback.xml
@@ -10,6 +10,7 @@
 
   <!-- Note: this will dump a large amount of data in the logs -->
   <!--<logger name="com.datastax.driver.core.QueryLogger" level="TRACE" />-->
+  <!--<logger name="zipkin.storage.cassandra" level="DEBUG" />-->
 
   <root level="info">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
### What this does

This skips index operations that don't wouldn't improve api queries. It does this by only indexing when it would change the gap of a trace's time interval.

For example, a trace that fans out into N spans against the same service
will end up with a fixed amount of cassandra inserts as opposed to a
function of N.
### What this doesn't do

This doesn't affect duration indexing, as that's a tricky part of the code. This also doesn't improve anything for single-span traces (as there's no redundant indexing),
### How this is configured

You can configure this via the [CassandraStorage](https://github.com/openzipkin/zipkin/blob/master/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java) or by environment variables (if using zipkin-server).
- `CASSANDRA_INDEX_CACHE_MAX`: Maximum trace index metadata entries to cache. Zero disables caching. Defaults to 100000.
- `CASSANDRA_INDEX_CACHE_TTL`: How many seconds to cache index metadata about a trace. Defaults to 60.
### When this works best

This particularly helps when traces with a lot of spans touch a small amount of services. It helps even more when the cardinality of annotation or binary annotation values are small (ex http.method = "GET").

This removes extra requests when a collector receives a large amount of span data for a single trace. That could be the case when one or more of the following are true:
- instrumentation bundles all local spans in a trace into the same message
- traces are routed consistently to a collector using this storage component
- there's only one collector
### What this costs

This costs memory, as it caches the state of index rows that this storage component wrote. Unless your annotations are very large, the overhead of default settings should be orders of tens of megabytes heap.
### Example

Here's results from running [brave's example](https://github.com/openzipkin/brave-resteasy-example)

```
2016-07-07 20:43:53.744 DEBUG 89424 --- [nio-9411-exec-1] zipkin.storage.cassandra.TraceIndexer    : optimized out 2/4 inserts into service_name_index
2016-07-07 20:43:53.745 DEBUG 89424 --- [nio-9411-exec-1] zipkin.storage.cassandra.TraceIndexer    : optimized out 2/4 inserts into service_span_name_index
2016-07-07 20:43:53.747 DEBUG 89424 --- [nio-9411-exec-1] zipkin.storage.cassandra.TraceIndexer    : optimized out 2/12 inserts into annotations_index
```

And here's results of self-tracing that (self-tracing uses a lot of local spans to indicate cassandra calls)

```
2016-07-07 20:43:54.127 DEBUG 89424 --- [pool-1-thread-1] zipkin.storage.cassandra.TraceIndexer    : optimized out 33/37 inserts into service_name_index
2016-07-07 20:43:54.130 DEBUG 89424 --- [pool-1-thread-1] zipkin.storage.cassandra.TraceIndexer    : optimized out 14/37 inserts into service_span_name_index
2016-07-07 20:43:54.136 DEBUG 89424 --- [pool-1-thread-1] zipkin.storage.cassandra.TraceIndexer    : optimized out 23/40 inserts into annotations_index
```
