### PR TITLE
Skips Cassandra indexing of zero-duration rows

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanConsumer.java
@@ -119,7 +119,7 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
 
     insertTraceIdBySpanDuration = session.prepare(
         maybeUseTtl(QueryBuilder
-            .insertInto("span_duration_index")
+            .insertInto(Tables.SPAN_DURATION_INDEX)
             .value("service_name", QueryBuilder.bindMarker("service_name"))
             .value("span_name", QueryBuilder.bindMarker("span_name"))
             .value("bucket", QueryBuilder.bindMarker("bucket"))
@@ -176,7 +176,7 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
           }
 
           // QueryRequest.min/maxDuration
-          if (span.duration != null) {
+          if (span.duration != null && span.duration > 0) {
             // Contract for Repository.storeTraceIdByDuration is to store the span twice, once with
             // the span name and another with empty string.
             futures.add(storeTraceIdByDuration(

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanStore.java
@@ -153,7 +153,7 @@ public final class CassandraSpanStore implements GuavaSpanStore {
             .orderBy(QueryBuilder.desc("ts")));
 
     int durationDefaultTtl = Schema.getKeyspaceMetadata(session)
-        .getTable("span_duration_index")
+        .getTable(Tables.SPAN_DURATION_INDEX)
         .getOptions()
         .getDefaultTimeToLive();
 
@@ -161,7 +161,7 @@ public final class CassandraSpanStore implements GuavaSpanStore {
 
     selectTraceIdsBySpanDuration = session.prepare(
         QueryBuilder.select("duration", "ts", "trace_id")
-            .from("span_duration_index")
+            .from(Tables.SPAN_DURATION_INDEX)
             .where(QueryBuilder.eq("service_name", QueryBuilder.bindMarker("service_name")))
             .and(QueryBuilder.eq("span_name", QueryBuilder.bindMarker("span_name")))
             .and(QueryBuilder.eq("bucket", QueryBuilder.bindMarker("time_bucket")))

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
@@ -234,7 +234,7 @@ public final class CassandraStorage
         Tables.SERVICE_NAME_INDEX,
         Tables.SERVICE_SPAN_NAME_INDEX,
         Tables.ANNOTATIONS_INDEX,
-        "span_duration_index"
+        Tables.SPAN_DURATION_INDEX
     )) {
       futures.add(session.get().executeAsync(format("TRUNCATE %s", cf)));
     }

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Tables.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Tables.java
@@ -81,6 +81,8 @@ final class Tables {
    */
   static final String ANNOTATIONS_INDEX = "annotations_index";
 
+  static final String SPAN_DURATION_INDEX = "span_duration_index";
+
   private Tables() {
   }
 }

--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -109,6 +109,9 @@ public final class Span implements Comparable<Span> {
    * <p>This field is i64 vs i32 to support spans longer than 35 minutes.
    */
   @Nullable
+  // TODO: should this be permitted to be zero?
+  // i.e. should we say durations <1 microsecond should roud up to 1 microsecond?
+  // Reason is that sometimes instrumentation accidentally store 0L when they mean null
   public final Long duration;
 
   /**

--- a/zipkin/src/main/java/zipkin/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin/storage/QueryRequest.java
@@ -144,8 +144,19 @@ public final class QueryRequest {
       checkArgument(!entry.getValue().isEmpty(),
           "binary annotation value for %s was empty", entry.getKey());
     }
-    this.minDuration = minDuration;
-    this.maxDuration = maxDuration;
+    if (minDuration != null) {
+      checkArgument(minDuration > 0, "minDuration must be a positive number of microseconds");
+      this.minDuration = minDuration;
+      if (maxDuration != null) {
+        checkArgument(maxDuration >= minDuration, "maxDuration should be >= minDuration");
+        this.maxDuration = maxDuration;
+      } else {
+        this.maxDuration = null;
+      }
+    } else {
+      checkArgument(maxDuration == null, "maxDuration is only valid with minDuration");
+      this.minDuration = this.maxDuration = null;
+    }
     this.endTs = endTs;
     this.lookback = lookback;
     this.limit = limit;

--- a/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
@@ -137,4 +137,28 @@ public class QueryRequestTest {
     assertThat(request.toAnnotationQuery())
         .isNull();
   }
+
+  @Test
+  public void minDuration_mustBePositive() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("minDuration must be a positive number of microseconds");
+
+    QueryRequest.builder().serviceName("foo").minDuration(0L).build();
+  }
+
+  @Test
+  public void maxDuration_onlyWithMinDuration() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("maxDuration is only valid with minDuration");
+
+    QueryRequest.builder().serviceName("foo").maxDuration(0L).build();
+  }
+
+  @Test
+  public void maxDuration_greaterThanOrEqualToMinDuration() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("maxDuration should be >= minDuration");
+
+    QueryRequest.builder().serviceName("foo").minDuration(1L).maxDuration(0L).build();
+  }
 }


### PR DESCRIPTION
`QueryRequest.minDuration=0` doesn't make sense, it expands to traces
who have `Span.duration >= 0`. In such case, the query will be faster
to remove the duration clause entirely.

By constraining this, we can eliminate some busy-work, indexing spans
that came in with a dubious duration of zero.
