### PR TITLE
Clarifies Span.duration as positive; coerces Span.duration 0 -> null

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanConsumer.java
@@ -176,7 +176,7 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
           }
 
           // QueryRequest.min/maxDuration
-          if (span.duration != null && span.duration > 0) {
+          if (span.duration != null) {
             // Contract for Repository.storeTraceIdByDuration is to store the span twice, once with
             // the span name and another with empty string.
             futures.add(storeTraceIdByDuration(

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
@@ -20,7 +20,6 @@ import zipkin.Constants;
 import zipkin.Span;
 import zipkin.TestObjects;
 import zipkin.internal.ApplyTimestampAndDuration;
-import zipkin.storage.QueryRequest;
 import zipkin.storage.SpanStoreTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,12 +70,12 @@ public class CassandraSpanStoreTest extends SpanStoreTest {
   }
 
   /**
-   * {@link Span#duration} == 0 is likely to be a mistake. Since {@link QueryRequest#minDuration}
-   * must be positive, it is not helpful to index rows with duration zero.
+   * {@link Span#duration} == 0 is likely to be a mistake, and coerces to null. It is not helpful to
+   * index rows who have no duration.
    */
   @Test
-  public void doesntIndexZeroDurationSpans() {
-    Span span = TestObjects.TRACE.get(1).toBuilder().duration(0L).build();
+  public void doesntIndexSpansMissingDuration() {
+    Span span = Span.builder().traceId(1L).id(1L).name("GET").duration(0L).build();
 
     accept(span);
 

--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -92,11 +92,12 @@ public final class Span implements Comparable<Span> {
   public final Long timestamp;
 
   /**
-   * Measurement in microseconds of the critical path, if known.
+   * Measurement in microseconds of the critical path, if known. Durations of less than one
+   * microsecond must be rounded up to 1 microsecond.
    *
-   * <p>This value should be set directly, as opposed to implicitly via annotation timestamps.
-   * Doing so encourages precision decoupled from problems of clocks, such as skew or NTP updates
-   * causing time to move backwards.
+   * <p>This value should be set directly, as opposed to implicitly via annotation timestamps. Doing
+   * so encourages precision decoupled from problems of clocks, such as skew or NTP updates causing
+   * time to move backwards.
    *
    * <p>For compatibility with instrumentation that precede this field, collectors or span stores
    * can derive this by subtracting {@link Annotation#timestamp}. For example, {@link
@@ -109,9 +110,6 @@ public final class Span implements Comparable<Span> {
    * <p>This field is i64 vs i32 to support spans longer than 35 minutes.
    */
   @Nullable
-  // TODO: should this be permitted to be zero?
-  // i.e. should we say durations <1 microsecond should roud up to 1 microsecond?
-  // Reason is that sometimes instrumentation accidentally store 0L when they mean null
   public final Long duration;
 
   /**
@@ -254,13 +252,13 @@ public final class Span implements Comparable<Span> {
 
     /** @see Span#timestamp */
     public Builder timestamp(@Nullable Long timestamp) {
-      this.timestamp = timestamp != null && timestamp == 0 ? null : timestamp;
+      this.timestamp = timestamp != null && timestamp == 0L ? null : timestamp;
       return this;
     }
 
     /** @see Span#duration */
     public Builder duration(@Nullable Long duration) {
-      this.duration = duration;
+      this.duration = duration != null && duration == 0L ? null : duration;
       return this;
     }
 

--- a/zipkin/src/test/java/zipkin/SpanTest.java
+++ b/zipkin/src/test/java/zipkin/SpanTest.java
@@ -142,4 +142,21 @@ public class SpanTest {
     assertThat(span.timestamp)
         .isNull();
   }
+
+  /**
+   * Catches common error when zero is passed instead of null for a duration. Durations of less than
+   * a microsecond must be recorded as 1.
+   */
+  @Test
+  public void coercesDurationZeroToNull() {
+    Span span = Span.builder()
+        .traceId(1L)
+        .name("GET")
+        .id(1L)
+        .duration(0L)
+        .build();
+
+    assertThat(span.duration)
+        .isNull();
+  }
 }


### PR DESCRIPTION
Duration of 0 is confusing to plot and can be misinterpreted as null.

Fixes #1174
