### PR TITLE
Over-fetches cassandra trace indexes to improve UX and fixes Cassandra index

### DIFF
--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
@@ -32,6 +32,8 @@ public class ZipkinCassandraStorageProperties {
   private int indexCacheMax = 100000;
   /** See {@link CassandraStorage.Builder#indexCacheTtl(int)} */
   private int indexCacheTtl = 60;
+  /** See {@link CassandraStorage.Builder#indexFetchMultiplier(int)} */
+  private int indexFetchMultiplier = 3;
 
   public String getKeyspace() {
     return keyspace;
@@ -137,6 +139,14 @@ public class ZipkinCassandraStorageProperties {
     this.indexCacheTtl = indexCacheTtl;
   }
 
+  public int getIndexFetchMultiplier() {
+    return indexFetchMultiplier;
+  }
+
+  public void setIndexFetchMultiplier(int indexFetchMultiplier) {
+    this.indexFetchMultiplier = indexFetchMultiplier;
+  }
+
   public CassandraStorage.Builder toBuilder() {
     return CassandraStorage.builder()
         .keyspace(keyspace)
@@ -149,6 +159,7 @@ public class ZipkinCassandraStorageProperties {
         .spanTtl(spanTtl)
         .indexTtl(indexTtl)
         .indexCacheMax(indexCacheMax)
-        .indexCacheTtl(indexCacheTtl);
+        .indexCacheTtl(indexCacheTtl)
+        .indexFetchMultiplier(indexFetchMultiplier);
   }
 }

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -113,6 +113,7 @@ The following are tuning parameters which may not concern all users:
     * `CASSANDRA_MAX_CONNECTIONS`: Max pooled connections per datacenter-local host. Defaults to 8
     * `CASSANDRA_INDEX_CACHE_MAX`: Maximum trace index metadata entries to cache. Zero disables caching. Defaults to 100000.
     * `CASSANDRA_INDEX_CACHE_TTL`: How many seconds to cache index metadata about a trace. Defaults to 60.
+    * `CASSANDRA_INDEX_FETCH_MULTIPLIER`: How many more index rows to fetch than the user-supplied query limit. Defaults to 3.
 
 Example usage:
 

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -49,6 +49,8 @@ zipkin:
       index-cache-max: ${CASSANDRA_INDEX_CACHE_MAX:100000}
       # how long to cache index metadata about a trace. 1 minute in seconds
       index-cache-ttl: ${CASSANDRA_INDEX_CACHE_TTL:60}
+      # how many more index rows to fetch than the user-supplied query limit
+      index-fetch-multiplier: ${CASSANDRA_INDEX_FETCH_MULTIPLIER:3}
     elasticsearch:
       cluster: ${ES_CLUSTER:elasticsearch}
       hosts: ${ES_HOSTS:localhost:9300}

--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -20,6 +20,10 @@ Redundant requests to store service or span names are ignored for an hour to red
 
 Indexing of traces are optimized by default. This reduces writes to Cassandra at the cost of memory
 needed to cache state. This cache is tunable based on your typical trace duration and span count.
+
+User-supplied query limits are over-fetched according to a configured index fetch multiplier in
+attempts to mitigate redundant data returned from index queries.
+
 See [CassandraStorage](src/main/java/zipkin/storage/cassandra/CassandraStorage.java) for details.
 
 ## Testing this component

--- a/zipkin-storage/cassandra/src/main/resources/cassandra-schema-cql3.txt
+++ b/zipkin-storage/cassandra/src/main/resources/cassandra-schema-cql3.txt
@@ -1,21 +1,21 @@
 CREATE KEYSPACE IF NOT EXISTS zipkin WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
 
 CREATE TABLE IF NOT EXISTS zipkin.service_span_name_index (
-    service_span_name text,
-    ts                timestamp,
-    trace_id          bigint,
-    PRIMARY KEY (service_span_name, ts)
+    service_span_name text,      // Endpoint.serviceName + "." + Span.name
+    ts                timestamp, // start timestamp of the span, truncated to millisecond precision
+    trace_id          bigint,    // trace ID. Included as a clustering column to avoid clashes (however unlikely)
+    PRIMARY KEY (service_span_name, ts, trace_id)
 )
     WITH CLUSTERING ORDER BY (ts DESC)
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_window_size_seconds': '86400'}
     AND default_time_to_live =  259200;
 
 CREATE TABLE IF NOT EXISTS zipkin.service_name_index (
-    service_name      text,
-    bucket            int,
-    ts                timestamp,
-    trace_id          bigint,
-    PRIMARY KEY ((service_name, bucket), ts)
+    service_name      text,      // Endpoint.serviceName
+    bucket            int,       // avoids hot spots by distributing writes across each bucket, usually 0-9
+    ts                timestamp, // start timestamp of the span, truncated to millisecond precision
+    trace_id          bigint,    // trace ID. Included as a clustering column to avoid clashes (however unlikely)
+    PRIMARY KEY ((service_name, bucket), ts, trace_id)
 )
     WITH CLUSTERING ORDER BY (ts DESC)
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_window_size_seconds': '86400'}
@@ -31,11 +31,11 @@ CREATE TABLE IF NOT EXISTS zipkin.span_names (
     AND default_time_to_live =  259200;
 
 CREATE TABLE IF NOT EXISTS zipkin.annotations_index (
-    annotation     blob,
-    bucket         int,
-    ts             timestamp,
-    trace_id       bigint,
-    PRIMARY KEY ((annotation, bucket), ts)
+    annotation     blob,      // Annotation.value or BinaryAnnotation.key
+    bucket         int,       // avoids hot spots by distributing writes across each bucket, usually 0-9
+    ts             timestamp, // start timestamp of the span, truncated to millisecond precision
+    trace_id       bigint,    // trace ID. Included as a clustering column to avoid clashes (however unlikely)
+    PRIMARY KEY ((annotation, bucket), ts, trace_id)
 )
     WITH CLUSTERING ORDER BY (ts DESC)
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_window_size_seconds': '86400'}

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
@@ -65,17 +65,6 @@ public class CassandraSpanStoreTest extends SpanStoreTest {
         .containsExactly(rawSpan);
   }
 
-  /**
-   * The PRIMARY KEY of {@link Tables#SERVICE_NAME_INDEX} doesn't consider trace_id, so will only
-   * see bucket count traces to a service per millisecond.
-   */
-  @Override public void getTraces_manyTraces() {
-    thrown.expect(AssertionError.class);
-    thrown.expectMessage("Expected size:<1000> but was:<10>");
-
-    super.getTraces_manyTraces();
-  }
-
   @Test
   public void overFetchesToCompensateForDuplicateIndexData() {
     int traceCount = 100;

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
@@ -13,14 +13,19 @@
  */
 package zipkin.storage.cassandra;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import zipkin.Annotation;
 import zipkin.Span;
 import zipkin.TestObjects;
 import zipkin.internal.ApplyTimestampAndDuration;
+import zipkin.storage.QueryRequest;
 import zipkin.storage.SpanStoreTest;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CassandraSpanStoreTest extends SpanStoreTest {
@@ -69,5 +74,40 @@ public class CassandraSpanStoreTest extends SpanStoreTest {
     thrown.expectMessage("Expected size:<1000> but was:<10>");
 
     super.getTraces_manyTraces();
+  }
+
+  @Test
+  public void overFetchesToCompensateForDuplicateIndexData() {
+    int traceCount = 100;
+
+    List<Span> spans = new ArrayList<>();
+    for (int i = 0; i < traceCount; i++) {
+      final long delta = i * 1000; // all timestamps happen a millisecond later
+      for (Span s : TestObjects.TRACE) {
+        spans.add(TestObjects.TRACE.get(0).toBuilder()
+            .traceId(s.traceId + i * 10)
+            .id(s.id + i * 10)
+            .timestamp(s.timestamp + delta)
+            .annotations(s.annotations.stream()
+                .map(a -> Annotation.create(a.timestamp + delta, a.value, a.endpoint))
+                .collect(toList()))
+            .build());
+      }
+    }
+
+    accept(spans.toArray(new Span[0]));
+
+    // Index ends up containing more rows than services * trace count, and cannot be de-duped
+    // in a server-side query.
+    assertThat(rowCount(Tables.SERVICE_NAME_INDEX))
+        .isGreaterThan(traceCount * store().getServiceNames().size());
+
+    // Implementation over-fetches on the index to allow the user to receive unsurprising results.
+    assertThat(store().getTraces(QueryRequest.builder().limit(traceCount).build()))
+        .hasSize(traceCount);
+  }
+
+  long rowCount(String table) {
+    return storage.session().execute("SELECT COUNT(*) from " + table).one().getLong(0);
   }
 }

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaSpanStoreTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaSpanStoreTest.java
@@ -18,4 +18,15 @@ public class CassandraWithOriginalSchemaSpanStoreTest extends CassandraSpanStore
   public CassandraWithOriginalSchemaSpanStoreTest() {
     super(CassandraWithOriginalSchemaTestGraph.INSTANCE.storage.get());
   }
+
+  /**
+   * The PRIMARY KEY of {@link Tables#SERVICE_NAME_INDEX} doesn't consider trace_id, so will only
+   * see bucket count traces to a service per millisecond.
+   */
+  @Override public void getTraces_manyTraces() {
+    thrown.expect(AssertionError.class);
+    thrown.expectMessage("Expected size:<1000> but was:<10>");
+
+    super.getTraces_manyTraces();
+  }
 }


### PR DESCRIPTION
This does two things:
- Over-fetches cassandra trace indexes to improve UX and fixes Cassandra index
- Restores fix for Cassandra indexes that lost traces in the same millisecond (#1153) 

The latter is possible because of recent optimizations including this change.
## New change below:

Even when optimized, cassandra indexes will have more rows than distinct
(trace_id, timestamp) needed to satisfy query requests. This side-effect
in most cases is that users get less than `QueryRequest.limit` results
back. Lacking the ability to do any deduplication server-side, the only
opportunity left is to address this client-side.

This over-fetches by a multiplier `CASSANDRA_INDEX_FETCH_MULTIPLIER`,
which defaults to 3. For example, if a user requests 10 traces, 30 rows
are requested from indexes, but only 10 distinct trace ids are queried
for span data.

To disable this feature, set `CASSANDRA_INDEX_FETCH_MULTIPLIER=1`

Fixes #1142
