### PR TITLE
Adds SCRIBE_ENABLED flag to control whether scribe starts or not

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -166,6 +166,7 @@ $ STORAGE_TYPE=elasticsearch ES_CLUSTER=monitoring ES_HOSTS=host1:9300,host2:930
 ### Scribe Collector
 The Scribe collector is enabled by default, configured by the following:
 
+    * `SCRIBE_ENABLED`: Set to false to prevent scribe from starting; Defaults to true
     * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410
 
 ### Kafka Collector

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -19,6 +19,7 @@ zipkin:
       # Maximum size of a message containing spans in bytes
       max-message-size: ${KAFKA_MAX_MESSAGE_SIZE:1048576}
     scribe:
+      enabled: ${SCRIBE_ENABLED:true}
       category: zipkin
       port: ${COLLECTOR_PORT:9410}
   query:


### PR DESCRIPTION
Scribe starts over a dozen threads using heap and nonheap memory.

By setting `SCRIBE_ENABLED=false`, users can recover those resources
for productive tasks.
