### PR TITLE
Makes types used in spark RDDs serializable

### DIFF
--- a/zipkin/src/main/java/zipkin/Codec.java
+++ b/zipkin/src/main/java/zipkin/Codec.java
@@ -37,6 +37,11 @@ public interface Codec {
 
   byte[] writeTraces(List<List<Span>> value);
 
+  /** throws {@linkplain IllegalArgumentException} if the dependency link couldn't be decoded */
+  DependencyLink readDependencyLink(byte[] bytes);
+
+  byte[] writeDependencyLink(DependencyLink value);
+
   /** throws {@linkplain IllegalArgumentException} if the dependency links couldn't be decoded */
   List<DependencyLink> readDependencyLinks(byte[] bytes);
 

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -454,6 +454,7 @@ public final class JsonCodec implements Codec {
   // a large encoded list.
 
   /** throws {@linkplain IllegalArgumentException} if the dependency link couldn't be decoded */
+  @Override
   public DependencyLink readDependencyLink(byte[] bytes) {
     checkArgument(bytes.length > 0, "Empty input reading DependencyLink");
     try {
@@ -465,6 +466,7 @@ public final class JsonCodec implements Codec {
 
   // Added since JSON-based storage usually works better with single documents rather than
   // a large encoded list.
+  @Override
   public byte[] writeDependencyLink(DependencyLink value) {
     Buffer buffer = new Buffer();
     write(DEPENDENCY_LINK_ADAPTER, value, buffer);

--- a/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
@@ -406,6 +406,16 @@ public final class ThriftCodec implements Codec {
 
   static final ThriftAdapter<List<DependencyLink>> DEPENDENCY_LINKS_ADAPTER = new ListAdapter<>(DEPENDENCY_LINK_ADAPTER);
 
+  @Override
+  public DependencyLink readDependencyLink(byte[] bytes) {
+    return read(DEPENDENCY_LINK_ADAPTER, ByteBuffer.wrap(bytes));
+  }
+
+  @Override
+  public byte[] writeDependencyLink(DependencyLink value) {
+    return write(DEPENDENCY_LINK_ADAPTER, value);
+  }
+
   /**
    * Added for DataStax Cassandra driver, which returns data in ByteBuffers. The implementation
    * takes care not to re-buffer the data.

--- a/zipkin/src/test/java/zipkin/CodecTest.java
+++ b/zipkin/src/test/java/zipkin/CodecTest.java
@@ -52,6 +52,14 @@ public abstract class CodecTest {
   }
 
   @Test
+  public void dependencyLinkRoundTrip() throws IOException {
+    DependencyLink link = DependencyLink.create("foo", "bar", 2);
+    byte[] bytes = codec().writeDependencyLink(link);
+    assertThat(codec().readDependencyLink(bytes))
+        .isEqualTo(link);
+  }
+
+  @Test
   public void dependencyLinksRoundTrip() throws IOException {
     List<DependencyLink> links = asList(
         DependencyLink.create("foo", "bar", 2),

--- a/zipkin/src/test/java/zipkin/DependencyLinkTest.java
+++ b/zipkin/src/test/java/zipkin/DependencyLinkTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import okio.Buffer;
+import okio.ByteString;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependencyLinkTest {
+
+  @Test
+  public void serialization() throws Exception {
+    DependencyLink link = TestObjects.LINKS.get(0);
+
+    Buffer buffer = new Buffer();
+    new ObjectOutputStream(buffer.outputStream()).writeObject(link);
+
+    assertThat(new ObjectInputStream(buffer.inputStream()).readObject())
+        .isEqualTo(link);
+  }
+
+  @Test
+  public void serializationUsesThrift() throws Exception {
+    DependencyLink link = TestObjects.LINKS.get(0);
+
+    Buffer buffer = new Buffer();
+    new ObjectOutputStream(buffer.outputStream()).writeObject(link);
+
+    byte[] thrift = Codec.THRIFT.writeDependencyLink(link);
+
+    assertThat(buffer.indexOf(ByteString.of(thrift)))
+        .isPositive();
+  }
+}

--- a/zipkin/src/test/java/zipkin/SpanTest.java
+++ b/zipkin/src/test/java/zipkin/SpanTest.java
@@ -13,7 +13,11 @@
  */
 package zipkin;
 
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Arrays;
+import okio.Buffer;
+import okio.ByteString;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -158,5 +162,29 @@ public class SpanTest {
 
     assertThat(span.duration)
         .isNull();
+  }
+
+  @Test
+  public void serialization() throws Exception {
+    Span span = TestObjects.TRACE.get(0);
+
+    Buffer buffer = new Buffer();
+    new ObjectOutputStream(buffer.outputStream()).writeObject(span);
+
+    assertThat(new ObjectInputStream(buffer.inputStream()).readObject())
+        .isEqualTo(span);
+  }
+
+  @Test
+  public void serializationUsesThrift() throws Exception {
+    Span span = TestObjects.TRACE.get(0);
+
+    Buffer buffer = new Buffer();
+    new ObjectOutputStream(buffer.outputStream()).writeObject(span);
+
+    byte[] thrift = Codec.THRIFT.writeSpan(span);
+
+    assertThat(buffer.indexOf(ByteString.of(thrift)))
+        .isPositive();
   }
 }


### PR DESCRIPTION
This makes Span and DependencyLink serializable. This uses thrift
encoding, as we've benchmarked it to be the fastest.

The approach used here is a rip-off of square wire's (protobuf library) approach https://github.com/square/wire/pull/192
