### PR TITLE
Allows dependency link jobs to be replayed

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchStorage.java
@@ -140,10 +140,10 @@ public final class ElasticsearchStorage
       request.add(lazyClient.get().prepareIndex(
           indexNameFormatter.indexNameForTimestamp(midnight),
           ElasticsearchConstants.DEPENDENCY_LINK)
+          .setId(link.parent + "|" + link.child) // Unique constraint
           .setSource(
               "parent", link.parent,
               "child", link.child,
-              "parent_child", link.parent + "|" + link.child,  // For aggregating callCount
               "callCount", link.callCount));
     }
     request.execute().actionGet();

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
@@ -29,7 +29,7 @@ enum ElasticsearchTestGraph {
 
     @Override protected ElasticsearchStorage compute() {
       if (ex != null) throw ex;
-      ElasticsearchStorage result = new ElasticsearchStorage.Builder().build();
+      ElasticsearchStorage result = new ElasticsearchStorage.Builder().index("test_zipkin").build();
       CheckResult check = result.check();
       if (check.ok) return result;
       throw ex = new AssumptionViolatedException(check.exception.getMessage());

--- a/zipkin/src/main/java/zipkin/DependencyLink.java
+++ b/zipkin/src/main/java/zipkin/DependencyLink.java
@@ -42,11 +42,11 @@ public final class DependencyLink implements Serializable {
     this.callCount = callCount;
   }
 
-  public Builder toBuilder(){
+  public Builder toBuilder() {
     return new Builder(this);
   }
 
-  public static Builder builder(){
+  public static Builder builder() {
     return new Builder();
   }
 

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
@@ -169,4 +169,18 @@ public class DependencyLinkerTest {
           .isEmpty();
     }
   }
+
+  @Test
+  public void merge() {
+    List<DependencyLink> links = asList(
+        DependencyLink.create("client", "server", 2L),
+        DependencyLink.create("client", "server", 2L),
+        DependencyLink.create("client", "client", 1L)
+    );
+
+    assertThat(DependencyLinker.merge(links)).containsExactly(
+        DependencyLink.create("client", "server", 4L),
+        DependencyLink.create("client", "client", 1L)
+    );
+  }
 }

--- a/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
@@ -84,6 +84,16 @@ public abstract class DependenciesTest {
         .containsOnlyElementsOf(LINKS);
   }
 
+  /** It should be safe to run dependency link jobs twice */
+  @Test
+  public void replayOverwrites() {
+    processDependencies(TRACE);
+    processDependencies(TRACE);
+
+    assertThat(store().getDependencies(TODAY + 1000L, null))
+        .containsOnlyElementsOf(LINKS);
+  }
+
   /** Edge-case when there are no spans, or instrumentation isn't logging annotations properly. */
   @Test
   public void empty() {


### PR DESCRIPTION
Before, the experimental Elasticsearch dependency link query would
double-count as there was no way to know if there were duplicates or
not. This does two things to address it:
- Sets the id of a dependency-link document to its parent-child
  - This makes documents overwritable in a bucket
- Moves summing of links from an aggregation query to client-side
  - This logic is simpler and matches the Cassandra implementation
