### PR TITLE
Uses default Elasticsearch port of 9300 instead of throwing exception

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
@@ -60,7 +60,7 @@ final class LazyClient extends LazyCloseable<Client> {
         .settings(settings)
         .build();
     for (String host : hosts) {
-      HostAndPort hostAndPort = HostAndPort.fromString(host);
+      HostAndPort hostAndPort = HostAndPort.fromString(host).withDefaultPort(9300);
       try {
         client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName(
             hostAndPort.getHostText()), hostAndPort.getPort()));

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/LazyClientTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/LazyClientTest.java
@@ -13,6 +13,10 @@
  */
 package zipkin.storage.elasticsearch;
 
+import org.elasticsearch.client.transport.NoNodeAvailableException;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
@@ -48,5 +52,19 @@ public class LazyClientTest {
     assertThat(lazyClient.indexTemplate)
         .contains("    \"index.number_of_shards\": 30,\n"
             + "    \"index.number_of_replicas\": 0,");
+  }
+
+  @Test
+  public void portDefaultsTo9300() {
+    try (LazyClient lazyClient = new LazyClient(new ElasticsearchStorage.Builder()
+        .hosts(asList("localhost")))) {
+
+      assertThat(((TransportClient) lazyClient.get()).transportAddresses())
+          .extracting(TransportAddress::getPort)
+          .containsOnly(9300);
+
+    } catch (NoNodeAvailableException e) {
+      throw new AssumptionViolatedException(e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
noticed this making a docker image
