### PR TITLE
Skips indexing of binary annotations longer than 256 characters

### DIFF
--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -42,8 +42,10 @@ Redundant requests to store service or span names are ignored for an hour to red
 Indexing of traces are optimized by default. This reduces writes to Cassandra at the cost of memory
 needed to cache state. This cache is tunable based on your typical trace duration and span count.
 
-[Core annotations](https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin/Constants.java#L184), ex "sr", are not written to `annotations_index`, as they aren't intended for use in user queries. This significantly reduces
-writes per trace.
+[Core annotations](https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin/Constants.java#L184),
+ex "sr", are not written to `annotations_index`, as they aren't intended for use in user queries.
+Also, binary annotation values longer than 256 characters are not indexed. These optimizations
+significantly limit writes per trace.
 
 ### Over-fetching on Trace indexes
 User-supplied query limits are over-fetched according to a configured index fetch multiplier in

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Tables.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Tables.java
@@ -72,7 +72,7 @@ final class Tables {
    *
    * <p>To keep the size of this index reasonable, {@link zipkin.Constants#CORE_ANNOTATIONS} are not
    * indexed. For example, "service:sr" won't be stored, as it isn't supported to search by core
-   * annotations.
+   * annotations. Also, binary annotation values longer than 256 characters are not indexed.
    *
    * <p>Lookups are by equals (not partial match), so it is expected that {@link zipkin.Annotation}
    * and {@link zipkin.BinaryAnnotation} keys and values will be low or bounded cardinality. To

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraUtilTest.java
@@ -13,9 +13,11 @@
  */
 package zipkin.storage.cassandra;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import zipkin.BinaryAnnotation;
 import zipkin.Constants;
 import zipkin.Span;
 import zipkin.TestObjects;
@@ -74,5 +76,22 @@ public class CassandraUtilTest {
 
     assertThat(CassandraUtil.annotationKeys(span))
         .isEmpty();
+  }
+
+  @Test
+  public void annotationKeys_skipsBinaryAnnotationsLongerThan256chars() throws Exception {
+    // example long value
+    String arn =
+        "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012";
+    // example too long value
+    String url =
+        "http://webservices.amazon.com/onca/xml?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&AssociateTag=mytag-20&ItemId=0679722769&Operation=ItemLookup&ResponseGroup=Images%2CItemAttributes%2COffers%2CReviews&Service=AWSECommerceService&Timestamp=2014-08-18T12%3A00%3A00Z&Version=2013-08-01&Signature=j7bZM0LXZ9eXeZruTqWm2DIvDYVUU3wxPPpp%2BiXxzQc%3D";
+    Span span = TestObjects.TRACE.get(1).toBuilder().binaryAnnotations(ImmutableList.of(
+        BinaryAnnotation.create("aws.arn", arn, TestObjects.WEB_ENDPOINT),
+        BinaryAnnotation.create(TraceKeys.HTTP_URL, url, TestObjects.WEB_ENDPOINT)
+    )).build();
+
+    assertThat(CassandraUtil.annotationKeys(span))
+        .containsOnly("web:aws.arn", "web:aws.arn:" + arn);
   }
 }


### PR DESCRIPTION
It is unlikely that someone has a valid use case to paste a key/value
match of a value longer than 256 characters. By limiting the length of
binary annotations indexed, we can reduce the size of indexes without
limiting users from storing larger values, like query data.
