### PR TITLE
Moves method used by dependencies job to reduce internal class leak

### DIFF
--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/DependencyLinkSpanIterator.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/DependencyLinkSpanIterator.java
@@ -70,6 +70,7 @@ final class DependencyLinkSpanIterator implements Iterator<DependencyLinkSpan> {
     Record5<Long, Long, Long, String, String> row = delegate.next();
 
     DependencyLinkSpan.Builder result = DependencyLinkSpan.builder(
+        traceId,
         row.getValue(ZipkinSpans.ZIPKIN_SPANS.PARENT_ID),
         row.getValue(ZipkinSpans.ZIPKIN_SPANS.ID)
     );

--- a/zipkin/src/main/java/zipkin/internal/DependencyLinkSpan.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinkSpan.java
@@ -27,7 +27,6 @@ import static zipkin.internal.Util.equal;
  */
 // fields not exposed as public to further discourage use as a general type
 public final class DependencyLinkSpan {
-
   /**
    * Indicates the primary span type.
    */
@@ -38,40 +37,71 @@ public final class DependencyLinkSpan {
     UNKNOWN
   }
 
-  final Kind kind;
+  final long traceId;
   @Nullable
   final Long parentId;
   final long id;
+  final Kind kind;
   @Nullable
   final String service;
   @Nullable
   final String peerService;
 
-  DependencyLinkSpan(Kind kind, Long parentId, long id, String service, String peerService) {
-    this.kind = checkNotNull(kind, "kind");
+  DependencyLinkSpan(long traceId, Long parentId, long id, Kind kind, String service,
+      String peerService) {
+    this.traceId = traceId;
     this.parentId = parentId;
     this.id = id;
+    this.kind = checkNotNull(kind, "kind");
     this.service = service;
     this.peerService = peerService;
   }
 
   @Override public String toString() {
-    StringBuilder json = new StringBuilder("{\"kind\": \"").append(kind).append('\"');
+    StringBuilder json = new StringBuilder();
+    json.append("{\"traceId\": \"").append(Util.toLowerHex(traceId)).append('\"');
     if (parentId != null) {
       json.append(", \"parentId\": \"").append(Util.toLowerHex(parentId)).append('\"');
     }
     json.append(", \"id\": \"").append(Util.toLowerHex(id)).append('\"');
+    json.append(", \"kind\": \"").append(kind).append('\"');
     if (service != null) json.append(", \"service\": \"").append(service).append('\"');
     if (peerService != null) json.append(", \"peerService\": \"").append(peerService).append('\"');
     return json.append("}").toString();
   }
 
-  public static Builder builder(Long parentId, long spanId){
-    return new Builder(parentId, spanId);
+  /** Only considers ID fields, as these spans are not expected to repeat */
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) return true;
+    if (o instanceof Span) {
+      Span that = (Span) o;
+      return (this.traceId == that.traceId)
+          && equal(this.parentId, that.parentId)
+          && (this.id == that.id);
+    }
+    return false;
+  }
+
+  /** Only considers ID fields, as these spans are not expected to repeat */
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= (traceId >>> 32) ^ traceId;
+    h *= 1000003;
+    h ^= (parentId == null) ? 0 : parentId.hashCode();
+    h *= 1000003;
+    h ^= (id >>> 32) ^ id;
+    return h;
+  }
+
+  public static Builder builder(long traceId, Long parentId, long spanId) {
+    return new Builder(traceId, parentId, spanId);
   }
 
   public static DependencyLinkSpan from(Span s) {
-    DependencyLinkSpan.Builder linkSpan = DependencyLinkSpan.builder(s.parentId, s.id);
+    DependencyLinkSpan.Builder linkSpan = DependencyLinkSpan.builder(s.traceId, s.parentId, s.id);
     for (BinaryAnnotation a : s.binaryAnnotations) {
       if (a.key.equals(Constants.CLIENT_ADDR) && a.endpoint != null) {
         linkSpan.caService(a.endpoint.serviceName);
@@ -89,13 +119,15 @@ public final class DependencyLinkSpan {
   }
 
   public static final class Builder {
+    private final long traceId;
     private final Long parentId;
     private final long spanId;
     private String srService;
     private String caService;
     private String saService;
 
-    Builder(Long parentId, long spanId) {
+    Builder(long traceId, Long parentId, long spanId) {
+      this.traceId = traceId;
       this.spanId = spanId;
       this.parentId = parentId;
     }
@@ -134,11 +166,11 @@ public final class DependencyLinkSpan {
         caService = null;
       }
       if (srService != null) {
-        return new DependencyLinkSpan(Kind.SERVER, parentId, spanId, srService, caService);
+        return new DependencyLinkSpan(traceId, parentId, spanId, Kind.SERVER, srService, caService);
       } else if (saService != null) {
-        return new DependencyLinkSpan(Kind.CLIENT, parentId, spanId, caService, saService);
+        return new DependencyLinkSpan(traceId, parentId, spanId, Kind.CLIENT, caService, saService);
       }
-      return new DependencyLinkSpan(Kind.UNKNOWN, parentId, spanId, null, null);
+      return new DependencyLinkSpan(traceId, parentId, spanId, Kind.UNKNOWN, null, null);
     }
   }
 }

--- a/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
@@ -16,10 +16,12 @@ package zipkin.internal;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import zipkin.DependencyLink;
+import zipkin.Span;
 
 import static java.util.logging.Level.FINE;
 
@@ -35,6 +37,19 @@ public final class DependencyLinker {
   private static final Logger logger = Logger.getLogger(DependencyLinker.class.getName());
 
   private final Map<Pair<String>, Long> linkMap = new LinkedHashMap<>();
+
+  /**
+   * @param spans spans where all spans have the same trace id
+   */
+  public DependencyLinker putTrace(List<Span> spans) {
+    if (spans.isEmpty()) return this;
+
+    List<DependencyLinkSpan> linkSpans = new LinkedList<>();
+    for (Span s : MergeById.apply(spans)) {
+      linkSpans.add(DependencyLinkSpan.from(s));
+    }
+    return putTrace(linkSpans.iterator());
+  }
 
   /**
    * @param spans spans where all spans have the same trace id

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkSpanTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkSpanTest.java
@@ -23,40 +23,40 @@ public class DependencyLinkSpanTest {
 
   @Test
   public void testToString() {
-    assertThat(DependencyLinkSpan.builder(null, 1L).build())
-        .hasToString("{\"kind\": \"UNKNOWN\", \"id\": \"0000000000000001\"}");
+    assertThat(DependencyLinkSpan.builder(1L, null, 1L).build())
+        .hasToString("{\"traceId\": \"0000000000000001\", \"id\": \"0000000000000001\", \"kind\": \"UNKNOWN\"}");
 
-    assertThat(DependencyLinkSpan.builder(1L, 2L).build())
-        .hasToString("{\"kind\": \"UNKNOWN\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\"}");
+    assertThat(DependencyLinkSpan.builder(1L, 1L, 2L).build())
+        .hasToString("{\"traceId\": \"0000000000000001\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\", \"kind\": \"UNKNOWN\"}");
 
-    assertThat(DependencyLinkSpan.builder(1L, 2L)
+    assertThat(DependencyLinkSpan.builder(1L, 1L, 2L)
         .srService("processor")
         .caService("kinesis").build())
-        .hasToString("{\"kind\": \"SERVER\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\", \"service\": \"processor\", \"peerService\": \"kinesis\"}");
+        .hasToString("{\"traceId\": \"0000000000000001\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\", \"kind\": \"SERVER\", \"service\": \"processor\", \"peerService\": \"kinesis\"}");
 
     // It is invalid to log "ca" without "sr", so marked as unknown
-    assertThat(DependencyLinkSpan.builder(1L, 2L)
+    assertThat(DependencyLinkSpan.builder(1L, 1L, 2L)
         .caService("kinesis").build())
-        .hasToString("{\"kind\": \"UNKNOWN\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\"}");
+        .hasToString("{\"traceId\": \"0000000000000001\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\", \"kind\": \"UNKNOWN\"}");
 
-    assertThat(DependencyLinkSpan.builder(1L, 2L)
+    assertThat(DependencyLinkSpan.builder(1L, 1L, 2L)
         .saService("mysql").build())
-        .hasToString("{\"kind\": \"CLIENT\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\", \"peerService\": \"mysql\"}");
+        .hasToString("{\"traceId\": \"0000000000000001\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\", \"kind\": \"CLIENT\", \"peerService\": \"mysql\"}");
 
     // arbitrary 2-sided span
-    assertThat(DependencyLinkSpan.builder(1L, 2L)
+    assertThat(DependencyLinkSpan.builder(1L, 1L, 2L)
         .caService("shell-script")
         .saService("mysql").build())
-        .hasToString("{\"kind\": \"CLIENT\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\", \"service\": \"shell-script\", \"peerService\": \"mysql\"}");
+        .hasToString("{\"traceId\": \"0000000000000001\", \"parentId\": \"0000000000000001\", \"id\": \"0000000000000002\", \"kind\": \"CLIENT\", \"service\": \"shell-script\", \"peerService\": \"mysql\"}");
   }
 
   @Test
   public void parentAndChildApply() {
-    DependencyLinkSpan span = DependencyLinkSpan.builder(null, 1L).build();
+    DependencyLinkSpan span = DependencyLinkSpan.builder(1L, null, 1L).build();
     assertThat(span.parentId).isNull();
     assertThat(span.id).isEqualTo(1L);
 
-    span = DependencyLinkSpan.builder(1L, 2L).build();
+    span = DependencyLinkSpan.builder(1L, 1L, 2L).build();
     assertThat(span.parentId).isEqualTo(1L);
     assertThat(span.id).isEqualTo(2L);
   }
@@ -64,7 +64,7 @@ public class DependencyLinkSpanTest {
   /** You cannot make a dependency link unless you know the the local or peer service. */
   @Test
   public void whenNoServiceLabelsExist_kindIsUnknown() {
-    DependencyLinkSpan span = DependencyLinkSpan.builder(null, 1L).build();
+    DependencyLinkSpan span = DependencyLinkSpan.builder(1L, null, 1L).build();
 
     assertThat(span.kind).isEqualTo(Kind.UNKNOWN);
     assertThat(span.peerService).isNull();
@@ -73,7 +73,7 @@ public class DependencyLinkSpanTest {
 
   @Test
   public void whenOnlyAddressLabelsExist_kindIsClient() {
-    DependencyLinkSpan span = DependencyLinkSpan.builder(null, 1L)
+    DependencyLinkSpan span = DependencyLinkSpan.builder(1L, null, 1L)
         .caService("service1")
         .saService("service2")
         .build();
@@ -86,7 +86,7 @@ public class DependencyLinkSpanTest {
   /** The linker is biased towards server spans, or client spans that know the peer service. */
   @Test
   public void whenServerLabelsAreMissing_kindIsUnknownAndLabelsAreCleared() {
-    DependencyLinkSpan span = DependencyLinkSpan.builder(null, 1L)
+    DependencyLinkSpan span = DependencyLinkSpan.builder(1L, null, 1L)
         .caService("service1")
         .build();
 
@@ -98,7 +98,7 @@ public class DependencyLinkSpanTest {
   /** {@link Constants#SERVER_RECV} is only applied when the local span is acting as a server */
   @Test
   public void whenSrServiceExists_kindIsServer() {
-    DependencyLinkSpan span = DependencyLinkSpan.builder(null, 1L)
+    DependencyLinkSpan span = DependencyLinkSpan.builder(1L, null, 1L)
         .srService("service")
         .build();
 
@@ -113,7 +113,7 @@ public class DependencyLinkSpanTest {
    */
   @Test
   public void whenSrAndCaServiceExists_caIsThePeer() {
-    DependencyLinkSpan span = DependencyLinkSpan.builder(null, 1L)
+    DependencyLinkSpan span = DependencyLinkSpan.builder(1L, null, 1L)
         .caService("service1")
         .srService("service2")
         .build();
@@ -126,7 +126,7 @@ public class DependencyLinkSpanTest {
   @Test
   public void specialCasesFinagleLocalSocketLabeling() {
     // Finagle labels two sides of the same socket ("ca", "sa") with the local service name.
-    DependencyLinkSpan span = DependencyLinkSpan.builder(null, 1L)
+    DependencyLinkSpan span = DependencyLinkSpan.builder(1L, null, 1L)
         .caService("service")
         .saService("service")
         .build();
@@ -136,7 +136,7 @@ public class DependencyLinkSpanTest {
     assertThat(span.service).isNull();
     assertThat(span.peerService).isEqualTo("service");
 
-    span = DependencyLinkSpan.builder(null, 1L)
+    span = DependencyLinkSpan.builder(1L, null, 1L)
         .srService("service")
         .caService("service")
         .saService("service")

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
@@ -16,6 +16,7 @@ package zipkin.internal;
 import java.util.List;
 import org.junit.Test;
 import zipkin.DependencyLink;
+import zipkin.TestObjects;
 import zipkin.internal.DependencyLinkSpan.Kind;
 
 import static java.util.Arrays.asList;
@@ -26,6 +27,14 @@ public class DependencyLinkerTest {
   @Test
   public void baseCase() {
     assertThat(new DependencyLinker().link()).isEmpty();
+  }
+
+  @Test
+  public void linksSpans() {
+    assertThat(new DependencyLinker().putTrace(TestObjects.TRACE).link()).containsExactly(
+        DependencyLink.create("web", "app", 1L),
+        DependencyLink.create("app", "db", 1L)
+    );
   }
 
   /**

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
@@ -44,9 +44,9 @@ public class DependencyLinkerTest {
   @Test
   public void doesntLinkUnknownRootSpans() {
     List<DependencyLinkSpan> unknownRootSpans = asList(
-        new DependencyLinkSpan(Kind.UNKNOWN, null, 1L, null, null),
-        new DependencyLinkSpan(Kind.UNKNOWN, null, 1L, "server", "client"),
-        new DependencyLinkSpan(Kind.UNKNOWN, null, 1L, "client", "server")
+        new DependencyLinkSpan(1L, null, 1L, Kind.UNKNOWN, null, null),
+        new DependencyLinkSpan(1L, null, 1L, Kind.UNKNOWN, "server", "client"),
+        new DependencyLinkSpan(1L, null, 1L, Kind.UNKNOWN, "client", "server")
     );
 
     for (DependencyLinkSpan span : unknownRootSpans) {
@@ -63,8 +63,8 @@ public class DependencyLinkerTest {
   @Test
   public void linksSpansDirectedByKind() {
     List<DependencyLinkSpan> validRootSpans = asList(
-        new DependencyLinkSpan(Kind.SERVER, null, 1L, "server", "client"),
-        new DependencyLinkSpan(Kind.CLIENT, null, 1L, "client", "server")
+        new DependencyLinkSpan(1L, null, 1L, Kind.SERVER, "server", "client"),
+        new DependencyLinkSpan(1L, null, 1L, Kind.CLIENT, "client", "server")
     );
 
     for (DependencyLinkSpan span : validRootSpans) {
@@ -77,9 +77,9 @@ public class DependencyLinkerTest {
   @Test
   public void callsAgainstTheSameLinkIncreasesCallCount_span() {
     List<DependencyLinkSpan> trace = asList(
-        new DependencyLinkSpan(Kind.SERVER, null, 1L, "client", null),
-        new DependencyLinkSpan(Kind.CLIENT, 1L, 2L, null, "server"),
-        new DependencyLinkSpan(Kind.CLIENT, 1L, 3L, null, "server")
+        new DependencyLinkSpan(1L, null, 1L, Kind.SERVER, "client", null),
+        new DependencyLinkSpan(1L, 1L, 2L, Kind.CLIENT, null, "server"),
+        new DependencyLinkSpan(1L, 1L, 3L, Kind.CLIENT, null, "server")
     );
 
     assertThat(new DependencyLinker()
@@ -90,8 +90,8 @@ public class DependencyLinkerTest {
   @Test
   public void callsAgainstTheSameLinkIncreasesCallCount_trace() {
     List<DependencyLinkSpan> trace = asList(
-        new DependencyLinkSpan(Kind.SERVER, null, 1L, "client", null),
-        new DependencyLinkSpan(Kind.CLIENT, 1L, 2L, null, "server")
+        new DependencyLinkSpan(1L, null, 1L, Kind.SERVER, "client", null),
+        new DependencyLinkSpan(1L, 1L, 2L, Kind.CLIENT, null, "server")
     );
 
     assertThat(new DependencyLinker()
@@ -108,12 +108,12 @@ public class DependencyLinkerTest {
   public void singleHostSpansResultInASingleCallCount() {
     List<List<DependencyLinkSpan>> singleLinks = asList(
         asList(
-            new DependencyLinkSpan(Kind.CLIENT, null, 1L, "client", "server"),
-            new DependencyLinkSpan(Kind.SERVER, 1L, 2L, "server", null)
+            new DependencyLinkSpan(1L, null, 1L, Kind.CLIENT, "client", "server"),
+            new DependencyLinkSpan(1L, 1L, 2L, Kind.SERVER, "server", null)
         ),
         asList(
-            new DependencyLinkSpan(Kind.SERVER, null, 1L, "client", null),
-            new DependencyLinkSpan(Kind.CLIENT, 1L, 2L, "client", "server")
+            new DependencyLinkSpan(3L, null, 3L, Kind.SERVER, "client", null),
+            new DependencyLinkSpan(3L, 3L, 4L, Kind.CLIENT, "client", "server")
         )
     );
 
@@ -131,10 +131,11 @@ public class DependencyLinkerTest {
   @Test
   public void intermediatedClientSpansMissingLocalServiceNameLinkToNearestServer() {
     List<DependencyLinkSpan> trace = asList(
-        new DependencyLinkSpan(Kind.SERVER, null, 1L, "client", null),
-        new DependencyLinkSpan(Kind.UNKNOWN, 1L, 2L, null, null), // possibly a local fan-out span
-        new DependencyLinkSpan(Kind.CLIENT, 2L, 3L, null, "server"),
-        new DependencyLinkSpan(Kind.CLIENT, 2L, 4L, null, "server")
+        new DependencyLinkSpan(1L, null, 1L, Kind.SERVER, "client", null),
+        new DependencyLinkSpan(1L, 1L, 2L, Kind.UNKNOWN, null, null),
+        // possibly a local fan-out span
+        new DependencyLinkSpan(1L, 2L, 3L, Kind.CLIENT, null, "server"),
+        new DependencyLinkSpan(1L, 2L, 4L, Kind.CLIENT, null, "server")
     );
 
     assertThat(new DependencyLinker()
@@ -146,8 +147,8 @@ public class DependencyLinkerTest {
   @Test
   public void linksLoopbackSpans() {
     List<DependencyLinkSpan> validRootSpans = asList(
-        new DependencyLinkSpan(Kind.SERVER, null, 1L, "service", "service"),
-        new DependencyLinkSpan(Kind.CLIENT, null, 1L, "service", "service")
+        new DependencyLinkSpan(1L, null, 1L, Kind.SERVER, "service", "service"),
+        new DependencyLinkSpan(2L, null, 2L, Kind.CLIENT, "service", "service")
     );
 
     for (DependencyLinkSpan span : validRootSpans) {
@@ -164,12 +165,12 @@ public class DependencyLinkerTest {
   @Test
   public void cannotLinkSingleSpanWithoutBothServiceNames() {
     List<DependencyLinkSpan> incompleteRootSpans = asList(
-        new DependencyLinkSpan(Kind.SERVER, null, 1L, null, null),
-        new DependencyLinkSpan(Kind.SERVER, null, 1L, "server", null),
-        new DependencyLinkSpan(Kind.SERVER, null, 1L, null, "client"),
-        new DependencyLinkSpan(Kind.CLIENT, null, 1L, null, null),
-        new DependencyLinkSpan(Kind.CLIENT, null, 1L, "client", null),
-        new DependencyLinkSpan(Kind.CLIENT, null, 1L, null, "server")
+        new DependencyLinkSpan(1L, null, 1L, Kind.SERVER, null, null),
+        new DependencyLinkSpan(1L, null, 1L, Kind.SERVER, "server", null),
+        new DependencyLinkSpan(1L, null, 1L, Kind.SERVER, null, "client"),
+        new DependencyLinkSpan(1L, null, 1L, Kind.CLIENT, null, null),
+        new DependencyLinkSpan(1L, null, 1L, Kind.CLIENT, "client", null),
+        new DependencyLinkSpan(1L, null, 1L, Kind.CLIENT, null, "server")
     );
 
     for (DependencyLinkSpan span : incompleteRootSpans) {


### PR DESCRIPTION
DependencyLinker isn't stable, yet, and creating the input from pieces
requires a MergeById type that's also internal. By hiding this op,
callers have less internal classes in their imports.
