### PR TITLE
Decouples maximum lookback from default lookback

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -83,7 +83,7 @@ When the UI loads, it reads default configuration from the `/config.json` endpoi
 Attribute | Property | Description
 --- | --- | ---
 environment | zipkin.ui.environment | The value here becomes a label in the top-right corner. Not required.
-defaultLookback | zipkin.ui.default-lookback | Default duration in millis to look back when finding traces or dependency links. Affects the "Start time" element in the UI. Defaults to 604800000 (7 days in millis).
+defaultLookback | zipkin.ui.default-lookback | Default duration in millis to look back when finding traces. Affects the "Start time" element in the UI. Defaults to 3600000 (1 hour in millis).
 queryLimit | zipkin.ui.query-limit | Default limit for Find Traces. Defaults to 10.
 instrumented | zipkin.ui.instrumented | Which sites this Zipkin UI covers. Regex syntax. e.g. `http:\/\/example.com\/.*` Defaults to match all websites (`.*`).
 
@@ -96,7 +96,7 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
 
     * `QUERY_PORT`: Listen port for the http api and web ui; Defaults to 9411
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
-    * `QUERY_LOOKBACK`: How many milliseconds queries look back from endTs; Defaults to 7 days
+    * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 7 days
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`
     * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410 
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -74,9 +74,9 @@ zipkin:
     query-limit: 10
     # The value here becomes a label in the top-right corner
     environment:
-    # Default duration to look back when finding traces or dependency links.
-    # Affects the "Start time" element in the UI. 7 days in millis
-    default-lookback: ${QUERY_LOOKBACK:604800000}
+    # Default duration to look back when finding traces.
+    # Affects the "Start time" element in the UI. 1 hour in millis
+    default-lookback: 3600000
     # Which sites this Zipkin UI covers. Regex syntax. (e.g. http:\/\/example.com\/.*)
     # Multiple sites can be specified, e.g.
     # - .*example1.com

--- a/zipkin-ui/js/config.js
+++ b/zipkin-ui/js/config.js
@@ -2,8 +2,8 @@ import $ from 'jquery';
 
 const defaults = {
   environment: '',
-  queryLimit: 15,
-  defaultLookback: 24 * 60 * 60 * 1000 // 24 hours
+  queryLimit: 10,
+  defaultLookback: 60 * 60 * 1000 // 1 hour
 };
 
 export default function loadConfig() {

--- a/zipkin-ui/js/page/dependency.js
+++ b/zipkin-ui/js/page/dependency.js
@@ -18,7 +18,8 @@ const DependencyPageComponent = component(function DependencyPage() {
 
     const {startTs, endTs} = queryString.parse(location.search);
     $('#endTs').val(endTs || moment().valueOf());
-    $('#startTs').val(startTs || moment().valueOf() - this.attr.config('defaultLookback'));
+    // When #1185 is complete, the only visible granularity is day
+    $('#startTs').val(startTs || moment().valueOf() - 86400000);
 
     DependencyData.attachTo('#dependency-container');
     DependencyGraphUI.attachTo('#dependency-container');


### PR DESCRIPTION
This does a number of things to improve performance.

QUERY_LOOKBACK prevents the server from having to construct queries that
are longer than indexes. This value was used by default which led to a
couple major problems.
- When looking for performance problems, you aren't usually looking for 7 day old data, and even if you were, it wouldn't fit into a limit of 10. Changing to a much smaller amount was requested in #1210
- Cassandra duration queries convert into lookback/1hr requests. A
  default of 7 days means 168 requests. This led to most users being
  unable to use the duration query function.
- By changing to 1hr, our 10 trace limit is very likely to apply, and in
  the case of Cassandra, we will only pull a single bucket.

In #1185, we know we want to change to daily granularity. By switching
lookback to 1 day (decoupled from the 1hr lookback on traces), we better
prepare for that change.

I also noticed that we document queryLimit to 10, but config.js says 15.
Regardless of the correct value, they should be aligned.
