### PR TITLE
Add Zipkin version to the /info endpoint

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -12,6 +12,7 @@ The following endpoints are defined for Zipkin:
 * /config.json - [Configuration for the UI](#configuration-for-the-ui)
 * /api/v1 - [Api](http://zipkin.io/zipkin-api/#/)
 * /health - Returns 200 status if OK
+* /info - Provides the version of the running instance
 * /metrics - Includes collector metrics broken down by transport type 
 
 There are more [built-in endpoints](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) provided by Spring Boot, such as `/metrics`. To comprehensively list endpoints, `GET /mappings`.

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -200,6 +200,12 @@
   </profiles>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -99,6 +99,11 @@ spring:
     exclude:
       # otherwise we might initialize even when not needed (ex when storage type is cassandra)
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
+info:
+  zipkin:
+    version: "@project.version@"
+
 logging:
   level:
     # Silence Invalid method name: '__can__finagle__trace__v3__'


### PR DESCRIPTION
In order to easily identify the version deployed and running, this exposes the Zipkin version from the /info endpoint.

Related to #1208
/cc @dragontree101

Before:

``` bash
curl -s http://localhost:9411/info | jq .
{}
```

Since we can add arbitrary properties to expose on the `/info` endpoint through configuration, including Maven variables (with Maven resource filtering), this pull request does the following.

``` yaml
info:
  zipkin:
    version: "@project.version@"
```

Which would show up in the `/info` endpoint as:

``` json
{
  "zipkin": {
    "version": "1.6.1-SNAPSHOT"
  }
}
```

See [this section](http://docs.spring.io/spring-boot/docs/1.4.0.RELEASE/reference/htmlsingle/#production-ready-application-info) of the Spring Boot documentation regarding this and related feature.
