### PR TITLE
Reduces the core jar from 272 to 188k by tuning codec and shade

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check out the [`zipkin-server`](/zipkin-server) documentation for configuration 
 ## Core Library
 The [core library](https://github.com/openzipkin/zipkin/tree/master/zipkin/src/main/java/io/zipkin) requires minimum language level 7. While currently only used by the server, we expect this library to be used in native instrumentation as well.
 
-This includes built-in codec for both thrift and json structs. Direct dependencies on thrift or moshi (json library) are avoided by minifying and repackaging classes used. The result is a 256k jar which won't conflict with any library you use.
+This includes built-in codec for both thrift and json structs. Direct dependencies on thrift or moshi (json library) are avoided by minifying and repackaging classes used. The result is a 190k jar which won't conflict with any library you use.
 
 Ex.
 ```java

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -71,6 +71,29 @@
             <configuration>
               <shadeTestJar>false</shadeTestJar>
               <minimizeJar>true</minimizeJar>
+              <filters>
+                <filter>
+                  <artifact>com.squareup.moshi:moshi</artifact>
+                  <includes>
+                    <include>com/squareup/moshi/BufferedSinkJsonWriter*</include>
+                    <include>com/squareup/moshi/BufferedSourceJsonReader*</include>
+                    <!-- don't get zipkin/internal/moshi/JsonAdapter$Factory.class -->
+                    <include>com/squareup/moshi/JsonAdapter.class</include>
+                    <include>com/squareup/moshi/JsonAdapter$?.class</include>
+                    <include>com/squareup/moshi/JsonDataException*</include>
+                    <include>com/squareup/moshi/JsonReader*</include>
+                    <include>com/squareup/moshi/JsonScope*</include>
+                    <include>com/squareup/moshi/JsonWriter*</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <!-- don't include pom files, some are kilobytes -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>okio</pattern>


### PR DESCRIPTION
Before, we used more reflection than necessary in codec. This implied
use of larger and more classes than we actually need. By slightly
changing codec, and manually controlling shade, we dropped the jar size
by 45%.
