### PR TITLE
Upload javadocs to gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ _site/
 dsc-cassandra-*
 elasticsearch-2*
 kafka_*
+# temporary directory used by travis/publish.sh for building gh-pages
+/javadoc-builddir

--- a/README.md
+++ b/README.md
@@ -93,3 +93,6 @@ Snapshots are uploaded to [JFrog](http://oss.jfrog.org/artifactory/oss-snapshot-
 ### Docker Images
 Released versions of zipkin-server are published to Docker Hub as `openzipkin/zipkin`.
 See [docker-zipkin-java](https://github.com/openzipkin/docker-zipkin-java) for details.
+### Javadocs
+http://zipkin.io/zipkin contains versioned folders with JavaDocs published on each (non-PR) build, as well
+as releases.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,10 @@ in mind when choosing version numbers.
 1. **Wait for Travis CI**
 
    This part is controlled by [`travis/publish.sh`](travis/publish.sh). It creates a bunch of new commits, bumps
-   the version, publishes artifacts, and syncs to Maven Central.
+   the version, publishes artifacts, syncs to Maven Central, and publishes Javaocs to http://zipkin.io/zipkin
+   into a versioned subdirectory.
+   (Note: Javaocs are also published on all builds of master; due to versioning, it doesn't overwrite docs built
+   for releases.)
 
 1. **Publish `docker-zipkin-java`**
 


### PR DESCRIPTION
Creates a directory structure that looks like this:

```
javadoc-builddir/
├── index.html
└── 1.6.1-SNAPSHOT
    ├── index.html
    ├── zipkin
    │   ├── META-INF
    │   │   └── MANIFEST.MF
    │   ├── allclasses-frame.html
    │   ├── allclasses-noframe.html
    │   ├── constant-values.html
    │   ├── deprecated-list.html
...
```

And makes the contents available via GitHub Pages. The URL is, somewhat counter-intuitively, http://zipkin.io/zipkin/ (where `zipkin.io` is the domain used by all GitHub Pages sites of the `openzipkin` org, and `/zipkin` is the name of this repo).

Uploads javadocs only when NOT on a pull request build.

Did some testing, and tried to avoid problems, but we might still hit problems around `git checkout`, `git commit`, and uncommitted files. If all else fails, we can always use a separate  clone in, say, `/tmp`.

(Also did some research; there doesn't seem to exist a Maven plugin for doing this.)
