### PR TITLE
Moves zipkin-core language level to JRE 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Once you've started, browse to http://your_host:9411 to find traces!
 Check out the [`zipkin-server`](/zipkin-server) documentation for configuration details, or [`docker-zipkin`](https://github.com/openzipkin/docker-zipkin) for how to use docker-compose.
 
 ## Core Library
-The [core library](https://github.com/openzipkin/zipkin/tree/master/zipkin/src/main/java/io/zipkin) requires minimum language level 7. While currently only used by the server, we expect this library to be used in native instrumentation as well.
+The [core library](https://github.com/openzipkin/zipkin/tree/master/zipkin/src/main/java/io/zipkin) is used by both Zipkin instrumentation and the Zipkin server. Its minimum Java language level is 6, in efforts to support those writing agent instrumentation.
 
-This includes built-in codec for both thrift and json structs. Direct dependencies on thrift or moshi (json library) are avoided by minifying and repackaging classes used. The result is a 190k jar which won't conflict with any library you use.
+This includes built-in codec for both thrift and json structs. A direct dependency on gson (json library) is avoided by minifying and repackaging classes used. The result is a 155k jar which won't conflict with any library you use.
 
 Ex.
 ```java

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
 
     <brave.version>3.9.0</brave.version>
     <cassandra-driver-core.version>3.1.0</cassandra-driver-core.version>
-    <moshi.version>1.2.0</moshi.version>
     <okio.version>1.9.0</okio.version>
     <jooq.version>3.8.4</jooq.version>
     <spring-boot.version>1.4.0.RELEASE</spring-boot.version>
@@ -274,12 +273,6 @@
         <version>${elasticsearch.version}</version>
       </dependency>
       <!-- End spring-boot-dependencies overrides -->
-
-      <dependency>
-        <groupId>com.squareup.moshi</groupId>
-        <artifactId>moshi</artifactId>
-        <version>${moshi.version}</version>
-      </dependency>
 
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -28,17 +28,21 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio</artifactId>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.7</version>
     </dependency>
 
     <dependency>
-      <groupId>com.squareup.moshi</groupId>
-      <artifactId>moshi</artifactId>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -73,17 +77,13 @@
               <minimizeJar>true</minimizeJar>
               <filters>
                 <filter>
-                  <artifact>com.squareup.moshi:moshi</artifact>
+                  <artifact>com.google.code.gson:gson</artifact>
                   <includes>
-                    <include>com/squareup/moshi/BufferedSinkJsonWriter*</include>
-                    <include>com/squareup/moshi/BufferedSourceJsonReader*</include>
-                    <!-- don't get zipkin/internal/moshi/JsonAdapter$Factory.class -->
-                    <include>com/squareup/moshi/JsonAdapter.class</include>
-                    <include>com/squareup/moshi/JsonAdapter$?.class</include>
-                    <include>com/squareup/moshi/JsonDataException*</include>
-                    <include>com/squareup/moshi/JsonReader*</include>
-                    <include>com/squareup/moshi/JsonScope*</include>
-                    <include>com/squareup/moshi/JsonWriter*</include>
+                    <include>com/google/gson/stream/JsonReader*.class</include>
+                    <include>com/google/gson/stream/JsonToken.class</include>
+                    <include>com/google/gson/stream/JsonWriter.class</include>
+                    <include>com/google/gson/stream/MalformedJsonException.class</include>
+                    <include>com/google/gson/internal/JsonReaderInternalAccess.class</include>
                   </includes>
                 </filter>
                 <filter>
@@ -96,12 +96,8 @@
               </filters>
               <relocations>
                 <relocation>
-                  <pattern>okio</pattern>
-                  <shadedPattern>zipkin.internal.okio</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.squareup.moshi</pattern>
-                  <shadedPattern>zipkin.internal.moshi</shadedPattern>
+                  <pattern>com.google.gson</pattern>
+                  <shadedPattern>zipkin.internal.gson</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>
@@ -109,7 +105,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>

--- a/zipkin/src/main/java/zipkin/Annotation.java
+++ b/zipkin/src/main/java/zipkin/Annotation.java
@@ -13,7 +13,6 @@
  */
 package zipkin;
 
-import zipkin.internal.JsonCodec;
 import zipkin.internal.Nullable;
 
 import static zipkin.internal.Util.checkNotNull;
@@ -101,11 +100,6 @@ public final class Annotation implements Comparable<Annotation> {
   }
 
   @Override
-  public String toString() {
-    return JsonCodec.ANNOTATION_ADAPTER.toJson(this);
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (o == this) {
       return true;
@@ -135,7 +129,7 @@ public final class Annotation implements Comparable<Annotation> {
   @Override
   public int compareTo(Annotation that) {
     if (this == that) return 0;
-    int byTimestamp = Long.compare(timestamp, that.timestamp);
+    int byTimestamp = timestamp < that.timestamp ? -1 : timestamp == that.timestamp ? 0 : 1;
     if (byTimestamp != 0) return byTimestamp;
     return value.compareTo(that.value);
   }

--- a/zipkin/src/main/java/zipkin/BinaryAnnotation.java
+++ b/zipkin/src/main/java/zipkin/BinaryAnnotation.java
@@ -14,7 +14,6 @@
 package zipkin;
 
 import java.util.Arrays;
-import zipkin.internal.JsonCodec;
 import zipkin.internal.Nullable;
 import zipkin.internal.Util;
 
@@ -194,11 +193,6 @@ public final class BinaryAnnotation implements Comparable<BinaryAnnotation> {
     public BinaryAnnotation build() {
       return new BinaryAnnotation(key, value, type, endpoint);
     }
-  }
-
-  @Override
-  public String toString() {
-    return JsonCodec.BINARY_ANNOTATION_ADAPTER.toJson(this);
   }
 
   @Override

--- a/zipkin/src/main/java/zipkin/DependencyLink.java
+++ b/zipkin/src/main/java/zipkin/DependencyLink.java
@@ -16,8 +16,8 @@ package zipkin;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.io.StreamCorruptedException;
-import zipkin.internal.JsonCodec;
 
+import static zipkin.internal.Util.UTF_8;
 import static zipkin.internal.Util.checkNotNull;
 
 public final class DependencyLink implements Serializable {
@@ -86,7 +86,7 @@ public final class DependencyLink implements Serializable {
 
   @Override
   public String toString() {
-    return JsonCodec.DEPENDENCY_LINK_ADAPTER.toJson(this);
+    return new String(Codec.JSON.writeDependencyLink(this), UTF_8);
   }
 
   @Override

--- a/zipkin/src/main/java/zipkin/Endpoint.java
+++ b/zipkin/src/main/java/zipkin/Endpoint.java
@@ -15,7 +15,6 @@ package zipkin;
 
 import java.util.Arrays;
 import java.util.Locale;
-import zipkin.internal.JsonCodec;
 import zipkin.internal.Nullable;
 import zipkin.internal.Util;
 
@@ -148,11 +147,6 @@ public final class Endpoint {
     public Endpoint build() {
       return new Endpoint(serviceName, ipv4 == null ? 0 : ipv4, ipv6, port);
     }
-  }
-
-  @Override
-  public String toString() {
-    return JsonCodec.ENDPOINT_ADAPTER.toJson(this);
   }
 
   @Override

--- a/zipkin/src/main/java/zipkin/collector/Collector.java
+++ b/zipkin/src/main/java/zipkin/collector/Collector.java
@@ -99,7 +99,7 @@ public final class Collector {
   }
 
   public void acceptSpans(List<byte[]> serializedSpans, Codec codec, Callback<Void> callback) {
-    List<Span> spans = new ArrayList<>(serializedSpans.size());
+    List<Span> spans = new ArrayList<Span>(serializedSpans.size());
     try {
       int bytesRead = 0;
       for (byte[] serializedSpan : serializedSpans) {
@@ -137,7 +137,7 @@ public final class Collector {
   }
 
   List<Span> sample(List<Span> input) {
-    List<Span> sampled = new ArrayList<>(input.size());
+    List<Span> sampled = new ArrayList<Span>(input.size());
     for (Span s : input) {
       if (sampler.isSampled(s)) sampled.add(s);
     }

--- a/zipkin/src/main/java/zipkin/internal/Base64.java
+++ b/zipkin/src/main/java/zipkin/internal/Base64.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * copied from okio.Base64 as JRE 6 doesn't have a base64Url encoder
+ *
+ * @author Alexander Y. Kleymenov
+ */
+final class Base64 {
+  private Base64() {
+  }
+
+  public static byte[] decode(String in) {
+    // Ignore trailing '=' padding and whitespace from the input.
+    int limit = in.length();
+    for (; limit > 0; limit--) {
+      char c = in.charAt(limit - 1);
+      if (c != '=' && c != '\n' && c != '\r' && c != ' ' && c != '\t') {
+        break;
+      }
+    }
+
+    // If the input includes whitespace, this output array will be longer than necessary.
+    byte[] out = new byte[(int) (limit * 6L / 8L)];
+    int outCount = 0;
+    int inCount = 0;
+
+    int word = 0;
+    for (int pos = 0; pos < limit; pos++) {
+      char c = in.charAt(pos);
+
+      int bits;
+      if (c >= 'A' && c <= 'Z') {
+        // char ASCII value
+        //  A    65    0
+        //  Z    90    25 (ASCII - 65)
+        bits = c - 65;
+      } else if (c >= 'a' && c <= 'z') {
+        // char ASCII value
+        //  a    97    26
+        //  z    122   51 (ASCII - 71)
+        bits = c - 71;
+      } else if (c >= '0' && c <= '9') {
+        // char ASCII value
+        //  0    48    52
+        //  9    57    61 (ASCII + 4)
+        bits = c + 4;
+      } else if (c == '+' || c == '-') {
+        bits = 62;
+      } else if (c == '/' || c == '_') {
+        bits = 63;
+      } else if (c == '\n' || c == '\r' || c == ' ' || c == '\t') {
+        continue;
+      } else {
+        return null;
+      }
+
+      // Append this char's 6 bits to the word.
+      word = (word << 6) | (byte) bits;
+
+      // For every 4 chars of input, we accumulate 24 bits of output. Emit 3 bytes.
+      inCount++;
+      if (inCount % 4 == 0) {
+        out[outCount++] = (byte) (word >> 16);
+        out[outCount++] = (byte) (word >> 8);
+        out[outCount++] = (byte) word;
+      }
+    }
+
+    int lastWordChars = inCount % 4;
+    if (lastWordChars == 1) {
+      // We read 1 char followed by "===". But 6 bits is a truncated byte! Fail.
+      return null;
+    } else if (lastWordChars == 2) {
+      // We read 2 chars followed by "==". Emit 1 byte with 8 of those 12 bits.
+      word = word << 12;
+      out[outCount++] = (byte) (word >> 16);
+    } else if (lastWordChars == 3) {
+      // We read 3 chars, followed by "=". Emit 2 bytes for 16 of those 18 bits.
+      word = word << 6;
+      out[outCount++] = (byte) (word >> 16);
+      out[outCount++] = (byte) (word >> 8);
+    }
+
+    // If we sized our out array perfectly, we're done.
+    if (outCount == out.length) return out;
+
+    // Copy the decoded bytes to a new, right-sized array.
+    byte[] prefix = new byte[outCount];
+    System.arraycopy(out, 0, prefix, 0, outCount);
+    return prefix;
+  }
+
+  private static final byte[] MAP = new byte[] {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+      'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+      'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
+      '5', '6', '7', '8', '9', '+', '/'
+  };
+
+  private static final byte[] URL_MAP = new byte[] {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+      'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+      'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
+      '5', '6', '7', '8', '9', '-', '_'
+  };
+
+  public static String encode(byte[] in) {
+    return encode(in, MAP);
+  }
+
+  public static String encodeUrl(byte[] in) {
+    return encode(in, URL_MAP);
+  }
+
+  private static String encode(byte[] in, byte[] map) {
+    int length = (in.length + 2) / 3 * 4;
+    byte[] out = new byte[length];
+    int index = 0, end = in.length - in.length % 3;
+    for (int i = 0; i < end; i += 3) {
+      out[index++] = map[(in[i] & 0xff) >> 2];
+      out[index++] = map[((in[i] & 0x03) << 4) | ((in[i + 1] & 0xff) >> 4)];
+      out[index++] = map[((in[i + 1] & 0x0f) << 2) | ((in[i + 2] & 0xff) >> 6)];
+      out[index++] = map[(in[i + 2] & 0x3f)];
+    }
+    switch (in.length % 3) {
+      case 1:
+        out[index++] = map[(in[end] & 0xff) >> 2];
+        out[index++] = map[(in[end] & 0x03) << 4];
+        out[index++] = '=';
+        out[index++] = '=';
+        break;
+      case 2:
+        out[index++] = map[(in[end] & 0xff) >> 2];
+        out[index++] = map[((in[end] & 0x03) << 4) | ((in[end + 1] & 0xff) >> 4)];
+        out[index++] = map[((in[end + 1] & 0x0f) << 2)];
+        out[index++] = '=';
+        break;
+    }
+    try {
+      return new String(out, "US-ASCII");
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/zipkin/src/main/java/zipkin/internal/Buffer.java
+++ b/zipkin/src/main/java/zipkin/internal/Buffer.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.io.OutputStream;
+import java.util.Arrays;
+
+/** Similar to {@link java.io.ByteArrayInputStream}, except specialized and unsynchronized */
+final class Buffer extends OutputStream {
+  static final int MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
+  private byte[] buf = new byte[128];
+  private int count;
+
+  @Override public void write(int v) {
+    ensureCapacity(count + 1);
+    buf[count++] = (byte) v;
+  }
+
+  @Override public void write(byte[] v) {
+    ensureCapacity(count + v.length);
+    System.arraycopy(v, 0, buf, count, v.length);
+    count += v.length;
+  }
+
+  void writeShort(int v) {
+    ensureCapacity(count + 2);
+    write((v >>> 8L) & 0xff);
+    write(v & 0xff);
+  }
+
+  void writeInt(int v) {
+    ensureCapacity(count + 4);
+    buf[count++] = (byte) ((v >>> 24L) & 0xff);
+    buf[count++] = (byte) ((v >>> 16L) & 0xff);
+    buf[count++] = (byte) ((v >>> 8L) & 0xff);
+    buf[count++] = (byte) (v & 0xff);
+  }
+
+  void writeLong(long v) {
+    ensureCapacity(count + 8);
+    buf[count++] = (byte) ((v >>> 56L) & 0xff);
+    buf[count++] = (byte) ((v >>> 48L) & 0xff);
+    buf[count++] = (byte) ((v >>> 40L) & 0xff);
+    buf[count++] = (byte) ((v >>> 32L) & 0xff);
+    buf[count++] = (byte) ((v >>> 24L) & 0xff);
+    buf[count++] = (byte) ((v >>> 16L) & 0xff);
+    buf[count++] = (byte) ((v >>> 8L) & 0xff);
+    buf[count++] = (byte) (v & 0xff);
+  }
+
+  /** Writes a length-prefixed string */
+  void writeUtf8(String v) {
+    byte[] temp = v.getBytes(Util.UTF_8);
+    writeInt(temp.length);
+    write(temp);
+  }
+
+  byte[] toByteArray() {
+    return Arrays.copyOf(buf, count);
+  }
+
+  /** Doubles up to {@link #MAX_ARRAY_LENGTH} if necessary */
+  private void ensureCapacity(int length) {
+    if (length <= buf.length) return;
+    if (length >= MAX_ARRAY_LENGTH) throw new OutOfMemoryError();
+
+    int newLength = buf.length;
+    while (newLength < length) {
+      newLength = newLength * 2;
+      if (newLength > Integer.MAX_VALUE) {
+        newLength = MAX_ARRAY_LENGTH;
+      }
+    }
+
+    buf = Arrays.copyOf(buf, newLength);
+  }
+}

--- a/zipkin/src/main/java/zipkin/internal/CallbackCaptor.java
+++ b/zipkin/src/main/java/zipkin/internal/CallbackCaptor.java
@@ -20,7 +20,7 @@ import zipkin.storage.Callback;
 public final class CallbackCaptor<V> implements Callback<V> {
   // countDown + ref as BlockingQueue forbids null
   final CountDownLatch countDown = new CountDownLatch(1);
-  final AtomicReference<Object> ref = new AtomicReference<>();
+  final AtomicReference<Object> ref = new AtomicReference<Object>();
 
   /**
    * Blocks until {@link Callback#onSuccess(Object)} or {@link Callback#onError(Throwable)}.

--- a/zipkin/src/main/java/zipkin/internal/CorrectForClockSkew.java
+++ b/zipkin/src/main/java/zipkin/internal/CorrectForClockSkew.java
@@ -45,7 +45,7 @@ public final class CorrectForClockSkew {
       if (s.parentId == null) {
         Node<Span> tree = Node.constructTree(spans);
         adjust(tree, null);
-        List<Span> result = new ArrayList<>(spans.size());
+        List<Span> result = new ArrayList<Span>(spans.size());
         for (Iterator<Node<Span>> i = tree.traverse(); i.hasNext();) {
           result.add(i.next().value());
         }
@@ -85,7 +85,7 @@ public final class CorrectForClockSkew {
       Annotation a = span.annotations.get(i);
       if (a.endpoint == null) continue;
       if (ipsMatch(skew.endpoint, a.endpoint)) {
-        if (annotations == null) annotations = new ArrayList<>(span.annotations);
+        if (annotations == null) annotations = new ArrayList<Annotation>(span.annotations);
         annotations.set(i, a.toBuilder().timestamp(a.timestamp - skew.skew).build());
       }
     }
@@ -145,7 +145,7 @@ public final class CorrectForClockSkew {
 
   /** Get the annotations as a map with value to annotation bindings. */
   static Map<String, Annotation> asMap(List<Annotation> annotations) {
-    Map<String, Annotation> result = new LinkedHashMap<>(annotations.size());
+    Map<String, Annotation> result = new LinkedHashMap<String, Annotation>(annotations.size());
     for (Annotation a : annotations) {
       result.put(a.value, a);
     }

--- a/zipkin/src/main/java/zipkin/internal/Dependencies.java
+++ b/zipkin/src/main/java/zipkin/internal/Dependencies.java
@@ -15,7 +15,6 @@ package zipkin.internal;
 
 import java.nio.ByteBuffer;
 import java.util.List;
-import okio.Buffer;
 import zipkin.DependencyLink;
 
 import static zipkin.internal.ThriftCodec.DEPENDENCY_LINKS_ADAPTER;
@@ -139,7 +138,7 @@ public final class Dependencies {
       LINKS.write(buffer);
       DEPENDENCY_LINKS_ADAPTER.write(value.links, buffer);
 
-      buffer.writeByte(TYPE_STOP);
+      buffer.write(TYPE_STOP);
     }
 
     @Override

--- a/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
@@ -36,7 +36,7 @@ import static java.util.logging.Level.FINE;
 public final class DependencyLinker {
   private static final Logger logger = Logger.getLogger(DependencyLinker.class.getName());
 
-  private final Map<Pair<String>, Long> linkMap = new LinkedHashMap<>();
+  private final Map<Pair<String>, Long> linkMap = new LinkedHashMap<Pair<String>, Long>();
 
   /**
    * @param spans spans where all spans have the same trace id
@@ -44,7 +44,7 @@ public final class DependencyLinker {
   public DependencyLinker putTrace(List<Span> spans) {
     if (spans.isEmpty()) return this;
 
-    List<DependencyLinkSpan> linkSpans = new LinkedList<>();
+    List<DependencyLinkSpan> linkSpans = new LinkedList<DependencyLinkSpan>();
     for (Span s : MergeById.apply(spans)) {
       linkSpans.add(DependencyLinkSpan.from(s));
     }
@@ -57,7 +57,7 @@ public final class DependencyLinker {
   public DependencyLinker putTrace(Iterator<DependencyLinkSpan> spans) {
     if (!spans.hasNext()) return this;
 
-    Node.TreeBuilder<DependencyLinkSpan> builder = new Node.TreeBuilder<>();
+    Node.TreeBuilder<DependencyLinkSpan> builder = new Node.TreeBuilder<DependencyLinkSpan>();
     while (spans.hasNext()) {
       DependencyLinkSpan next = spans.next();
       builder.addNode(next.parentId, next.id, next);
@@ -128,7 +128,7 @@ public final class DependencyLinker {
 
   public List<DependencyLink> link() {
     // links are merged by mapping to parent/child and summing corresponding links
-    List<DependencyLink> result = new ArrayList<>(linkMap.size());
+    List<DependencyLink> result = new ArrayList<DependencyLink>(linkMap.size());
     for (Map.Entry<Pair<String>, Long> entry : linkMap.entrySet()) {
       result.add(DependencyLink.create(entry.getKey()._1, entry.getKey()._2, entry.getValue()));
     }
@@ -137,7 +137,7 @@ public final class DependencyLinker {
 
   /** links are merged by mapping to parent/child and summing corresponding links */
   public static List<DependencyLink> merge(Iterable<DependencyLink> in) {
-    Map<Pair<String>, Long> links = new LinkedHashMap<>();
+    Map<Pair<String>, Long> links = new LinkedHashMap<Pair<String>, Long>();
 
     for (DependencyLink link : in) {
       Pair<String> parentChild = Pair.create(link.parent, link.child);
@@ -146,7 +146,7 @@ public final class DependencyLinker {
       links.put(parentChild, callCount);
     }
 
-    List<DependencyLink> result = new ArrayList<>(links.size());
+    List<DependencyLink> result = new ArrayList<DependencyLink>(links.size());
     for (Map.Entry<Pair<String>, Long> link : links.entrySet()) {
       result.add(DependencyLink.create(link.getKey()._1, link.getKey()._2, link.getValue()));
     }

--- a/zipkin/src/main/java/zipkin/internal/MergeById.java
+++ b/zipkin/src/main/java/zipkin/internal/MergeById.java
@@ -26,8 +26,8 @@ import static zipkin.internal.Util.sortedList;
 public class MergeById {
 
   public static List<Span> apply(Collection<Span> spans) {
-    List<Span> result = new ArrayList<>(spans.size());
-    Map<Long, List<Span>> spanIdToSpans = new LinkedHashMap<>();
+    List<Span> result = new ArrayList<Span>(spans.size());
+    Map<Long, List<Span>> spanIdToSpans = new LinkedHashMap<Long, List<Span>>();
     for (Span span : spans) {
       if (!spanIdToSpans.containsKey(span.id)) {
         spanIdToSpans.put(span.id, new LinkedList<Span>());

--- a/zipkin/src/main/java/zipkin/internal/Node.java
+++ b/zipkin/src/main/java/zipkin/internal/Node.java
@@ -57,7 +57,7 @@ public final class Node<V> {
 
   public Node<V> addChild(Node<V> child) {
     child.parent = this;
-    if (children.equals(Collections.emptyList())) children = new LinkedList<>();
+    if (children.equals(Collections.emptyList())) children = new LinkedList<Node<V>>();
     children.add(child);
     return this;
   }
@@ -69,11 +69,11 @@ public final class Node<V> {
 
   /** Traverses the tree, breadth-first. */
   public Iterator<Node<V>> traverse() {
-    return new BreadthFirstIterator<>(this);
+    return new BreadthFirstIterator<V>(this);
   }
 
   static final class BreadthFirstIterator<V> implements Iterator<Node<V>> {
-    private final Queue<Node<V>> queue = new ArrayDeque<>();
+    private final Queue<Node<V>> queue = new ArrayDeque<Node<V>>();
 
     BreadthFirstIterator(Node<V> root) {
       queue.add(root);
@@ -101,7 +101,7 @@ public final class Node<V> {
    * @param trace spans that belong to the same {@link Span#traceId trace}, in any order.
    */
   static Node<Span> constructTree(List<Span> trace) {
-    TreeBuilder<Span> treeBuilder = new TreeBuilder<>();
+    TreeBuilder<Span> treeBuilder = new TreeBuilder<Span>();
     for (Span s : trace) {
       treeBuilder.addNode(s.parentId, s.id, s);
     }
@@ -118,9 +118,9 @@ public final class Node<V> {
     Node<V> rootNode = null;
 
     // Nodes representing the trace tree
-    Map<Long, Node<V>> idToNode = new LinkedHashMap<>();
+    Map<Long, Node<V>> idToNode = new LinkedHashMap<Long, Node<V>>();
     // Collect the parent-child relationships between all spans.
-    Map<Long, Long> idToParent = new LinkedHashMap<>(idToNode.size());
+    Map<Long, Long> idToParent = new LinkedHashMap<Long, Long>(idToNode.size());
 
     public void addNode(Long parentId, long id, @Nullable V value) {
       Node<V> node = new Node<V>().value(value);

--- a/zipkin/src/main/java/zipkin/internal/Pair.java
+++ b/zipkin/src/main/java/zipkin/internal/Pair.java
@@ -19,7 +19,7 @@ import static zipkin.internal.Util.checkNotNull;
 public final class Pair<T> {
 
   public static <T> Pair<T> create(T _1, T _2) {
-    return new Pair<>(_1, _2);
+    return new Pair<T>(_1, _2);
   }
 
   public final T _1;

--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -86,7 +86,7 @@ public final class Util {
     long to = midnightUTC(endTs);
     long from = midnightUTC(endTs - (lookback != null ? lookback : endTs));
 
-    List<Date> days = new ArrayList<>();
+    List<Date> days = new ArrayList<Date>();
     for (long time = from; time <= to; time += TimeUnit.DAYS.toMillis(1)) {
       days.add(new Date(time));
     }
@@ -143,6 +143,13 @@ public final class Util {
   static void writeHexByte(char[] data, int pos, byte b) {
     data[pos + 0] = HEX_DIGITS[(b >> 4) & 0xf];
     data[pos + 1] = HEX_DIGITS[b & 0xf];
+  }
+
+  // throwable ctor not present in JRE 6
+  static AssertionError assertionError(String message, Throwable cause) {
+    AssertionError error = new AssertionError(message);
+    error.initCause(cause);
+    throw error;
   }
 
   private Util() {

--- a/zipkin/src/main/java/zipkin/storage/InternalAsyncToBlockingSpanStoreAdapter.java
+++ b/zipkin/src/main/java/zipkin/storage/InternalAsyncToBlockingSpanStoreAdapter.java
@@ -27,37 +27,37 @@ final class InternalAsyncToBlockingSpanStoreAdapter implements SpanStore {
   }
 
   @Override public List<List<Span>> getTraces(QueryRequest request) {
-    CallbackCaptor<List<List<Span>>> captor = new CallbackCaptor<>();
+    CallbackCaptor<List<List<Span>>> captor = new CallbackCaptor<List<List<Span>>>();
     delegate.getTraces(request, captor);
     return captor.get();
   }
 
   @Override public List<Span> getTrace(long id) {
-    CallbackCaptor<List<Span>> captor = new CallbackCaptor<>();
+    CallbackCaptor<List<Span>> captor = new CallbackCaptor<List<Span>>();
     delegate.getTrace(id, captor);
     return captor.get();
   }
 
   @Override public List<Span> getRawTrace(long traceId) {
-    CallbackCaptor<List<Span>> captor = new CallbackCaptor<>();
+    CallbackCaptor<List<Span>> captor = new CallbackCaptor<List<Span>>();
     delegate.getRawTrace(traceId, captor);
     return captor.get();
   }
 
   @Override public List<String> getServiceNames() {
-    CallbackCaptor<List<String>> captor = new CallbackCaptor<>();
+    CallbackCaptor<List<String>> captor = new CallbackCaptor<List<String>>();
     delegate.getServiceNames(captor);
     return captor.get();
   }
 
   @Override public List<String> getSpanNames(String serviceName) {
-    CallbackCaptor<List<String>> captor = new CallbackCaptor<>();
+    CallbackCaptor<List<String>> captor = new CallbackCaptor<List<String>>();
     delegate.getSpanNames(serviceName, captor);
     return captor.get();
   }
 
   @Override public List<DependencyLink> getDependencies(long endTs, @Nullable Long lookback) {
-    CallbackCaptor<List<DependencyLink>> captor = new CallbackCaptor<>();
+    CallbackCaptor<List<DependencyLink>> captor = new CallbackCaptor<List<DependencyLink>>();
     delegate.getDependencies(endTs, lookback, captor);
     return captor.get();
   }

--- a/zipkin/src/main/java/zipkin/storage/InternalCallbackRunnable.java
+++ b/zipkin/src/main/java/zipkin/storage/InternalCallbackRunnable.java
@@ -27,9 +27,9 @@ abstract class InternalCallbackRunnable<V> implements Runnable {
   @Override public void run() {
     try {
       callback.onSuccess(complete());
-    } catch (RuntimeException | Error e) {
+    } catch (Throwable e) {
       callback.onError(e);
-      if (e instanceof Error) throw e;
+      if (e instanceof Error) throw (Error) e;
     }
   }
 }

--- a/zipkin/src/main/java/zipkin/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin/storage/QueryRequest.java
@@ -173,8 +173,8 @@ public final class QueryRequest {
   public static final class Builder {
     private String serviceName;
     private String spanName;
-    private List<String> annotations = new LinkedList<>();
-    private Map<String, String> binaryAnnotations = new LinkedHashMap<>();
+    private List<String> annotations = new LinkedList<String>();
+    private Map<String, String> binaryAnnotations = new LinkedHashMap<String, String>();
     private Long minDuration;
     private Long maxDuration;
     private Long endTs;


### PR DESCRIPTION
This is an api compatible change to allow code sharing between zipkin
server and instrumentation, and without having to publish 2 jar files.

We accidentally broke the ability to make agent-based instrumentation by
compiling our model classes against Java 7 bytecode. Particularly, this
causes a regression in Brave.

To move back to Java 6 bytecode, we had to do a few things:
- replace moshi internal dependency with gson, which is java 6 compliant
- remove okio dependency and copy its Base64 class 
  - incidentally a class it also copied!
- do variable-size buffer writes w/ byte arrays instead of okio
- fix a few nags about diamond ops etc.

See https://github.com/openzipkin/brave/issues/225
