### PR TITLE
Adds Codec.gather for use in reporters

### DIFF
--- a/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
@@ -17,6 +17,8 @@ import com.google.common.io.ByteStreams;
 import com.twitter.zipkin.thriftjava.Annotation;
 import com.twitter.zipkin.thriftjava.BinaryAnnotation;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
@@ -197,6 +199,42 @@ public class CodecBenchmarks {
   @Benchmark
   public byte[] writeRpcV6Span_thrift_libthrift() throws TException {
     return serialize(rpcV6SpanLibThrift);
+  }
+
+  @Benchmark
+  public byte[] write100Spans_thrift() {
+    return write100Spans(Codec.THRIFT);
+  }
+
+  @Benchmark
+  public byte[] write100Spans_json() {
+    return write100Spans(Codec.JSON);
+  }
+
+  @Benchmark
+  public byte[] writeAndGather100Spans_thrift() {
+    return writeAndGather100Spans(Codec.THRIFT);
+  }
+
+  @Benchmark
+  public byte[] writeAndGather100Spans_json() {
+    return writeAndGather100Spans(Codec.JSON);
+  }
+
+  static byte[] write100Spans(Codec codec) {
+    List<Span> spans = new ArrayList<>(100);
+    for (int i = 0; i < 100; i++) {
+      spans.add(clientSpan);
+    }
+    return codec.writeSpans(spans);
+  }
+
+  static byte[] writeAndGather100Spans(Codec codec) {
+    List<byte[]> spans = new ArrayList<>(100);
+    for (int i = 0; i < 100; i++) {
+      spans.add(codec.writeSpan(clientSpan));
+    }
+    return codec.gather(spans);
   }
 
   // Convenience main entry-point

--- a/zipkin/src/main/java/zipkin/Codec.java
+++ b/zipkin/src/main/java/zipkin/Codec.java
@@ -46,4 +46,18 @@ public interface Codec {
   List<DependencyLink> readDependencyLinks(byte[] bytes);
 
   byte[] writeDependencyLinks(List<DependencyLink> value);
+
+  /**
+   * Combines a list of pre-encoded values into an encoded list. For example, in thrift, this would
+   * be length-prefixed, whereas in json, this would be comma-separated and enclosed by brackets.
+   *
+   * <p>This will be less efficient than calling {@link #writeSpans(List)}, as the latter can reuse
+   * an internal buffer for each encode operation. Only use this when you need to process spans
+   * encoded in a different scope, or encoded with a different library.
+   *
+   * <p>The primary use of this is batch reporting spans. For example, spans are {@link
+   * #writeSpan(Span) written} one-by-one into a queue. This queue is drained up to a byte
+   * threshold. Then, the list is encoded with this function and reported out-of-process.
+   */
+  byte[] gather(List<byte[]> value);
 }

--- a/zipkin/src/main/java/zipkin/internal/Buffer.java
+++ b/zipkin/src/main/java/zipkin/internal/Buffer.java
@@ -19,44 +19,52 @@ import java.util.Arrays;
 /** Similar to {@link java.io.ByteArrayInputStream}, except specialized and unsynchronized */
 final class Buffer extends OutputStream {
   static final int MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
-  private byte[] buf = new byte[128];
-  private int count;
+  private byte[] buf;
+  private int pos;
+
+  Buffer() {
+    this(128);
+  }
+
+  Buffer(int initialLength) {
+    buf = new byte[initialLength];
+  }
 
   @Override public void write(int v) {
-    ensureCapacity(count + 1);
-    buf[count++] = (byte) v;
+    ensureCapacity(pos + 1);
+    buf[pos++] = (byte) v;
   }
 
   @Override public void write(byte[] v) {
-    ensureCapacity(count + v.length);
-    System.arraycopy(v, 0, buf, count, v.length);
-    count += v.length;
+    ensureCapacity(pos + v.length);
+    System.arraycopy(v, 0, buf, pos, v.length);
+    pos += v.length;
   }
 
   void writeShort(int v) {
-    ensureCapacity(count + 2);
+    ensureCapacity(pos + 2);
     write((v >>> 8L) & 0xff);
     write(v & 0xff);
   }
 
   void writeInt(int v) {
-    ensureCapacity(count + 4);
-    buf[count++] = (byte) ((v >>> 24L) & 0xff);
-    buf[count++] = (byte) ((v >>> 16L) & 0xff);
-    buf[count++] = (byte) ((v >>> 8L) & 0xff);
-    buf[count++] = (byte) (v & 0xff);
+    ensureCapacity(pos + 4);
+    buf[pos++] = (byte) ((v >>> 24L) & 0xff);
+    buf[pos++] = (byte) ((v >>> 16L) & 0xff);
+    buf[pos++] = (byte) ((v >>> 8L) & 0xff);
+    buf[pos++] = (byte) (v & 0xff);
   }
 
   void writeLong(long v) {
-    ensureCapacity(count + 8);
-    buf[count++] = (byte) ((v >>> 56L) & 0xff);
-    buf[count++] = (byte) ((v >>> 48L) & 0xff);
-    buf[count++] = (byte) ((v >>> 40L) & 0xff);
-    buf[count++] = (byte) ((v >>> 32L) & 0xff);
-    buf[count++] = (byte) ((v >>> 24L) & 0xff);
-    buf[count++] = (byte) ((v >>> 16L) & 0xff);
-    buf[count++] = (byte) ((v >>> 8L) & 0xff);
-    buf[count++] = (byte) (v & 0xff);
+    ensureCapacity(pos + 8);
+    buf[pos++] = (byte) ((v >>> 56L) & 0xff);
+    buf[pos++] = (byte) ((v >>> 48L) & 0xff);
+    buf[pos++] = (byte) ((v >>> 40L) & 0xff);
+    buf[pos++] = (byte) ((v >>> 32L) & 0xff);
+    buf[pos++] = (byte) ((v >>> 24L) & 0xff);
+    buf[pos++] = (byte) ((v >>> 16L) & 0xff);
+    buf[pos++] = (byte) ((v >>> 8L) & 0xff);
+    buf[pos++] = (byte) (v & 0xff);
   }
 
   /** Writes a length-prefixed string */
@@ -66,8 +74,9 @@ final class Buffer extends OutputStream {
     write(temp);
   }
 
+  /** Shares the internal buffer, if it is fully written */
   byte[] toByteArray() {
-    return Arrays.copyOf(buf, count);
+    return pos == buf.length ? buf : Arrays.copyOf(buf, pos);
   }
 
   /** Doubles up to {@link #MAX_ARRAY_LENGTH} if necessary */

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -529,6 +529,24 @@ public final class JsonCodec implements Codec {
     return writeList(DEPENDENCY_LINK_ADAPTER, value);
   }
 
+  @Override public byte[] gather(List<byte[]> values) {
+    int sizeOfArray = 2;
+    int length = values.size();
+    for (int i = 0; i < length; ) {
+      sizeOfArray += values.get(i++).length;
+      if (i < length) sizeOfArray++;
+    }
+
+    Buffer out = new Buffer(sizeOfArray);
+    out.write('[');
+    for (int i = 0; i < length; ) {
+      out.write(values.get(i++));
+      if (i < length) out.write(',');
+    }
+    out.write(']');
+    return out.toByteArray();
+  }
+
   static final JsonAdapter<String> STRING_ADAPTER = new JsonAdapter<String>() {
     @Override
     public String fromJson(JsonReader reader) throws IOException {

--- a/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
@@ -436,6 +436,22 @@ public final class ThriftCodec implements Codec {
     return write(DEPENDENCY_LINKS_ADAPTER, value);
   }
 
+  @Override
+  public byte[] gather(List<byte[]> values) {
+    int sizeOfArray = 5;
+    int length = values.size();
+    for (int i = 0; i < length; i++) {
+      sizeOfArray += values.get(i).length;
+    }
+
+    Buffer buffer = new Buffer(sizeOfArray);
+    writeListBegin(buffer, length);
+    for (int i = 0; i < length; i++) {
+      buffer.write(values.get(i));
+    }
+    return buffer.toByteArray();
+  }
+
   static <T> T read(ThriftReader<T> reader, ByteBuffer bytes) {
     checkArgument(bytes.remaining() > 0, "Empty input reading %s", reader);
     try {

--- a/zipkin/src/test/java/zipkin/CodecTest.java
+++ b/zipkin/src/test/java/zipkin/CodecTest.java
@@ -14,6 +14,7 @@
 package zipkin;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,6 +43,17 @@ public abstract class CodecTest {
     byte[] bytes = codec().writeSpans(TestObjects.TRACE);
     assertThat(codec().readSpans(bytes))
         .isEqualTo(TestObjects.TRACE);
+  }
+
+  @Test
+  public void gatherSpans() throws IOException {
+    List<byte[]> spans = new ArrayList<>(TestObjects.TRACE.size());
+    for (Span span: TestObjects.TRACE) {
+      spans.add(codec().writeSpan(span));
+    }
+
+    assertThat(codec().gather(spans))
+        .isEqualTo(codec().writeSpans(TestObjects.TRACE));
   }
 
   @Test


### PR DESCRIPTION
This adds `Codec.gather`, which allows you to gather a list of byte
arrays into a single encoded message.

Reporters like HTrace dequeue spans reported into a list of byte arrays.

This allows insight into the size of message before you send it. For
example, you can pop until you have up to 1MB of spans as opposed to
100 spans (which might end up as 100MB!).

Note this is slightly less efficient than writing a list directly, so
it is special-cased for the reporting use case, where spans are encoded
in a separate scope than sent.

```
Benchmark                                       Mode  Cnt  Score   Error   Units
CodecBenchmarks.write100Spans_json             thrpt   15  0.539 ± 0.009  ops/ms
CodecBenchmarks.write100Spans_thrift           thrpt   15  8.315 ± 0.377  ops/ms
CodecBenchmarks.writeAndGather100Spans_json    thrpt   15  0.549 ± 0.021  ops/ms
CodecBenchmarks.writeAndGather100Spans_thrift  thrpt   15  8.964 ± 0.163  ops/ms
```

See https://github.com/openzipkin/zipkin-reporter-java/issues/1
