### PR TITLE
Build, publish using CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,6 +41,7 @@ dependencies:
 database:
   override:
     - mysql -u ubuntu -e 'SET GLOBAL innodb_file_format=Barracuda'
+    - mysql -u ubuntu -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
     - mysql -u ubuntu circle_test < zipkin-storage/mysql/src/main/resources/mysql.sql
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -54,3 +54,7 @@ test:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 
+# Send notifications to Gitter
+notify:
+  webhooks:
+    - url: https://webhooks.gitter.im/e/e63be97ca10d2fbd09c3

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,55 @@
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+machine:
+  services:
+    - mysql
+    - cassandra
+    - elasticsearch
+  java:
+    version: openjdk8
+  post:
+    - curl -SL http://www.us.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz | tar xz
+    - ./kafka_*/bin/zookeeper-server-start.sh ./kafka_*/config/zookeeper.properties:
+        background: true
+    - ./kafka_*/bin/kafka-server-start.sh ./kafka_*/config/server.properties:
+        background: true
+  environment:
+    MYSQL_USER: ubuntu
+    MYSQL_DB: circle_test
+
+dependencies:
+  override:
+    - sudo apt-get install xsltproc
+    - ./circleci/go-offline.sh
+    - ./mvnw frontend:install-node-and-npm frontend:npm -pl zipkin-ui
+  cache_directories:
+    - "~/.npm"
+    - "zipkin-ui/node_modules"
+
+database:
+  override:
+    - mysql -u ubuntu -e 'SET GLOBAL innodb_file_format=Barracuda'
+    - mysql -u ubuntu circle_test < zipkin-storage/mysql/src/main/resources/mysql.sql
+
+test:
+  override:
+    - ./circleci/test.sh:
+        parallel: true
+        files:
+          - "**/test/**/*Test.java"
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+

--- a/circleci/go-offline.sh
+++ b/circleci/go-offline.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# Due to https://issues.apache.org/jira/browse/MDEP-323 and cross-module dependencies,
+# we can't easily run mvn dependency:go-offline. This is a workaround for that.
+# It removes all dependencies on io.zipkin.java and ${project.groupId} using XSLT,
+# then runs go-offline on the resulting POMs.
+
+set -xeuo pipefail
+
+rm -rf go-offline-builddir
+mkdir -p go-offline-builddir
+trap "rm -rf $(pwd)/go-offline-builddir" EXIT
+
+for f in $(find . -name 'pom.xml'); do
+    echo $f
+    mkdir -p $(dirname go-offline-builddir/$f)
+    xsltproc ./circleci/pom-no-crossmodule-dependencies.xsl $f > go-offline-builddir/$f
+done
+
+cd go-offline-builddir
+../mvnw dependency:go-offline

--- a/circleci/pom-no-crossmodule-dependencies.xsl
+++ b/circleci/pom-no-crossmodule-dependencies.xsl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:pom="http://maven.apache.org/POM/4.0.0">
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>  
+  </xsl:template>
+
+  <xsl:template match="pom:dependency[pom:groupId = 'io.zipkin.java']" />
+  <xsl:template match="pom:dependency[pom:groupId = '${project.groupId}']" />
+</xsl:stylesheet>

--- a/circleci/test.sh
+++ b/circleci/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -ex
+tests="$(echo "$@" | xargs basename -s .java | tr '\n' ',' | sed -e 's/,$//')"
+./mvnw -Dtest="$tests" -DfailIfNoTests=false test

--- a/zipkin-collector/kafka/src/test/java/zipkin/collector/kafka/KafkaCollectorTest.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin/collector/kafka/KafkaCollectorTest.java
@@ -40,7 +40,7 @@ import static zipkin.TestObjects.TRACE;
 public class KafkaCollectorTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
-  @ClassRule public static Timeout globalTimeout = Timeout.seconds(10);
+  @ClassRule public static Timeout globalTimeout = Timeout.seconds(20);
   Producer<String, byte[]> producer = KafkaTestGraph.INSTANCE.producer();
   InMemoryCollectorMetrics metrics = new InMemoryCollectorMetrics();
   InMemoryCollectorMetrics kafkaMetrics = metrics.forTransport("kafka");

--- a/zipkin-ui/pom.xml
+++ b/zipkin-ui/pom.xml
@@ -44,6 +44,8 @@
         <version>${frontend-maven-plugin.version}</version>
         <configuration>
           <installDirectory>target</installDirectory>
+          <nodeVersion>v5.5.0</nodeVersion>
+          <npmVersion>3.6.0</npmVersion>
         </configuration>
         <executions>
           <execution>
@@ -51,10 +53,6 @@
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <configuration>
-              <nodeVersion>v5.5.0</nodeVersion>
-              <npmVersion>3.6.0</npmVersion>
-            </configuration>
           </execution>
           <execution>
             <id>npm install</id>


### PR DESCRIPTION
_openzipkin/zipkin on CircleCI_: https://circleci.com/gh/openzipkin/zipkin

Why: https://github.com/openzipkin/zipkin/issues/1237
## Points of interest
- Support for the test-runtime-based balancing of tests CircleCI does for running tests in parallel
- Caching the `node_modules` dir of `zipkin-ui` saves around 90 seconds
- Overall build time is around 6-7 minutes (about half of that on Travis)
- Release process drafted in #1250, still needs thinking.
