### PR TITLE
Publish using CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -54,3 +54,19 @@ test:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 
+# If a release commit fails to deploy for a transient reason, delete the broken version from bintray and click rebuild
+deployment:
+  # Commits to master trigger a -SNAPSHOT release
+  master:
+    branch: master
+    owner: openzipkin
+    commands:
+      - ./circleci/publish-snapshot.sh
+      - ./circleci/javadoc-to-gh-pages.sh
+  # Release tags trigger a non-SNAPSHOT release
+  release:
+    tag: /^release-[0-9]+\.[0-9]+\.[0-9]\.$/
+    owner: openzipkin
+    commands:
+      - ./circleci/publish-stable.sh
+      - ./circleci/javadoc-to-gh-pages.sh $CIRCLE_TAG

--- a/circle.yml
+++ b/circle.yml
@@ -41,6 +41,7 @@ dependencies:
 database:
   override:
     - mysql -u ubuntu -e 'SET GLOBAL innodb_file_format=Barracuda'
+    - mysql -u ubuntu -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
     - mysql -u ubuntu circle_test < zipkin-storage/mysql/src/main/resources/mysql.sql
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,55 @@
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+machine:
+  services:
+    - mysql
+    - cassandra
+    - elasticsearch
+  java:
+    version: openjdk8
+  post:
+    - curl -SL http://www.us.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz | tar xz
+    - ./kafka_*/bin/zookeeper-server-start.sh ./kafka_*/config/zookeeper.properties:
+        background: true
+    - ./kafka_*/bin/kafka-server-start.sh ./kafka_*/config/server.properties:
+        background: true
+  environment:
+    MYSQL_USER: ubuntu
+    MYSQL_DB: circle_test
+
+dependencies:
+  override:
+    - sudo apt-get install xsltproc
+    - ./circleci/go-offline.sh
+    - ./mvnw frontend:install-node-and-npm frontend:npm -pl zipkin-ui
+  cache_directories:
+    - "~/.npm"
+    - "zipkin-ui/node_modules"
+
+database:
+  override:
+    - mysql -u ubuntu -e 'SET GLOBAL innodb_file_format=Barracuda'
+    - mysql -u ubuntu circle_test < zipkin-storage/mysql/src/main/resources/mysql.sql
+
+test:
+  override:
+    - ./circleci/test.sh:
+        parallel: true
+        files:
+          - "**/test/**/*Test.java"
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+

--- a/circleci/go-offline.sh
+++ b/circleci/go-offline.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# Due to https://issues.apache.org/jira/browse/MDEP-323 and cross-module dependencies,
+# we can't easily run mvn dependency:go-offline. This is a workaround for that.
+# It removes all dependencies on io.zipkin.java and ${project.groupId} using XSLT,
+# then runs go-offline on the resulting POMs.
+
+set -xeuo pipefail
+
+rm -rf go-offline-builddir
+mkdir -p go-offline-builddir
+trap "rm -rf $(pwd)/go-offline-builddir" EXIT
+
+for f in $(find . -name 'pom.xml'); do
+    echo $f
+    mkdir -p $(dirname go-offline-builddir/$f)
+    xsltproc ./circleci/pom-no-crossmodule-dependencies.xsl $f > go-offline-builddir/$f
+done
+
+cd go-offline-builddir
+../mvnw dependency:go-offline

--- a/circleci/javadoc-to-gh-pages.sh
+++ b/circleci/javadoc-to-gh-pages.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -xeuo pipefail
+
+if [ $# -eq 1 ]; then
+    # After releasing a non-SNAPSHOT version
+    # We need this extra logic because by the time `publish-stable.sh` is finished,
+    # the current project version is (release-version + 0.0.1)-SNAPSHOT
+    version="$(echo $1 | sed 's/^release-//')"
+else
+    # After releasing a SNAPSHOT version
+    version="$(./mvnw help:evaluate -N -Dexpression=project.version|grep -v '\[')"
+fi
+
+rm -rf javadoc-builddir
+builddir="javadoc-builddir/$version"
+
+# Collect javadoc for all modules
+for jar in $(find . -name "*${version}-javadoc.jar"); do
+    module="$(echo "$jar" | sed "s~.*/\(.*\)-${version}-javadoc.jar~\1~")"
+    this_builddir="$builddir/$module"
+    mkdir -p "$this_builddir"
+    unzip "$jar" -d "$this_builddir"
+    # Build a simple module-level index
+    echo "<li><a href=\"${module}/index.html\">${module}</a></li>" >> "${builddir}/index.html"
+done
+
+# Update the live docs
+git checkout gh-pages
+rm -rf "$version"
+mv "javadoc-builddir/$version" ./
+rm -rf "javadoc-builddir"
+
+# Update simple version-level index
+if ! grep "$version" index.html 2>/dev/null; then
+    echo "<li><a href=\"${version}/index.html\">${version}</a></li>" >> index.html
+fi
+
+# Ensure the docs are in descending order of version numbers
+sort -rV index.html > index.html.sorted
+mv index.html.sorted index.html
+
+# Publish
+git add "$version" index.html
+git commit -m "Automatically updated javadocs for $version"
+git push

--- a/circleci/pom-no-crossmodule-dependencies.xsl
+++ b/circleci/pom-no-crossmodule-dependencies.xsl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:pom="http://maven.apache.org/POM/4.0.0">
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>  
+  </xsl:template>
+
+  <xsl:template match="pom:dependency[pom:groupId = 'io.zipkin.java']" />
+  <xsl:template match="pom:dependency[pom:groupId = '${project.groupId}']" />
+</xsl:stylesheet>

--- a/circleci/publish-snapshot.sh
+++ b/circleci/publish-snapshot.sh
@@ -13,9 +13,7 @@
 # the License.
 #
 
-set -xeuo pipefail
+set -xueo pipefail
 
-# Read filename arguments, passed in by CircleCI. This is our integration with the
-# runtime-based balancing of tests across parallel test executors that CircleCI does.
-tests="$(echo "$@" | xargs basename -s .java | tr '\n' ',' | sed -e 's/,$//')"
-./mvnw -Dtest="$tests" -DfailIfNoTests=false test
+# Upload snapshot release to Bintray
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -pl -:benchmarks -DskipTests deploy

--- a/circleci/publish-stable.sh
+++ b/circleci/publish-stable.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -xueo pipefail
+
+# We need to be on a branch for release:perform to be able to create
+# commits, and we want that branch to be master. But we also want to make
+# sure that we build and release exactly the tagged version, so we verify
+# that the remote master is where our tag is.
+git checkout -B master
+git fetch origin master:origin/master
+commit_local_master="$(git show --pretty='format:%H' master)"
+commit_remote_master="$(git show --pretty='format:%H' origin/master)"
+if [ "$commit_local_master" != "$commit_remote_master" ]; then
+    echo "Master on remote 'origin' has commits since the version under release, aborting"
+    exit 1
+fi
+
+# This creates
+#   - A commit in git that removes the `-SNAPSHOT` from the version.
+#     This commit will not trigger a separate build due to the [skip ci] in the
+#     commit message.
+#   - A tag `X.Y.Z`. This will also not trigger another build, because on
+#     CircleCI only tags with a matching `deployment` section in their
+#     circle.yml trigger builds
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu \
+       -DreleaseVersion="$(echo $CIRCLE_TAG | sed 's/^release-//')" \
+       -DscmCommentPrefix='[maven-release-plugin][skip ci] ' \
+       -Darguments="-DskipTests" \
+       release:prepare
+
+# This next line will
+#   - Publish the project to Bintray
+#   - Create a commit bumping versions to the next version and adding -SNAPSHOT.
+#     This commit will not trigger a separate build due to the [skip ci] in the
+#     commit message.
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -pl -:benchmarks \
+       -DskipTests -DscmCommentPrefix='[maven-release-plugin][skip ci] ' \
+       deploy
+
+# And this syncs it to Maven Central. Note: this needs to be done once per
+# project, not module, hence -N
+./mvnw --batch-mode -s ./.settings.xml -nsu -N \
+       io.zipkin.centralsync-maven-plugin:centralsync-maven-plugin:sync

--- a/circleci/test.sh
+++ b/circleci/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -ex
+tests="$(echo "$@" | xargs basename -s .java | tr '\n' ',' | sed -e 's/,$//')"
+./mvnw -Dtest="$tests" -DfailIfNoTests=false test

--- a/zipkin-collector/kafka/src/test/java/zipkin/collector/kafka/KafkaCollectorTest.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin/collector/kafka/KafkaCollectorTest.java
@@ -40,7 +40,7 @@ import static zipkin.TestObjects.TRACE;
 public class KafkaCollectorTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
-  @ClassRule public static Timeout globalTimeout = Timeout.seconds(10);
+  @ClassRule public static Timeout globalTimeout = Timeout.seconds(20);
   Producer<String, byte[]> producer = KafkaTestGraph.INSTANCE.producer();
   InMemoryCollectorMetrics metrics = new InMemoryCollectorMetrics();
   InMemoryCollectorMetrics kafkaMetrics = metrics.forTransport("kafka");

--- a/zipkin-ui/pom.xml
+++ b/zipkin-ui/pom.xml
@@ -44,6 +44,8 @@
         <version>${frontend-maven-plugin.version}</version>
         <configuration>
           <installDirectory>target</installDirectory>
+          <nodeVersion>v5.5.0</nodeVersion>
+          <npmVersion>3.6.0</npmVersion>
         </configuration>
         <executions>
           <execution>
@@ -51,10 +53,6 @@
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <configuration>
-              <nodeVersion>v5.5.0</nodeVersion>
-              <npmVersion>3.6.0</npmVersion>
-            </configuration>
           </execution>
           <execution>
             <id>npm install</id>


### PR DESCRIPTION
# DO NOT MERGE YET

Continuing the work in #1248, this PR is the place to discuss whether, when, and how we want to move releasing from Travis to CircleCI.

_openzipkin/zipkin on CircleCI_: https://circleci.com/gh/openzipkin/zipkin

Why: https://github.com/openzipkin/zipkin/issues/1237
## Things to consider before merging
- Do we like the trade-off CircleCI makes in terms of build executors? OSS orgs (NOT repos) get a total of 4 containers, meaning we can do 4 things at the same time. At the moment `openzipkin/zipkin` is configured to use all 4 containers for running tests in parallel, but over time we may want to have concurrent builds of separate commits / branches. PRs also run on the same pool of containers, as well as any other `openzipkin` projects we may migrate to CircleCI in the future. OTOH we can pay monies for more containers, unlike with Travis (citation needed).
- Do we want to spend extra effort on doing a test-run of the deployment process on "non-production" Bintray / Maven repos?
- Are we really comfortable jumping onto CircleCI? Maybe run a dual setup for a while and learn by doing.
## Things to do before merging
- Review! ;)
- Add credentials to CircleCI, in one of two ways:
  - Via the web UI: https://circleci.com/docs/environment-variables/#setting-environment-variables-for-all-commands-without-adding-them-to-git
  - Encrypted in `circle.yml`, tooling more rudimentary than in Travis: https://github.com/circleci/encrypted-files
- Disable builds on Travis to avoid confusion when they both want to upload to Bintray
- Enable "GitHub Status updates" on https://circleci.com/gh/openzipkin/zipkin/edit#advanced-settings
- Replace build badge in `README.md` (https://circleci.com/gh/openzipkin/zipkin/edit#badges)
