### PR TITLE
New datamodel using Cassandra-3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ _site/
 *.iml
 *.swp
 # .travis.yml installs things
-dsc-cassandra-*
+apache-cassandra-*
 elasticsearch-2*
 kafka_*
 # temporary directory used by travis/publish.sh for building gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,12 @@ services:
   - mysql
 
 before_install:
-  # Manually install cassandra until https://github.com/travis-ci/travis-ci/issues/3952
-  # See https://github.com/openzipkin/zipkin/issues/706
-  - curl -SL http://downloads.datastax.com/community/dsc-cassandra-2.2.5-bin.tar.gz | tar xz
-  - sed -i -e 's/INFO/WARN/g' dsc-cassandra-*/conf/logback.xml
-  - sudo dsc-cassandra-*/bin/cassandra
+  # Manually install very recent version of cassandra; unless we create a user we have to run it as root
+  # uncomment below when datastax has version 3.9 available. at time of commit, latest was 3.7
+  #- curl -SL http://www-us.apache.org/dist/cassandra/3.9/apache-cassandra-3.9-bin.tar.gz | tar xz
+  - curl -SL http://cassci.datastax.com/job/trunk/lastSuccessfulBuild/artifact/build/apache-cassandra-3.10-SNAPSHOT-bin.tar.gz | tar xz
+  - sed -i -e 's/INFO/WARN/g' apache-cassandra-*/conf/logback.xml
+  - sudo apache-cassandra-*/bin/cassandra -R
   # install mysql schema
   - mysql -uroot -e 'SET GLOBAL innodb_file_format=Barracuda'
   - mysql -uroot -e 'create database if not exists zipkin'

--- a/circle.yml
+++ b/circle.yml
@@ -15,11 +15,16 @@
 machine:
   services:
     - mysql
-    - cassandra
     - elasticsearch
   java:
     version: openjdk8
   post:
+    # Manually install very recent version of cassandra; unless we create a user we have to run it as root
+    # uncomment below when datastax has version 3.9 available. at time of commit, latest was 3.7
+    #- curl -SL http://www-us.apache.org/dist/cassandra/3.9/apache-cassandra-3.9-bin.tar.gz | tar xz
+    - curl -SL http://cassci.datastax.com/job/trunk/lastSuccessfulBuild/artifact/build/apache-cassandra-3.10-SNAPSHOT-bin.tar.gz | tar xz
+    - sed -i -e 's/INFO/WARN/g' apache-cassandra-*/conf/logback.xml
+    - sudo ./apache-cassandra-*/bin/cassandra -R
     - curl -SL http://www.us.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz | tar xz
     - ./kafka_*/bin/zookeeper-server-start.sh ./kafka_*/config/zookeeper.properties:
         background: true

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,18 @@
 
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-storage-cassandra3</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-autoconfigure-storage-cassandra3</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-storage-mysql</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -260,6 +272,11 @@
       <dependency>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-core</artifactId>
+        <version>${cassandra-driver-core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-mapping</artifactId>
         <version>${cassandra-driver-core.version}</version>
       </dependency>
       <dependency>
@@ -476,7 +493,7 @@
             <exclude>**/.idea/**</exclude>
             <exclude>LICENSE</exclude>
             <exclude>**/*.md</exclude>
-            <exclude>dsc-cassandra-*/**</exclude>
+            <exclude>apache-cassandra-*/**</exclude>
             <exclude>elasticsearch-2*/**</exclude>
             <exclude>kafka_*/**</exclude>
             <exclude>src/test/resources/**</exclude>

--- a/zipkin-autoconfigure/pom.xml
+++ b/zipkin-autoconfigure/pom.xml
@@ -36,6 +36,7 @@
     <module>collector-kafka</module>
     <module>collector-scribe</module>
     <module>storage-cassandra</module>
+    <module>storage-cassandra3</module>
     <module>storage-elasticsearch</module>
     <module>storage-mysql</module>
     <module>metrics-prometheus</module>

--- a/zipkin-autoconfigure/storage-cassandra/src/test/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/test/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.cassandra;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin.storage.cassandra.CassandraStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinCassandraStorageAutoConfigurationTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  AnnotationConfigApplicationContext context;
+
+  @After
+  public void close() {
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  @Test
+  public void doesntProvidesStorageComponent_whenStorageTypeNotCassandra() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:elasticsearch");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinCassandraStorageAutoConfiguration.class);
+    context.refresh();
+
+    thrown.expect(NoSuchBeanDefinitionException.class);
+    context.getBean(CassandraStorage.class);
+  }
+
+  @Test
+  public void providesStorageComponent_whenStorageTypeCassandra() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:cassandra");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinCassandraStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(CassandraStorage.class)).isNotNull();
+  }
+
+  @Test
+  public void canOverridesProperty_contactPoints() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.storage.type:cassandra",
+        "zipkin.storage.cassandra.contact-points:host1,host2" // note snake-case supported
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinCassandraStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinCassandraStorageProperties.class).getContactPoints())
+        .isEqualTo("host1,host2");
+  }
+}

--- a/zipkin-autoconfigure/storage-cassandra3/pom.xml
+++ b/zipkin-autoconfigure/storage-cassandra3/pom.xml
@@ -19,22 +19,30 @@
 
   <parent>
     <groupId>io.zipkin.java</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-autoconfigure</artifactId>
     <version>1.8.5-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-storage</artifactId>
-  <name>Storage</name>
-  <packaging>pom</packaging>
+  <artifactId>zipkin-autoconfigure-storage-cassandra3</artifactId>
+  <name>Auto Configuration: Cassandra 3 Storage</name>
 
   <properties>
-    <main.basedir>${project.basedir}/..</main.basedir>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
-  <modules>
-    <module>cassandra</module>
-    <module>cassandra3</module>
-    <module>mysql</module>
-    <module>elasticsearch</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-storage-cassandra3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-core</artifactId>
+      <version>${brave.version}</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
 </project>

--- a/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageAutoConfiguration.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.cassandra3;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin.storage.StorageComponent;
+import zipkin.storage.cassandra3.Cassandra3Storage.SessionFactory;
+
+/**
+ * This storage accepts Cassandra logs in a specified category. Each log entry is expected to contain
+ * a single span, which is TBinaryProtocol big-endian, then base64 encoded. Decoded spans are stored
+ * asynchronously.
+ */
+@Configuration
+@EnableConfigurationProperties(ZipkinCassandra3StorageProperties.class)
+@ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "cassandra3")
+@ConditionalOnMissingBean(StorageComponent.class)
+// This component is named .*Cassandra3.* even though the package already says cassandra3 because
+// Spring Boot configuration endpoints only printout the simple name of the class
+public class ZipkinCassandra3StorageAutoConfiguration {
+
+  @Autowired(required = false)
+  @Qualifier("tracingSessionFactory")
+  SessionFactory tracingSessionFactory;
+
+  @Bean StorageComponent storage(ZipkinCassandra3StorageProperties properties) {
+    return tracingSessionFactory == null
+        ? properties.toBuilder().build()
+        : properties.toBuilder().sessionFactory(tracingSessionFactory).build();
+  }
+}

--- a/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageProperties.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.cassandra3;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import zipkin.storage.cassandra3.Cassandra3Storage;
+
+import static zipkin.storage.cassandra3.Cassandra3Storage.Builder;
+import static zipkin.storage.cassandra3.Cassandra3Storage.builder;
+
+@ConfigurationProperties("zipkin.storage.cassandra3")
+public class ZipkinCassandra3StorageProperties {
+  private String keyspace = "zipkin3";
+  private String contactPoints = "localhost";
+  private String localDc;
+  private int maxConnections = 8;
+  private boolean ensureSchema = true;
+  private String username;
+  private String password;
+  /** See {@link Cassandra3Storage.Builder#indexFetchMultiplier(int)} */
+  private int indexFetchMultiplier = 3;
+
+  public String getKeyspace() {
+    return keyspace;
+  }
+
+  public void setKeyspace(String keyspace) {
+    this.keyspace = keyspace;
+  }
+
+  public String getContactPoints() {
+    return contactPoints;
+  }
+
+  public void setContactPoints(String contactPoints) {
+    this.contactPoints = contactPoints;
+  }
+
+  public String getLocalDc() {
+    return localDc;
+  }
+
+  public void setLocalDc(String localDc) {
+    this.localDc = "".equals(localDc) ? null : localDc;
+  }
+
+  public int getMaxConnections() {
+    return maxConnections;
+  }
+
+  public void setMaxConnections(int maxConnections) {
+    this.maxConnections = maxConnections;
+  }
+
+  public boolean isEnsureSchema() {
+    return ensureSchema;
+  }
+
+  public void setEnsureSchema(boolean ensureSchema) {
+    this.ensureSchema = ensureSchema;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = "".equals(username) ? null : username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = "".equals(password) ? null : password;
+  }
+
+  public int getIndexFetchMultiplier() {
+    return indexFetchMultiplier;
+  }
+
+  public void setIndexFetchMultiplier(int indexFetchMultiplier) {
+    this.indexFetchMultiplier = indexFetchMultiplier;
+  }
+
+  public Builder toBuilder() {
+    return builder()
+        .keyspace(keyspace)
+        .contactPoints(contactPoints)
+        .localDc(localDc)
+        .maxConnections(maxConnections)
+        .ensureSchema(ensureSchema)
+        .username(username)
+        .password(password)
+        .indexFetchMultiplier(indexFetchMultiplier);
+  }
+}

--- a/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/brave/TraceZipkinCassandra3StorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/brave/TraceZipkinCassandra3StorageAutoConfiguration.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.cassandra3.brave;
+
+import com.datastax.driver.core.Session;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.SpanCollector;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import zipkin.storage.cassandra3.Cassandra3Storage;
+import zipkin.storage.cassandra3.Cassandra3Storage.SessionFactory;
+
+/** Sets up the Cassandra tracing in Brave as an initialization. */
+@ConditionalOnBean(Brave.class)
+@ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "cassandra3")
+@Configuration
+// This component is named .*Cassandra3.* even though the package already says cassandra3 because
+// Spring Boot configuration endpoints only printout the simple name of the class
+public class TraceZipkinCassandra3StorageAutoConfiguration {
+  final SessionFactory delegate = SessionFactory.DEFAULT;
+
+  // Lazy to unwind a circular dep: we are tracing the storage used by brave
+  @Autowired @Lazy Brave brave;
+  @Autowired @Lazy SpanCollector collector;
+
+  @Bean SessionFactory tracingSessionFactory() {
+    return new SessionFactory() {
+      @Override public Session create(Cassandra3Storage storage) {
+        return TracedSession.create(delegate.create(storage), brave, collector);
+      }
+    };
+  }
+}

--- a/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/brave/TracedSession.java
+++ b/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/brave/TracedSession.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.cassandra3.brave;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.LatencyTracker;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerSpan;
+import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.SpanId;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.AbstractInvocationHandler;
+import com.google.common.reflect.Reflection;
+import com.twitter.zipkin.gen.Annotation;
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin.Constants;
+
+import static java.util.Collections.singletonMap;
+import static zipkin.internal.Util.checkNotNull;
+
+/**
+ * Creates traced sessions, which write directly to brave's collector to preserve the correct
+ * duration.
+ */
+public final class TracedSession extends AbstractInvocationHandler implements LatencyTracker {
+  private static final Logger LOG = LoggerFactory.getLogger(TracedSession.class);
+
+  private final ProtocolVersion version;
+
+  public static Session create(Session target, Brave brave, SpanCollector collector) {
+    return Reflection.newProxy(Session.class, new TracedSession(target, brave, collector));
+  }
+
+  final Session target;
+  final Brave brave;
+  final SpanCollector collector;
+  /**
+   * Manual Propagation, as opposed to attempting to control the {@link
+   * Cluster#register(LatencyTracker) latency tracker callback thread}.
+   */
+  final Map<BoundStatement, Span> cache = Maps.newConcurrentMap();
+
+  TracedSession(Session target, Brave brave, SpanCollector collector) {
+    this.target = checkNotNull(target, "target");
+    this.brave = checkNotNull(brave, "brave");
+    this.collector = checkNotNull(collector, "collector");
+    this.version = target.getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
+    target.getCluster().register(this);
+  }
+
+  @Override protected Object handleInvocation(Object proxy, Method method, Object[] args)
+      throws Throwable {
+    // Only join traces, don't start them. This prevents LocalCollector's thread from amplifying.
+    if (brave.serverSpanThreadBinder().getCurrentServerSpan() != null &&
+        brave.serverSpanThreadBinder().getCurrentServerSpan().getSpan() != null
+        && method.getName().equals("executeAsync") && args[0] instanceof BoundStatement) {
+      BoundStatement statement = (BoundStatement) args[0];
+
+      // via an internal class z.s.cassandra3.NamedBoundStatement, toString() is a nice name
+      SpanId spanId = brave.clientTracer().startNewSpan(statement.toString());
+
+      // o.a.c.tracing.Tracing.newSession must use the same format for the key zipkin
+      if (version.compareTo(ProtocolVersion.V4) >= 0) {
+        statement.enableTracing();
+        statement.setOutgoingPayload(singletonMap("zipkin", ByteBuffer.wrap(spanId.bytes())));
+      }
+
+      brave.clientTracer().setClientSent(); // start the span and store it
+      brave.clientTracer()
+          .submitBinaryAnnotation("cql.query", statement.preparedStatement().getQueryString());
+      cache.put(statement, brave.clientSpanThreadBinder().getCurrentClientSpan());
+      // let go of the client span as it is only used for the RPC (will have no local children)
+      brave.clientSpanThreadBinder().setCurrentSpan(null);
+      return new BraveResultSetFuture(target.executeAsync(statement), brave);
+    }
+    try {
+      return method.invoke(target, args);
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof RuntimeException) throw e.getCause();
+      throw e;
+    }
+  }
+
+  @Override public void update(Host host, Statement statement, Exception e, long nanos) {
+    if (!(statement instanceof BoundStatement)) return;
+    Span span = cache.remove(statement);
+    if (span == null) {
+      if (statement.isTracing()) {
+        LOG.warn("{} not in the cache eventhough tracing is on", statement);
+      }
+      return;
+    }
+    span.setDuration(nanos / 1000); // TODO: allow client tracer to end with duration
+    Endpoint local = span.getAnnotations().get(0).host; // TODO: expose in brave
+    long endTs = span.getTimestamp() + span.getDuration();
+    span.addToAnnotations(Annotation.create(endTs, "cr", local));
+    if (e != null) {
+      span.addToBinary_annotations(BinaryAnnotation.create(Constants.ERROR, e.getMessage(), local));
+    }
+    int ipv4 = ByteBuffer.wrap(host.getAddress().getAddress()).getInt();
+    Endpoint endpoint = Endpoint.create("cassandra3", ipv4, host.getSocketAddress().getPort());
+    span.addToBinary_annotations(BinaryAnnotation.address("sa", endpoint));
+    collector.collect(span);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof TracedSession) {
+      TracedSession other = (TracedSession) obj;
+      return target.equals(other.target);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return target.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return target.toString();
+  }
+
+  @Override public void onRegister(Cluster cluster) {
+  }
+
+  @Override public void onUnregister(Cluster cluster) {
+  }
+
+  static class BraveResultSetFuture<T> implements ResultSetFuture {
+    final ResultSetFuture delegate;
+    final ServerSpanThreadBinder threadBinder;
+    final ServerSpan parent;
+
+    BraveResultSetFuture(ResultSetFuture delegate, Brave brave) {
+      this.delegate = delegate;
+      this.threadBinder = brave.serverSpanThreadBinder();
+      this.parent = threadBinder.getCurrentServerSpan();
+    }
+
+    @Override public ResultSet getUninterruptibly() {
+      return delegate.getUninterruptibly();
+    }
+
+    @Override public ResultSet getUninterruptibly(long timeout, TimeUnit unit)
+        throws TimeoutException {
+      return delegate.getUninterruptibly(timeout, unit);
+    }
+
+    @Override public boolean cancel(boolean mayInterruptIfRunning) {
+      return delegate.cancel(mayInterruptIfRunning);
+    }
+
+    @Override public boolean isCancelled() {
+      return delegate.isCancelled();
+    }
+
+    @Override public boolean isDone() {
+      return delegate.isDone();
+    }
+
+    @Override public ResultSet get() throws InterruptedException, ExecutionException {
+      return delegate.get();
+    }
+
+    @Override public ResultSet get(long timeout, TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+      return delegate.get(timeout, unit);
+    }
+
+    @Override public void addListener(Runnable listener, Executor executor) {
+      delegate.addListener(() -> {
+        threadBinder.setCurrentSpan(parent);
+        try {
+          listener.run();
+        } finally {
+          threadBinder.setCurrentSpan(null);
+        }
+      }, executor);
+    }
+  }
+}

--- a/zipkin-autoconfigure/storage-cassandra3/src/main/resources/META-INF/spring.factories
+++ b/zipkin-autoconfigure/storage-cassandra3/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+zipkin.autoconfigure.storage.cassandra3.ZipkinCassandra3StorageAutoConfiguration,\
+zipkin.autoconfigure.storage.cassandra3.brave.TraceZipkinCassandra3StorageAutoConfiguration

--- a/zipkin-autoconfigure/storage-cassandra3/src/test/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-cassandra3/src/test/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageAutoConfigurationTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.autoconfigure.storage.cassandra;
+package zipkin.autoconfigure.storage.cassandra3;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -20,12 +20,12 @@ import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import zipkin.storage.cassandra.CassandraStorage;
+import zipkin.storage.cassandra3.Cassandra3Storage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
 
-public class ZipkinCassandraStorageAutoConfigurationTests {
+public class ZipkinCassandra3StorageAutoConfigurationTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -44,36 +44,36 @@ public class ZipkinCassandraStorageAutoConfigurationTests {
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context, "zipkin.storage.type:elasticsearch");
     context.register(PropertyPlaceholderAutoConfiguration.class,
-        ZipkinCassandraStorageAutoConfiguration.class);
+        ZipkinCassandra3StorageAutoConfiguration.class);
     context.refresh();
 
     thrown.expect(NoSuchBeanDefinitionException.class);
-    context.getBean(CassandraStorage.class);
+    context.getBean(Cassandra3Storage.class);
   }
 
   @Test
   public void providesStorageComponent_whenStorageTypeCassandra() {
     context = new AnnotationConfigApplicationContext();
-    addEnvironment(context, "zipkin.storage.type:cassandra");
+    addEnvironment(context, "zipkin.storage.type:cassandra3");
     context.register(PropertyPlaceholderAutoConfiguration.class,
-        ZipkinCassandraStorageAutoConfiguration.class);
+        ZipkinCassandra3StorageAutoConfiguration.class);
     context.refresh();
 
-    assertThat(context.getBean(CassandraStorage.class)).isNotNull();
+    assertThat(context.getBean(Cassandra3Storage.class)).isNotNull();
   }
 
   @Test
   public void canOverridesProperty_contactPoints() {
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context,
-        "zipkin.storage.type:cassandra",
-        "zipkin.storage.cassandra.contact-points:host1,host2" // note snake-case supported
+        "zipkin.storage.type:cassandra3",
+        "zipkin.storage.cassandra3.contact-points:host1,host2" // note snake-case supported
     );
     context.register(PropertyPlaceholderAutoConfiguration.class,
-        ZipkinCassandraStorageAutoConfiguration.class);
+        ZipkinCassandra3StorageAutoConfiguration.class);
     context.refresh();
 
-    assertThat(context.getBean(ZipkinCassandraStorageProperties.class).getContactPoints())
+    assertThat(context.getBean(ZipkinCassandra3StorageProperties.class).getContactPoints())
         .isEqualTo("host1,host2");
   }
 }

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -84,6 +84,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Cassandra 3 backend -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-autoconfigure-storage-cassandra3</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Elasticsearch backend -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
@@ -49,7 +49,7 @@ public class ZipkinQueryApiV1 {
 
   @Autowired
   @Value("${zipkin.query.lookback:86400000}")
-  int defaultLookback = 86400000; // 7 days in millis
+  int defaultLookback = 86400000; // 1 day in millis
 
   /** The Cache-Control max-age (seconds) for /api/v1/services and /api/v1/spans */
   @Value("${zipkin.query.names-max-age:300}")

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -57,6 +57,21 @@ zipkin:
       index-cache-ttl: ${CASSANDRA_INDEX_CACHE_TTL:60}
       # how many more index rows to fetch than the user-supplied query limit
       index-fetch-multiplier: ${CASSANDRA_INDEX_FETCH_MULTIPLIER:3}
+    cassandra3:
+      # Comma separated list of hosts / ip addresses part of Cassandra cluster.
+      contact-points: ${CASSANDRA3_CONTACT_POINTS:localhost}
+      # Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
+      local-dc: ${CASSANDRA3_LOCAL_DC:}
+      # Will throw an exception on startup if authentication fails.
+      username: ${CASSANDRA3_USERNAME:}
+      password: ${CASSANDRA3_PASSWORD:}
+      keyspace: ${CASSANDRA3_KEYSPACE:zipkin3}
+      # Max pooled connections per datacenter-local host.
+      max-connections: ${CASSANDRA3_MAX_CONNECTIONS:8}
+      # Ensuring that schema exists, if enabled tries to execute script /cassandra3-schema.cql
+      ensure-schema: ${CASSANDRA3_ENSURE_SCHEMA:true}
+      # how many more index rows to fetch than the user-supplied query limit
+      index-fetch-multiplier: ${CASSANDRA3_INDEX_FETCH_MULTIPLIER:3}
     elasticsearch:
       cluster: ${ES_CLUSTER:elasticsearch}
       hosts: ${ES_HOSTS:localhost:9300}

--- a/zipkin-storage/cassandra3/README.md
+++ b/zipkin-storage/cassandra3/README.md
@@ -1,0 +1,65 @@
+# storage-cassandra3
+
+*This module is experimental. Please help test this, but do not use it in production.*
+
+This CQL-based Cassandra 3.9+ storage component includes a `GuavaSpanStore` and `GuavaSpanConsumer`.
+`GuavaSpanStore.getDependencies()` returns pre-aggregated dependency links (ex via [zipkin-dependencies](https://github.com/openzipkin/zipkin-dependencies)).
+
+The implementation uses the [Datastax Java Driver 3.x](https://github.com/datastax/java-driver).
+
+`zipkin.storage.cassandra3.Cassandra3Storage.Builder` includes defaults that will operate against a local Cassandra installation.
+
+## Logging
+Queries are logged to the category "com.datastax.driver.core.QueryLogger" when debug or trace is
+enabled via SLF4J. Trace level includes bound values.
+
+See [Logging Query Latencies](http://docs.datastax.com/en/developer/java-driver/3.0/supplemental/manual/logging/#logging-query-latencies) for more details.
+
+## Testing
+This module conditionally runs integration tests against a local Cassandra instance.
+
+Tests are configured to automatically access Cassandra started with its defaults.
+To ensure tests execute, download a Cassandra 3.9+ distribution, extract it, and run `bin/cassandra`.
+
+If you run tests via Maven or otherwise when Cassandra is not running,
+you'll notice tests are silently skipped.
+```
+Results :
+
+Tests run: 62, Failures: 0, Errors: 0, Skipped: 48
+```
+
+This behaviour is intentional: We don't want to burden developers with
+installing and running all storage options to test unrelated change.
+That said, all integration tests run on pull request via Travis.
+
+## Tuning
+This component is tuned to help reduce the size of indexes needed to
+perform query operations. The most important aspects are described below.
+See [Cassandra3Storage](src/main/java/zipkin/storage/cassandra3/Cassandra3Storage.java) for details.
+
+### Trace indexing
+
+Indexing in CQL is simplified by using both MATERIALIZED VIEWs and SASI.
+This has reduced the number of tables from 7 down to 2. This also reduces the write-amplification in CassandraSpanConsumer.
+This write amplification now happens internally to C*, and is visible in the increase write latency (although write latency
+remains performant at single digit milliseconds).
+A SASI index on its 'all_annotations' column permits full-text searches against annotations.
+A SASI index on the 'duration' column.
+A materialized view of the 'trace_by_service_span' table exists as 'trace_by_service'.
+
+[Core annotations](../zipkin/src/main/java/zipkin/Constants.java#L184),
+ex "sr", and non-string annotations, are not written to the `all_annotations` SASI, as they aren't intended for use in user queries.
+
+### Time-To_live
+Time-To-Live is default now at the table level. It can not be overridden in write requests.
+
+### Compaction
+Time-series data is compacted using TimeWindowCompactionStrategy, a known improved over DateTieredCompactionStrategy. Data is
+optimised for queries with a single day. The penalty of reading multiple days is small, a few disk seeks, compared to the
+otherwise overhead of reading a significantly larger amount of data.
+
+### Benchmarking
+Benchmarking the new datamodel demonstrates a significant performance improvement on reads. How much of this translates to te
+Zipkin UI is hard to tell due to the complexity of CassandraSpanConsumer and how searches are possible. Benchmarking stress
+profiles are found in traces-stress.yaml and trace_by_service_span-stress.yaml.

--- a/zipkin-storage/cassandra3/pom.xml
+++ b/zipkin-storage/cassandra3/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.java</groupId>
+    <artifactId>zipkin-storage</artifactId>
+    <version>1.8.5-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-storage-cassandra3</artifactId>
+  <name>Storage: Cassandra 3</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-mapping</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- To test nuance of load balancing behavior -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Cassandra3Storage.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Cassandra3Storage.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import zipkin.internal.LazyCloseable;
+import zipkin.internal.Nullable;
+import zipkin.storage.QueryRequest;
+import zipkin.storage.guava.LazyGuavaStorageComponent;
+
+import static java.lang.String.format;
+import static zipkin.internal.Util.checkNotNull;
+
+/**
+ * CQL3 implementation of zipkin storage.
+ *
+ * <p>Queries are logged to the category "com.datastax.driver.core.QueryLogger" when debug or trace
+ * is enabled via SLF4J. Trace level includes bound values.
+ *
+ * <p>Schema is installed by default from "/cassandra3-schema.cql"
+ */
+// This component is named Cassandra3Storage as it correlates to "cassandra3" storage types, and
+// makes health-checks more obvious. Note: this is the only public type in the package.
+public final class Cassandra3Storage
+    extends LazyGuavaStorageComponent<CassandraSpanStore, CassandraSpanConsumer> {
+
+  // @FunctionalInterface, except safe for lower language levels
+  public interface SessionFactory {
+    SessionFactory DEFAULT = new DefaultSessionFactory();
+
+    Session create(Cassandra3Storage storage);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    String keyspace = Schema.DEFAULT_KEYSPACE;
+    String contactPoints = "localhost";
+    String localDc;
+    int maxConnections = 8;
+    boolean ensureSchema = true;
+    String username;
+    String password;
+    int maxTraceCols = 100000;
+    int indexFetchMultiplier = 3;
+    SessionFactory sessionFactory = SessionFactory.DEFAULT;
+
+    /** Override to control how sessions are created. */
+    public Builder sessionFactory(SessionFactory sessionFactory) {
+      this.sessionFactory = checkNotNull(sessionFactory, "sessionFactory");
+      return this;
+    }
+
+    /** Keyspace to store span and index data. Defaults to "zipkin3" */
+    public Builder keyspace(String keyspace) {
+      this.keyspace = checkNotNull(keyspace, "keyspace");
+      return this;
+    }
+
+    /** Comma separated list of hosts / IPs part of Cassandra cluster. Defaults to localhost */
+    public Builder contactPoints(String contactPoints) {
+      this.contactPoints = checkNotNull(contactPoints, "contactPoints");
+      return this;
+    }
+
+    /**
+     * Name of the datacenter that will be considered "local" for latency load balancing. When
+     * unset, load-balancing is round-robin.
+     */
+    public Builder localDc(@Nullable String localDc) {
+      this.localDc = localDc;
+      return this;
+    }
+
+    /** Max pooled connections per datacenter-local host. Defaults to 8 */
+    public Builder maxConnections(int maxConnections) {
+      this.maxConnections = maxConnections;
+      return this;
+    }
+
+    /**
+     * Ensures that schema exists, if enabled tries to execute script io.zipkin:zipkin-cassandra-core/cassandra-schema-cql3.txt.
+     * Defaults to true.
+     */
+    public Builder ensureSchema(boolean ensureSchema) {
+      this.ensureSchema = ensureSchema;
+      return this;
+    }
+
+    /** Will throw an exception on startup if authentication fails. No default. */
+    public Builder username(@Nullable String username) {
+      this.username = username;
+      return this;
+    }
+
+    /** Will throw an exception on startup if authentication fails. No default. */
+    public Builder password(@Nullable String password) {
+      this.password = password;
+      return this;
+    }
+
+    /**
+     * Spans have multiple values for the same id. For example, a client and server contribute to
+     * the same span id. When searching for spans by id, the amount of results may be larger than
+     * the ids. This defines a threshold which accommodates this situation, without looking for an
+     * unbounded number of results.
+     */
+    public Builder maxTraceCols(int maxTraceCols) {
+      this.maxTraceCols = maxTraceCols;
+      return this;
+    }
+
+    /**
+     * How many more index rows to fetch than the user-supplied query limit. Defaults to 3.
+     *
+     * <p>Backend requests will request {@link QueryRequest#limit} times this factor rows from
+     * Cassandra indexes in attempts to return {@link QueryRequest#limit} traces.
+     *
+     * <p>Indexing in cassandra will usually have more rows than trace identifiers due to factors
+     * including table design and collection implementation. As there's no way to DISTINCT out
+     * duplicates server-side, this over-fetches client-side when {@code indexFetchMultiplier} > 1.
+     */
+    public Builder indexFetchMultiplier(int indexFetchMultiplier) {
+      this.indexFetchMultiplier = indexFetchMultiplier;
+      return this;
+    }
+
+    public Cassandra3Storage build() {
+      return new Cassandra3Storage(this);
+    }
+
+    Builder() {
+    }
+  }
+
+  final int maxTraceCols;
+  final String contactPoints;
+  final int maxConnections;
+  final String localDc;
+  final String username;
+  final String password;
+  final boolean ensureSchema;
+  final String keyspace;
+  final int indexFetchMultiplier;
+  final LazyCloseable<Session> session;
+
+  Cassandra3Storage(Builder builder) {
+    this.contactPoints = builder.contactPoints;
+    this.maxConnections = builder.maxConnections;
+    this.localDc = builder.localDc;
+    this.username = builder.username;
+    this.password = builder.password;
+    this.ensureSchema = builder.ensureSchema;
+    this.keyspace = builder.keyspace;
+    this.maxTraceCols = builder.maxTraceCols;
+    this.indexFetchMultiplier = builder.indexFetchMultiplier;
+    final SessionFactory sessionFactory = builder.sessionFactory;
+    this.session = new LazyCloseable<Session>() {
+      @Override protected Session compute() {
+        return sessionFactory.create(Cassandra3Storage.this);
+      }
+    };
+  }
+
+  /** Lazy initializes or returns the session in use by this storage component. */
+  public Session session() {
+    return session.get();
+  }
+
+  @Override protected CassandraSpanStore computeGuavaSpanStore() {
+    return new CassandraSpanStore(session.get(), maxTraceCols, indexFetchMultiplier);
+  }
+
+  @Override protected CassandraSpanConsumer computeGuavaSpanConsumer() {
+    return new CassandraSpanConsumer(session.get());
+  }
+
+  @Override public CheckResult check() {
+    try {
+      session.get().execute(QueryBuilder.select("trace_id").from("traces").limit(1));
+    } catch (RuntimeException e) {
+      return CheckResult.failed(e);
+    }
+    return CheckResult.OK;
+  }
+
+  @Override public void close() throws IOException {
+    session.close();
+  }
+
+  /** Truncates all the column families, or throws on any failure. */
+  @VisibleForTesting void clear() {
+    List<ListenableFuture<?>> futures = new LinkedList<>();
+    for (String cf : ImmutableList.of(
+        Schema.TABLE_TRACES,
+        Schema.TABLE_TRACE_BY_SERVICE_SPAN,
+        Schema.TABLE_DEPENDENCIES
+    )) {
+      futures.add(session.get().executeAsync(format("TRUNCATE %s", cf)));
+    }
+    Futures.getUnchecked(Futures.allAsList(futures));
+  }
+}

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanConsumer.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Span;
+import zipkin.internal.ApplyTimestampAndDuration;
+import zipkin.storage.cassandra3.Schema.AnnotationUDT;
+import zipkin.storage.cassandra3.Schema.BinaryAnnotationUDT;
+import zipkin.storage.guava.GuavaSpanConsumer;
+
+import static com.google.common.util.concurrent.Futures.transform;
+import static zipkin.storage.cassandra3.CassandraUtil.bindWithName;
+import static zipkin.storage.cassandra3.CassandraUtil.durationIndexBucket;
+
+final class CassandraSpanConsumer implements GuavaSpanConsumer {
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraSpanConsumer.class);
+  private static final Function<Object, Void> TO_VOID = Functions.<Void>constant(null);
+
+  private final Session session;
+  private final PreparedStatement insertSpan;
+  private final PreparedStatement insertServiceSpanName;
+  private final Schema.Metadata metadata;
+
+  CassandraSpanConsumer(Session session) {
+    this.session = session;
+    this.metadata = Schema.readMetadata(session);
+
+    insertSpan = session.prepare(
+        QueryBuilder
+            .insertInto(Schema.TABLE_TRACES)
+            .value("trace_id", QueryBuilder.bindMarker("trace_id"))
+            .value("ts_uuid", QueryBuilder.bindMarker("ts_uuid"))
+            .value("id", QueryBuilder.bindMarker("id"))
+            .value("ts", QueryBuilder.bindMarker("ts"))
+            .value("span_name", QueryBuilder.bindMarker("span_name"))
+            .value("parent_id", QueryBuilder.bindMarker("parent_id"))
+            .value("duration", QueryBuilder.bindMarker("duration"))
+            .value("annotations", QueryBuilder.bindMarker("annotations"))
+            .value("binary_annotations", QueryBuilder.bindMarker("binary_annotations"))
+            .value("all_annotations", QueryBuilder.bindMarker("all_annotations")));
+
+    insertServiceSpanName = session.prepare(
+        QueryBuilder
+            .insertInto(Schema.TABLE_TRACE_BY_SERVICE_SPAN)
+            .value("service_name", QueryBuilder.bindMarker("service_name"))
+            .value("span_name", QueryBuilder.bindMarker("span_name"))
+            .value("bucket", QueryBuilder.bindMarker("bucket"))
+            .value("ts", QueryBuilder.bindMarker("ts"))
+            .value("trace_id", QueryBuilder.bindMarker("trace_id"))
+            .value("duration", QueryBuilder.bindMarker("duration")));
+  }
+
+  /**
+   * This fans out into many requests, last count was 2 * spans.size. If any of these fail, the
+   * returned future will fail. Most callers drop or log the result.
+   */
+  @Override
+  public ListenableFuture<Void> accept(List<Span> rawSpans) {
+    ImmutableSet.Builder<ListenableFuture<?>> futures = ImmutableSet.builder();
+
+    for (Span rawSpan : rawSpans) {
+      // indexing occurs by timestamp, so derive one if not present.
+      Span span = ApplyTimestampAndDuration.apply(rawSpan);
+      futures.add(storeSpan(rawSpan, span));
+
+      for (String serviceName : span.serviceNames()) {
+        // QueryRequest.min/maxDuration
+        if (span.timestamp != null) {
+          // Contract for Repository.storeServiceSpanName is to store the span twice, once with
+          // the span name and another with empty string.
+          futures.add(storeServiceSpanName(serviceName, span.name, span.timestamp, span.duration,
+              span.traceId));
+          if (!span.name.isEmpty()) { // If span.name == "", this would be redundant
+            futures.add(
+                storeServiceSpanName(serviceName, "", span.timestamp, span.duration, span.traceId));
+          }
+        }
+      }
+    }
+    return transform(Futures.allAsList(futures.build()), TO_VOID);
+  }
+
+  /**
+   * Store the span in the underlying storage for later retrieval.
+   */
+  ListenableFuture<?> storeSpan(Span rawSpan, Span span) {
+    try {
+      if ((null == span.timestamp || 0 == span.timestamp)
+          && metadata.compactionClass.contains("TimeWindowCompactionStrategy")) {
+
+        LOG.warn("Span {} in trace {} had no timestamp. "
+            + "If this happens a lot consider switching back to SizeTieredCompactionStrategy for "
+            + "{}.traces", span.id, span.traceId, session.getLoggedKeyspace());
+      }
+
+      List<AnnotationUDT> annotations = new ArrayList<>(span.annotations.size());
+      for (Annotation annotation : span.annotations) {
+        annotations.add(new AnnotationUDT(annotation));
+      }
+      List<BinaryAnnotationUDT> binaryAnnotations = new ArrayList<>(span.binaryAnnotations.size());
+      for (BinaryAnnotation annotation : span.binaryAnnotations) {
+        binaryAnnotations.add(new BinaryAnnotationUDT(annotation));
+      }
+      Set<String> annotationKeys = CassandraUtil.annotationKeys(span);
+
+      BoundStatement bound = bindWithName(insertSpan, "insert-span")
+          .setVarint("trace_id", BigInteger.valueOf(span.traceId))
+          .setUUID("ts_uuid", new UUID(
+              UUIDs.startOf(null != span.timestamp ? (span.timestamp / 1000) : 0)
+                  .getMostSignificantBits(),
+              UUIDs.random().getLeastSignificantBits()))
+          .setLong("id", span.id)
+          .setString("span_name", span.name)
+          .setList("annotations", annotations)
+          .setList("binary_annotations", binaryAnnotations)
+          .setString("all_annotations", Joiner.on(',').join(annotationKeys));
+
+      if (null != rawSpan.timestamp) {
+        bound = bound.setLong("ts", rawSpan.timestamp);
+      }
+      if (null != rawSpan.duration) {
+        bound = bound.setLong("duration", rawSpan.duration);
+      }
+      if (null != span.parentId) {
+        bound = bound.setLong("parent_id", span.parentId);
+      }
+
+      return session.executeAsync(bound);
+    } catch (RuntimeException ex) {
+      return Futures.immediateFailedFuture(ex);
+    }
+  }
+
+  ListenableFuture<?> storeServiceSpanName(
+      String serviceName,
+      String spanName,
+      long timestamp_micro,
+      Long duration,
+      long traceId) {
+
+    int bucket = durationIndexBucket(timestamp_micro);
+    try {
+      BoundStatement bound =
+          bindWithName(insertServiceSpanName, "insert-service-span-name")
+              .setString("service_name", serviceName)
+              .setString("span_name", spanName)
+              .setInt("bucket", bucket)
+              .setUUID("ts", new UUID(
+                  UUIDs.startOf(timestamp_micro / 1000).getMostSignificantBits(),
+                  UUIDs.random().getLeastSignificantBits()))
+              .setVarint("trace_id", BigInteger.valueOf(traceId));
+
+      if (null != duration) {
+        bound = bound.setLong("duration", duration);
+      }
+
+      return session.executeAsync(bound);
+    } catch (RuntimeException ex) {
+      return Futures.immediateFailedFuture(ex);
+    }
+  }
+}

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
@@ -1,0 +1,501 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.base.Function;
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Range;
+import com.google.common.util.concurrent.AsyncFunction;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin.Codec;
+import zipkin.DependencyLink;
+import zipkin.Span;
+import zipkin.internal.CorrectForClockSkew;
+import zipkin.internal.DependencyLinker;
+import zipkin.internal.MergeById;
+import zipkin.internal.Nullable;
+import zipkin.storage.QueryRequest;
+import zipkin.storage.cassandra3.Schema.AnnotationUDT;
+import zipkin.storage.cassandra3.Schema.BinaryAnnotationUDT;
+import zipkin.storage.guava.GuavaSpanStore;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.DiscreteDomain.integers;
+import static com.google.common.util.concurrent.Futures.allAsList;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.transform;
+import static zipkin.internal.Util.getDays;
+import static zipkin.storage.cassandra3.Schema.TABLE_TRACES;
+import static zipkin.storage.cassandra3.Schema.TABLE_TRACE_BY_SERVICE_SPAN;
+
+final class CassandraSpanStore implements GuavaSpanStore {
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraSpanStore.class);
+
+  static final ListenableFuture<List<String>> EMPTY_LIST =
+      immediateFuture(Collections.<String>emptyList());
+
+  static final Ordering<List<Span>> TRACE_DESCENDING = Ordering.from(new Comparator<List<Span>>() {
+    @Override
+    public int compare(List<Span> left, List<Span> right) {
+      return right.get(0).compareTo(left.get(0));
+    }
+  });
+
+  private final int maxTraceCols;
+  private final int indexFetchMultiplier;
+  private final Session session;
+  private final PreparedStatement selectTraces;
+  private final PreparedStatement selectDependencies;
+  private final PreparedStatement selectServiceNames;
+  private final PreparedStatement selectSpanNames;
+  private final PreparedStatement selectTraceIdsByServiceSpanName;
+  private final PreparedStatement selectTraceIdsByServiceSpanNameAndDuration;
+  private final PreparedStatement selectTraceIdsByAnnotation;
+  private final Function<ResultSet, Map<BigInteger, Long>> traceIdToTimestamp;
+  private final Function<List<Map<BigInteger, Long>>, Map<BigInteger, Long>> collapseTraceIdMaps;
+  private final int traceTtl;
+  private final int indexTtl;
+
+  CassandraSpanStore(Session session, int maxTraceCols, int indexFetchMultiplier) {
+    this.session = session;
+    this.maxTraceCols = maxTraceCols;
+    this.indexFetchMultiplier = indexFetchMultiplier;
+
+    selectTraces = session.prepare(
+        QueryBuilder.select("trace_id", "id", "ts", "span_name", "parent_id", "duration",
+            "annotations", "binary_annotations")
+            .from(TABLE_TRACES)
+            .where(QueryBuilder.in("trace_id", QueryBuilder.bindMarker("trace_id")))
+            .limit(QueryBuilder.bindMarker("limit_")));
+
+    selectDependencies = session.prepare(
+        QueryBuilder.select("links")
+            .from(Schema.TABLE_DEPENDENCIES)
+            .where(QueryBuilder.in("day", QueryBuilder.bindMarker("days"))));
+
+    selectServiceNames = session.prepare(
+        QueryBuilder.select("service_name")
+            .distinct()
+            .from(Schema.VIEW_TRACE_BY_SERVICE));
+
+    selectSpanNames = session.prepare(
+        QueryBuilder.select("span_name")
+            .from(Schema.VIEW_TRACE_BY_SERVICE)
+            .where(QueryBuilder.eq("service_name", QueryBuilder.bindMarker("service_name")))
+            .limit(QueryBuilder.bindMarker("limit_")));
+
+    selectTraceIdsByServiceSpanName = session.prepare(
+        QueryBuilder.select("ts", "trace_id")
+            .from(TABLE_TRACE_BY_SERVICE_SPAN)
+            .where(QueryBuilder.eq("service_name", QueryBuilder.bindMarker("service_name")))
+            .and(QueryBuilder.eq("span_name", QueryBuilder.bindMarker("span_name")))
+            .and(QueryBuilder.eq("bucket", QueryBuilder.bindMarker("bucket")))
+            .and(QueryBuilder.gte("ts", QueryBuilder.bindMarker("start_ts")))
+            .and(QueryBuilder.lte("ts", QueryBuilder.bindMarker("end_ts")))
+            .limit(QueryBuilder.bindMarker("limit_")));
+
+    selectTraceIdsByServiceSpanNameAndDuration = session.prepare(
+        QueryBuilder.select("ts", "trace_id")
+            .from(TABLE_TRACE_BY_SERVICE_SPAN)
+            .where(QueryBuilder.eq("service_name", QueryBuilder.bindMarker("service_name")))
+            .and(QueryBuilder.eq("span_name", QueryBuilder.bindMarker("span_name")))
+            .and(QueryBuilder.eq("bucket", QueryBuilder.bindMarker("bucket")))
+            .and(QueryBuilder.gte("ts", QueryBuilder.bindMarker("start_ts")))
+            .and(QueryBuilder.lte("ts", QueryBuilder.bindMarker("end_ts")))
+            .and(QueryBuilder.gte("duration", QueryBuilder.bindMarker("start_duration")))
+            .and(QueryBuilder.lte("duration", QueryBuilder.bindMarker("end_duration")))
+            .limit(QueryBuilder.bindMarker("limit_")));
+
+    selectTraceIdsByAnnotation = session.prepare(
+        QueryBuilder.select("ts", "trace_id")
+            .from(TABLE_TRACES)
+            .where(QueryBuilder.like("all_annotations", QueryBuilder.bindMarker("annotation")))
+            .and(QueryBuilder.gte("ts_uuid", QueryBuilder.bindMarker("start_ts")))
+            .and(QueryBuilder.lte("ts_uuid", QueryBuilder.bindMarker("end_ts")))
+            .limit(QueryBuilder.bindMarker("limit_"))
+            .allowFiltering());
+
+    traceIdToTimestamp = new Function<ResultSet, Map<BigInteger, Long>>() {
+      @Override public Map<BigInteger, Long> apply(ResultSet input) {
+        Map<BigInteger, Long> traceIdsToTimestamps = new LinkedHashMap<>();
+        for (Row row : input) {
+          traceIdsToTimestamps.put(row.getVarint("trace_id"),
+              UUIDs.unixTimestamp(row.getUUID("ts")));
+        }
+        return traceIdsToTimestamps;
+      }
+    };
+
+    collapseTraceIdMaps = new Function<List<Map<BigInteger, Long>>, Map<BigInteger, Long>>() {
+      @Override
+      public Map<BigInteger, Long> apply(List<Map<BigInteger, Long>> input) {
+        Map<BigInteger, Long> result = new LinkedHashMap<>();
+        for (Map<BigInteger, Long> m : input) {
+          result.putAll(m);
+        }
+        return result;
+      }
+    };
+
+    KeyspaceMetadata md = Schema.getKeyspaceMetadata(session);
+    this.traceTtl = md.getTable(TABLE_TRACES).getOptions().getDefaultTimeToLive();
+    this.indexTtl = md.getTable(TABLE_TRACE_BY_SERVICE_SPAN).getOptions().getDefaultTimeToLive();
+  }
+
+  /**
+   * This fans out into a number of requests. The returned future will fail if any of the
+   * inputs fail.
+   *
+   * <p>When {@link QueryRequest#serviceName service name} is unset, service names will be
+   * fetched eagerly, implying an additional query.
+   *
+   * <p>The duration query is the most expensive query in cassandra, as it turns into 1 request per
+   * hour of {@link QueryRequest#lookback lookback}. Because many times lookback is set to a day,
+   * this means 24 requests to the backend!
+   *
+   * <p>See https://github.com/openzipkin/zipkin-java/issues/200
+   */
+  @Override
+  public ListenableFuture<List<List<Span>>> getTraces(final QueryRequest request) {
+    // Over fetch on indexes as they don't return distinct (trace id, timestamp) rows.
+    final int traceIndexFetchSize = request.limit * indexFetchMultiplier;
+    ListenableFuture<Map<BigInteger, Long>> traceIdToTimestamp = getTraceIdsByServiceNames(request);
+    List<String> annotationKeys = CassandraUtil.annotationKeys(request);
+    ListenableFuture<Collection<BigInteger>> traceIds;
+    if (annotationKeys.isEmpty()) {
+      // Simplest case is when there is no annotation query. Limit is valid since there's no AND
+      // query that could reduce the results returned to less than the limit.
+      traceIds =
+          Futures.transform(traceIdToTimestamp, CassandraUtil.traceIdsSortedByDescTimestamp());
+    } else {
+      // While a valid port of the scala cassandra span store (from zipkin 1.35), there is a fault.
+      // each annotation key is an intersection, meaning we likely return < traceIndexFetchSize.
+      List<ListenableFuture<Map<BigInteger, Long>>> futureKeySetsToIntersect = new ArrayList<>();
+      futureKeySetsToIntersect.add(traceIdToTimestamp);
+      for (String annotationKey : annotationKeys) {
+        futureKeySetsToIntersect
+            .add(getTraceIdsByAnnotation(annotationKey, request.endTs, request.lookback,
+                traceIndexFetchSize));
+      }
+      // We achieve the AND goal, by intersecting each of the key sets.
+      traceIds =
+          Futures.transform(allAsList(futureKeySetsToIntersect), CassandraUtil.intersectKeySets());
+      // @xxx the sorting by timestamp desc is broken here^
+    }
+    return transform(traceIds, new AsyncFunction<Collection<BigInteger>, List<List<Span>>>() {
+      @Override public ListenableFuture<List<List<Span>>> apply(Collection<BigInteger> traceIds) {
+        traceIds = FluentIterable.from(traceIds).limit(request.limit).toSet();
+        return transform(getSpansByTraceIds(ImmutableSet.copyOf(traceIds), maxTraceCols),
+            AdjustTraces.INSTANCE);
+      }
+
+      @Override public String toString() {
+        return "getSpansByTraceIds";
+      }
+    });
+  }
+
+  enum AdjustTraces implements Function<Collection<List<Span>>, List<List<Span>>> {
+    INSTANCE;
+
+    @Override public List<List<Span>> apply(Collection<List<Span>> unmerged) {
+      List<List<Span>> result = new ArrayList<>(unmerged.size());
+      for (List<Span> spans : unmerged) {
+        result.add(CorrectForClockSkew.apply(MergeById.apply(spans)));
+      }
+      return TRACE_DESCENDING.immutableSortedCopy(result);
+    }
+  }
+
+  @Override public ListenableFuture<List<Span>> getRawTrace(long traceId) {
+    return transform(
+        getSpansByTraceIds(Collections.singleton(BigInteger.valueOf(traceId)), maxTraceCols),
+        new Function<Collection<List<Span>>, List<Span>>() {
+          @Override public List<Span> apply(Collection<List<Span>> encodedTraces) {
+            if (encodedTraces.isEmpty()) return null;
+            return encodedTraces.iterator().next();
+          }
+        });
+  }
+
+  @Override public ListenableFuture<List<Span>> getTrace(long traceId) {
+    return transform(getRawTrace(traceId), new Function<List<Span>, List<Span>>() {
+      @Override public List<Span> apply(List<Span> input) {
+        if (input == null || input.isEmpty()) return null;
+        return ImmutableList.copyOf(CorrectForClockSkew.apply(MergeById.apply(input)));
+      }
+    });
+  }
+
+  @Override public ListenableFuture<List<String>> getServiceNames() {
+    try {
+      BoundStatement bound = CassandraUtil.bindWithName(selectServiceNames, "select-service-names");
+      return transform(session.executeAsync(bound), new Function<ResultSet, List<String>>() {
+            @Override public List<String> apply(ResultSet input) {
+              Set<String> serviceNames = new LinkedHashSet<>();
+              for (Row row : input) {
+                serviceNames.add(row.getString("service_name"));
+              }
+              return Ordering.natural().sortedCopy(serviceNames);
+            }
+          }
+      );
+    } catch (RuntimeException ex) {
+      return immediateFailedFuture(ex);
+    }
+  }
+
+  @Override public ListenableFuture<List<String>> getSpanNames(String serviceName) {
+    if (serviceName == null || serviceName.isEmpty()) return EMPTY_LIST;
+    serviceName = checkNotNull(serviceName, "serviceName").toLowerCase();
+    try {
+      BoundStatement bound = CassandraUtil.bindWithName(selectSpanNames, "select-span-names")
+          .setString("service_name", serviceName)
+          // no one is ever going to browse so many span names
+          .setInt("limit_", 1000);
+
+      return transform(session.executeAsync(bound), new Function<ResultSet, List<String>>() {
+            @Override public List<String> apply(ResultSet input) {
+              Set<String> spanNames = new LinkedHashSet<>();
+              for (Row row : input) {
+                if (!row.getString("span_name").isEmpty()) {
+                  spanNames.add(row.getString("span_name"));
+                }
+              }
+              return Ordering.natural().sortedCopy(spanNames);
+            }
+          }
+      );
+    } catch (RuntimeException ex) {
+      return immediateFailedFuture(ex);
+    }
+  }
+
+  @Override public ListenableFuture<List<DependencyLink>> getDependencies(long endTs,
+      @Nullable Long lookback) {
+    List<Date> days = getDays(endTs, lookback);
+    try {
+      BoundStatement bound = CassandraUtil.bindWithName(selectDependencies, "select-dependencies")
+          .setList("days", days);
+      return transform(session.executeAsync(bound), ConvertDependenciesResponse.INSTANCE);
+    } catch (RuntimeException ex) {
+      return immediateFailedFuture(ex);
+    }
+  }
+
+  enum ConvertDependenciesResponse implements Function<ResultSet, List<DependencyLink>> {
+    INSTANCE;
+
+    @Override public List<DependencyLink> apply(ResultSet rs) {
+      ImmutableList.Builder<DependencyLink> unmerged = ImmutableList.builder();
+      for (Row row : rs) {
+        ByteBuffer encodedDayOfDependencies = row.getBytes("links");
+        for (DependencyLink link : Codec.THRIFT.readDependencyLinks(encodedDayOfDependencies)) {
+          unmerged.add(link);
+        }
+      }
+      return DependencyLinker.merge(unmerged.build());
+    }
+  }
+
+  /**
+   * Get the available trace information from the storage system. Spans in trace should be sorted by
+   * the first annotation timestamp in that span. First event should be first in the spans list. <p>
+   * The return list will contain only spans that have been found, thus the return list may not
+   * match the provided list of ids.
+   */
+  ListenableFuture<Collection<List<Span>>> getSpansByTraceIds(Set<BigInteger> traceIds, int limit) {
+    checkNotNull(traceIds, "traceIds");
+    if (traceIds.isEmpty()) {
+      return immediateFuture((Collection<List<Span>>) Collections.<List<Span>>emptyList());
+    }
+
+    try {
+      BoundStatement bound = CassandraUtil.bindWithName(selectTraces, "select-traces")
+          .setSet("trace_id", traceIds)
+          .setInt("limit_", limit);
+
+      bound.setFetchSize(Integer.MAX_VALUE);
+
+      return transform(session.executeAsync(bound),
+          new Function<ResultSet, Collection<List<Span>>>() {
+            @Override public Collection<List<Span>> apply(ResultSet input) {
+              Map<BigInteger, List<Span>> spans = new LinkedHashMap<>();
+
+              for (Row row : input) {
+                BigInteger traceId = row.getVarint("trace_id");
+                if (!spans.containsKey(traceId)) {
+                  spans.put(traceId, new ArrayList<Span>());
+                }
+                Span.Builder builder = Span.builder()
+                    .traceId(row.getVarint("trace_id").longValue())
+                    .id(row.getLong("id"))
+                    .name(row.getString("span_name"))
+                    .duration(row.getLong("duration"));
+
+                if (!row.isNull("ts")) {
+                  builder = builder.timestamp(row.getLong("ts"));
+                }
+                if (!row.isNull("duration")) {
+                  builder = builder.duration(row.getLong("duration"));
+                }
+                if (!row.isNull("parent_id")) {
+                  builder = builder.parentId(row.getLong("parent_id"));
+                }
+                for (AnnotationUDT udt : row.getList("annotations", AnnotationUDT.class)) {
+                  builder = builder.addAnnotation(udt.toAnnotation());
+                }
+                for (BinaryAnnotationUDT udt : row.getList("binary_annotations",
+                    BinaryAnnotationUDT.class)) {
+                  builder = builder.addBinaryAnnotation(udt.toBinaryAnnotation());
+                }
+                spans.get(traceId).add(builder.build());
+              }
+
+              return spans.values();
+            }
+          }
+      );
+    } catch (RuntimeException ex) {
+      return immediateFailedFuture(ex);
+    }
+  }
+
+  ListenableFuture<Map<BigInteger, Long>> getTraceIdsByServiceNames(QueryRequest request) {
+    long oldestData = indexTtl == 0 ? 0 : (System.currentTimeMillis() - indexTtl * 1000);
+    long startTsMillis = Math.max((request.endTs - request.lookback), oldestData);
+    long endTsMillis = Math.max(request.endTs, oldestData);
+
+    try {
+      Set<String> serviceNames;
+      if (null != request.serviceName) {
+        serviceNames = Collections.singleton(request.serviceName);
+      } else {
+        serviceNames = new LinkedHashSet<>(getServiceNames().get());
+        if (serviceNames.isEmpty()) {
+          return immediateFuture(Collections.<BigInteger, Long>emptyMap());
+        }
+      }
+
+      int startBucket = CassandraUtil.durationIndexBucket(startTsMillis * 1000);
+      int endBucket = CassandraUtil.durationIndexBucket(endTsMillis * 1000);
+      if (startBucket > endBucket) {
+        throw new IllegalArgumentException(
+            "Start bucket (" + startBucket + ") > end bucket (" + endBucket + ")");
+      }
+      Set<Integer> buckets = ContiguousSet.create(Range.closed(startBucket, endBucket), integers());
+      boolean withDuration = null != request.minDuration || null != request.maxDuration;
+      List<ListenableFuture<Map<BigInteger, Long>>> futures = new ArrayList<>();
+
+      if (200 < serviceNames.size() * buckets.size()) {
+        LOG.warn("read against " + TABLE_TRACE_BY_SERVICE_SPAN
+            + " fanning out to " + serviceNames.size() * buckets.size() + " requests");
+        //@xxx the fan-out of requests here can be improved
+      }
+
+      for (String serviceName : serviceNames) {
+        for (Integer bucket : buckets) {
+          BoundStatement bound = CassandraUtil
+              .bindWithName(
+                  withDuration ? selectTraceIdsByServiceSpanNameAndDuration
+                      : selectTraceIdsByServiceSpanName,
+                  "select-trace-ids-by-service-name")
+              .setString("service_name", serviceName)
+              .setString("span_name", null != request.spanName ? request.spanName : "")
+              .setInt("bucket", bucket)
+              .setUUID("start_ts", UUIDs.startOf(startTsMillis))
+              .setUUID("end_ts", UUIDs.endOf(endTsMillis))
+              .setInt("limit_", request.limit);
+
+          if (withDuration) {
+            bound = bound
+                .setLong("start_duration", null != request.minDuration ? request.minDuration : 0)
+                .setLong("end_duration",
+                    null != request.maxDuration ? request.maxDuration : Long.MAX_VALUE);
+          }
+          bound.setFetchSize(Integer.MAX_VALUE);
+          futures.add(transform(session.executeAsync(bound), traceIdToTimestamp));
+        }
+      }
+
+      return transform(allAsList(futures), collapseTraceIdMaps);
+    } catch (RuntimeException | InterruptedException | ExecutionException ex) {
+      return immediateFailedFuture(ex);
+    }
+  }
+
+  ListenableFuture<Map<BigInteger, Long>> getTraceIdsByAnnotation(
+      String annotationKey,
+      long endTsMillis,
+      long lookbackMillis,
+      int limit) {
+    long oldestData = traceTtl == 0 ? 0 : (System.currentTimeMillis() - traceTtl * 1000);
+    long startTsMillis = Math.max((endTsMillis - lookbackMillis), oldestData);
+    endTsMillis = Math.max(endTsMillis, oldestData);
+
+    try {
+      BoundStatement bound =
+          CassandraUtil.bindWithName(selectTraceIdsByAnnotation, "select-trace-ids-by-annotation")
+              .setString("annotation", "%" + annotationKey + "%")
+              .setUUID("start_ts", UUIDs.startOf(startTsMillis))
+              .setUUID("end_ts", UUIDs.endOf(endTsMillis))
+              .setInt("limit_", limit);
+
+      bound.setFetchSize(Integer.MAX_VALUE);
+
+      return transform(session.executeAsync(bound),
+          new Function<ResultSet, Map<BigInteger, Long>>() {
+            @Override public Map<BigInteger, Long> apply(ResultSet input) {
+              Map<BigInteger, Long> traceIdsToTimestamps = new LinkedHashMap<>();
+              for (Row row : input) {
+                traceIdsToTimestamps.put(row.getVarint("trace_id"), row.getLong("ts"));
+              }
+              return traceIdsToTimestamps;
+            }
+          }
+      );
+    } catch (RuntimeException ex) {
+      return immediateFailedFuture(ex);
+    }
+  }
+}

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraUtil.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraUtil.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.google.common.base.Function;
+import com.google.common.collect.Sets;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Span;
+import zipkin.storage.QueryRequest;
+
+import static zipkin.internal.Util.UTF_8;
+import static zipkin.internal.Util.checkArgument;
+import static zipkin.internal.Util.sortedList;
+
+final class CassandraUtil {
+
+  /**
+   * Zipkin's {@link QueryRequest#binaryAnnotations} are equals match. Not all binary annotations
+   * are lookup keys. For example, sql query isn't something that is likely to be looked up by value
+   * and indexing that could add a potentially kilobyte partition key on {@link Schema#TABLE_TRACES}
+   */
+  static final int LONGEST_VALUE_TO_INDEX = 256;
+
+  // Time window covered by a single bucket of the Span Duration Index, in seconds. Default: 1 day
+  private static final long DURATION_INDEX_BUCKET_WINDOW_SECONDS
+      = Long.getLong("zipkin.store.cassandra.internal.durationIndexBucket", 24 * 60 * 60);
+
+  public static int durationIndexBucket(long ts_micro) {
+    // if the window constant has microsecond precision, the division produces negative values
+    return (int) ((ts_micro / DURATION_INDEX_BUCKET_WINDOW_SECONDS) / 1000000);
+  }
+
+  /**
+   * Returns keys that concatenate the serviceName associated with an annotation, a binary
+   * annotation key, or a binary annotation key with value.
+   *
+   * <p>Note: in the case of binary annotations, only string types are returned, as that's the only
+   * queryable type, per {@link QueryRequest#binaryAnnotations}.
+   *
+   * @see QueryRequest#annotations
+   * @see QueryRequest#binaryAnnotations
+   */
+  static Set<String> annotationKeys(Span span) {
+    Set<String> annotationKeys = new LinkedHashSet<>();
+    for (Annotation a : span.annotations) {
+      // don't index core annotations as they aren't queryable
+      if (Constants.CORE_ANNOTATIONS.contains(a.value)) continue;
+
+      if (a.endpoint != null && !a.endpoint.serviceName.isEmpty()) {
+        annotationKeys.add(a.endpoint.serviceName + ":" + a.value);
+      }
+    }
+    for (BinaryAnnotation b : span.binaryAnnotations) {
+      if (b.type == BinaryAnnotation.Type.STRING
+          && b.endpoint != null
+          && !b.endpoint.serviceName.isEmpty()
+          && b.value.length <= LONGEST_VALUE_TO_INDEX * 4) { // UTF_8 is up to 4bytes/char
+        String value = new String(b.value, UTF_8);
+        if (value.length() > LONGEST_VALUE_TO_INDEX) continue;
+
+        annotationKeys.add(b.endpoint.serviceName + ":" + b.key);
+        annotationKeys.add(b.endpoint.serviceName + ":" + b.key + ":" + new String(b.value, UTF_8));
+      }
+    }
+    return annotationKeys;
+  }
+
+  static List<String> annotationKeys(QueryRequest request) {
+    if (request.annotations.isEmpty() && request.binaryAnnotations.isEmpty()) {
+      return Collections.emptyList();
+    }
+    checkArgument(request.serviceName != null, "serviceName needed with annotation query");
+    Set<String> annotationKeys = new LinkedHashSet<>();
+    for (String a : request.annotations) { // doesn't include CORE_ANNOTATIONS
+      annotationKeys.add(request.serviceName + ":" + a);
+    }
+    for (Map.Entry<String, String> b : request.binaryAnnotations.entrySet()) {
+      annotationKeys.add(request.serviceName + ":" + b.getKey() + ":" + b.getValue());
+    }
+    return sortedList(annotationKeys);
+  }
+
+  static Function<Map<BigInteger, Long>, Set<BigInteger>> keyset() {
+    return (Function) KeySet.INSTANCE;
+  }
+
+  static BoundStatement bindWithName(PreparedStatement prepared, String name) {
+    return new NamedBoundStatement(prepared, name);
+  }
+
+  /** Used to assign a friendly name when tracing and debugging */
+  static final class NamedBoundStatement extends BoundStatement {
+
+    final String name;
+
+    NamedBoundStatement(PreparedStatement statement, String name) {
+      super(statement);
+      this.name = name;
+    }
+
+    @Override public String toString() {
+      return name;
+    }
+  }
+
+  enum KeySet implements Function<Map<Object, ?>, Set<Object>> {
+    INSTANCE;
+
+    @Override public Set<Object> apply(Map<Object, ?> input) {
+      return input.keySet();
+    }
+  }
+
+  static Function<List<Map<BigInteger, Long>>, Collection<BigInteger>> intersectKeySets() {
+    return (Function) IntersectKeySets.INSTANCE;
+  }
+
+  static Function<Map<BigInteger, Long>, Collection<BigInteger>> traceIdsSortedByDescTimestamp() {
+    return TraceIdsSortedByDescTimestamp.INSTANCE;
+  }
+
+  enum IntersectKeySets implements Function<List<Map<Object, ?>>, Collection<Object>> {
+    INSTANCE;
+
+    @Override public Collection<Object> apply(List<Map<Object, ?>> input) {
+      Set<Object> traceIds = Sets.newLinkedHashSet(input.get(0).keySet());
+      for (int i = 1; i < input.size(); i++) {
+        traceIds.retainAll(input.get(i).keySet());
+      }
+      return traceIds;
+    }
+  }
+
+  enum TraceIdsSortedByDescTimestamp
+      implements Function<Map<BigInteger, Long>, Collection<BigInteger>> {
+    INSTANCE;
+
+    @Override public Collection<BigInteger> apply(Map<BigInteger, Long> map) {
+      // timestamps can collide, so we need to add some random digits on end before using them as keys
+      SortedMap<BigInteger, BigInteger> sorted = new TreeMap<>(Collections.reverseOrder());
+      for (Map.Entry<BigInteger, Long> e : map.entrySet()) {
+        sorted.put(
+            BigInteger.valueOf(e.getValue())
+                .multiply(OFFSET)
+                .add(BigInteger.valueOf(RAND.nextInt())),
+            e.getKey());
+      }
+      return sorted.values();
+    }
+
+    private static final Random RAND = new Random(System.nanoTime());
+    private static final BigInteger OFFSET = BigInteger.valueOf(Integer.MAX_VALUE);
+  }
+}

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.PoolingOptions;
+import com.datastax.driver.core.QueryLogger;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.LatencyAwarePolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
+import com.datastax.driver.mapping.MappingManager;
+import com.google.common.collect.Sets;
+import com.google.common.io.Closer;
+import com.google.common.net.HostAndPort;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import zipkin.storage.cassandra3.Schema.AnnotationUDT;
+import zipkin.storage.cassandra3.Schema.BinaryAnnotationUDT;
+import zipkin.storage.cassandra3.Schema.EndpointUDT;
+import zipkin.storage.cassandra3.Schema.TypeCodecImpl;
+
+import static zipkin.storage.cassandra3.Schema.DEFAULT_KEYSPACE;
+
+/**
+ * Creates a session and ensures schema if configured. Closes the cluster and session if any
+ * exception occurred.
+ */
+final class DefaultSessionFactory implements Cassandra3Storage.SessionFactory {
+
+  /**
+   * Creates a session and ensures schema if configured. Closes the cluster and session if any
+   * exception occurred.
+   */
+  @Override public Session create(Cassandra3Storage cassandra) {
+    Closer closer = Closer.create();
+    try {
+      Cluster cluster = closer.register(buildCluster(cassandra));
+      cluster.register(new QueryLogger.Builder().build());
+      Session session;
+      if (cassandra.ensureSchema) {
+        session = closer.register(cluster.connect());
+        Schema.ensureExists(cassandra.keyspace, session);
+        session.execute("USE " + cassandra.keyspace);
+      } else {
+        session = cluster.connect(cassandra.keyspace);
+      }
+
+      initializeUDTs(session);
+
+      return session;
+    } catch (RuntimeException e) {
+      try {
+        closer.close();
+      } catch (IOException ignored) {
+      }
+      throw e;
+    }
+  }
+
+  private static void initializeUDTs(Session session) {
+    Schema.ensureExists(DEFAULT_KEYSPACE + "_udts", session);
+    MappingManager mapping = new MappingManager(session);
+    TypeCodec<AnnotationUDT> annoCodec = mapping.udtCodec(AnnotationUDT.class);
+    TypeCodec<BinaryAnnotationUDT> bAnnoCodec = mapping.udtCodec(BinaryAnnotationUDT.class);
+
+    // The UDTs are hardcoded against the zipkin keyspace.
+    // If a different keyspace is being used the codecs must be re-applied to this different keyspace
+    TypeCodec<EndpointUDT> endpointCodec = mapping.udtCodec(EndpointUDT.class);
+    KeyspaceMetadata keyspace =
+        session.getCluster().getMetadata().getKeyspace(session.getLoggedKeyspace());
+
+    session.getCluster().getConfiguration().getCodecRegistry()
+        .register(
+            new TypeCodecImpl(keyspace.getUserType("endpoint"), EndpointUDT.class, endpointCodec))
+        .register(
+            new TypeCodecImpl(keyspace.getUserType("annotation"), AnnotationUDT.class, annoCodec))
+        .register(
+            new TypeCodecImpl(keyspace.getUserType("binary_annotation"), BinaryAnnotationUDT.class,
+                bAnnoCodec));
+  }
+
+  // Visible for testing
+  static Cluster buildCluster(Cassandra3Storage cassandra) {
+    Cluster.Builder builder = Cluster.builder();
+    List<InetSocketAddress> contactPoints = parseContactPoints(cassandra);
+    int defaultPort = findConnectPort(contactPoints);
+    builder.addContactPointsWithPorts(contactPoints);
+    builder.withPort(defaultPort); // This ends up protocolOptions.port
+    if (cassandra.username != null && cassandra.password != null) {
+      builder.withCredentials(cassandra.username, cassandra.password);
+    }
+    builder.withRetryPolicy(ZipkinRetryPolicy.INSTANCE);
+    builder.withLoadBalancingPolicy(new TokenAwarePolicy(new LatencyAwarePolicy.Builder(
+        cassandra.localDc != null
+            ? DCAwareRoundRobinPolicy.builder().withLocalDc(cassandra.localDc).build()
+            : new RoundRobinPolicy()
+        // This can select remote, but LatencyAwarePolicy will prefer local
+    ).build()));
+    builder.withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(
+        HostDistance.LOCAL, cassandra.maxConnections
+    ));
+    return builder.build();
+  }
+
+  static List<InetSocketAddress> parseContactPoints(Cassandra3Storage cassandra) {
+    List<InetSocketAddress> result = new LinkedList<>();
+    for (String contactPoint : cassandra.contactPoints.split(",")) {
+      HostAndPort parsed = HostAndPort.fromString(contactPoint);
+      result.add(
+          new InetSocketAddress(parsed.getHostText(), parsed.getPortOrDefault(9042)));
+    }
+    return result;
+  }
+
+  /** Returns the consistent port across all contact points or 9042 */
+  static int findConnectPort(List<InetSocketAddress> contactPoints) {
+    Set<Integer> ports = Sets.newLinkedHashSet();
+    for (InetSocketAddress contactPoint : contactPoints) {
+      ports.add(contactPoint.getPort());
+    }
+    return ports.size() == 1 ? ports.iterator().next() : 9042;
+  }
+}

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Schema.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Schema.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.driver.mapping.annotations.UDT;
+import com.google.common.io.CharStreams;
+import com.google.common.net.InetAddresses;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Endpoint;
+
+final class Schema {
+  private static final Logger LOG = LoggerFactory.getLogger(Schema.class);
+
+  static final String TABLE_TRACES = "traces";
+  static final String TABLE_TRACE_BY_SERVICE_SPAN = "trace_by_service_span";
+  static final String TABLE_DEPENDENCIES = "dependencies";
+  static final String VIEW_TRACE_BY_SERVICE = "trace_by_service";
+
+  static final String DEFAULT_KEYSPACE = "zipkin3";
+  private static final String SCHEMA_RESOURCE = "/cassandra3-schema.cql";
+
+  private Schema() {
+  }
+
+  static Metadata readMetadata(Session session) {
+    KeyspaceMetadata keyspaceMetadata = getKeyspaceMetadata(session);
+
+    Map<String, String> replication = keyspaceMetadata.getReplication();
+    if ("SimpleStrategy".equals(replication.get("class")) && "1".equals(
+        replication.get("replication_factor"))) {
+      LOG.warn("running with RF=1, this is not suitable for production. Optimal is 3+");
+    }
+    String compactionClass =
+        keyspaceMetadata.getTable("traces").getOptions().getCompaction().get("class");
+
+    return new Metadata(compactionClass);
+  }
+
+  static final class Metadata {
+    final String compactionClass;
+
+    Metadata(String compactionClass) {
+      this.compactionClass = compactionClass;
+    }
+  }
+
+  static KeyspaceMetadata getKeyspaceMetadata(Session session) {
+    String keyspace = session.getLoggedKeyspace();
+    Cluster cluster = session.getCluster();
+    KeyspaceMetadata keyspaceMetadata = cluster.getMetadata().getKeyspace(keyspace);
+
+    if (keyspaceMetadata == null) {
+      throw new IllegalStateException(String.format(
+          "Cannot read keyspace metadata for give keyspace: %s and cluster: %s",
+          keyspace, cluster.getClusterName()));
+    }
+    return keyspaceMetadata;
+  }
+
+  static KeyspaceMetadata ensureExists(String keyspace, Session session) {
+    KeyspaceMetadata result = session.getCluster().getMetadata().getKeyspace(keyspace);
+    if (result == null || result.getTable("traces") == null) {
+      LOG.info("Installing schema {}", SCHEMA_RESOURCE);
+      applyCqlFile(keyspace, session, SCHEMA_RESOURCE);
+      // refresh metadata since we've installed the schema
+      result = session.getCluster().getMetadata().getKeyspace(keyspace);
+    }
+    return result;
+  }
+
+  static void applyCqlFile(String keyspace, Session session, String resource) {
+    try (Reader reader = new InputStreamReader(Schema.class.getResourceAsStream(resource))) {
+      for (String cmd : CharStreams.toString(reader).split(";")) {
+        cmd = cmd.trim().replace(" " + DEFAULT_KEYSPACE, " " + keyspace);
+        if (!cmd.isEmpty()) {
+          session.execute(cmd);
+        }
+      }
+    } catch (IOException ex) {
+      LOG.error(ex.getMessage(), ex);
+    }
+  }
+
+  @UDT(keyspace = DEFAULT_KEYSPACE + "_udts", name = "endpoint")
+  static final class EndpointUDT {
+
+    private String service_name;
+    private InetAddress ipv4;
+    private InetAddress ipv6;
+    private Short port;
+
+    EndpointUDT() {
+      this.service_name = null;
+      this.ipv4 = null;
+      this.ipv6 = null;
+      this.port = null;
+    }
+
+    EndpointUDT(Endpoint endpoint) {
+      this.service_name = endpoint.serviceName;
+      this.ipv4 = endpoint.ipv4 == 0 ? null : InetAddresses.fromInteger(endpoint.ipv4);
+      if (endpoint.ipv6 != null && endpoint.ipv6.length == 16) {
+        try {
+          this.ipv6 = Inet6Address.getByAddress(endpoint.ipv6);
+        } catch (UnknownHostException ex) { // We already checked for illegal length, so unexpected!
+        }
+      }
+      this.port = endpoint.port;
+    }
+
+    public String getService_name() {
+      return service_name;
+    }
+
+    public InetAddress getIpv4() {
+      return ipv4;
+    }
+
+    public InetAddress getIpv6() {
+      return ipv6;
+    }
+
+    public Short getPort() {
+      return port;
+    }
+
+    public void setService_name(String service_name) {
+      this.service_name = service_name;
+    }
+
+    public void setIpv4(InetAddress ipv4) {
+      this.ipv4 = ipv4;
+    }
+
+    public void setIpv6(InetAddress ipv6) {
+      this.ipv6 = ipv6;
+    }
+
+    public void setPort(short port) {
+      this.port = port;
+    }
+
+    private Endpoint toEndpoint() {
+      Endpoint.Builder builder = Endpoint.builder()
+          .serviceName(service_name)
+          .ipv4(ipv4 == null ? 0 : ByteBuffer.wrap(ipv4.getAddress()).getInt())
+          .port(port);
+
+      if (null != ipv6) {
+        builder = builder.ipv6(ipv6.getAddress());
+      }
+      return builder.build();
+    }
+  }
+
+  @UDT(keyspace = DEFAULT_KEYSPACE + "_udts", name = "annotation")
+  static final class AnnotationUDT {
+
+    private long ts;
+    private String v;
+    private EndpointUDT ep;
+
+    AnnotationUDT() {
+      this.ts = 0;
+      this.v = null;
+      this.ep = null;
+    }
+
+    AnnotationUDT(Annotation annotation) {
+      this.ts = annotation.timestamp;
+      this.v = annotation.value;
+      this.ep = annotation.endpoint != null ? new EndpointUDT(annotation.endpoint) : null;
+    }
+
+    public long getTs() {
+      return ts;
+    }
+
+    public String getV() {
+      return v;
+    }
+
+    public EndpointUDT getEp() {
+      return ep;
+    }
+
+    public void setTs(long ts) {
+      this.ts = ts;
+    }
+
+    public void setV(String v) {
+      this.v = v;
+    }
+
+    public void setEp(EndpointUDT ep) {
+      this.ep = ep;
+    }
+
+    Annotation toAnnotation() {
+      Annotation.Builder builder = Annotation.builder().timestamp(ts).value(v);
+      if (null != ep) {
+        builder = builder.endpoint(ep.toEndpoint());
+      }
+      return builder.build();
+    }
+  }
+
+  @UDT(keyspace = DEFAULT_KEYSPACE + "_udts", name = "binary_annotation")
+  static final class BinaryAnnotationUDT {
+
+    private String k;
+    private ByteBuffer v;
+    private String t;
+    private EndpointUDT ep;
+
+    BinaryAnnotationUDT() {
+      this.k = null;
+      this.v = null;
+      this.t = null;
+      this.ep = null;
+    }
+
+    BinaryAnnotationUDT(BinaryAnnotation annotation) {
+      this.k = annotation.key;
+      this.v = annotation.value != null ? ByteBuffer.wrap(annotation.value) : null;
+      this.t = annotation.type.name();
+      this.ep = annotation.endpoint != null ? new EndpointUDT(annotation.endpoint) : null;
+    }
+
+    public String getK() {
+      return k;
+    }
+
+    public ByteBuffer getV() {
+      return v.duplicate();
+    }
+
+    public String getT() {
+      return t;
+    }
+
+    public EndpointUDT getEp() {
+      return ep;
+    }
+
+    public void setK(String k) {
+      this.k = k;
+    }
+
+    public void setV(ByteBuffer v) {
+      byte[] bytes = new byte[v.remaining()];
+      v.duplicate().get(bytes);
+      this.v = ByteBuffer.wrap(bytes);
+    }
+
+    public void setT(String t) {
+      this.t = t;
+    }
+
+    public void setEp(EndpointUDT ep) {
+      this.ep = ep;
+    }
+
+    BinaryAnnotation toBinaryAnnotation() {
+      BinaryAnnotation.Builder builder = BinaryAnnotation.builder()
+          .key(k)
+          .value(v.array())
+          .type(BinaryAnnotation.Type.valueOf(t));
+      if (ep != null) builder.endpoint(ep.toEndpoint());
+      return builder.build();
+    }
+  }
+
+  static final class TypeCodecImpl<T> extends TypeCodec<T> {
+
+    private final TypeCodec<T> codec;
+
+    public TypeCodecImpl(DataType cqlType, Class<T> javaClass, TypeCodec<T> codec) {
+      super(cqlType, javaClass);
+      this.codec = codec;
+    }
+
+    @Override
+    public ByteBuffer serialize(T t, ProtocolVersion pv) throws InvalidTypeException {
+      return codec.serialize(t, pv);
+    }
+
+    @Override
+    public T deserialize(ByteBuffer bb, ProtocolVersion pv) throws InvalidTypeException {
+      return codec.deserialize(bb, pv);
+    }
+
+    @Override
+    public T parse(String string) throws InvalidTypeException {
+      return codec.parse(string);
+    }
+
+    @Override
+    public String format(T t) throws InvalidTypeException {
+      return codec.format(t);
+    }
+  }
+}

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/ZipkinRetryPolicy.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/ZipkinRetryPolicy.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.WriteType;
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.policies.RetryPolicy;
+
+/** This class was copied from org.twitter.zipkin.storage.cassandra.ZipkinRetryPolicy */
+final class ZipkinRetryPolicy implements RetryPolicy {
+
+  public static final ZipkinRetryPolicy INSTANCE = new ZipkinRetryPolicy();
+
+  private ZipkinRetryPolicy() {
+  }
+
+  @Override
+  public RetryDecision onReadTimeout(Statement statement, ConsistencyLevel cl,
+      int requiredResponses, int receivedResponses, boolean dataRetrieved, int nbRetry) {
+    return RetryDecision.retry(ConsistencyLevel.ONE);
+  }
+
+  @Override
+  public RetryDecision onWriteTimeout(Statement statement, ConsistencyLevel cl, WriteType writeType,
+      int requiredAcks, int receivedAcks, int nbRetry) {
+    return RetryDecision.retry(ConsistencyLevel.ONE);
+  }
+
+  @Override
+  public RetryDecision onUnavailable(Statement statement, ConsistencyLevel cl, int requiredReplica,
+      int aliveReplica, int nbRetry) {
+    return RetryDecision.retry(ConsistencyLevel.ONE);
+  }
+
+  @Override
+  public RetryDecision onRequestError(Statement statement, ConsistencyLevel cl,
+      DriverException e, int nbRetry) {
+    return RetryDecision.tryNextHost(ConsistencyLevel.ONE);
+  }
+
+  @Override
+  public void init(Cluster cluster) {
+    // nothing to do
+  }
+
+  @Override
+  public void close() {
+    // nothing to do
+  }
+}

--- a/zipkin-storage/cassandra3/src/main/resources/cassandra3-schema.cql
+++ b/zipkin-storage/cassandra3/src/main/resources/cassandra3-schema.cql
@@ -1,0 +1,82 @@
+CREATE KEYSPACE IF NOT EXISTS zipkin3 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
+
+CREATE TYPE IF NOT EXISTS zipkin3.endpoint (
+    service_name text,
+    ipv4         inet,
+    ipv6         inet,
+    port         smallint,
+);
+
+CREATE TYPE IF NOT EXISTS zipkin3.annotation (
+    ts bigint,
+    v  text,
+    ep frozen<endpoint>
+);
+
+CREATE TYPE IF NOT EXISTS zipkin3.binary_annotation (
+    k  text,
+    v  blob,
+    t  text,
+    ep frozen<endpoint>
+);
+
+CREATE TABLE IF NOT EXISTS zipkin3.traces (
+    trace_id            varint,
+    ts_uuid             timeuuid,
+    id                  bigint,
+    ts                  bigint,
+    span_name           text,
+    parent_id           bigint,
+    duration            bigint,
+    annotations         list<frozen<annotation>>,
+    binary_annotations  list<frozen<binary_annotation>>,
+    all_annotations     text, // can't do SASI on set<text>: comma-joined until CASSANDRA-11182
+    PRIMARY KEY (trace_id, ts_uuid, id)
+)
+    WITH CLUSTERING ORDER BY (ts_uuid DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND default_time_to_live =  604800;
+
+
+CREATE TABLE zipkin3.trace_by_service_span (
+    service_name  text,      // service name
+    span_name     text,      // span name, or blank for queries without span name
+    bucket        int,       // time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1 day.
+    ts            timeuuid,  // start timestamp of the span, truncated to millisecond precision
+    trace_id      varint,    // trace ID
+    duration      bigint,    // span duration, in microseconds
+    PRIMARY KEY ((service_name, span_name, bucket), ts)
+)
+   WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND default_time_to_live =  259200;
+
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS zipkin3.trace_by_service
+    AS SELECT service_name, span_name, bucket, ts, trace_id FROM trace_by_service_span
+            WHERE service_name is not null AND span_name is not null AND bucket is not null AND ts is not null
+            PRIMARY KEY (service_name, bucket, span_name, ts)
+        WITH CLUSTERING ORDER BY (bucket DESC, ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+        AND default_time_to_live =  259200;
+
+CREATE CUSTOM INDEX ON zipkin3.traces (all_annotations) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {
+    'mode': 'CONTAINS',
+    'analyzed': 'true',
+    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.NonTokenizingAnalyzer',
+    'case_sensitive': 'false'
+   };
+
+CREATE CUSTOM INDEX ON zipkin3.trace_by_service_span (duration) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {'mode': 'PREFIX'};
+
+
+CREATE TABLE IF NOT EXISTS zipkin3.dependencies (
+    day          timestamp,
+    links        blob,
+    PRIMARY KEY (day)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND default_time_to_live =  259200;
+

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/Cassandra3StorageTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/Cassandra3StorageTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import org.junit.Test;
+import zipkin.Component.CheckResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Cassandra3StorageTest {
+
+  @Test
+  public void check_failsInsteadOfThrowing() {
+    CheckResult result =
+        Cassandra3Storage.builder().contactPoints("1.1.1.1").build().check();
+
+    assertThat(result.ok).isFalse();
+    assertThat(result.exception)
+        .isInstanceOf(NoHostAvailableException.class);
+  }
+}

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/Cassandra3TestGraph.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/Cassandra3TestGraph.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import org.junit.AssumptionViolatedException;
+import zipkin.Component.CheckResult;
+import zipkin.internal.LazyCloseable;
+
+enum Cassandra3TestGraph {
+  INSTANCE;
+
+  final LazyCloseable<Cassandra3Storage> storage = new LazyCloseable<Cassandra3Storage>() {
+    AssumptionViolatedException ex = null;
+
+    @Override protected Cassandra3Storage compute() {
+      if (ex != null) throw ex;
+      Cassandra3Storage result = Cassandra3Storage.builder().keyspace("test_zipkin3").build();
+      CheckResult check = result.check();
+      if (check.ok) return result;
+      throw ex = new AssumptionViolatedException(check.exception.getMessage());
+    }
+  };
+}

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraDependenciesTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraDependenciesTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.List;
+import zipkin.Codec;
+import zipkin.DependencyLink;
+import zipkin.Span;
+import zipkin.internal.MergeById;
+import zipkin.internal.Util;
+import zipkin.storage.DependenciesTest;
+import zipkin.storage.InMemorySpanStore;
+import zipkin.storage.InMemoryStorage;
+
+import static zipkin.TestObjects.DAY;
+import static zipkin.TestObjects.TODAY;
+import static zipkin.internal.Util.midnightUTC;
+
+public class CassandraDependenciesTest extends DependenciesTest {
+  private final Cassandra3Storage storage;
+
+  public CassandraDependenciesTest() {
+    this.storage = Cassandra3TestGraph.INSTANCE.storage.get();
+  }
+
+  @Override protected Cassandra3Storage storage() {
+    return storage;
+  }
+
+  @Override public void clear() {
+    storage.clear();
+  }
+
+  /**
+   * The current implementation does not include dependency aggregation. It includes retrieval of
+   * pre-aggregated links.
+   *
+   * <p>This uses {@link InMemorySpanStore} to prepare links and {@link CassandraDependenciesWriter}
+   * to store them.
+   *
+   * <p>Note: The zipkin-dependencies-spark doesn't use any of these classes: it reads and writes to
+   * the keyspace directly.
+   */
+  @Override
+  public void processDependencies(List<Span> spans) {
+    InMemoryStorage mem = new InMemoryStorage();
+    mem.spanConsumer().accept(spans);
+    List<DependencyLink> links = mem.spanStore().getDependencies(TODAY + DAY, null);
+
+    // This gets or derives a timestamp from the spans
+    long midnight = midnightUTC(MergeById.apply(spans).get(0).timestamp / 1000);
+    new CassandraDependenciesWriter(storage.session.get()).write(links, midnight);
+  }
+
+  static final class CassandraDependenciesWriter {
+    private final PreparedStatement insertDependencies;
+    private final Session session;
+
+    CassandraDependenciesWriter(Session session) {
+      this.session = session;
+      insertDependencies = session.prepare(QueryBuilder.insertInto(Schema.TABLE_DEPENDENCIES)
+          .value("day", QueryBuilder.bindMarker("day"))
+          .value("links", QueryBuilder.bindMarker("links")));
+    }
+
+    @VisibleForTesting void write(List<DependencyLink> links, long timestampMillis) {
+      long midnight = Util.midnightUTC(timestampMillis);
+      ByteBuffer thrift = ByteBuffer.wrap(Codec.THRIFT.writeDependencyLinks(links));
+      Futures.getUnchecked(storeDependencies(midnight, thrift));
+    }
+
+    ListenableFuture<?> storeDependencies(long epochDayMillis, ByteBuffer links) {
+      Date startFlooredToDay = new Date(epochDayMillis);
+      try {
+        BoundStatement bound = CassandraUtil.bindWithName(insertDependencies, "insert-dependencies")
+            .setTimestamp("day", startFlooredToDay)
+            .setBytes("links", links);
+
+        return session.executeAsync(bound);
+      } catch (RuntimeException ex) {
+        return Futures.immediateFailedFuture(ex);
+      }
+    }
+  }
+}

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanConsumerTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.Span;
+import zipkin.TestObjects;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CassandraSpanConsumerTest {
+
+  private final Cassandra3Storage storage;
+
+  public CassandraSpanConsumerTest() {
+    this.storage = Cassandra3TestGraph.INSTANCE.storage.get();
+  }
+
+  @Before
+  public void clear() {
+    storage.clear();
+  }
+
+  /**
+   * {@link Span#duration} == 0 is likely to be a mistake, and coerces to null. It is not helpful to
+   * index rows who have no duration.
+   */
+  @Test
+  public void doesntIndexSpansMissingDuration() {
+    Span span = Span.builder().traceId(1L).id(1L).name("get").duration(0L).build();
+
+    accept(span);
+
+    assertThat(rowCount(Schema.TABLE_TRACE_BY_SERVICE_SPAN)).isZero();
+  }
+
+  /**
+   * Simulates a trace with a step pattern, where each span starts a millisecond after the prior
+   * one. The consumer code optimizes index inserts to only represent the interval represented by
+   * the trace as opposed to each individual timestamp.
+   */
+  @Test
+  public void skipsRedundantIndexingInATrace() {
+    Span[] trace = new Span[101];
+    trace[0] = TestObjects.TRACE.get(0);
+
+    IntStream.range(0, 100).forEach(i -> {
+      Span s = TestObjects.TRACE.get(1);
+      trace[i + 1] = s.toBuilder()
+          .id(s.id + i)
+          .timestamp(s.timestamp + i * 1000) // all peer span timestamps happen a millisecond later
+          .annotations(s.annotations.stream()
+              .map(a -> Annotation.create(a.timestamp + i * 1000, a.value, a.endpoint))
+              .collect(toList()))
+          .build();
+    });
+
+    accept(trace);
+    assertThat(rowCount(Schema.TABLE_TRACE_BY_SERVICE_SPAN)).isGreaterThanOrEqualTo(4L);
+    assertThat(rowCount(Schema.TABLE_TRACE_BY_SERVICE_SPAN)).isGreaterThanOrEqualTo(4L);
+
+    // sanity check base case
+    clear();
+
+    CassandraSpanConsumer withoutOptimization = new CassandraSpanConsumer(storage.session());
+    Futures.getUnchecked(withoutOptimization.accept(ImmutableList.copyOf(trace)));
+    assertThat(rowCount(Schema.TABLE_TRACE_BY_SERVICE_SPAN)).isGreaterThanOrEqualTo(201L);
+    assertThat(rowCount(Schema.TABLE_TRACE_BY_SERVICE_SPAN)).isGreaterThanOrEqualTo(201L);
+  }
+
+  void accept(Span... spans) {
+    Futures.getUnchecked(storage.computeGuavaSpanConsumer().accept(ImmutableList.copyOf(spans)));
+  }
+
+  long rowCount(String table) {
+    return storage.session().execute("SELECT COUNT(*) from " + table).one().getLong(0);
+  }
+}

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanStoreTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.Annotation;
+import zipkin.Span;
+import zipkin.TestObjects;
+import zipkin.internal.ApplyTimestampAndDuration;
+import zipkin.storage.QueryRequest;
+import zipkin.storage.SpanStoreTest;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CassandraSpanStoreTest extends SpanStoreTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private final Cassandra3Storage storage;
+
+  public CassandraSpanStoreTest() {
+    this.storage = Cassandra3TestGraph.INSTANCE.storage.get();
+  }
+
+  CassandraSpanStoreTest(Cassandra3Storage storage) {
+    this.storage = storage;
+  }
+
+  @Override protected Cassandra3Storage storage() {
+    return storage;
+  }
+
+  @Override public void clear() {
+    storage.clear();
+  }
+
+  /** Cassandra indexing is performed separately, allowing the raw span to be stored unaltered. */
+  @Test
+  public void rawTraceStoredWithoutAdjustments() {
+    Span rawSpan = TestObjects.TRACE.get(0).toBuilder().timestamp(null).duration(null).build();
+    accept(rawSpan);
+
+    // At query time, timestamp and duration are added.
+    assertThat(store().getTrace(rawSpan.traceId))
+        .containsExactly(ApplyTimestampAndDuration.apply(rawSpan));
+
+    // Unlike other stores, Cassandra can show that timestamp and duration weren't reported
+    assertThat(store().getRawTrace(rawSpan.traceId))
+        .containsExactly(rawSpan);
+  }
+
+  @Test
+  public void overFetchesToCompensateForDuplicateIndexData() {
+    int traceCount = 100;
+
+    List<Span> spans = new ArrayList<>();
+    for (int i = 0; i < traceCount; i++) {
+      final long delta = i * 1000; // all timestamps happen a millisecond later
+      for (Span s : TestObjects.TRACE) {
+        spans.add(TestObjects.TRACE.get(0).toBuilder()
+            .traceId(s.traceId + i * 10)
+            .id(s.id + i * 10)
+            .timestamp(s.timestamp + delta)
+            .annotations(s.annotations.stream()
+                .map(a -> Annotation.create(a.timestamp + delta, a.value, a.endpoint))
+                .collect(toList()))
+            .build());
+      }
+    }
+
+    accept(spans.toArray(new Span[spans.size()]));
+
+    // Index ends up containing more rows than services * trace count, and cannot be de-duped
+    // in a server-side query.
+    assertThat(rowCount(Schema.TABLE_TRACE_BY_SERVICE_SPAN))
+        .isGreaterThan(traceCount * store().getServiceNames().size());
+
+    // Implementation over-fetches on the index to allow the user to receive unsurprising results.
+    assertThat(
+        store().getTraces(QueryRequest.builder().lookback(86400000L).limit(traceCount).build()))
+        .hasSize(traceCount);
+  }
+
+  long rowCount(String table) {
+    return storage.session().execute("SELECT COUNT(*) from " + table).one().getLong(0);
+  }
+}

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Span;
+import zipkin.TestObjects;
+import zipkin.TraceKeys;
+import zipkin.storage.QueryRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CassandraUtilTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void annotationKeys_emptyRequest() {
+    assertThat(CassandraUtil.annotationKeys(QueryRequest.builder().lookback(86400000L).build()))
+        .isEmpty();
+  }
+
+  @Test
+  public void annotationKeys_serviceNameRequired() {
+    thrown.expect(IllegalArgumentException.class);
+
+    CassandraUtil.annotationKeys(
+        QueryRequest.builder().lookback(86400000L).addAnnotation("sr").build());
+  }
+
+  @Test
+  public void annotationKeys() {
+    assertThat(CassandraUtil.annotationKeys(QueryRequest.builder()
+        .lookback(86400000L)
+        .serviceName("service")
+        .addAnnotation(Constants.ERROR)
+        .addBinaryAnnotation(TraceKeys.HTTP_METHOD, "GET").build()))
+        .containsExactly("service:error", "service:http.method:GET");
+  }
+
+  @Test
+  public void annotationKeys_dedupes() {
+    assertThat(CassandraUtil.annotationKeys(QueryRequest.builder()
+        .lookback(86400000L)
+        .serviceName("service")
+        .addAnnotation(Constants.ERROR)
+        .addAnnotation(Constants.ERROR).build()))
+        .containsExactly("service:error");
+  }
+
+  @Test
+  public void annotationKeys_skipsCoreAndAddressAnnotations() throws Exception {
+    Span span = TestObjects.TRACE.get(1);
+
+    assertThat(span.annotations)
+        .extracting(a -> a.value)
+        .matches(Constants.CORE_ANNOTATIONS::containsAll);
+
+    assertThat(span.binaryAnnotations)
+        .extracting(b -> b.key)
+        .containsOnly(Constants.SERVER_ADDR, Constants.CLIENT_ADDR);
+
+    assertThat(CassandraUtil.annotationKeys(span))
+        .isEmpty();
+  }
+
+  @Test
+  public void annotationKeys_skipsBinaryAnnotationsLongerThan256chars() throws Exception {
+    // example long value
+    String arn =
+        "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012";
+    // example too long value
+    String url =
+        "http://webservices.amazon.com/onca/xml?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&AssociateTag=mytag-20&ItemId=0679722769&Operation=ItemLookup&ResponseGroup=Images%2CItemAttributes%2COffers%2CReviews&Service=AWSECommerceService&Timestamp=2014-08-18T12%3A00%3A00Z&Version=2013-08-01&Signature=j7bZM0LXZ9eXeZruTqWm2DIvDYVUU3wxPPpp%2BiXxzQc%3D";
+    Span span = TestObjects.TRACE.get(1).toBuilder().binaryAnnotations(ImmutableList.of(
+        BinaryAnnotation.create("aws.arn", arn, TestObjects.WEB_ENDPOINT),
+        BinaryAnnotation.create(TraceKeys.HTTP_URL, url, TestObjects.WEB_ENDPOINT)
+    )).build();
+
+    assertThat(CassandraUtil.annotationKeys(span))
+        .containsOnly("web:aws.arn", "web:aws.arn:" + arn);
+  }
+}

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/EnsureSchemaTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/EnsureSchemaTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Session;
+import com.google.common.io.Closer;
+import java.io.IOException;
+import org.junit.After;
+import org.junit.AssumptionViolatedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.storage.cassandra3.DefaultSessionFactory.buildCluster;
+
+public final class EnsureSchemaTest {
+
+  @Rule
+  public TestName name = new TestName();
+
+  @BeforeClass public static void checkCassandraIsUp() {
+    try (Cluster cluster = buildCluster(Cassandra3Storage.builder().build());
+         Session session = cluster.newSession()) {
+      session.execute("SELECT now() FROM system.local");
+    } catch (RuntimeException e) {
+      throw new AssumptionViolatedException(e.getMessage(), e);
+    }
+  }
+
+  Closer closer = Closer.create();
+  String keyspace;
+  Cluster cluster;
+  Session session;
+
+  @Before
+  public void connectAndDropKeyspace() {
+    keyspace = name.getMethodName().toLowerCase();
+    cluster = closer.register(buildCluster(Cassandra3Storage.builder().keyspace(keyspace).build()));
+    session = closer.register(cluster.newSession());
+    session.execute("DROP KEYSPACE IF EXISTS " + keyspace);
+    assertThat(session.getCluster().getMetadata().getKeyspace(keyspace)).isNull();
+  }
+
+  @After
+  public void close() throws IOException {
+    closer.close();
+  }
+
+  @Test public void installsKeyspaceWhenMissing() {
+    Schema.ensureExists(keyspace, session);
+
+    KeyspaceMetadata metadata = session.getCluster().getMetadata().getKeyspace(keyspace);
+    assertThat(metadata).isNotNull();
+  }
+
+  @Test public void installsTablesWhenMissing() {
+    session.execute("CREATE KEYSPACE " + keyspace
+        + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+
+    Schema.ensureExists(keyspace, session);
+
+    KeyspaceMetadata metadata = session.getCluster().getMetadata().getKeyspace(keyspace);
+    assertThat(metadata).isNotNull();
+  }
+}

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/SessionFactoryTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/SessionFactoryTest.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import com.datastax.driver.core.AuthProvider;
+import com.datastax.driver.core.Authenticator;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.PoolingOptions;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.LatencyAwarePolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static zipkin.storage.cassandra3.DefaultSessionFactory.buildCluster;
+import static zipkin.storage.cassandra3.DefaultSessionFactory.parseContactPoints;
+
+public class SessionFactoryTest {
+
+  @Test
+  public void contactPoints_defaultsToLocalhost() {
+    assertThat(parseContactPoints(Cassandra3Storage.builder().build()))
+        .containsExactly(new InetSocketAddress("127.0.0.1", 9042));
+  }
+
+  @Test
+  public void contactPoints_defaultsToPort9042() {
+    assertThat(parseContactPoints(Cassandra3Storage.builder().contactPoints("1.1.1.1").build()))
+        .containsExactly(new InetSocketAddress("1.1.1.1", 9042));
+  }
+
+  @Test
+  public void contactPoints_defaultsToPort9042_multi() {
+    assertThat(parseContactPoints(
+        Cassandra3Storage.builder().contactPoints("1.1.1.1:9143,2.2.2.2").build()))
+        .containsExactly(
+            new InetSocketAddress("1.1.1.1", 9143),
+            new InetSocketAddress("2.2.2.2", 9042)
+        );
+  }
+
+  @Test
+  public void contactPoints_hostAndPort() {
+    assertThat(parseContactPoints(Cassandra3Storage.builder().contactPoints("1.1.1.1:9142").build()))
+        .containsExactly(new InetSocketAddress("1.1.1.1", 9142));
+  }
+
+  @Test
+  public void connectPort_singleContactPoint() {
+    assertThat(buildCluster(Cassandra3Storage.builder().contactPoints("1.1.1.1:9142").build())
+        .getConfiguration().getProtocolOptions().getPort())
+        .isEqualTo(9142);
+  }
+
+  @Test
+  public void connectPort_whenContactPointsHaveSamePort() {
+    assertThat(
+        buildCluster(Cassandra3Storage.builder().contactPoints("1.1.1.1:9143,2.2.2.2:9143").build())
+            .getConfiguration().getProtocolOptions().getPort())
+        .isEqualTo(9143);
+  }
+
+  @Test
+  public void connectPort_whenContactPointsHaveMixedPorts_coercesToDefault() {
+    assertThat(
+        buildCluster(Cassandra3Storage.builder().contactPoints("1.1.1.1:9143,2.2.2.2").build())
+            .getConfiguration().getProtocolOptions().getPort())
+        .isEqualTo(9042);
+  }
+
+  @Test
+  public void usernamePassword_impliesNullDelimitedUtf8Bytes() {
+    Authenticator authenticator =
+        buildCluster(Cassandra3Storage.builder().username("bob").password("secret").build())
+            .getConfiguration().getProtocolOptions().getAuthProvider()
+            .newAuthenticator(new InetSocketAddress("localhost", 8080), null);
+
+    byte[] SASLhandshake = {0, 'b', 'o', 'b', 0, 's', 'e', 'c', 'r', 'e', 't'};
+    assertThat(authenticator.initialResponse())
+        .isEqualTo(SASLhandshake);
+  }
+
+  @Test
+  public void authProvider_defaultsToNone() {
+    assertThat(buildCluster(Cassandra3Storage.builder().build())
+        .getConfiguration().getProtocolOptions().getAuthProvider())
+        .isEqualTo(AuthProvider.NONE);
+  }
+
+  @Test
+  public void loadBalancing_defaultsToRoundRobin() {
+    RoundRobinPolicy policy = toRoundRobinPolicy(Cassandra3Storage.builder().build());
+
+    Host foo = mock(Host.class);
+    when(foo.getDatacenter()).thenReturn("foo");
+    Host bar = mock(Host.class);
+    when(bar.getDatacenter()).thenReturn("bar");
+    policy.init(mock(Cluster.class), asList(foo, bar));
+
+    assertThat(policy.distance(foo)).isEqualTo(HostDistance.LOCAL);
+    assertThat(policy.distance(bar)).isEqualTo(HostDistance.LOCAL);
+  }
+
+  RoundRobinPolicy toRoundRobinPolicy(Cassandra3Storage storage) {
+    return (RoundRobinPolicy) ((LatencyAwarePolicy) ((TokenAwarePolicy) buildCluster(storage)
+        .getConfiguration()
+        .getPolicies()
+        .getLoadBalancingPolicy())
+        .getChildPolicy()).getChildPolicy();
+  }
+
+  @Test
+  public void loadBalancing_settingLocalDcIgnoresOtherDatacenters() {
+    DCAwareRoundRobinPolicy policy = toDCAwareRoundRobinPolicy(
+        Cassandra3Storage.builder().localDc("bar").build());
+
+    Host foo = mock(Host.class);
+    when(foo.getDatacenter()).thenReturn("foo");
+    Host bar = mock(Host.class);
+    when(bar.getDatacenter()).thenReturn("bar");
+    policy.init(mock(Cluster.class), asList(foo, bar));
+
+    assertThat(policy.distance(foo)).isEqualTo(HostDistance.IGNORED);
+    assertThat(policy.distance(bar)).isEqualTo(HostDistance.LOCAL);
+  }
+
+  DCAwareRoundRobinPolicy toDCAwareRoundRobinPolicy(Cassandra3Storage storage) {
+    return (DCAwareRoundRobinPolicy) ((LatencyAwarePolicy) ((TokenAwarePolicy) buildCluster(storage)
+        .getConfiguration()
+        .getPolicies()
+        .getLoadBalancingPolicy())
+        .getChildPolicy()).getChildPolicy();
+  }
+
+  @Test
+  public void maxConnections_defaultsTo8() {
+    PoolingOptions poolingOptions = buildCluster(Cassandra3Storage.builder().build())
+        .getConfiguration().getPoolingOptions();
+
+    assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(8);
+  }
+
+  @Test
+  public void maxConnections_setsMaxConnectionsPerDatacenterLocalHost() {
+    PoolingOptions poolingOptions =
+        buildCluster(Cassandra3Storage.builder().maxConnections(16).build())
+            .getConfiguration().getPoolingOptions();
+
+    assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(16);
+  }
+}

--- a/zipkin-storage/cassandra3/src/test/resources/logback.xml
+++ b/zipkin-storage/cassandra3/src/test/resources/logback.xml
@@ -1,0 +1,32 @@
+<configuration>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Note: this will dump a large amount of data in the logs -->
+  <!--<logger name="com.datastax.driver.core.QueryLogger" level="TRACE" />-->
+  <!--<logger name="zipkin.storage.cassandra" level="DEBUG" />-->
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/zipkin-storage/cassandra3/src/test/resources/trace-stress.yaml
+++ b/zipkin-storage/cassandra3/src/test/resources/trace-stress.yaml
@@ -1,0 +1,84 @@
+#    Copyright 2015-2016 The OpenZipkin Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#    in compliance with the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software distributed under the License
+#    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#    or implied. See the License for the specific language governing permissions and limitations under
+#    the License.
+#
+### Stress test for zipkin3 traces table
+###
+### Stress testing is done using the `cassandra-stress` tool
+###
+### For example
+###  cassandra-stress  user profile=trace-stress.yaml ops\(insert=1\)  duration=1m  -rate threads=4 throttle=50/s
+###
+### after a benchmark has been run with only writes, a mixed read-write benchmark can be run with
+###  cassandra-stress  user profile=trace-stress.yaml ops\(insert=1,by_trace=1,by_trace_ts_id=1,by_annotation=1\)  duration=1m  -rate threads=4 throttle=50/s
+
+# Keyspace Name
+keyspace: zipkin3
+
+# Table name
+table: traces
+
+
+### Column Distribution Specifications ###
+#
+# the UDT columns must be dropped before running stress
+
+columnspec:
+  - name: trace_id
+    size: fixed(32)
+    population: uniform(1..10k)
+
+  - name: ts_uuid
+    population: uniform(1..10k)
+
+  - name: id
+    size: fixed(32)
+    population: uniform(1..10k)
+
+  - name: ts
+    size: fixed(12)
+    population: uniform(1..10k)
+
+  - name: span_name
+    size: uniform(5..20)
+    population: uniform(1..100)
+
+  - name: duration
+    size: fixed(12)
+    population: uniform(1..10k)
+
+  - name: all_annotations
+    size: gaussian(50..500)
+    population: uniform(1..1k)
+
+
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # 1 pertition key at a time inserts to model a message being generated
+  select:  fixed(1)/1000
+  batchtype: UNLOGGED             # Unlogged batches
+
+
+#
+# A set of basic queries
+#
+queries:
+   by_trace:
+    cql: SELECT * FROM traces WHERE trace_id = ?
+    fields: samerow
+   by_trace_ts_id:
+    cql: SELECT * FROM traces WHERE trace_id = ? AND ts_uuid = ? AND id = ?
+    fields: samerow
+   by_annotation:
+    cql: SELECT trace_id, ts, id FROM traces WHERE all_annotations LIKE ?
+    fields: samerow

--- a/zipkin-storage/cassandra3/src/test/resources/trace_by_service_span-stress.yaml
+++ b/zipkin-storage/cassandra3/src/test/resources/trace_by_service_span-stress.yaml
@@ -1,0 +1,77 @@
+#    Copyright 2015-2016 The OpenZipkin Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#    in compliance with the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software distributed under the License
+#    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#    or implied. See the License for the specific language governing permissions and limitations under
+#    the License.
+#
+###
+### Stress test for zipkin3 service_span_name_index table
+###
+### Stress testing is done using the `cassandra-stress` tool
+###
+### For example
+###  cassandra-stress  user profile=trace_by_service_span-stress.yaml ops\(insert=1\)  duration=1m  -rate threads=4 throttle=50/s
+###
+### after a benchmark has been run with only writes, a mixed read-write benchmark can be run with
+###  cassandra-stress  user profile=trace_by_service_span-stress.yaml ops\(insert=1,select=1,by_duration=1\)  duration=1m  -rate threads=4 throttle=50/s
+
+# Keyspace Name
+keyspace: zipkin3
+
+# Table name
+table: trace_by_service_span
+
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: service_name
+    size: uniform(5..20)
+    population: uniform(1..100)
+
+  - name: span_name
+    size: uniform(5..20)
+    population: uniform(1..100)
+
+  - name: bucket
+    size: fixed(12)
+    population: fixed(123456789012)
+
+  - name: ts
+    size: fixed(12)
+    population: uniform(1..10k)
+
+  - name: trace_id
+    size: fixed(32)
+    population: uniform(1..10k)
+
+  - name: duration
+    size: fixed(12)
+    population: uniform(1..10k)
+
+
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # 1 pertition key at a time inserts to model a message being generated
+  select:  fixed(1)/1000
+  batchtype: UNLOGGED             # Unlogged batches
+
+
+#
+# A set of basic queries
+#
+queries:
+   select:
+    cql: SELECT * FROM trace_by_service_span WHERE service_name = ? AND span_name = ? AND bucket = ? LIMIT 1
+    fields: samerow
+   by_duration:
+    cql: SELECT * FROM trace_by_service_span WHERE service_name = ? AND span_name = ? AND bucket = ? AND duration < ? LIMIT 1
+    fields: samerow

--- a/zipkin/src/test/java/zipkin/TestObjects.java
+++ b/zipkin/src/test/java/zipkin/TestObjects.java
@@ -49,6 +49,7 @@ public final class TestObjects {
       Endpoint.create("app", 172 << 24 | 17 << 16 | 2, 8080);
   public static final Endpoint DB_ENDPOINT =
       Endpoint.create("db", 172 << 24 | 17 << 16 | 2, 3306);
+  public static final Endpoint NO_IP_ENDPOINT = Endpoint.builder().serviceName("no_ip").build();
 
   static final long WEB_SPAN_ID = -692101025335252320L;
   static final long APP_SPAN_ID = -7842865617155193778L;
@@ -70,10 +71,10 @@ public final class TestObjects {
       Span.builder().traceId(WEB_SPAN_ID).parentId(APP_SPAN_ID).id(DB_SPAN_ID).name("query")
           .addAnnotation(Annotation.create((TODAY + 150) * 1000, CLIENT_SEND, APP_ENDPOINT))
           .addAnnotation(Annotation.create((TODAY + 200) * 1000, CLIENT_RECV, APP_ENDPOINT))
-          .addAnnotation(Annotation.create((TODAY + 200) * 1000, "⻩", APP_ENDPOINT))
+          .addAnnotation(Annotation.create((TODAY + 190) * 1000, "⻩", NO_IP_ENDPOINT))
           .addBinaryAnnotation(BinaryAnnotation.address(CLIENT_ADDR, APP_ENDPOINT))
           .addBinaryAnnotation(BinaryAnnotation.address(SERVER_ADDR, DB_ENDPOINT))
-          .addBinaryAnnotation(BinaryAnnotation.create(ERROR, "\uD83D\uDCA9", APP_ENDPOINT))
+          .addBinaryAnnotation(BinaryAnnotation.create(ERROR, "\uD83D\uDCA9", NO_IP_ENDPOINT))
           .build()
   ).stream().map(ApplyTimestampAndDuration::apply).collect(toList());
 


### PR DESCRIPTION
Discussions in https://github.com/openzipkin/zipkin/pull/1204 lead to an agreement that upgrading the C\* datamodel and taking advantage of latest features may be the best path forward.

Zipkin Cassandra clusters are expected to be dedicated clusters, therefore should be relatively free to upgrade.

The new datamodel takes advantage of MATERIALIZED VIEWS and SASI (b-tree secondary indexes).

It reduces 7 tables down to 2 tables. (Excluding the dependencies table.)

The new schema is…

```

CREATE TYPE IF NOT EXISTS endpoint (
    service_name text,
    ipv4         inet,
    ipv6         inet,
    port         smallint,
);

CREATE TYPE IF NOT EXISTS annotation (
    ts bigint,
    v  text,
    ep frozen<endpoint>
);

CREATE TYPE IF NOT EXISTS binary_annotation (
    k  text,
    v  blob,
    t  text,
    ep frozen<endpoint>
);

CREATE TABLE IF NOT EXISTS traces (
    trace_id            varint,
    ts_uuid             timeuuid,
    id                  bigint,
    ts                  bigint,
    span_name           text,
    parent_id           bigint,
    duration            bigint,
    annotations         list<frozen<annotation>>,
    binary_annotations  list<frozen<binary_annotation>>,
    all_annotations     text,
    PRIMARY KEY (trace_id, ts_uuid, id)
)
    WITH CLUSTERING ORDER BY (ts_uuid DESC)
    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
    AND default_time_to_live =  604800;


CREATE TABLE trace_by_service_span (
    service_name  text,      // service name
    span_name     text,      // span name, or blank for queries without span name
    bucket        int,       // time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1 day.
    ts            timeuuid,  // start timestamp of the span, truncated to millisecond precision
    trace_id      varint,    // trace ID
    duration      bigint,    // span duration, in microseconds
    PRIMARY KEY ((service_name, span_name, bucket), ts)
)
   WITH CLUSTERING ORDER BY (ts DESC)
    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
    AND default_time_to_live =  259200;


CREATE MATERIALIZED VIEW IF NOT EXISTS trace_by_service
    AS SELECT service_name, span_name, bucket, ts, trace_id FROM trace_by_service_span
            WHERE service_name is not null AND span_name is not null AND bucket is not null AND ts is not null
            PRIMARY KEY (service_name, bucket, span_name, ts)
        WITH CLUSTERING ORDER BY (bucket DESC, ts DESC)
    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
        AND default_time_to_live =  259200;

CREATE CUSTOM INDEX ON traces (all_annotations) USING 'org.apache.cassandra.index.sasi.SASIIndex'
   WITH OPTIONS = {
    'mode': 'CONTAINS',
    'analyzed': 'true',
    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.NonTokenizingAnalyzer',
    'case_sensitive': 'false'
   };

CREATE CUSTOM INDEX ON trace_by_service_span (duration) USING 'org.apache.cassandra.index.sasi.SASIIndex'
   WITH OPTIONS = {'mode': 'PREFIX'};
```
