### PR TITLE
Improves thrift encoding performance by special-casing ascii

### DIFF
--- a/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
@@ -51,8 +51,8 @@ import zipkin.Span;
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 10, time = 1)
 @Fork(3)
-@BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
 @Threads(1)
 public class CodecBenchmarks {

--- a/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
@@ -145,7 +145,7 @@ public final class ThriftCodec implements Codec {
       buffer.writeShort(value.port == null ? 0 : value.port);
 
       SERVICE_NAME.write(buffer);
-      buffer.writeUtf8(value.serviceName);
+      buffer.writeLengthPrefixed(value.serviceName);
 
       if (value.ipv6 != null) {
         IPV6.write(buffer);
@@ -192,7 +192,7 @@ public final class ThriftCodec implements Codec {
 
       if (value.value != null) {
         VALUE.write(buffer);
-        buffer.writeUtf8(value.value);
+        buffer.writeLengthPrefixed(value.value);
       }
 
       if (value.endpoint != null) {
@@ -237,7 +237,7 @@ public final class ThriftCodec implements Codec {
     @Override
     public void write(BinaryAnnotation value, Buffer buffer) {
       KEY.write(buffer);
-      buffer.writeUtf8(value.key);
+      buffer.writeLengthPrefixed(value.key);
 
       VALUE.write(buffer);
       buffer.writeInt(value.value.length);
@@ -312,7 +312,7 @@ public final class ThriftCodec implements Codec {
       buffer.writeLong(value.traceId);
 
       NAME.write(buffer);
-      buffer.writeUtf8(value.name);
+      buffer.writeLengthPrefixed(value.name);
 
       ID.write(buffer);
       buffer.writeLong(value.id);
@@ -387,10 +387,10 @@ public final class ThriftCodec implements Codec {
     @Override
     public void write(DependencyLink value, Buffer buffer) {
       PARENT.write(buffer);
-      buffer.writeUtf8(value.parent);
+      buffer.writeLengthPrefixed(value.parent);
 
       CHILD.write(buffer);
-      buffer.writeUtf8(value.child);
+      buffer.writeLengthPrefixed(value.child);
 
       CALL_COUNT.write(buffer);
       buffer.writeLong(value.callCount);


### PR DESCRIPTION
In many cases, annotation values are ascii strings. This special-cases
for this, improving thrift encoding performance dramatically.

This finally gets encoding overhead of a client span under 1 microsecond
  (on "my laptop")

Before:

```
Benchmark                                         Mode  Cnt  Score   Error  Units
CodecBenchmarks.writeClientSpan_thrift_zipkin     avgt   15  1.029 ± 0.041  us/op
CodecBenchmarks.writeLocalSpan_thrift_zipkin      avgt   15  0.741 ± 0.108  us/op
CodecBenchmarks.writeRpcSpan_thrift_zipkin        avgt   15  2.956 ± 0.128  us/op
CodecBenchmarks.writeRpcV6Span_thrift_zipkin      avgt   15  3.490 ± 0.104  us/op
```

After:

```
Benchmark                                         Mode  Cnt  Score   Error  Units
CodecBenchmarks.writeClientSpan_thrift_zipkin     avgt   15  0.779 ± 0.024  us/op
CodecBenchmarks.writeLocalSpan_thrift_zipkin      avgt   15  0.497 ± 0.026  us/op
CodecBenchmarks.writeRpcSpan_thrift_zipkin        avgt   15  2.018 ± 0.093  us/op
CodecBenchmarks.writeRpcV6Span_thrift_zipkin      avgt   15  2.407 ± 0.048  us/op
```
