### PR TITLE
Cuts thrift encoding overhead by allocating the correct sized array

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/Dependencies.java
+++ b/zipkin/src/main/java/zipkin/internal/Dependencies.java
@@ -126,6 +126,15 @@ public final class Dependencies {
       return Dependencies.create(startTs, endTs, links);
     }
 
+    @Override public int sizeInBytes(Dependencies value) {
+      int sizeInBytes = 0;
+      sizeInBytes += 3 + 8; // START_TS
+      sizeInBytes += 3 + 8; // END_TS
+      sizeInBytes += 3 + DEPENDENCY_LINKS_ADAPTER.sizeInBytes(value.links);
+      sizeInBytes++; //TYPE_STOP
+      return sizeInBytes;
+    }
+
     @Override
     public void write(Dependencies value, Buffer buffer) {
 

--- a/zipkin/src/test/java/zipkin/internal/BufferTest.java
+++ b/zipkin/src/test/java/zipkin/internal/BufferTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import org.junit.Test;
+
+public class BufferTest {
+
+  // Adapted from http://stackoverflow.com/questions/8511490/calculating-length-in-utf-8-of-java-string-without-actually-encoding-it
+  @Test public void testUtf8Len() {
+    for (int codepoint = 0; codepoint <= 0x10FFFF; codepoint++) {
+      if (codepoint == 0xD800) codepoint = 0xDFFF + 1; // skip surrogates
+      if (Character.isDefined(codepoint)) {
+        String test = new String(Character.toChars(codepoint));
+        int expected = test.getBytes(Util.UTF_8).length;
+        int actual = Buffer.utf8SizeInBytes(test);
+        if (actual != expected) {
+          throw new AssertionError(actual + " length != " + expected + " for " + codepoint);
+        }
+      }
+    }
+  }
+}

--- a/zipkin/src/test/java/zipkin/internal/ThriftCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/ThriftCodecTest.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import org.junit.Test;
-import zipkin.Codec;
 import zipkin.CodecTest;
 import zipkin.DependencyLink;
 import zipkin.Span;
@@ -41,6 +40,25 @@ public final class ThriftCodecTest extends CodecTest {
       assertThat(codec().readSpan(ByteBuffer.wrap(bytes)))
           .isEqualTo(span);
     }
+  }
+
+  @Test
+  public void sizeInBytes_span() throws IOException {
+    Span span = TestObjects.LOTS_OF_SPANS[0];
+    assertThat(ThriftCodec.SPAN_ADAPTER.sizeInBytes(span))
+        .isEqualTo(codec().writeSpan(span).length);
+  }
+
+  @Test
+  public void sizeInBytes_trace() throws IOException {
+    assertThat(ThriftCodec.SPANS_ADAPTER.sizeInBytes(TestObjects.TRACE))
+        .isEqualTo(codec().writeSpans(TestObjects.TRACE).length);
+  }
+
+  @Test
+  public void sizeInBytes_links() throws IOException {
+    assertThat(ThriftCodec.DEPENDENCY_LINKS_ADAPTER.sizeInBytes(TestObjects.LINKS))
+        .isEqualTo(codec().writeDependencyLinks(TestObjects.LINKS).length);
   }
 
   @Test


### PR DESCRIPTION
This computes the serialized length prior to serializing thrifts. Then,
a buffer of exactly the right size is allocated, avoiding growth via
rebuffering. The resulting array can be returned directly as it is the
correct length.

This is the last low-hanging fruit of thrift write optimization, and
results in ~4x higher efficiency than typical libthrift usage.

```
Benchmark                                         Mode  Cnt  Score   Error  Units
CodecBenchmarks.writeClientSpan_json_zipkin       avgt   15  17.165 ± 0.785  us/op
CodecBenchmarks.writeClientSpan_thrift_libthrift  avgt   15   2.112 ± 0.073  us/op
CodecBenchmarks.writeClientSpan_thrift_zipkin     avgt   15   0.488 ± 0.026  us/op
```
