### PR TITLE
Adds Codec.sizeInBytes and changes json to write fixed-length arrays

### DIFF
--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -81,7 +81,6 @@
                   <includes>
                     <include>com/google/gson/stream/JsonReader*.class</include>
                     <include>com/google/gson/stream/JsonToken.class</include>
-                    <include>com/google/gson/stream/JsonWriter.class</include>
                     <include>com/google/gson/stream/MalformedJsonException.class</include>
                     <include>com/google/gson/internal/JsonReaderInternalAccess.class</include>
                   </includes>

--- a/zipkin/src/main/java/zipkin/Codec.java
+++ b/zipkin/src/main/java/zipkin/Codec.java
@@ -28,6 +28,8 @@ public interface Codec {
   /** throws {@linkplain IllegalArgumentException} if the span couldn't be decoded */
   Span readSpan(byte[] bytes);
 
+  int sizeInBytes(Span value);
+
   byte[] writeSpan(Span value);
 
   /** throws {@linkplain IllegalArgumentException} if the spans couldn't be decoded */

--- a/zipkin/src/main/java/zipkin/internal/Base64.java
+++ b/zipkin/src/main/java/zipkin/internal/Base64.java
@@ -13,10 +13,8 @@
  */
 package zipkin.internal;
 
-import java.io.UnsupportedEncodingException;
-
 /**
- * copied from okio.Base64 as JRE 6 doesn't have a base64Url encoder
+ * Adapted from okio.Base64 as JRE 6 doesn't have a base64Url encoder
  *
  * @author Alexander Y. Kleymenov
  */
@@ -103,58 +101,5 @@ final class Base64 {
     byte[] prefix = new byte[outCount];
     System.arraycopy(out, 0, prefix, 0, outCount);
     return prefix;
-  }
-
-  private static final byte[] MAP = new byte[] {
-      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
-      'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
-      'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
-      '5', '6', '7', '8', '9', '+', '/'
-  };
-
-  private static final byte[] URL_MAP = new byte[] {
-      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
-      'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
-      'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
-      '5', '6', '7', '8', '9', '-', '_'
-  };
-
-  public static String encode(byte[] in) {
-    return encode(in, MAP);
-  }
-
-  public static String encodeUrl(byte[] in) {
-    return encode(in, URL_MAP);
-  }
-
-  private static String encode(byte[] in, byte[] map) {
-    int length = (in.length + 2) / 3 * 4;
-    byte[] out = new byte[length];
-    int index = 0, end = in.length - in.length % 3;
-    for (int i = 0; i < end; i += 3) {
-      out[index++] = map[(in[i] & 0xff) >> 2];
-      out[index++] = map[((in[i] & 0x03) << 4) | ((in[i + 1] & 0xff) >> 4)];
-      out[index++] = map[((in[i + 1] & 0x0f) << 2) | ((in[i + 2] & 0xff) >> 6)];
-      out[index++] = map[(in[i + 2] & 0x3f)];
-    }
-    switch (in.length % 3) {
-      case 1:
-        out[index++] = map[(in[end] & 0xff) >> 2];
-        out[index++] = map[(in[end] & 0x03) << 4];
-        out[index++] = '=';
-        out[index++] = '=';
-        break;
-      case 2:
-        out[index++] = map[(in[end] & 0xff) >> 2];
-        out[index++] = map[((in[end] & 0x03) << 4) | ((in[end + 1] & 0xff) >> 4)];
-        out[index++] = map[((in[end + 1] & 0x0f) << 2)];
-        out[index++] = '=';
-        break;
-    }
-    try {
-      return new String(out, "US-ASCII");
-    } catch (UnsupportedEncodingException e) {
-      throw new AssertionError(e);
-    }
   }
 }

--- a/zipkin/src/main/java/zipkin/internal/Buffer.java
+++ b/zipkin/src/main/java/zipkin/internal/Buffer.java
@@ -13,43 +13,40 @@
  */
 package zipkin.internal;
 
-import java.io.OutputStream;
-import java.util.Arrays;
+import static zipkin.internal.Util.checkArgument;
 
-/** Similar to {@link java.io.ByteArrayInputStream}, except specialized and unsynchronized */
-final class Buffer extends OutputStream {
-  static final int MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
-  private byte[] buf;
-  private int pos;
+final class Buffer {
+  interface Writer<T> {
+    int sizeInBytes(T value);
 
-  Buffer() {
-    this(128);
+    void write(T value, Buffer buffer);
   }
+
+  private final byte[] buf;
+  private int pos;
 
   Buffer(int size) {
     buf = new byte[size];
   }
 
-  @Override public void write(int v) {
-    ensureCapacity(pos + 1);
+  Buffer writeByte(int v) {
     buf[pos++] = (byte) v;
+    return this;
   }
 
-  @Override public void write(byte[] v) {
-    ensureCapacity(pos + v.length);
+  Buffer write(byte[] v) {
     System.arraycopy(v, 0, buf, pos, v.length);
     pos += v.length;
+    return this;
   }
 
   Buffer writeShort(int v) {
-    ensureCapacity(pos + 2);
-    write((v >>> 8L) & 0xff);
-    write(v & 0xff);
+    writeByte((v >>> 8L) & 0xff);
+    writeByte(v & 0xff);
     return this;
   }
 
   Buffer writeInt(int v) {
-    ensureCapacity(pos + 4);
     buf[pos++] = (byte) ((v >>> 24L) & 0xff);
     buf[pos++] = (byte) ((v >>> 16L) & 0xff);
     buf[pos++] = (byte) ((v >>> 8L) & 0xff);
@@ -58,7 +55,6 @@ final class Buffer extends OutputStream {
   }
 
   Buffer writeLong(long v) {
-    ensureCapacity(pos + 8);
     buf[pos++] = (byte) ((v >>> 56L) & 0xff);
     buf[pos++] = (byte) ((v >>> 48L) & 0xff);
     buf[pos++] = (byte) ((v >>> 40L) & 0xff);
@@ -68,6 +64,10 @@ final class Buffer extends OutputStream {
     buf[pos++] = (byte) ((v >>> 8L) & 0xff);
     buf[pos++] = (byte) (v & 0xff);
     return this;
+  }
+
+  static int asciiSizeInBytes(String string) {
+    return string.length();
   }
 
   static int utf8SizeInBytes(String string) {
@@ -105,7 +105,6 @@ final class Buffer extends OutputStream {
 
   Buffer writeAscii(String v) {
     int length = v.length();
-    ensureCapacity(pos + length);
     for (char i = 0; i < length; i++) {
       buf[pos++] = (byte) v.charAt(i);
     }
@@ -121,24 +120,191 @@ final class Buffer extends OutputStream {
     return true;
   }
 
-  byte[] toByteArray() {
-    if (pos == buf.length) return buf;
-    return Arrays.copyOf(buf, pos);
+  Buffer writeUtf8(String v) {
+    if (isAscii(v)) return writeAscii(v);
+    byte[] temp = v.getBytes(Util.UTF_8);
+    write(temp);
+    return this;
   }
 
-  /** Doubles up to {@link #MAX_ARRAY_LENGTH} if necessary */
-  private void ensureCapacity(int length) {
-    if (length <= buf.length) return;
-    if (length >= MAX_ARRAY_LENGTH) throw new OutOfMemoryError();
+  Buffer writeLowerHex(long v) {
+    writeHexByte((byte) ((v >>> 56L) & 0xff));
+    writeHexByte((byte) ((v >>> 48L) & 0xff));
+    writeHexByte((byte) ((v >>> 40L) & 0xff));
+    writeHexByte((byte) ((v >>> 32L) & 0xff));
+    writeHexByte((byte) ((v >>> 24L) & 0xff));
+    writeHexByte((byte) ((v >>> 16L) & 0xff));
+    writeHexByte((byte) ((v >>> 8L) & 0xff));
+    writeHexByte((byte) (v & 0xff));
+    return this;
+  }
 
-    int newLength = buf.length;
-    while (newLength < length) {
-      newLength = newLength * 2;
-      if (newLength > Integer.MAX_VALUE) {
-        newLength = MAX_ARRAY_LENGTH;
+  // the code to get the size of ipv6 is long and basically the same as encoding it.
+  static int ipv6SizeInBytes(byte[] ipv6) {
+    int result = IPV6_SIZE.get().writeIpV6(ipv6).pos;
+    IPV6_SIZE.get().pos = 0;
+    return result;
+  }
+
+  private static final ThreadLocal<Buffer> IPV6_SIZE = new ThreadLocal<Buffer>() {
+    @Override protected Buffer initialValue() {
+      return new Buffer(39); // maximum length of encoded ipv6
+    }
+  };
+
+  Buffer writeIpV6(byte[] ipv6) {
+    // Compress the longest string of zeros
+    int zeroCompressionIndex = -1;
+    int zeroCompressionLength = -1;
+    int zeroIndex = -1;
+    boolean allZeros = true;
+    for (int i = 0; i < ipv6.length; i += 2) {
+      if (ipv6[i] == 0 && ipv6[i + 1] == 0) {
+        if (zeroIndex < 0) zeroIndex = i;
+        continue;
+      }
+      allZeros = false;
+      if (zeroIndex >= 0) {
+        int zeroLength = i - zeroIndex;
+        if (zeroLength > zeroCompressionLength) {
+          zeroCompressionIndex = zeroIndex;
+          zeroCompressionLength = zeroLength;
+        }
+        zeroIndex = -1;
       }
     }
 
-    buf = Arrays.copyOf(buf, newLength);
+    // handle all zeros: 0:0:0:0:0:0:0:0 -> ::
+    if (allZeros) {
+      buf[pos++] = ':';
+      buf[pos++] = ':';
+      return this;
+    }
+
+    // handle trailing zeros: 2001:0:0:4:0:0:0:0 -> 2001:0:0:4::
+    if (zeroCompressionIndex == -1 && zeroIndex != -1) {
+      zeroCompressionIndex = zeroIndex;
+      zeroCompressionLength = 16 - zeroIndex;
+    }
+
+    int i = 0;
+    while (i < ipv6.length) {
+      if (i == zeroCompressionIndex) {
+        buf[pos++] = ':';
+        i += zeroCompressionLength;
+        if (i == ipv6.length) buf[pos++] = ':';
+        continue;
+      }
+      if (i != 0) buf[pos++] = ':';
+
+      byte high = ipv6[i++];
+      byte low = ipv6[i++];
+
+      // handle leading zeros: 2001:0:0:4:0000:0:0:8 -> 2001:0:0:4::8
+      boolean leadingZero;
+      byte val = HEX_DIGITS[(high >> 4) & 0xf];
+      if (!(leadingZero = val == '0')) buf[pos++] = val;
+      val = HEX_DIGITS[high & 0xf];
+      if (!(leadingZero = (leadingZero && val == '0'))) buf[pos++] = val;
+      val = HEX_DIGITS[(low >> 4) & 0xf];
+      if (!(leadingZero && val == '0')) buf[pos++] = val;
+      buf[pos++] = HEX_DIGITS[low & 0xf];
+    }
+    return this;
+  }
+
+  /**
+   * Binary search for character width which favors matching lower numbers.
+   *
+   * <p>Adapted from okio.Buffer
+   */
+  static int asciiSizeInBytes(long v) {
+    if (v == 0) return 1;
+    return //
+        v < 100000000L
+            ? v < 10000L
+            ? v < 100L
+            ? v < 10L ? 1 : 2
+            : v < 1000L ? 3 : 4
+            : v < 1000000L
+                ? v < 100000L ? 5 : 6
+                : v < 10000000L ? 7 : 8
+            : v < 1000000000000L
+                ? v < 10000000000L
+                ? v < 1000000000L ? 9 : 10
+                : v < 100000000000L ? 11 : 12
+                : v < 1000000000000000L
+                    ? v < 10000000000000L ? 13
+                    : v < 100000000000000L ? 14 : 15
+                    : v < 100000000000000000L
+                        ? v < 10000000000000000L ? 16 : 17
+                        : v < 1000000000000000000L ? 18 : 19;
+  }
+
+  Buffer writeAscii(long v) {
+    if (v == 0) return writeByte('0');
+    checkArgument(v > 0, "Expected %s to be unsigned", v);
+    int width = asciiSizeInBytes(v);
+    int pos = this.pos += width; // We write backwards from right to left.
+    while (v != 0) {
+      int digit = (int) (v % 10);
+      buf[--pos] = HEX_DIGITS[digit];
+      v /= 10;
+    }
+    return this;
+  }
+
+  static final byte[] HEX_DIGITS =
+      {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+  void writeHexByte(byte b) {
+    buf[pos++] = HEX_DIGITS[(b >> 4) & 0xf];
+    buf[pos++] = HEX_DIGITS[b & 0xf];
+  }
+
+  static final byte[] URL_MAP = new byte[] {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+      'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+      'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
+      '5', '6', '7', '8', '9', '-', '_'
+  };
+
+  static int base64UrlSizeInBytes(byte[] in) {
+    return (in.length + 2) / 3 * 4;
+  }
+
+  /**
+   * Adapted from okio.Base64 as JRE 6 doesn't have a base64Url encoder
+   *
+   * <p>Original author: Alexander Y. Kleymenov
+   */
+  Buffer writeBase64Url(byte[] in) {
+    int end = in.length - in.length % 3;
+    for (int i = 0; i < end; i += 3) {
+      buf[pos++] = URL_MAP[(in[i] & 0xff) >> 2];
+      buf[pos++] = URL_MAP[((in[i] & 0x03) << 4) | ((in[i + 1] & 0xff) >> 4)];
+      buf[pos++] = URL_MAP[((in[i + 1] & 0x0f) << 2) | ((in[i + 2] & 0xff) >> 6)];
+      buf[pos++] = URL_MAP[(in[i + 2] & 0x3f)];
+    }
+    switch (in.length % 3) {
+      case 1:
+        buf[pos++] = URL_MAP[(in[end] & 0xff) >> 2];
+        buf[pos++] = URL_MAP[(in[end] & 0x03) << 4];
+        buf[pos++] = '=';
+        buf[pos++] = '=';
+        break;
+      case 2:
+        buf[pos++] = URL_MAP[(in[end] & 0xff) >> 2];
+        buf[pos++] = URL_MAP[((in[end] & 0x03) << 4) | ((in[end + 1] & 0xff) >> 4)];
+        buf[pos++] = URL_MAP[((in[end + 1] & 0x0f) << 2)];
+        buf[pos++] = '=';
+        break;
+    }
+    return this;
+  }
+
+  byte[] toByteArray() {
+    //assert pos == buf.length;
+    return buf;
   }
 }

--- a/zipkin/src/main/java/zipkin/internal/Dependencies.java
+++ b/zipkin/src/main/java/zipkin/internal/Dependencies.java
@@ -147,7 +147,7 @@ public final class Dependencies {
       LINKS.write(buffer);
       DEPENDENCY_LINKS_ADAPTER.write(value.links, buffer);
 
-      buffer.write(TYPE_STOP);
+      buffer.writeByte(TYPE_STOP);
     }
 
     @Override

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -15,13 +15,11 @@ package zipkin.internal;
 
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
 import com.google.gson.stream.MalformedJsonException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.net.InetAddress;
+import java.net.Inet6Address;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Iterator;
@@ -36,9 +34,14 @@ import zipkin.Endpoint;
 import zipkin.Span;
 
 import static java.lang.Double.doubleToRawLongBits;
+import static zipkin.internal.Buffer.asciiSizeInBytes;
+import static zipkin.internal.Buffer.base64UrlSizeInBytes;
+import static zipkin.internal.Buffer.ipv6SizeInBytes;
+import static zipkin.internal.Buffer.utf8SizeInBytes;
 import static zipkin.internal.Util.UTF_8;
 import static zipkin.internal.Util.assertionError;
 import static zipkin.internal.Util.checkArgument;
+import static zipkin.internal.Util.lowerHexToUnsignedLong;
 
 /**
  * This explicitly constructs instances of model classes via manual parsing for a number of
@@ -56,18 +59,6 @@ import static zipkin.internal.Util.checkArgument;
  * this should be easy to justify as these objects don't change much at all.
  */
 public final class JsonCodec implements Codec {
-  static final JsonAdapter<Long> HEX_LONG_ADAPTER = new JsonAdapter<Long>() {
-    @Override
-    public Long fromJson(JsonReader reader) throws IOException {
-      return Util.lowerHexToUnsignedLong(reader.nextString());
-    }
-
-    @Override
-    public void toJson(JsonWriter writer, Long value) throws IOException {
-      writer.value(Util.toLowerHex(value));
-    }
-  };
-
   static final JsonAdapter<Endpoint> ENDPOINT_ADAPTER = new JsonAdapter<Endpoint>() {
     @Override
     public Endpoint fromJson(JsonReader reader) throws IOException {
@@ -80,15 +71,14 @@ public final class JsonCodec implements Codec {
         } else if (nextName.equals("ipv4")) {
           String[] ipv4String = reader.nextString().split("\\.", 5);
           int ipv4 = 0;
-          for (String b : ipv4String) {
-            ipv4 = ipv4 << 8 | (Integer.parseInt(b) & 0xff);
+          for (String part : ipv4String) {
+            ipv4 = ipv4 << 8 | (Integer.parseInt(part) & 0xff);
           }
           result.ipv4(ipv4);
         } else if (nextName.equals("ipv6")) {
           String input = reader.nextString();
           // Shouldn't hit DNS, because it's an IP string literal.
-          byte[] ipv6 = InetAddress.getByName(input).getAddress();
-          result.ipv6(ipv6);
+          result.ipv6(Inet6Address.getByName(input).getAddress());
         } else if (nextName.equals("port")) {
           result.port((short) reader.nextInt());
         } else {
@@ -99,55 +89,45 @@ public final class JsonCodec implements Codec {
       return result.build();
     }
 
-    @Override
-    public void toJson(JsonWriter writer, Endpoint value) throws IOException {
-      writer.beginObject();
-      writer.name("serviceName").value(value.serviceName);
-      String ipv4 = String.format("%d.%d.%d.%d",
-          value.ipv4 >> 24 & 0xff,
-          value.ipv4 >> 16 & 0xff,
-          value.ipv4 >> 8 & 0xff,
-          value.ipv4 & 0xff
-      );
-      writer.name("ipv4").value(ipv4);
-      if (value.port != null) {
-        int port = value.port & 0xffff;
-        if (port != 0) writer.name("port").value(port);
+    @Override public int sizeInBytes(Endpoint value) {
+      int sizeInBytes = 0;
+      sizeInBytes += asciiSizeInBytes(",\"endpoint\":{\"serviceName\":\"");
+      sizeInBytes += utf8SizeInBytes(value.serviceName) + 1; // for end quote
+      if (value.ipv4 != 0) {
+        sizeInBytes += asciiSizeInBytes(",\"ipv4\":\"");
+        sizeInBytes += asciiSizeInBytes(value.ipv4 >> 24 & 0xff) + 1; // for dot
+        sizeInBytes += asciiSizeInBytes(value.ipv4 >> 16 & 0xff) + 1; // for dot
+        sizeInBytes += asciiSizeInBytes(value.ipv4 >> 8 & 0xff) + 1; // for dot
+        sizeInBytes += asciiSizeInBytes(value.ipv4 & 0xff) + 1; // for end quote
+      }
+      if (value.port != null && value.port != 0) {
+        sizeInBytes += asciiSizeInBytes(",\"port\":") + asciiSizeInBytes(value.port & 0xffff);
       }
       if (value.ipv6 != null) {
-        writer.name("ipv6").value(InetAddress.getByAddress(value.ipv6).getHostAddress());
+        sizeInBytes += asciiSizeInBytes(",\"ipv6\":\"") + ipv6SizeInBytes(value.ipv6) + 1;
       }
-      writer.endObject();
-    }
-  }.nullSafe();
-
-  static final JsonAdapter<Long> NULLABLE_LONG_ADAPTER = new JsonAdapter<Long>() {
-    @Override public Long fromJson(JsonReader reader) throws IOException {
-      return reader.nextLong();
+      return ++sizeInBytes;// end curly-brace
     }
 
-    @Override public void toJson(JsonWriter writer, Long value) throws IOException {
-      writer.value(value.longValue());
+    @Override public void write(Endpoint value, Buffer b) {
+      b.writeAscii(",\"endpoint\":{\"serviceName\":\"");
+      b.writeUtf8(value.serviceName).writeByte('"');
+      if (value.ipv4 != 0) {
+        b.writeAscii(",\"ipv4\":\"");
+        b.writeAscii(value.ipv4 >> 24 & 0xff).writeByte('.');
+        b.writeAscii(value.ipv4 >> 16 & 0xff).writeByte('.');
+        b.writeAscii(value.ipv4 >> 8 & 0xff).writeByte('.');
+        b.writeAscii(value.ipv4 & 0xff).writeByte('"');
+      }
+      if (value.port != null && value.port != 0) {
+        b.writeAscii(",\"port\":").writeAscii(value.port & 0xffff);
+      }
+      if (value.ipv6 != null) {
+        b.writeAscii(",\"ipv6\":\"").writeIpV6(value.ipv6).writeByte('"');
+      }
+      b.writeByte('}');
     }
-
-    @Override public String toString() {
-      return "Long";
-    }
-  }.nullSafe();
-
-  static final JsonAdapter<Boolean> NULLABLE_BOOLEAN_ADAPTER = new JsonAdapter<Boolean>() {
-    @Override public Boolean fromJson(JsonReader reader) throws IOException {
-      return reader.nextBoolean();
-    }
-
-    @Override public void toJson(JsonWriter writer, Boolean value) throws IOException {
-      writer.value(value.booleanValue());
-    }
-
-    @Override public String toString() {
-      return "Boolean";
-    }
-  }.nullSafe();
+  };
 
   static final JsonAdapter<Annotation> ANNOTATION_ADAPTER = new JsonAdapter<Annotation>() {
     @Override
@@ -160,7 +140,7 @@ public final class JsonCodec implements Codec {
           result.timestamp(reader.nextLong());
         } else if (nextName.equals("value")) {
           result.value(reader.nextString());
-        } else if (nextName.equals("endpoint")) {
+        } else if (nextName.equals("endpoint") && reader.peek() != JsonToken.NULL) {
           result.endpoint(ENDPOINT_ADAPTER.fromJson(reader));
         } else {
           reader.skipValue();
@@ -170,26 +150,23 @@ public final class JsonCodec implements Codec {
       return result.build();
     }
 
-    @Override
-    public void toJson(JsonWriter writer, Annotation value) throws IOException {
-      writer.beginObject();
-      writer.name("timestamp").value(value.timestamp);
-      writer.name("value").value(value.value);
-      if (value.endpoint != null) {
-        writer.name("endpoint");
-        ENDPOINT_ADAPTER.toJson(writer, value.endpoint);
-      }
-      writer.endObject();
+    @Override public int sizeInBytes(Annotation value) {
+      int sizeInBytes = 0;
+      sizeInBytes += asciiSizeInBytes("{\"timestamp\":") + asciiSizeInBytes(value.timestamp);
+      sizeInBytes += asciiSizeInBytes(",\"value\":\"") + utf8SizeInBytes(value.value) + 1;
+      if (value.endpoint != null) sizeInBytes += ENDPOINT_ADAPTER.sizeInBytes(value.endpoint);
+      return ++sizeInBytes;// end curly-brace
     }
 
-    @Override
-    public String toString() {
-      return "Annotation";
+    @Override public void write(Annotation value, Buffer b) {
+      b.writeAscii("{\"timestamp\":").writeAscii(value.timestamp);
+      b.writeAscii(",\"value\":\"").writeUtf8(value.value).writeByte('"');
+      if (value.endpoint != null) ENDPOINT_ADAPTER.write(value.endpoint, b);
+      b.writeByte('}');
     }
   };
 
   static final JsonAdapter<BinaryAnnotation> BINARY_ANNOTATION_ADAPTER = new JsonAdapter<BinaryAnnotation>() {
-
     @Override
     public BinaryAnnotation fromJson(JsonReader reader) throws IOException {
       BinaryAnnotation.Builder result = BinaryAnnotation.builder();
@@ -220,7 +197,7 @@ public final class JsonCodec implements Codec {
           }
         } else if (nextName.equals("type")) {
           type = Type.valueOf(reader.nextString());
-        } else if (nextName.equals("endpoint")) {
+        } else if (nextName.equals("endpoint") && reader.peek() != JsonToken.NULL) {
           result.endpoint(ENDPOINT_ADAPTER.fromJson(reader));
         } else {
           reader.skipValue();
@@ -254,43 +231,75 @@ public final class JsonCodec implements Codec {
       return result.value(value).build();
     }
 
-    @Override
-    public void toJson(JsonWriter writer, BinaryAnnotation value) throws IOException {
-      writer.beginObject();
-      writer.name("key").value(value.key);
-      writer.name("value");
+    @Override public int sizeInBytes(BinaryAnnotation value) {
+      int sizeInBytes = 0;
+      sizeInBytes += asciiSizeInBytes("{\"key\":\"") + utf8SizeInBytes(value.key);
+      sizeInBytes += asciiSizeInBytes("\",\"value\":");
       switch (value.type) {
         case BOOL:
-          writer.value(value.value[0] == 1);
+          sizeInBytes += asciiSizeInBytes(value.value[0] == 1 ? "true" : "false");
           break;
         case STRING:
-          writer.value(new String(value.value, UTF_8));
+          sizeInBytes += value.value.length +2; //for quotes
           break;
         case BYTES:
-          writer.value(Base64.encodeUrl(value.value));
+          sizeInBytes += base64UrlSizeInBytes(value.value) +2; //for quotes
           break;
         case I16:
-          writer.value(ByteBuffer.wrap(value.value).getShort());
+          sizeInBytes += asciiSizeInBytes(ByteBuffer.wrap(value.value).getShort());
           break;
         case I32:
-          writer.value(ByteBuffer.wrap(value.value).getInt());
+          sizeInBytes += asciiSizeInBytes(ByteBuffer.wrap(value.value).getInt());
           break;
         case I64:
-          writer.value(ByteBuffer.wrap(value.value).getLong());
+          sizeInBytes += asciiSizeInBytes(ByteBuffer.wrap(value.value).getLong());
           break;
         case DOUBLE:
-          writer.value(Double.longBitsToDouble(ByteBuffer.wrap(value.value).getLong()));
+          double wrapped = Double.longBitsToDouble(ByteBuffer.wrap(value.value).getLong());
+          sizeInBytes += asciiSizeInBytes(Double.toString(wrapped));
           break;
         default:
       }
-      if (value.type != Type.STRING && value.type != Type.BOOL) {
-        writer.name("type").value(value.type.name());
+      if (value.type != BinaryAnnotation.Type.STRING && value.type != BinaryAnnotation.Type.BOOL) {
+        sizeInBytes += asciiSizeInBytes(",\"type\":\"") + utf8SizeInBytes(value.type.name()) + 1;
       }
-      if (value.endpoint != null) {
-        writer.name("endpoint");
-        ENDPOINT_ADAPTER.toJson(writer, value.endpoint);
+      if (value.endpoint != null) sizeInBytes += ENDPOINT_ADAPTER.sizeInBytes(value.endpoint);
+      return ++sizeInBytes;// end curly-brace
+    }
+
+    @Override public void write(BinaryAnnotation value, Buffer b) {
+      b.writeAscii("{\"key\":\"").writeUtf8(value.key);
+      b.writeAscii("\",\"value\":");
+      switch (value.type) {
+        case BOOL:
+          b.writeAscii(value.value[0] == 1 ? "true" : "false");
+          break;
+        case STRING:
+          b.writeByte('"').write(value.value).writeByte('"');
+          break;
+        case BYTES:
+          b.writeByte('"').writeBase64Url(value.value).writeByte('"');
+          break;
+        case I16:
+          b.writeAscii(ByteBuffer.wrap(value.value).getShort());
+          break;
+        case I32:
+          b.writeAscii(ByteBuffer.wrap(value.value).getInt());
+          break;
+        case I64:
+          b.writeAscii(ByteBuffer.wrap(value.value).getLong());
+          break;
+        case DOUBLE:
+          double wrapped = Double.longBitsToDouble(ByteBuffer.wrap(value.value).getLong());
+          b.writeAscii(Double.toString(wrapped));
+          break;
+        default:
       }
-      writer.endObject();
+      if (value.type != BinaryAnnotation.Type.STRING && value.type != BinaryAnnotation.Type.BOOL) {
+        b.writeAscii(",\"type\":\"").writeAscii(value.type.name()).writeByte('"');
+      }
+      if (value.endpoint != null) ENDPOINT_ADAPTER.write(value.endpoint, b);
+      b.writeByte('}');
     }
   };
 
@@ -302,21 +311,17 @@ public final class JsonCodec implements Codec {
       while (reader.hasNext()) {
         String nextName = reader.nextName();
         if (nextName.equals("traceId")) {
-          result.traceId(HEX_LONG_ADAPTER.fromJson(reader));
+          result.traceId(lowerHexToUnsignedLong(reader.nextString()));
         } else if (nextName.equals("name")) {
           result.name(reader.nextString());
         } else if (nextName.equals("id")) {
-          result.id(HEX_LONG_ADAPTER.fromJson(reader));
-        } else if (nextName.equals("parentId")) {
-          if (reader.peek() != JsonToken.NULL) {
-            result.parentId(HEX_LONG_ADAPTER.fromJson(reader));
-          } else {
-            reader.skipValue();
-          }
-        } else if (nextName.equals("timestamp")) {
-          result.timestamp(NULLABLE_LONG_ADAPTER.fromJson(reader));
-        } else if (nextName.equals("duration")) {
-          result.duration(NULLABLE_LONG_ADAPTER.fromJson(reader));
+          result.id(lowerHexToUnsignedLong(reader.nextString()));
+        } else if (nextName.equals("parentId") && reader.peek() != JsonToken.NULL) {
+          result.parentId(lowerHexToUnsignedLong(reader.nextString()));
+        } else if (nextName.equals("timestamp") && reader.peek() != JsonToken.NULL) {
+          result.timestamp(reader.nextLong());
+        } else if (nextName.equals("duration") && reader.peek() != JsonToken.NULL) {
+          result.duration(reader.nextLong());
         } else if (nextName.equals("annotations")) {
           reader.beginArray();
           while (reader.hasNext()) {
@@ -329,8 +334,8 @@ public final class JsonCodec implements Codec {
             result.addBinaryAnnotation(BINARY_ANNOTATION_ADAPTER.fromJson(reader));
           }
           reader.endArray();
-        } else if (nextName.equals("debug")) {
-          result.debug(NULLABLE_BOOLEAN_ADAPTER.fromJson(reader));
+        } else if (nextName.equals("debug") && reader.peek() != JsonToken.NULL) {
+          if (reader.nextBoolean()) result.debug(true);
         } else {
           reader.skipValue();
         }
@@ -339,44 +344,62 @@ public final class JsonCodec implements Codec {
       return result.build();
     }
 
-    @Override
-    public void toJson(JsonWriter writer, Span value) throws IOException {
-      writer.beginObject();
-      writer.name("traceId");
-      HEX_LONG_ADAPTER.toJson(writer, value.traceId);
-      writer.name("name").value(value.name);
-      writer.name("id");
-      HEX_LONG_ADAPTER.toJson(writer, value.id);
+    @Override public int sizeInBytes(Span value) {
+      int sizeInBytes = 0;
+      sizeInBytes += asciiSizeInBytes("{\"traceId\":\"") + 16; // fixed-width hex
+      sizeInBytes += asciiSizeInBytes("\",\"id\":\"") + 16;
+      sizeInBytes += asciiSizeInBytes("\",\"name\":\"") + utf8SizeInBytes(value.name) + 1;
       if (value.parentId != null) {
-        writer.name("parentId");
-        HEX_LONG_ADAPTER.toJson(writer, value.parentId);
+        sizeInBytes += asciiSizeInBytes(",\"parentId\":\"") + 16 + 1;
       }
       if (value.timestamp != null) {
-        writer.name("timestamp").value(value.timestamp);
+        sizeInBytes += asciiSizeInBytes(",\"timestamp\":") + asciiSizeInBytes(value.timestamp);
       }
       if (value.duration != null) {
-        writer.name("duration").value(value.duration);
+        sizeInBytes += asciiSizeInBytes(",\"duration\":") + asciiSizeInBytes(value.duration);
       }
-      writer.name("annotations");
-      writer.beginArray();
-      for (int i = 0, length = value.annotations.size(); i < length; i++) {
-        ANNOTATION_ADAPTER.toJson(writer, value.annotations.get(i));
+      if (!value.annotations.isEmpty()) {
+        sizeInBytes += asciiSizeInBytes(",\"annotations\":");
+        sizeInBytes += JsonCodec.sizeInBytes(ANNOTATION_ADAPTER, value.annotations);
       }
-      writer.endArray();
-      writer.name("binaryAnnotations");
-      writer.beginArray();
-      for (int i = 0, length = value.binaryAnnotations.size(); i < length; i++) {
-        BINARY_ANNOTATION_ADAPTER.toJson(writer, value.binaryAnnotations.get(i));
+      if (!value.binaryAnnotations.isEmpty()) {
+        sizeInBytes += asciiSizeInBytes(",\"binaryAnnotations\":");
+        sizeInBytes += JsonCodec.sizeInBytes(BINARY_ANNOTATION_ADAPTER, value.binaryAnnotations);
       }
-      writer.endArray();
-      if (value.debug != null) {
-        writer.name("debug").value(value.debug);
+      if (value.debug != null && value.debug) {
+        sizeInBytes += asciiSizeInBytes(",\"debug\":true");
       }
-      writer.endObject();
+      return ++sizeInBytes;// end curly-brace
     }
 
-    @Override
-    public String toString() {
+    @Override public void write(Span value, Buffer b) {
+      b.writeAscii("{\"traceId\":\"").writeLowerHex(value.traceId);
+      b.writeAscii("\",\"id\":\"").writeLowerHex(value.id);
+      b.writeAscii("\",\"name\":\"").writeUtf8(value.name).writeByte('"');
+      if (value.parentId != null) {
+        b.writeAscii(",\"parentId\":\"").writeLowerHex(value.parentId).writeByte('"');
+      }
+      if (value.timestamp != null) {
+        b.writeAscii(",\"timestamp\":").writeAscii(value.timestamp);
+      }
+      if (value.duration != null) {
+        b.writeAscii(",\"duration\":").writeAscii(value.duration);
+      }
+      if (!value.annotations.isEmpty()) {
+        b.writeAscii(",\"annotations\":");
+        writeList(ANNOTATION_ADAPTER, value.annotations, b);
+      }
+      if (!value.binaryAnnotations.isEmpty()) {
+        b.writeAscii(",\"binaryAnnotations\":");
+        writeList(BINARY_ANNOTATION_ADAPTER, value.binaryAnnotations, b);
+      }
+      if (value.debug != null && value.debug) {
+        b.writeAscii(",\"debug\":true");
+      }
+      b.writeByte('}');
+    }
+
+    @Override public String toString() {
       return "Span";
     }
   };
@@ -391,13 +414,13 @@ public final class JsonCodec implements Codec {
     }
   }
 
+  @Override public int sizeInBytes(Span value) {
+    return SPAN_ADAPTER.sizeInBytes(value);
+  }
+
   @Override
   public byte[] writeSpan(Span value) {
-    Buffer out = new Buffer();
-    JsonWriter writer = new JsonWriter(new OutputStreamWriter(out));
-    write(SPAN_ADAPTER, value, writer);
-    closeQuietly(writer);
-    return out.toByteArray();
+    return write(SPAN_ADAPTER, value);
   }
 
   @Override
@@ -408,30 +431,31 @@ public final class JsonCodec implements Codec {
 
   @Override
   public byte[] writeSpans(List<Span> value) {
-    return writeList(SPAN_ADAPTER, value);
+    if (value.isEmpty()) return new byte[] {'[', ']'};
+    Buffer result = new Buffer(sizeInBytes(SPAN_ADAPTER, value));
+    writeList(SPAN_ADAPTER, value, result);
+    return result.toByteArray();
   }
 
   @Override
   public byte[] writeTraces(List<List<Span>> traces) {
-    Buffer out = new Buffer();
-    JsonWriter writer = new JsonWriter(new OutputStreamWriter(out));
-    writer.setLenient(true); // multiple top-level values
-    out.write('['); // start list of traces
-    for (Iterator<List<Span>> trace = traces.iterator(); trace.hasNext(); ) {
-
-      out.write('['); // start trace
-      // write each span
-      for (Iterator<Span> span = trace.next().iterator(); span.hasNext(); ) {
-        write(SPAN_ADAPTER, span.next(), writer);
-        flushQuietly(writer);
-
-        if (span.hasNext()) out.write(',');
+    // Get the encoded size of the nested list so that we don't need to grow the buffer
+    int sizeInBytes = overheadInBytes(traces);
+    for (int i = 0; i < traces.size(); i++) {
+      List<Span> spans = traces.get(i);
+      sizeInBytes += overheadInBytes(spans);
+      for (int j = 0; j < spans.size(); j++) {
+        sizeInBytes += SPAN_ADAPTER.sizeInBytes(spans.get(j));
       }
-      out.write(']'); // stop trace
-
-      if (trace.hasNext()) out.write(',');
     }
-    out.write(']'); // stop list of traces
+
+    Buffer out = new Buffer(sizeInBytes);
+    out.writeByte('['); // start list of traces
+    for (Iterator<List<Span>> trace = traces.iterator(); trace.hasNext(); ) {
+      writeList(SPAN_ADAPTER, trace.next(), out);
+      if (trace.hasNext()) out.writeByte(',');
+    }
+    out.writeByte(']'); // stop list of traces
     return out.toByteArray();
   }
 
@@ -457,7 +481,6 @@ public final class JsonCodec implements Codec {
   }
 
   static final JsonAdapter<DependencyLink> DEPENDENCY_LINK_ADAPTER = new JsonAdapter<DependencyLink>() {
-
     @Override
     public DependencyLink fromJson(JsonReader reader) throws IOException {
       DependencyLink.Builder result = DependencyLink.builder();
@@ -478,25 +501,25 @@ public final class JsonCodec implements Codec {
       return result.build();
     }
 
-    @Override
-    public void toJson(JsonWriter writer, DependencyLink value) throws IOException {
-      writer.beginObject();
-      writer.name("parent").value(value.parent);
-      writer.name("child").value(value.child);
-      writer.name("callCount").value(value.callCount);
-      writer.endObject();
+    @Override public int sizeInBytes(DependencyLink value) {
+      int sizeInBytes = 0;
+      sizeInBytes += asciiSizeInBytes("{\"parent\":\"") + utf8SizeInBytes(value.parent);
+      sizeInBytes += asciiSizeInBytes("\",\"child\":\"") + utf8SizeInBytes(value.child);
+      sizeInBytes += asciiSizeInBytes("\",\"callCount\":") + asciiSizeInBytes(value.callCount);
+      return ++sizeInBytes;// end curly-brace
     }
 
-    @Override
-    public String toString() {
+    @Override public void write(DependencyLink value, Buffer b) {
+      b.writeAscii("{\"parent\":\"").writeUtf8(value.parent);
+      b.writeAscii("\",\"child\":\"").writeUtf8(value.child);
+      b.writeAscii("\",\"callCount\":").writeAscii(value.callCount).writeByte('}');
+    }
+
+    @Override public String toString() {
       return "DependencyLink";
     }
   };
 
-  // Added since JSON-based storage usually works better with single documents rather than
-  // a large encoded list.
-
-  /** throws {@linkplain IllegalArgumentException} if the dependency link couldn't be decoded */
   @Override
   public DependencyLink readDependencyLink(byte[] bytes) {
     checkArgument(bytes.length > 0, "Empty input reading DependencyLink");
@@ -507,15 +530,9 @@ public final class JsonCodec implements Codec {
     }
   }
 
-  // Added since JSON-based storage usually works better with single documents rather than
-  // a large encoded list.
   @Override
   public byte[] writeDependencyLink(DependencyLink value) {
-    Buffer out = new Buffer();
-    JsonWriter writer = new JsonWriter(new OutputStreamWriter(out));
-    write(DEPENDENCY_LINK_ADAPTER, value, writer);
-    closeQuietly(writer);
-    return out.toByteArray();
+    return write(DEPENDENCY_LINK_ADAPTER, value);
   }
 
   @Override
@@ -526,23 +543,24 @@ public final class JsonCodec implements Codec {
 
   @Override
   public byte[] writeDependencyLinks(List<DependencyLink> value) {
-    return writeList(DEPENDENCY_LINK_ADAPTER, value);
+    Buffer result = new Buffer(sizeInBytes(DEPENDENCY_LINK_ADAPTER, value));
+    writeList(DEPENDENCY_LINK_ADAPTER, value, result);
+    return result.toByteArray();
   }
 
   static final JsonAdapter<String> STRING_ADAPTER = new JsonAdapter<String>() {
+
     @Override
     public String fromJson(JsonReader reader) throws IOException {
       return reader.nextString();
     }
 
-    @Override
-    public void toJson(JsonWriter writer, String value) throws IOException {
-      writer.value(value);
+    @Override public int sizeInBytes(String value) {
+      return utf8SizeInBytes(value) + 2; // For quotes
     }
 
-    @Override
-    public String toString() {
-      return "String";
+    @Override public void write(String value, Buffer buffer) {
+      buffer.writeByte('"').writeUtf8(value).writeByte('"');
     }
   };
 
@@ -552,7 +570,9 @@ public final class JsonCodec implements Codec {
   }
 
   public byte[] writeStrings(List<String> value) {
-    return writeList(STRING_ADAPTER, value);
+    Buffer result = new Buffer(sizeInBytes(STRING_ADAPTER, value));
+    writeList(STRING_ADAPTER, value, result);
+    return result.toByteArray();
   }
 
   static <T> List<T> readList(JsonAdapter<T> adapter, byte[] bytes) {
@@ -579,45 +599,38 @@ public final class JsonCodec implements Codec {
     return new JsonReader(new InputStreamReader(new ByteArrayInputStream(bytes)));
   }
 
-  static <T> byte[] writeList(JsonAdapter<T> adapter, List<T> values) {
-    Buffer out = new Buffer();
-    JsonWriter writer = new JsonWriter(new OutputStreamWriter(out));
-    writer.setLenient(true); // multiple top-level values
-
-    out.write('[');
-    int length = values.size();
-    for (int i = 0; i < length; ) {
-      write(adapter, values.get(i++), writer);
-      flushQuietly(writer);
-      if (i < length) out.write(',');
-    }
-    out.write(']');
-    return out.toByteArray();
-  }
-
-  private static void flushQuietly(JsonWriter writer) {
-    try {
-      writer.flush();
-    } catch (IOException e) {
-      throw new AssertionError(e);
-    }
-  }
-
-  private static void closeQuietly(JsonWriter writer) {
-    try {
-      writer.close();
-    } catch (IOException e) {
-      throw new AssertionError(e);
-    }
-  }
-
   /** Inability to encode is a programming bug. */
-  static <T> void write(JsonAdapter<T> adapter, T value, JsonWriter writer) {
+  static <T> byte[] write(Buffer.Writer<T> writer, T value) {
+    Buffer b = new Buffer(writer.sizeInBytes(value));
     try {
-      adapter.toJson(writer, value);
-    } catch (Exception e) {
+      writer.write(value, b);
+    } catch (RuntimeException e) {
       throw assertionError("Could not write " + value + " as json", e);
     }
+    return b.toByteArray();
+  }
+
+  static <T> int sizeInBytes(Buffer.Writer<T> writer, List<T> value) {
+    int sizeInBytes = overheadInBytes(value);
+    for (int i = 0, length = value.size(); i < length; i++) {
+      sizeInBytes += writer.sizeInBytes(value.get(i));
+    }
+    return sizeInBytes;
+  }
+
+  static <T> int overheadInBytes(List<T> value) {
+    int sizeInBytes = 2; // brackets
+    if (value.size() > 1) sizeInBytes += value.size() - 1; // comma to join elements
+    return sizeInBytes;
+  }
+
+  static <T> void writeList(Buffer.Writer<T> writer, List<T> value, Buffer b) {
+    b.writeByte('[');
+    for (int i = 0, length = value.size(); i < length; ) {
+      writer.write(value.get(i++), b);
+      if (i < length) b.writeByte(',');
+    }
+    b.writeByte(']');
   }
 
   static IllegalArgumentException exceptionReading(String type, byte[] bytes, Exception e) {
@@ -627,37 +640,7 @@ public final class JsonCodec implements Codec {
     throw new IllegalArgumentException(message, e);
   }
 
-  static abstract class JsonAdapter<T> {
+  static abstract class JsonAdapter<T> implements Buffer.Writer<T> {
     abstract T fromJson(JsonReader reader) throws IOException;
-
-    public abstract void toJson(JsonWriter writer, T value) throws IOException;
-
-    /**
-     * Returns a JSON adapter equal to this JSON adapter, but with support for reading and writing
-     * nulls. Borrowed pattern from moshi
-     */
-    public final JsonAdapter<T> nullSafe() {
-      final JsonAdapter<T> delegate = this;
-      return new JsonAdapter<T>() {
-        @Override public T fromJson(JsonReader reader) throws IOException {
-          if (reader.peek() == JsonToken.NULL) {
-            reader.nextNull();
-            return null;
-          } else {
-            return delegate.fromJson(reader);
-          }
-        }
-        @Override public void toJson(JsonWriter writer, T value) throws IOException {
-          if (value == null) {
-            writer.nullValue();
-          } else {
-            delegate.toJson(writer, value);
-          }
-        }
-        @Override public String toString() {
-          return delegate + ".nullSafe()";
-        }
-      };
-    }
   }
 }

--- a/zipkin/src/test/java/zipkin/CodecTest.java
+++ b/zipkin/src/test/java/zipkin/CodecTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import zipkin.internal.JsonCodec;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +35,14 @@ public abstract class CodecTest {
       byte[] bytes = codec().writeSpan(span);
       assertThat(codec().readSpan(bytes))
           .isEqualTo(span);
+    }
+  }
+
+  @Test
+  public void sizeInBytes() throws IOException {
+    for (Span span : TestObjects.TRACE) {
+      assertThat(codec().sizeInBytes(span))
+          .isEqualTo(codec().writeSpan(span).length);
     }
   }
 

--- a/zipkin/src/test/java/zipkin/TestObjects.java
+++ b/zipkin/src/test/java/zipkin/TestObjects.java
@@ -24,9 +24,11 @@ import static java.util.stream.Collectors.toList;
 import static zipkin.Constants.CLIENT_ADDR;
 import static zipkin.Constants.CLIENT_RECV;
 import static zipkin.Constants.CLIENT_SEND;
+import static zipkin.Constants.ERROR;
 import static zipkin.Constants.SERVER_ADDR;
 import static zipkin.Constants.SERVER_RECV;
 import static zipkin.Constants.SERVER_SEND;
+import static zipkin.internal.Util.UTF_8;
 import static zipkin.internal.Util.midnightUTC;
 
 public final class TestObjects {
@@ -68,8 +70,10 @@ public final class TestObjects {
       Span.builder().traceId(WEB_SPAN_ID).parentId(APP_SPAN_ID).id(DB_SPAN_ID).name("query")
           .addAnnotation(Annotation.create((TODAY + 150) * 1000, CLIENT_SEND, APP_ENDPOINT))
           .addAnnotation(Annotation.create((TODAY + 200) * 1000, CLIENT_RECV, APP_ENDPOINT))
+          .addAnnotation(Annotation.create((TODAY + 200) * 1000, "⻩", APP_ENDPOINT))
           .addBinaryAnnotation(BinaryAnnotation.address(CLIENT_ADDR, APP_ENDPOINT))
           .addBinaryAnnotation(BinaryAnnotation.address(SERVER_ADDR, DB_ENDPOINT))
+          .addBinaryAnnotation(BinaryAnnotation.create(ERROR, "\uD83D\uDCA9", APP_ENDPOINT))
           .build()
   ).stream().map(ApplyTimestampAndDuration::apply).collect(toList());
 

--- a/zipkin/src/test/java/zipkin/internal/BufferTest.java
+++ b/zipkin/src/test/java/zipkin/internal/BufferTest.java
@@ -14,11 +14,14 @@
 package zipkin.internal;
 
 import org.junit.Test;
+import sun.net.util.IPAddressUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.internal.Util.UTF_8;
 
 public class BufferTest {
-
   // Adapted from http://stackoverflow.com/questions/8511490/calculating-length-in-utf-8-of-java-string-without-actually-encoding-it
-  @Test public void testUtf8Len() {
+  @Test public void utf8SizeInBytes() {
     for (int codepoint = 0; codepoint <= 0x10FFFF; codepoint++) {
       if (codepoint == 0xD800) codepoint = 0xDFFF + 1; // skip surrogates
       if (Character.isDefined(codepoint)) {
@@ -30,5 +33,48 @@ public class BufferTest {
         }
       }
     }
+  }
+
+  @Test public void emoji() {
+    byte[] emojiBytes = {(byte) 0xF0, (byte) 0x9F, (byte) 0x98, (byte) 0x81};
+    String emoji = new String(emojiBytes, UTF_8);
+    assertThat(Buffer.utf8SizeInBytes(emoji))
+        .isEqualTo(emojiBytes.length);
+    assertThat(new Buffer(emojiBytes.length).writeUtf8(emoji).toByteArray())
+        .isEqualTo(emojiBytes);
+  }
+
+  // Test borrowed from guava InetAddressesTest
+  @Test public void ipv6() {
+    assertThat(writeIpV6("1:2:3:4:5:6:7:8"))
+        .isEqualTo("1:2:3:4:5:6:7:8");
+    assertThat(writeIpV6("2001:0:0:4:0000:0:0:8"))
+        .isEqualTo("2001:0:0:4::8");
+    assertThat(writeIpV6("2001:0:0:4:5:6:7:8"))
+        .isEqualTo("2001::4:5:6:7:8");
+    assertThat(writeIpV6("2001:0:3:4:5:6:7:8"))
+        .isEqualTo("2001::3:4:5:6:7:8");
+    assertThat(writeIpV6("0:0:3:0:0:0:0:ffff"))
+        .isEqualTo("0:0:3::ffff");
+    assertThat(writeIpV6("0:0:0:4:0:0:0:ffff"))
+        .isEqualTo("::4:0:0:0:ffff");
+    assertThat(writeIpV6("0:0:0:0:5:0:0:ffff"))
+        .isEqualTo("::5:0:0:ffff");
+    assertThat(writeIpV6("1:0:0:4:0:0:7:8"))
+        .isEqualTo("1::4:0:0:7:8");
+    assertThat(writeIpV6("0:0:0:0:0:0:0:0"))
+        .isEqualTo("::");
+    assertThat(writeIpV6("0:0:0:0:0:0:0:1"))
+        .isEqualTo("::1");
+    assertThat(writeIpV6("2001:0658:022a:cafe::"))
+        .isEqualTo("2001:658:22a:cafe::");
+    assertThat(writeIpV6("::1.2.3.4"))
+        .isEqualTo("::102:304");
+  }
+
+  static String writeIpV6(String address) {
+    byte[] ipv6 = IPAddressUtil.textToNumericFormatV6(address);
+    byte[] buffered = new Buffer(Buffer.ipv6SizeInBytes(ipv6)).writeIpV6(ipv6).toByteArray();
+    return new String(buffered, UTF_8);
   }
 }

--- a/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
@@ -214,6 +214,19 @@ public final class JsonCodecTest extends CodecTest {
         .isEqualTo(span);
   }
 
+  @Test
+  public void sizeInBytes_span() throws IOException {
+    Span span = TestObjects.LOTS_OF_SPANS[0];
+    assertThat(JsonCodec.SPAN_ADAPTER.sizeInBytes(span))
+        .isEqualTo(codec().writeSpan(span).length);
+  }
+
+  @Test
+  public void sizeInBytes_link() throws IOException {
+    assertThat(JsonCodec.DEPENDENCY_LINK_ADAPTER.sizeInBytes(TestObjects.LINKS.get(0)))
+        .isEqualTo(codec().writeDependencyLink(TestObjects.LINKS.get(0)).length);
+  }
+
   static byte[] toBytes(long v) {
     okio.Buffer buffer = new okio.Buffer();
     buffer.writeLong(v);


### PR DESCRIPTION
This adds `Codec.sizeInBytes(Span)`, which is used to pre-allocate a
buffer to write the span into.

This changes the json encoder to use this approach, which drops its
encoding overhead by an order of magnitude:

Was:

```
Benchmark                                         Mode  Cnt  Score   Error  Units
CodecBenchmarks.writeClientSpan_json_zipkin       avgt   15  17.165 ± 0.785  us/op
```

Now, it is in the same order as thrift:

```
CodecBenchmarks.writeClientSpan_json_zipkin       avgt   15   1.445 ± 0.036  us/op
CodecBenchmarks.writeClientSpan_thrift_libthrift  avgt   15   1.951 ± 0.014  us/op
CodecBenchmarks.writeClientSpan_thrift_zipkin     avgt   15   0.433 ± 0.011  us/op
CodecBenchmarks.writeLocalSpan_json_zipkin        avgt   15   0.813 ± 0.010  us/op
CodecBenchmarks.writeLocalSpan_thrift_libthrift   avgt   15   1.191 ± 0.016  us/op
CodecBenchmarks.writeLocalSpan_thrift_zipkin      avgt   15   0.268 ± 0.004  us/op
CodecBenchmarks.writeRpcSpan_json_zipkin          avgt   15   3.606 ± 0.068  us/op
CodecBenchmarks.writeRpcSpan_thrift_libthrift     avgt   15   5.134 ± 0.081  us/op
CodecBenchmarks.writeRpcSpan_thrift_zipkin        avgt   15   1.384 ± 0.078  us/op
CodecBenchmarks.writeRpcV6Span_json_zipkin        avgt   15   3.912 ± 0.115  us/op
CodecBenchmarks.writeRpcV6Span_thrift_libthrift   avgt   15   5.488 ± 0.098  us/op
CodecBenchmarks.writeRpcV6Span_thrift_zipkin      avgt   15   1.323 ± 0.014  us/op
```
