### PR TITLE
Leniently reads span.annotations and span.binaryAnnotations in UI

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -15,7 +15,7 @@ export default component(function spanPanel() {
     this.$node.find('.service-names').text(span.serviceNames);
 
     const $annoBody = this.$node.find('#annotations tbody').text('');
-    $.each(span.annotations, (i, anno) => {
+    $.each((span.annotations || []), (i, anno) => {
       const $row = self.$annotationTemplate.clone();
       if (anno.value === Constants.ERROR) {
         $row.addClass('anno-error-transient');
@@ -34,7 +34,7 @@ export default component(function spanPanel() {
     });
 
     const $binAnnoBody = this.$node.find('#binaryAnnotations tbody').text('');
-    $.each(span.binaryAnnotations, (i, anno) => {
+    $.each((span.binaryAnnotations || []), (i, anno) => {
       const $row = self.$binaryAnnotationTemplate.clone();
       if (anno.key === Constants.ERROR) {
         $row.addClass('anno-error-critical');

--- a/zipkin-ui/js/component_ui/traceSummary.js
+++ b/zipkin-ui/js/component_ui/traceSummary.js
@@ -6,8 +6,8 @@ import {Constants} from './traceConstants';
 
 function endpointsForSpan(span) {
   return _.union(
-    span.annotations.map(a => a.endpoint),
-    span.binaryAnnotations.map(a => a.endpoint)
+    (span.annotations || []).map(a => a.endpoint),
+    (span.binaryAnnotations || []).map(a => a.endpoint)
   ).filter(h => h != null);
 }
 

--- a/zipkin-ui/js/component_ui/traceToMustache.js
+++ b/zipkin-ui/js/component_ui/traceToMustache.js
@@ -114,7 +114,7 @@ export default function traceToMustache(trace) {
       const width = (span.duration || 0) / summary.duration * 100;
       let errorType = 'none';
 
-      const binaryAnnotations = span.binaryAnnotations.map((a) => {
+      const binaryAnnotations = (span.binaryAnnotations || []).map((a) => {
         if (a.key === Constants.ERROR) {
           errorType = 'critical';
         }
@@ -140,7 +140,7 @@ export default function traceToMustache(trace) {
         }
       }
 
-      const localComponentAnnotation = _(span.binaryAnnotations)
+      const localComponentAnnotation = _(span.binaryAnnotations || [])
           .find((s) => s.key === Constants.LOCAL_COMPONENT);
       if (localComponentAnnotation && localComponentAnnotation.endpoint) {
         binaryAnnotations.push({
@@ -163,7 +163,7 @@ export default function traceToMustache(trace) {
         depth: (spanDepth + 1) * 5,
         depthClass: (spanDepth - 1) % 6,
         children: (groupByParentId[span.id] || []).map((s) => s.id).join(','),
-        annotations: span.annotations.map((a) => ({
+        annotations: (span.annotations || []).map((a) => ({
           isCore: Constants.CORE_ANNOTATIONS.indexOf(a.value) !== -1,
           left: (a.timestamp - spanStartTs) / span.duration * 100,
           endpoint: a.endpoint ? formatEndpoint(a.endpoint) : null,

--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -86,7 +86,6 @@ describe('get service name of a span', () => {
 
   it('should get service name from some server annotation', () => {
     const testSpan = {
-      binaryAnnotations: [],
       annotations: [{
         value: Constants.SERVER_RECEIVE_FRAGMENT,
         endpoint: {
@@ -375,25 +374,20 @@ describe('traceSummariesToMustache', () => {
       name: 'get',
       id: '6ff1c14161f7bde1',
       timestamp: 1457186441657000,
-      duration: 4000,
-      annotations: [], binaryAnnotations: []}]);
+      duration: 4000}]);
     const summary2 = traceSummary([{
       traceId: traceId2,
       name: 'get',
       id: '9ed44141f679130b',
       timestamp: 1457186568026000,
-      duration: 4000,
-      annotations: [],
-      binaryAnnotations: []
+      duration: 4000
     }]);
     const summary3 = traceSummary([{
       traceId: traceId3,
       name: 'get',
       id: '6677567324735',
       timestamp: 1457186568027000,
-      duration: 3000,
-      annotations: [],
-      binaryAnnotations: []
+      duration: 3000
     }]);
 
     const model = traceSummariesToMustache(null, [summary1, summary2, summary3]);

--- a/zipkin-ui/test/component_ui/traceToMustache.test.js
+++ b/zipkin-ui/test/component_ui/traceToMustache.test.js
@@ -96,6 +96,45 @@ describe('traceToMustache', () => {
     testSpan.annotations[1].value.should.equal('Server Send');
     testSpan.binaryAnnotations[0].key.should.equal('Server Address');
   });
+
+  it('should tolerate spans without annotations', () => {
+    const testTrace = [{
+      traceId: '2480ccca8df0fca5',
+      name: 'get',
+      id: '2480ccca8df0fca5',
+      timestamp: 1457186385375000,
+      duration: 333000,
+      binaryAnnotations: [{
+        key: 'lc',
+        value: 'component',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      }]
+    }];
+    const {spans: [testSpan]} = traceToMustache(testTrace);
+    testSpan.binaryAnnotations[0].key.should.equal('Local Component');
+  });
+
+  it('should tolerate spans without binary annotations', () => {
+    const testTrace = [{
+      traceId: '2480ccca8df0fca5',
+      name: 'get',
+      id: '2480ccca8df0fca5',
+      timestamp: 1457186385375000,
+      duration: 333000,
+      annotations: [{
+        timestamp: 1457186385375000,
+        value: 'sr',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      }, {
+        timestamp: 1457186385708000,
+        value: 'ss',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      }]
+    }];
+    const {spans: [testSpan]} = traceToMustache(testTrace);
+    testSpan.annotations[0].value.should.equal('Server Receive');
+    testSpan.annotations[1].value.should.equal('Server Send');
+  });
 });
 
 describe('get root spans', () => {


### PR DESCRIPTION
Before, only some branches of code guarded reads to `span.annotations`
and `span.binaryAnnotations`. This guards the rest.

The impact is that we now tolerate json that omits the array fields on
empty.

Fixes #1263
