### PR TITLE
Fix: pathspec 'gh-pages' did not match any file(s) known to git

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -126,6 +126,7 @@ javadoc_to_gh_pages() {
   done
 
   # Update gh-pages
+  git fetch origin
   git checkout gh-pages
   rm -rf "$version"
   mv "javadoc-builddir/$version" ./


### PR DESCRIPTION
As seen at https://travis-ci.org/openzipkin/zipkin/builds/156529896, javadoc publishing is currently broken. This is an attempt to fix it.
