### PR TITLE
Fixes regression writing I64 binary annotations

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -170,7 +170,7 @@ public final class JsonCodec implements Codec {
     @Override
     public BinaryAnnotation fromJson(JsonReader reader) throws IOException {
       BinaryAnnotation.Builder result = BinaryAnnotation.builder();
-      Double number = null;
+      String number = null;
       String string = null;
       Type type = Type.STRING;
       reader.beginObject();
@@ -188,7 +188,7 @@ public final class JsonCodec implements Codec {
               string = reader.nextString();
               break;
             case NUMBER:
-              number = reader.nextDouble();
+              number = reader.nextString();
               break;
             default:
               throw new MalformedJsonException(
@@ -217,13 +217,15 @@ public final class JsonCodec implements Codec {
       }
       final byte[] value;
       if (type == Type.I16) {
-        short v = number.shortValue();
+        short v = Short.parseShort(number);
         value = ByteBuffer.allocate(2).putShort(0, v).array();
       } else if (type == Type.I32) {
-        int v = number.intValue();
+        int v = Integer.parseInt(number);
         value = ByteBuffer.allocate(4).putInt(0, v).array();
       } else if (type == Type.I64 || type == Type.DOUBLE) {
-        long v = type == Type.I64 ? number.longValue() : doubleToRawLongBits(number);
+        long v = type == Type.I64
+            ? Long.parseLong(number)
+            : doubleToRawLongBits(Double.parseDouble(number));
         value = ByteBuffer.allocate(8).putLong(0, v).array();
       } else {
         throw new AssertionError("BinaryAnnotationType " + type + " was added, but not handled");

--- a/zipkin/src/test/java/zipkin/CodecTest.java
+++ b/zipkin/src/test/java/zipkin/CodecTest.java
@@ -14,11 +14,11 @@
 package zipkin;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import zipkin.internal.JsonCodec;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,6 +44,66 @@ public abstract class CodecTest {
       assertThat(codec().sizeInBytes(span))
           .isEqualTo(codec().writeSpan(span).length);
     }
+  }
+
+  @Test
+  public void binaryAnnotation_long() throws IOException {
+    Span span = TestObjects.LOTS_OF_SPANS[0].toBuilder().binaryAnnotations(asList(
+        BinaryAnnotation.builder()
+            .key("Long.zero")
+            .type(BinaryAnnotation.Type.I64)
+            .value(ByteBuffer.allocate(8).putLong(0, 0L).array())
+            .build(),
+        BinaryAnnotation.builder()
+            .key("Long.negative")
+            .type(BinaryAnnotation.Type.I64)
+            .value(ByteBuffer.allocate(8).putLong(0, -1005656679588439279L).array())
+            .build(),
+        BinaryAnnotation.builder()
+            .key("Long.MIN_VALUE")
+            .type(BinaryAnnotation.Type.I64)
+            .value(ByteBuffer.allocate(8).putLong(0, Long.MIN_VALUE).array())
+            .build(),
+        BinaryAnnotation.builder()
+            .key("Long.MAX_VALUE")
+            .type(BinaryAnnotation.Type.I64)
+            .value(ByteBuffer.allocate(8).putLong(0, Long.MAX_VALUE).array())
+            .build()
+    )).build();
+
+    byte[] bytes = codec().writeSpan(span);
+    assertThat(codec().readSpan(bytes))
+        .isEqualTo(span);
+  }
+
+  @Test
+  public void binaryAnnotation_double() throws IOException {
+    Span span = TestObjects.LOTS_OF_SPANS[0].toBuilder().binaryAnnotations(asList(
+        BinaryAnnotation.builder()
+            .key("Double.zero")
+            .type(BinaryAnnotation.Type.DOUBLE)
+            .value(ByteBuffer.allocate(8).putDouble(0, 0.0).array())
+            .build(),
+        BinaryAnnotation.builder()
+            .key("Double.negative")
+            .type(BinaryAnnotation.Type.DOUBLE)
+            .value(ByteBuffer.allocate(8).putDouble(0, -1.005656679588439279).array())
+            .build(),
+        BinaryAnnotation.builder()
+            .key("Double.MIN_VALUE")
+            .type(BinaryAnnotation.Type.DOUBLE)
+            .value(ByteBuffer.allocate(8).putDouble(0, Double.MIN_VALUE).array())
+            .build(),
+        BinaryAnnotation.builder()
+            .key("Double.MAX_VALUE")
+            .type(BinaryAnnotation.Type.I64)
+            .value(ByteBuffer.allocate(8).putDouble(0, Double.MAX_VALUE).array())
+            .build()
+    )).build();
+
+    byte[] bytes = codec().writeSpan(span);
+    assertThat(codec().readSpan(bytes))
+        .isEqualTo(span);
   }
 
   @Test


### PR DESCRIPTION
Before, we special-cased writing numbers, except we had no tests to
cover I64 binary annotations. Eventhough these are niche, they should
work!
