### PR TITLE
Only write good span timestamp guesses at ingest

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Indexer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Indexer.java
@@ -36,6 +36,7 @@ import zipkin.storage.QueryRequest;
 
 import static com.google.common.base.CaseFormat.LOWER_HYPHEN;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
 import static zipkin.storage.cassandra.CassandraUtil.bindWithName;
 
 /**
@@ -82,10 +83,11 @@ final class Indexer {
     // First parse each span into partition keys used to support query requests
     Builder<PartitionKeyToTraceId, Long> parsed = ImmutableSetMultimap.builder();
     for (Span span : spans) {
-      if (span.timestamp == null) continue;
+      Long timestamp = guessTimestamp(span);
+      if (timestamp == null) continue;
       for (String partitionKey : index.partitionKeys(span)) {
         parsed.put(new PartitionKeyToTraceId(index.table(), partitionKey, span.traceId),
-            1000 * (span.timestamp / 1000)); // index precision is millis
+            1000 * (timestamp / 1000)); // index precision is millis
       }
     }
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
@@ -95,11 +95,10 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
     long endMillis = request.endTs;
     long beginMillis = endMillis - request.lookback;
 
-    // TODO: once timestamp_millis is sufficiently deployed, switch this logic to use it
     BoolQueryBuilder filter = boolQuery()
-        .must(rangeQuery("timestamp")
-            .gte(TimeUnit.MILLISECONDS.toMicros(beginMillis))
-            .lte(TimeUnit.MILLISECONDS.toMicros(endMillis)));
+        .must(rangeQuery("timestamp_millis")
+            .gte(beginMillis)
+            .lte(endMillis));
 
     if (request.serviceName != null) {
       filter.must(boolQuery()
@@ -150,7 +149,8 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
             .addAggregation(
                 AggregationBuilders.terms("traceId_agg")
                     .field("traceId")
-                    .subAggregation(AggregationBuilders.min("timestamps_agg").field("timestamp"))
+                    .subAggregation(AggregationBuilders.min("timestamps_agg")
+                        .field("timestamp_millis"))
                     .order(Order.aggregation("timestamps_agg", false))
                     .size(request.limit));
 

--- a/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
@@ -28,7 +28,6 @@ import zipkin.Annotation;
 import zipkin.BinaryAnnotation;
 import zipkin.DependencyLink;
 import zipkin.Span;
-import zipkin.internal.ApplyTimestampAndDuration;
 import zipkin.internal.CorrectForClockSkew;
 import zipkin.internal.DependencyLinkSpan;
 import zipkin.internal.DependencyLinker;
@@ -37,6 +36,7 @@ import zipkin.internal.Nullable;
 import zipkin.internal.Pair;
 import zipkin.internal.Util;
 
+import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
 import static zipkin.internal.Util.UTF_8;
 import static zipkin.internal.Util.sortedList;
 
@@ -51,9 +51,9 @@ public final class InMemorySpanStore implements SpanStore {
   final StorageAdapters.SpanConsumer spanConsumer = new StorageAdapters.SpanConsumer() {
     @Override public void accept(List<Span> spans) {
       for (Span span : spans) {
-        span = ApplyTimestampAndDuration.apply(span);
+        Long timestamp = guessTimestamp(span);
         Pair<Long> traceIdTimeStamp =
-            Pair.create(span.traceId, span.timestamp == null ? Long.MIN_VALUE : span.timestamp);
+            Pair.create(span.traceId, timestamp == null ? Long.MIN_VALUE : timestamp);
         String spanName = span.name;
         synchronized (InMemorySpanStore.this) {
           traceIdTimeStamps.add(traceIdTimeStamp);

--- a/zipkin/src/test/java/zipkin/internal/ApplyTimestampAndDurationTest.java
+++ b/zipkin/src/test/java/zipkin/internal/ApplyTimestampAndDurationTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.Endpoint;
+import zipkin.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.Constants.CLIENT_SEND;
+import static zipkin.Constants.SERVER_RECV;
+import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
+
+public class ApplyTimestampAndDurationTest {
+
+  Endpoint frontend = Endpoint.create("frontend", 192 << 24 | 168 << 16 | 2, 8080);
+  Annotation cs = Annotation.create((50) * 1000, CLIENT_SEND, frontend);
+
+  Endpoint backend = Endpoint.create("backend", 192 << 24 | 168 << 16 | 2, 8080);
+  Annotation sr = Annotation.create((95) * 1000, SERVER_RECV, backend);
+
+  Span.Builder span = Span.builder().traceId(1).name("method1").id(666);
+
+  @Test
+  public void bestTimestamp_isSpanTimestamp() {
+    assertThat(guessTimestamp(span.timestamp(1L).build()))
+        .isEqualTo(1L);
+  }
+
+  @Test
+  public void bestTimestamp_isNotARandomAnnotation() {
+    assertThat(guessTimestamp(span.addAnnotation(Annotation.create(1L, "foo", frontend)).build()))
+        .isNull();
+  }
+
+  @Test
+  public void bestTimestamp_isARootServerSpan() {
+    assertThat(guessTimestamp(span.addAnnotation(sr).build()))
+        .isEqualTo(sr.timestamp);
+  }
+
+  @Test
+  public void bestTimestamp_isClientSideOFARootSpan() {
+    assertThat(guessTimestamp(span.addAnnotation(cs).addAnnotation(sr).build()))
+        .isEqualTo(cs.timestamp);
+  }
+
+  @Test
+  public void bestTimestamp_isNotAChildServerSpan() {
+    assertThat(guessTimestamp(span.parentId(2L).addAnnotation(sr).build()))
+        .isNull();
+  }
+
+  @Test
+  public void bestTimestamp_isAChildClientSpan() {
+    assertThat(guessTimestamp(span.parentId(2L).addAnnotation(cs).build()))
+        .isEqualTo(cs.timestamp);
+  }
+}


### PR DESCRIPTION
Previously, Zipkin wrote the wrong timestamp when receiving spans that
are missing timestamp data. It is still the case that instrumentation
libraries aren't updated to add this. Until then, we have to guess a
little more smartly so as to not record incorrect timestamps.

This does the following when Span.timestamp is missing:
- If there is a "cs", use that (because client always is authoritative)
- If there is an "sr" in a root span, use that
- Otherwise, return null instead of choosing an arbitrary low value.

This also is more careful when updating timestamps, for example, in
MySQL, we only update if the span's timestamp is set or on client send.

This change has some impact, notably that duration queries now require
instrumentation to update to actually set Span.duration. Also,
elasticsearch "timestamp_millis" field is now used directly for queries.

To facilitate better instrumentation, I've added more documentation:
https://github.com/openzipkin/openzipkin.github.io/pull/46

Fixes #1281
