### PR TITLE
Removes duration query support from Cassandra 2.2

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanConsumer.java
@@ -40,7 +40,6 @@ import zipkin.storage.guava.GuavaSpanConsumer;
 
 import static com.google.common.util.concurrent.Futures.transform;
 import static zipkin.storage.cassandra.CassandraUtil.bindWithName;
-import static zipkin.storage.cassandra.CassandraUtil.durationIndexBucket;
 
 final class CassandraSpanConsumer implements GuavaSpanConsumer {
   private static final Logger LOG = LoggerFactory.getLogger(CassandraSpanConsumer.class);
@@ -58,7 +57,6 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
   private final PreparedStatement insertSpan;
   private final PreparedStatement insertServiceName;
   private final PreparedStatement insertSpanName;
-  private final PreparedStatement insertTraceIdBySpanDuration;
   private final Schema.Metadata metadata;
   private final DeduplicatingExecutor deduplicatingExecutor;
   private final CompositeIndexer indexer;
@@ -89,16 +87,6 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
             .value("service_name", QueryBuilder.bindMarker("service_name"))
             .value("bucket", 0) // bucket is deprecated on this index
             .value("span_name", QueryBuilder.bindMarker("span_name"))));
-
-    insertTraceIdBySpanDuration = session.prepare(
-        maybeUseTtl(QueryBuilder
-            .insertInto(Tables.SPAN_DURATION_INDEX)
-            .value("service_name", QueryBuilder.bindMarker("service_name"))
-            .value("span_name", QueryBuilder.bindMarker("span_name"))
-            .value("bucket", QueryBuilder.bindMarker("bucket"))
-            .value("duration", QueryBuilder.bindMarker("duration"))
-            .value("ts", QueryBuilder.bindMarker("ts"))
-            .value("trace_id", QueryBuilder.bindMarker("trace_id"))));
 
     deduplicatingExecutor = new DeduplicatingExecutor(session, WRITTEN_NAMES_TTL);
     indexer = new CompositeIndexer(session, indexCacheSpec, bucketCount, this.indexTtl);
@@ -140,18 +128,6 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
         if (!span.name.isEmpty()) {
           // SpanStore.getSpanNames
           futures.add(storeSpanName(serviceName, span.name));
-        }
-
-        // QueryRequest.min/maxDuration
-        if (span.timestamp != null && span.duration != null) {
-          // Contract for Repository.storeTraceIdByDuration is to store the span twice, once with
-          // the span name and another with empty string.
-          futures.add(storeTraceIdByDuration(
-              serviceName, span.name, span.timestamp, span.duration, span.traceId));
-          if (!span.name.isEmpty()) { // If span.name == "", this would be redundant
-            futures.add(storeTraceIdByDuration(
-                serviceName, "", span.timestamp, span.duration, span.traceId));
-          }
         }
       }
     }
@@ -196,26 +172,6 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
         .setString("span_name", spanName);
     if (indexTtl != null) bound.setInt("ttl_", indexTtl);
     return deduplicatingExecutor.maybeExecuteAsync(bound, Pair.create(serviceName, spanName));
-  }
-
-  ListenableFuture<?> storeTraceIdByDuration(String serviceName, String spanName,
-      long timestamp, long duration, long traceId) {
-    int bucket = durationIndexBucket(timestamp);
-    try {
-      BoundStatement bound =
-          bindWithName(insertTraceIdBySpanDuration, "insert-trace-id-by-span-duration")
-              .setInt("bucket", bucket)
-              .setString("service_name", serviceName)
-              .setString("span_name", spanName)
-              .setBytesUnsafe("ts", timestampCodec.serialize(timestamp))
-              .setLong("duration", duration)
-              .setLong("trace_id", traceId);
-      if (indexTtl != null) bound.setInt("ttl_", indexTtl);
-
-      return session.executeAsync(bound);
-    } catch (RuntimeException ex) {
-      return Futures.immediateFailedFuture(ex);
-    }
   }
 
   /** Clears any caches */

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
@@ -295,8 +295,7 @@ public final class CassandraStorage
         Tables.SPAN_NAMES,
         Tables.SERVICE_NAME_INDEX,
         Tables.SERVICE_SPAN_NAME_INDEX,
-        Tables.ANNOTATIONS_INDEX,
-        Tables.SPAN_DURATION_INDEX
+        Tables.ANNOTATIONS_INDEX
     )) {
       futures.add(session.get().executeAsync(format("TRUNCATE %s", cf)));
     }

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
@@ -47,15 +47,6 @@ final class CassandraUtil {
    */
   static final int LONGEST_VALUE_TO_INDEX = 256;
 
-  // Time window covered by a single bucket of the Span Duration Index, in seconds. Default: 1hr
-  private static final long DURATION_INDEX_BUCKET_WINDOW_SECONDS
-      = Long.getLong("zipkin.store.cassandra.internal.durationIndexBucket", 60 * 60);
-
-  public static int durationIndexBucket(long ts) {
-    // if the window constant has microsecond precision, the division produces negative values
-    return (int) ((ts / DURATION_INDEX_BUCKET_WINDOW_SECONDS) / 1000000);
-  }
-
   private static final ThreadLocal<CharsetEncoder> UTF8_ENCODER =
       new ThreadLocal<CharsetEncoder>() {
         @Override protected CharsetEncoder initialValue() {

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Tables.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/Tables.java
@@ -81,8 +81,6 @@ final class Tables {
    */
   static final String ANNOTATIONS_INDEX = "annotations_index";
 
-  static final String SPAN_DURATION_INDEX = "span_duration_index";
-
   private Tables() {
   }
 }

--- a/zipkin-storage/cassandra/src/main/resources/cassandra-schema-cql3-upgrade-1.txt
+++ b/zipkin-storage/cassandra/src/main/resources/cassandra-schema-cql3-upgrade-1.txt
@@ -28,7 +28,3 @@ ALTER TABLE zipkin.service_names
 ALTER TABLE zipkin.traces
     WITH compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_window_size_seconds': '86400'}
     AND default_time_to_live =  604800;
-
-ALTER TABLE zipkin.span_duration_index
-    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_window_size_seconds': '86400'}
-    AND default_time_to_live =  259200;

--- a/zipkin-storage/cassandra/src/main/resources/cassandra-schema-cql3.txt
+++ b/zipkin-storage/cassandra/src/main/resources/cassandra-schema-cql3.txt
@@ -65,16 +65,3 @@ CREATE TABLE IF NOT EXISTS zipkin.traces (
 )
     WITH compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_window_size_seconds': '86400'}
     AND default_time_to_live =  604800;
-
-CREATE TABLE IF NOT EXISTS zipkin.span_duration_index (
-    service_name  text,      // service name
-    span_name     text,      // span name, or blank for queries without span name
-    bucket        int,       // time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1h.
-    duration      bigint,    // span duration, in microseconds
-    ts            timestamp, // start timestamp of the span, truncated to millisecond precision
-    trace_id      bigint,    // trace ID. Included as a clustering column to avoid clashes (however unlikely)
-    PRIMARY KEY ((service_name, span_name, bucket), duration, ts, trace_id)
-)
-    WITH CLUSTERING ORDER BY (duration DESC, ts DESC)
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_window_size_seconds': '86400'}
-    AND default_time_to_live =  259200;

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanConsumerTest.java
@@ -62,19 +62,6 @@ public class CassandraSpanConsumerTest {
   }
 
   /**
-   * {@link Span#duration} == 0 is likely to be a mistake, and coerces to null. It is not helpful to
-   * index rows who have no duration.
-   */
-  @Test
-  public void doesntIndexSpansMissingDuration() {
-    Span span = Span.builder().traceId(1L).id(1L).name("get").duration(0L).build();
-
-    accept(span);
-
-    assertThat(rowCount(Tables.SPAN_DURATION_INDEX)).isZero();
-  }
-
-  /**
    * Simulates a trace with a step pattern, where each span starts a millisecond after the prior
    * one. The consumer code optimizes index inserts to only represent the interval represented by
    * the trace as opposed to each individual timestamp.

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
@@ -15,6 +15,8 @@ package zipkin.storage.cassandra;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.AssumptionViolatedException;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,6 +31,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CassandraSpanStoreTest extends SpanStoreTest {
+
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -98,5 +101,11 @@ public class CassandraSpanStoreTest extends SpanStoreTest {
 
   long rowCount(String table) {
     return storage.session().execute("SELECT COUNT(*) from " + table).one().getLong(0);
+  }
+
+  @Test
+  @Override
+  public void getTraces_duration() {
+    throw new AssumptionViolatedException("Upgrade to cassandra3 if you want duration queries");
   }
 }


### PR DESCRIPTION
The duration query is unusable for most people, yet adds load every time
a span is written. It is also complicated code that hasn't improved much
since being written.

This removes this feature, punting to cassandra3 which can address the
problem more effectively via SASI indexing.

Fixes #1224
Obviates #1204
