### PR TITLE
Skips indexing of non-string binary annotations in Elasticsearch

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
+++ b/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
@@ -33,6 +33,7 @@
           "value": {
             "match": "value",
             "mapping": {
+              "match_mapping_type": "string",
               "index": "not_analyzed",
               "ignore_malformed": true,
               "type": "string"


### PR DESCRIPTION
Fixes #1239
