### PR TITLE
 Store annotations in the indexed text column individually

### DIFF
--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanConsumer.java
@@ -99,8 +99,7 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
         if (timestamp != null) {
           // Contract for Repository.storeServiceSpanName is to store the span twice, once with
           // the span name and another with empty string.
-          futures.add(storeServiceSpanName(serviceName, span.name, timestamp, span.duration,
-              span.traceId));
+          futures.add(storeServiceSpanName(serviceName, span.name, timestamp, span.duration, span.traceId));
           if (!span.name.isEmpty()) { // If span.name == "", this would be redundant
             futures.add(
                 storeServiceSpanName(serviceName, "", timestamp, span.duration, span.traceId));

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
@@ -214,8 +214,7 @@ final class CassandraSpanStore implements GuavaSpanStore {
       futureKeySetsToIntersect.add(traceIdToTimestamp);
       for (String annotationKey : annotationKeys) {
         futureKeySetsToIntersect
-            .add(getTraceIdsByAnnotation(annotationKey, request.endTs, request.lookback,
-                traceIndexFetchSize));
+            .add(getTraceIdsByAnnotation(annotationKey, request.endTs, request.lookback, traceIndexFetchSize));
       }
       // We achieve the AND goal, by intersecting each of the key sets.
       traceIds =
@@ -225,8 +224,7 @@ final class CassandraSpanStore implements GuavaSpanStore {
     return transform(traceIds, new AsyncFunction<Collection<BigInteger>, List<List<Span>>>() {
       @Override public ListenableFuture<List<List<Span>>> apply(Collection<BigInteger> traceIds) {
         traceIds = FluentIterable.from(traceIds).limit(request.limit).toSet();
-        return transform(getSpansByTraceIds(ImmutableSet.copyOf(traceIds), maxTraceCols),
-            AdjustTraces.INSTANCE);
+        return transform(getSpansByTraceIds(ImmutableSet.copyOf(traceIds), maxTraceCols), AdjustTraces.INSTANCE);
       }
 
       @Override public String toString() {
@@ -355,8 +353,6 @@ final class CassandraSpanStore implements GuavaSpanStore {
           .setSet("trace_id", traceIds)
           .setInt("limit_", limit);
 
-      bound.setFetchSize(Integer.MAX_VALUE);
-
       return transform(session.executeAsync(bound),
           new Function<ResultSet, Collection<List<Span>>>() {
             @Override public Collection<List<Span>> apply(ResultSet input) {
@@ -480,8 +476,6 @@ final class CassandraSpanStore implements GuavaSpanStore {
               .setUUID("start_ts", UUIDs.startOf(startTsMillis))
               .setUUID("end_ts", UUIDs.endOf(endTsMillis))
               .setInt("limit_", limit);
-
-      bound.setFetchSize(Integer.MAX_VALUE);
 
       return transform(session.executeAsync(bound),
           new Function<ResultSet, Map<BigInteger, Long>>() {

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraUtil.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraUtil.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,19 +74,20 @@ final class CassandraUtil {
       if (Constants.CORE_ANNOTATIONS.contains(a.value)) continue;
 
       if (a.endpoint != null && !a.endpoint.serviceName.isEmpty()) {
-        annotationKeys.add(a.endpoint.serviceName + ":" + a.value);
+        annotationKeys.add(a.endpoint.serviceName);
+        annotationKeys.add(a.value);
       }
     }
     for (BinaryAnnotation b : span.binaryAnnotations) {
-      if (b.type == BinaryAnnotation.Type.STRING
-          && b.endpoint != null
-          && !b.endpoint.serviceName.isEmpty()
-          && b.value.length <= LONGEST_VALUE_TO_INDEX * 4) { // UTF_8 is up to 4bytes/char
-        String value = new String(b.value, UTF_8);
-        if (value.length() > LONGEST_VALUE_TO_INDEX) continue;
-
-        annotationKeys.add(b.endpoint.serviceName + ":" + b.key);
-        annotationKeys.add(b.endpoint.serviceName + ":" + b.key + ":" + new String(b.value, UTF_8));
+      if (b.endpoint != null && !b.endpoint.serviceName.isEmpty() && !Constants.CORE_ANNOTATIONS.contains(b.key)) {
+        annotationKeys.add(b.endpoint.serviceName);
+        if (b.type == BinaryAnnotation.Type.STRING) {
+            String value = new String(b.value, UTF_8);
+            value = value.substring(0, Math.min(value.length(), LONGEST_VALUE_TO_INDEX));
+            annotationKeys.add(b.key + ":" + value);
+        } else {
+            annotationKeys.add(b.key);
+        }
       }
     }
     return annotationKeys;
@@ -96,12 +98,13 @@ final class CassandraUtil {
       return Collections.emptyList();
     }
     checkArgument(request.serviceName != null, "serviceName needed with annotation query");
-    Set<String> annotationKeys = new LinkedHashSet<>();
+    Set<String> annotationKeys = new HashSet<>();
+    annotationKeys.add(request.serviceName);
     for (String a : request.annotations) { // doesn't include CORE_ANNOTATIONS
-      annotationKeys.add(request.serviceName + ":" + a);
+      annotationKeys.add(a);
     }
     for (Map.Entry<String, String> b : request.binaryAnnotations.entrySet()) {
-      annotationKeys.add(request.serviceName + ":" + b.getKey() + ":" + b.getValue());
+      annotationKeys.add(b.getKey() + ":" + b.getValue());
     }
     return sortedList(annotationKeys);
   }

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
@@ -52,7 +52,7 @@ public class CassandraUtilTest {
         .serviceName("service")
         .addAnnotation(Constants.ERROR)
         .addBinaryAnnotation(TraceKeys.HTTP_METHOD, "GET").build()))
-        .containsExactly("service:error", "service:http.method:GET");
+        .containsExactly("error", "http.method:GET", "service");
   }
 
   @Test
@@ -62,7 +62,7 @@ public class CassandraUtilTest {
         .serviceName("service")
         .addAnnotation(Constants.ERROR)
         .addAnnotation(Constants.ERROR).build()))
-        .containsExactly("service:error");
+        .containsExactly( "error", "service");
   }
 
   @Test
@@ -78,7 +78,7 @@ public class CassandraUtilTest {
         .containsOnly(Constants.SERVER_ADDR, Constants.CLIENT_ADDR);
 
     assertThat(CassandraUtil.annotationKeys(span))
-        .isEmpty();
+        .containsExactly("web", "ca", "app", "sa");
   }
 
   @Test
@@ -95,6 +95,9 @@ public class CassandraUtilTest {
     )).build();
 
     assertThat(CassandraUtil.annotationKeys(span))
-        .containsOnly("web:aws.arn", "web:aws.arn:" + arn);
+        .containsOnly(
+                "web",
+                "aws.arn:" + arn,
+                TraceKeys.HTTP_URL + ":" + url.substring(0, CassandraUtil.LONGEST_VALUE_TO_INDEX));
   }
 }


### PR DESCRIPTION
- store annotations in the indexed text column individually, providing better search usability in the UI, and less disk space used,
- remove fetch size to statements. that's not needed against this datamodel.
