### PR TITLE
Rewrite of self-tracing in Cassandra3 storage

### DIFF
--- a/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/brave/TracedSession.java
+++ b/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/brave/TracedSession.java
@@ -11,204 +11,182 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package zipkin.autoconfigure.storage.cassandra3.brave;
 
-import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.AbstractSession;
+import com.datastax.driver.core.CloseFuture;
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Host;
-import com.datastax.driver.core.LatencyTracker;
+import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ProtocolVersion;
-import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.github.kristofa.brave.Brave;
-import com.github.kristofa.brave.ServerSpan;
-import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanCollector;
 import com.github.kristofa.brave.SpanId;
-import com.google.common.collect.Maps;
-import com.google.common.reflect.AbstractInvocationHandler;
-import com.google.common.reflect.Reflection;
-import com.twitter.zipkin.gen.Annotation;
-import com.twitter.zipkin.gen.BinaryAnnotation;
-import com.twitter.zipkin.gen.Endpoint;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.twitter.zipkin.gen.Span;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import zipkin.Constants;
+import zipkin.storage.cassandra3.Cassandra3Storage;
 
-import static java.util.Collections.singletonMap;
-import static zipkin.internal.Util.checkNotNull;
+final class TracedSession extends AbstractSession {
 
-/**
- * Creates traced sessions, which write directly to brave's collector to preserve the correct
- * duration.
- */
-public final class TracedSession extends AbstractInvocationHandler implements LatencyTracker {
-  private static final Logger LOG = LoggerFactory.getLogger(TracedSession.class);
+    private static final Executor EXECUTOR = MoreExecutors.directExecutor();
+    private final Session session;
+    private final Brave brave;
+    private final SpanCollector collector;
+    private final ClientTracer clientTracer;
+    private final long useKeyspaceTimeout;
+    private volatile boolean keyspaceSet = false;
+    private final ProtocolVersion version;
 
-  private final ProtocolVersion version;
-
-  public static Session create(Session target, Brave brave, SpanCollector collector) {
-    return Reflection.newProxy(Session.class, new TracedSession(target, brave, collector));
-  }
-
-  final Session target;
-  final Brave brave;
-  final SpanCollector collector;
-  /**
-   * Manual Propagation, as opposed to attempting to control the {@link
-   * Cluster#register(LatencyTracker) latency tracker callback thread}.
-   */
-  final Map<BoundStatement, Span> cache = Maps.newConcurrentMap();
-
-  TracedSession(Session target, Brave brave, SpanCollector collector) {
-    this.target = checkNotNull(target, "target");
-    this.brave = checkNotNull(brave, "brave");
-    this.collector = checkNotNull(collector, "collector");
-    this.version = target.getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
-    target.getCluster().register(this);
-  }
-
-  @Override protected Object handleInvocation(Object proxy, Method method, Object[] args)
-      throws Throwable {
-    // Only join traces, don't start them. This prevents LocalCollector's thread from amplifying.
-    if (brave.serverSpanThreadBinder().getCurrentServerSpan() != null &&
-        brave.serverSpanThreadBinder().getCurrentServerSpan().getSpan() != null
-        && method.getName().equals("executeAsync") && args[0] instanceof BoundStatement) {
-      BoundStatement statement = (BoundStatement) args[0];
-
-      // via an internal class z.s.cassandra3.NamedBoundStatement, toString() is a nice name
-      SpanId spanId = brave.clientTracer().startNewSpan(statement.toString());
-
-      // o.a.c.tracing.Tracing.newSession must use the same format for the key zipkin
-      if (version.compareTo(ProtocolVersion.V4) >= 0) {
-        statement.enableTracing();
-        statement.setOutgoingPayload(singletonMap("zipkin", ByteBuffer.wrap(spanId.bytes())));
-      }
-
-      brave.clientTracer().setClientSent(); // start the span and store it
-      brave.clientTracer()
-          .submitBinaryAnnotation("cql.query", statement.preparedStatement().getQueryString());
-      cache.put(statement, brave.clientSpanThreadBinder().getCurrentClientSpan());
-      // let go of the client span as it is only used for the RPC (will have no local children)
-      brave.clientSpanThreadBinder().setCurrentSpan(null);
-      return new BraveResultSetFuture(target.executeAsync(statement), brave);
-    }
-    try {
-      return method.invoke(target, args);
-    } catch (InvocationTargetException e) {
-      if (e.getCause() instanceof RuntimeException) throw e.getCause();
-      throw e;
-    }
-  }
-
-  @Override public void update(Host host, Statement statement, Exception e, long nanos) {
-    if (!(statement instanceof BoundStatement)) return;
-    Span span = cache.remove(statement);
-    if (span == null) {
-      if (statement.isTracing()) {
-        LOG.warn("{} not in the cache eventhough tracing is on", statement);
-      }
-      return;
-    }
-    span.setDuration(nanos / 1000); // TODO: allow client tracer to end with duration
-    Endpoint local = span.getAnnotations().get(0).host; // TODO: expose in brave
-    long endTs = span.getTimestamp() + span.getDuration();
-    span.addToAnnotations(Annotation.create(endTs, "cr", local));
-    if (e != null) {
-      span.addToBinary_annotations(BinaryAnnotation.create(Constants.ERROR, e.getMessage(), local));
-    }
-    int ipv4 = ByteBuffer.wrap(host.getAddress().getAddress()).getInt();
-    Endpoint endpoint = Endpoint.create("cassandra3", ipv4, host.getSocketAddress().getPort());
-    span.addToBinary_annotations(BinaryAnnotation.address("sa", endpoint));
-    collector.collect(span);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (obj instanceof TracedSession) {
-      TracedSession other = (TracedSession) obj;
-      return target.equals(other.target);
-    }
-    return false;
-  }
-
-  @Override
-  public int hashCode() {
-    return target.hashCode();
-  }
-
-  @Override
-  public String toString() {
-    return target.toString();
-  }
-
-  @Override public void onRegister(Cluster cluster) {
-  }
-
-  @Override public void onUnregister(Cluster cluster) {
-  }
-
-  static class BraveResultSetFuture<T> implements ResultSetFuture {
-    final ResultSetFuture delegate;
-    final ServerSpanThreadBinder threadBinder;
-    final ServerSpan parent;
-
-    BraveResultSetFuture(ResultSetFuture delegate, Brave brave) {
-      this.delegate = delegate;
-      this.threadBinder = brave.serverSpanThreadBinder();
-      this.parent = threadBinder.getCurrentServerSpan();
+    static TracedSession create(final Session session, Brave brave, SpanCollector collector) {
+        return new TracedSession(session, brave, collector);
     }
 
-    @Override public ResultSet getUninterruptibly() {
-      return delegate.getUninterruptibly();
+    private TracedSession(final Session session, Brave brave, SpanCollector collector) {
+        this.session = session;
+        this.brave = brave;
+        this.collector = collector;
+        this.clientTracer = brave.clientTracer();
+        this.useKeyspaceTimeout = session.getCluster().getConfiguration().getSocketOptions().getConnectTimeoutMillis();
+        this.version = session.getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
     }
 
-    @Override public ResultSet getUninterruptibly(long timeout, TimeUnit unit)
-        throws TimeoutException {
-      return delegate.getUninterruptibly(timeout, unit);
+    @Override
+    public String getLoggedKeyspace() {
+        return session.getLoggedKeyspace();
     }
 
-    @Override public boolean cancel(boolean mayInterruptIfRunning) {
-      return delegate.cancel(mayInterruptIfRunning);
+    @Override
+    public Session init() {
+        return session.init();
     }
 
-    @Override public boolean isCancelled() {
-      return delegate.isCancelled();
-    }
+    @Override
+    public ResultSetFuture executeAsync(final Statement statement) {
+        // don't trace any already self-traced spans
+        boolean alreadySelfTraced = null != statement.getOutgoingPayload()
+                && statement.getOutgoingPayload().containsKey(Cassandra3Storage.SELF_TRACING_KEY);
 
-    @Override public boolean isDone() {
-      return delegate.isDone();
-    }
+        // o.a.c.tracing.Tracing.newSession must use the same format for the key zipkin
+        boolean supported = version.compareTo(ProtocolVersion.V4) >= 0;
+        if (supported && !alreadySelfTraced) {
+            useKeyspace(session, statement.getKeyspace());
+            SpanId spanId = null;
+            spanId = clientTracer.startNewSpan(statement.toString());
+            clientTracer.submitBinaryAnnotation(Cassandra3Storage.SELF_TRACING_KEY, "true");
+            if (null != spanId) {
+                String ks = null != statement.getKeyspace() ? statement.getKeyspace() : session.getLoggedKeyspace();
+                assert null != ks : "this cluster/session only for keyspace " + ks;
+                clientTracer.setClientSent();
+            }
+            statement.enableTracing();
+            Map<String,ByteBuffer> payload = new HashMap<>();
+            if (null != statement.getOutgoingPayload()) {
+                payload.putAll(statement.getOutgoingPayload());
+            }
+            payload.put("zipkin", ByteBuffer.wrap(spanId.bytes()));
+            statement.setOutgoingPayload(payload);
 
-    @Override public ResultSet get() throws InterruptedException, ExecutionException {
-      return delegate.get();
-    }
-
-    @Override public ResultSet get(long timeout, TimeUnit unit)
-        throws InterruptedException, ExecutionException, TimeoutException {
-      return delegate.get(timeout, unit);
-    }
-
-    @Override public void addListener(Runnable listener, Executor executor) {
-      delegate.addListener(() -> {
-        threadBinder.setCurrentSpan(parent);
-        try {
-          listener.run();
-        } finally {
-          threadBinder.setCurrentSpan(null);
+            final Span span = null != spanId ? brave.clientSpanThreadBinder().getCurrentClientSpan() : null;
+            ResultSetFuture future = session.executeAsync(statement);
+            if (null != spanId) {
+                future.addListener(new Runnable() {
+                    @Override
+                    public void run() {
+                        brave.clientSpanThreadBinder().setCurrentSpan(span);
+                        clientTracer.setClientReceived();
+                        collector.collect(span);
+                        brave.clientSpanThreadBinder().setCurrentSpan(null);
+                    }
+                }, EXECUTOR);
+            }
+            return future;
         }
-      }, executor);
+        return session.executeAsync(statement);
     }
-  }
+
+    @Override
+    public ListenableFuture<PreparedStatement> prepareAsync(final String query) {
+        useKeyspace(session, null);
+        return session.prepareAsync(query);
+    }
+
+    @Override
+    public ListenableFuture<PreparedStatement> prepareAsync(final RegularStatement statement) {
+        useKeyspace(session, statement.getKeyspace());
+        return super.prepareAsync(statement);
+    }
+
+    @Override
+    public CloseFuture closeAsync() {
+        return session.closeAsync();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return session.isClosed();
+    }
+
+    @Override
+    public Cluster getCluster() {
+        return session.getCluster();
+    }
+
+    @Override
+    public Session.State getState() {
+        return session.getState();
+    }
+
+    private void useKeyspace(final Session session, final String ks) {
+        String keyspace = null != ks ? ks : session.getLoggedKeyspace();
+        // this method exists because ZipkinTracingCluster.connect() loops if it calls super.connect(keyspace)
+        if (!keyspaceSet) {
+            try {
+                ResultSetFuture future = session.executeAsync("USE " + QueryBuilder.quote(keyspace));
+                Uninterruptibles.getUninterruptibly(future, useKeyspaceTimeout, TimeUnit.MILLISECONDS);
+                keyspaceSet = true;
+            } catch (TimeoutException e) {
+                throw new DriverInternalError(""
+                        + "No responses after " + useKeyspaceTimeout + " milliseconds while setting current keyspace. "
+                        + "This should not happen, unless you have setup a very low connection timeout.");
+            } catch (ExecutionException e) {
+                // see DefaultResultSetFuture.extractCauseFromExecutionException(e);
+                if (e.getCause() instanceof DriverException) {
+                    throw ((DriverException) e.getCause()).copy();
+                } else {
+                    throw new DriverInternalError("Unexpected exception thrown", e.getCause());
+                }
+            } catch (RuntimeException e) {
+                session.close();
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    protected ListenableFuture<PreparedStatement> prepareAsync(String query, Map<String, ByteBuffer> customPayload) {
+        return session.prepareAsync(query);
+    }
+
+    @Override
+    public ListenableFuture<Session> initAsync() {
+        return session.initAsync();
+    }
+
 }

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Cassandra3Storage.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Cassandra3Storage.java
@@ -155,6 +155,8 @@ public final class Cassandra3Storage
     }
   }
 
+  public static final String SELF_TRACING_KEY = "zipkin-self-traced";
+
   final int maxTraceCols;
   final String contactPoints;
   final int maxConnections;


### PR DESCRIPTION
Self Tracing used in combination with a Zipkin-tracing Cassandra installation does not work (recursion of traces).

This rewrites the self-tracing implementation from using a java.lang.reflect.InvocationHandler to subclassing the CQL driver's AbstractSession class.

Avoiding the repeated self-tracing of self-tracing generated spans is done through a combination of adding a binary annotation to the span and a flag to the statement's
outgoing payload.
