### PR TITLE
Qualifies annotation queries against a service

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
@@ -59,8 +59,8 @@ final class CassandraUtil {
   }
 
   /**
-   * Returns keys that concatenate the serviceName associated with an annotation, a binary
-   * annotation key, or a binary annotation key with value.
+   * Returns keys that concatenate the serviceName associated with an annotation or a binary
+   * annotation.
    *
    * <p>Note: in the case of binary annotations, only string types are returned, as that's the only
    * queryable type, per {@link QueryRequest#binaryAnnotations}.
@@ -86,7 +86,6 @@ final class CassandraUtil {
         String value = new String(b.value, UTF_8);
         if (value.length() > LONGEST_VALUE_TO_INDEX) continue;
 
-        annotationKeys.add(b.endpoint.serviceName + ":" + b.key);
         annotationKeys.add(b.endpoint.serviceName + ":" + b.key + ":" + new String(b.value, UTF_8));
       }
     }

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraUtilTest.java
@@ -92,6 +92,6 @@ public class CassandraUtilTest {
     )).build();
 
     assertThat(CassandraUtil.annotationKeys(span))
-        .containsOnly("web:aws.arn", "web:aws.arn:" + arn);
+        .containsOnly("web:aws.arn:" + arn);
   }
 }

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
@@ -214,8 +214,7 @@ final class CassandraSpanStore implements GuavaSpanStore {
       futureKeySetsToIntersect.add(traceIdToTimestamp);
       for (String annotationKey : annotationKeys) {
         futureKeySetsToIntersect
-            .add(getTraceIdsByAnnotation(annotationKey, request.endTs, request.lookback,
-                traceIndexFetchSize));
+            .add(getTraceIdsByAnnotation(annotationKey, request.endTs, request.lookback, traceIndexFetchSize));
       }
       // We achieve the AND goal, by intersecting each of the key sets.
       traceIds =
@@ -225,8 +224,7 @@ final class CassandraSpanStore implements GuavaSpanStore {
     return transform(traceIds, new AsyncFunction<Collection<BigInteger>, List<List<Span>>>() {
       @Override public ListenableFuture<List<List<Span>>> apply(Collection<BigInteger> traceIds) {
         traceIds = FluentIterable.from(traceIds).limit(request.limit).toSet();
-        return transform(getSpansByTraceIds(ImmutableSet.copyOf(traceIds), maxTraceCols),
-            AdjustTraces.INSTANCE);
+        return transform(getSpansByTraceIds(ImmutableSet.copyOf(traceIds), maxTraceCols), AdjustTraces.INSTANCE);
       }
 
       @Override public String toString() {
@@ -355,8 +353,6 @@ final class CassandraSpanStore implements GuavaSpanStore {
           .setSet("trace_id", traceIds)
           .setInt("limit_", limit);
 
-      bound.setFetchSize(Integer.MAX_VALUE);
-
       return transform(session.executeAsync(bound),
           new Function<ResultSet, Collection<List<Span>>>() {
             @Override public Collection<List<Span>> apply(ResultSet input) {
@@ -480,8 +476,6 @@ final class CassandraSpanStore implements GuavaSpanStore {
               .setUUID("start_ts", UUIDs.startOf(startTsMillis))
               .setUUID("end_ts", UUIDs.endOf(endTsMillis))
               .setInt("limit_", limit);
-
-      bound.setFetchSize(Integer.MAX_VALUE);
 
       return transform(session.executeAsync(bound),
           new Function<ResultSet, Map<BigInteger, Long>>() {

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
@@ -52,7 +52,7 @@ public class CassandraUtilTest {
         .serviceName("service")
         .addAnnotation(Constants.ERROR)
         .addBinaryAnnotation(TraceKeys.HTTP_METHOD, "GET").build()))
-        .containsExactly("service:error", "service:http.method:GET");
+        .containsExactly("service:error", "service;http.method;GET");
   }
 
   @Test
@@ -95,6 +95,6 @@ public class CassandraUtilTest {
     )).build();
 
     assertThat(CassandraUtil.annotationKeys(span))
-        .containsOnly("web:aws.arn", "web:aws.arn:" + arn);
+        .containsOnly("web;aws.arn;" + arn);
   }
 }

--- a/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
+++ b/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
@@ -50,6 +50,14 @@
           }
         },
         {
+          "annotations": {
+            "match": "annotations",
+            "mapping": {
+              "type": "nested"
+            }
+          }
+        },
+        {
           "binaryAnnotations": {
             "match": "binaryAnnotations",
             "mapping": {
@@ -67,6 +75,9 @@
         "timestamp_millis": {
           "type":   "date",
           "format": "epoch_millis"
+        },
+        "annotations": {
+          "type": "nested"
         },
         "binaryAnnotations": {
           "type": "nested"


### PR DESCRIPTION
This ensures that annotation or binary annotation queries are qualified
against a service.

This also removes the binary annotation key indexing used in cassandra,
but nowhere else. There's nothing in the api, javadoc or web UI docs
that suggest binary annotation key should substitute for annotation
value. Removing this indexing halves writes per binary annotation
without violating our api contract.
