### PR TITLE
Renders client-originated traces in the dependencies diagram

### DIFF
--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/DependencyLinkSpanIterator.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/DependencyLinkSpanIterator.java
@@ -20,6 +20,7 @@ import zipkin.internal.PeekingIterator;
 import zipkin.storage.mysql.internal.generated.tables.ZipkinSpans;
 
 import static zipkin.Constants.CLIENT_ADDR;
+import static zipkin.Constants.CLIENT_SEND;
 import static zipkin.Constants.SERVER_ADDR;
 import static zipkin.Constants.SERVER_RECV;
 import static zipkin.storage.mysql.internal.generated.tables.ZipkinAnnotations.ZIPKIN_ANNOTATIONS;
@@ -102,6 +103,9 @@ final class DependencyLinkSpanIterator implements Iterator<DependencyLinkSpan> {
     switch (key) {
       case CLIENT_ADDR:
         span.caService(value);
+        break;
+      case CLIENT_SEND:
+        span.csService(value);
         break;
       case SERVER_ADDR:
         span.saService(value);

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanStore.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanStore.java
@@ -57,6 +57,7 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.groupingBy;
 import static zipkin.BinaryAnnotation.Type.STRING;
 import static zipkin.Constants.CLIENT_ADDR;
+import static zipkin.Constants.CLIENT_SEND;
 import static zipkin.Constants.SERVER_ADDR;
 import static zipkin.Constants.SERVER_RECV;
 import static zipkin.internal.Util.UTF_8;
@@ -314,7 +315,7 @@ final class MySQLSpanStore implements SpanStore {
         .from(ZIPKIN_SPANS.leftJoin(ZIPKIN_ANNOTATIONS)
             .on(ZIPKIN_SPANS.TRACE_ID.eq(ZIPKIN_ANNOTATIONS.TRACE_ID).and(
                 ZIPKIN_SPANS.ID.eq(ZIPKIN_ANNOTATIONS.SPAN_ID)))
-            .and(ZIPKIN_ANNOTATIONS.A_KEY.in(CLIENT_ADDR, SERVER_RECV, SERVER_ADDR)))
+            .and(ZIPKIN_ANNOTATIONS.A_KEY.in(CLIENT_SEND, CLIENT_ADDR, SERVER_RECV, SERVER_ADDR)))
         .where(lookback == null ?
             ZIPKIN_SPANS.START_TS.lessOrEqual(endTs) :
             ZIPKIN_SPANS.START_TS.between(endTs - lookback * 1000, endTs))

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkSpanTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkSpanTest.java
@@ -123,6 +123,36 @@ public class DependencyLinkSpanTest {
     assertThat(span.peerService).isEqualTo("service1");
   }
 
+  /**
+   * {@link Constants#CLIENT_SEND} indicates the peer, which is a client in the case of a server
+   * span
+   */
+  @Test
+  public void whenSrAndCsServiceExists_caIsThePeer() {
+    DependencyLinkSpan span = DependencyLinkSpan.builder(1L, null, 1L)
+        .csService("service1")
+        .srService("service2")
+        .build();
+
+    assertThat(span.kind).isEqualTo(Kind.SERVER);
+    assertThat(span.service).isEqualTo("service2");
+    assertThat(span.peerService).isEqualTo("service1");
+  }
+
+  /** {@link Constants#CLIENT_ADDR} is more authoritative than {@link Constants#CLIENT_SEND} */
+  @Test
+  public void whenCrAndCaServiceExists_caIsThePeer() {
+    DependencyLinkSpan span = DependencyLinkSpan.builder(1L, null, 1L)
+        .csService("foo")
+        .caService("service1")
+        .srService("service2")
+        .build();
+
+    assertThat(span.kind).isEqualTo(Kind.SERVER);
+    assertThat(span.service).isEqualTo("service2");
+    assertThat(span.peerService).isEqualTo("service1");
+  }
+
   @Test
   public void specialCasesFinagleLocalSocketLabeling() {
     // Finagle labels two sides of the same socket ("ca", "sa") with the local service name.


### PR DESCRIPTION
Most root spans have uninstrumented clients. This change allows
instrumented clients to appear in the dependencies view. Particularly,
this looks for a "cs" annotation.

Fixes #1288
