### PR TITLE
Tolerate 128bit ids in json and http api by throwing out high bits

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -93,14 +93,20 @@ public final class Util {
     return days;
   }
 
-  /** Parses a 1 to 16 character lower-hex string with no prefix int an unsigned long. */
+  /**
+   * Parses a 1 to 32 character lower-hex string with no prefix into an unsigned long, tossing any
+   * bits higher than 64.
+   */
   public static long lowerHexToUnsignedLong(String lowerHex) {
-    char[] array = lowerHex.toCharArray();
-    if (array.length < 1 || array.length > 16) {
-      throw isntLowerHexLong(lowerHex);
-    }
+    int length = lowerHex.length();
+    if (length < 1 || length > 32) throw isntLowerHexLong(lowerHex);
+
+    // trim off any high bits
+    int i = length > 16 ? length - 16 : 0;
+
     long result = 0;
-    for (char c : array) {
+    for (; i < length; i++) {
+      char c = lowerHex.charAt(i);
       result <<= 4;
       if (c >= '0' && c <= '9') {
         result |= c - '0';
@@ -115,7 +121,7 @@ public final class Util {
 
   static NumberFormatException isntLowerHexLong(String lowerHex) {
     throw new NumberFormatException(
-        lowerHex + " should be a 1 to 16 character lower-hex string with no prefix");
+        lowerHex + " should be a 1 to 32 character lower-hex string with no prefix");
   }
 
   /** Inspired by {@code okio.Buffer.writeLong} */

--- a/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
@@ -24,6 +24,7 @@ import zipkin.TestObjects;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.internal.Util.UTF_8;
 
 public final class JsonCodecTest extends CodecTest {
 
@@ -49,6 +50,23 @@ public final class JsonCodecTest extends CodecTest {
   }
 
   @Test
+  public void tolerates128bitTraceIds_byTossingHighBits() {
+    byte[] with128BitTraceId = ("{\n"
+        + "  \"traceId\": \"48485a3953bb61246b221d5bc9e6496c\",\n"
+        + "  \"name\": \"get-traces\",\n"
+        + "  \"id\": \"6b221d5bc9e6496c\"\n"
+        + "}").getBytes(UTF_8);
+    byte[] withLower64bitsTraceId = ("{\n"
+        + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+        + "  \"name\": \"get-traces\",\n"
+        + "  \"id\": \"6b221d5bc9e6496c\"\n"
+        + "}").getBytes(UTF_8);
+
+    assertThat(Codec.JSON.readSpan(with128BitTraceId))
+        .isEqualTo(Codec.JSON.readSpan(withLower64bitsTraceId));
+  }
+
+  @Test
   public void ignoreNull_parentId() {
     String json = "{\n"
         + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
@@ -57,7 +75,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  \"parentId\": null\n"
         + "}";
 
-    Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
   }
 
   @Test
@@ -69,7 +87,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  \"timestamp\": null\n"
         + "}";
 
-    Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
   }
 
   @Test
@@ -81,7 +99,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  \"duration\": null\n"
         + "}";
 
-    Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
   }
 
   @Test
@@ -93,7 +111,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  \"debug\": null\n"
         + "}";
 
-    Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
   }
 
   @Test
@@ -111,7 +129,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  ]\n"
         + "}";
 
-    Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
   }
 
   @Test
@@ -129,7 +147,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  ]\n"
         + "}";
 
-    Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
   }
 
   @Test
@@ -143,7 +161,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  \"id\": \"6b221d5bc9e6496c\"\n"
         + "}";
 
-    Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
   }
 
   @Test
@@ -157,7 +175,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  \"id\": null\n"
         + "}";
 
-    Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
   }
 
   @Test
@@ -175,7 +193,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  ]\n"
         + "}";
 
-    Span span = Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Span span = Codec.JSON.readSpan(json.getBytes(UTF_8));
     assertThat(span.binaryAnnotations)
         .containsExactly(BinaryAnnotation.builder()
             .key("num")
@@ -202,7 +220,7 @@ public final class JsonCodecTest extends CodecTest {
         + "  ]\n"
         + "}";
 
-    Span span = Codec.JSON.readSpan(json.getBytes(Util.UTF_8));
+    Span span = Codec.JSON.readSpan(json.getBytes(UTF_8));
     assertThat(span.binaryAnnotations)
         .containsExactly(BinaryAnnotation.builder()
             .key("num")

--- a/zipkin/src/test/java/zipkin/internal/UtilTest.java
+++ b/zipkin/src/test/java/zipkin/internal/UtilTest.java
@@ -54,13 +54,19 @@ public class UtilTest {
   }
 
   @Test
+  public void lowerHexToUnsignedLong_downgrades128bitIdsByDroppingHighBits() {
+    assertThat(lowerHexToUnsignedLong("463ac35c9f6413ad48485a3953bb6124"))
+        .isEqualTo(lowerHexToUnsignedLong("48485a3953bb6124"));
+  }
+
+  @Test
   public void lowerHexToUnsignedLongTest() {
     assertThat(lowerHexToUnsignedLong("ffffffffffffffff")).isEqualTo(-1);
     assertThat(lowerHexToUnsignedLong("0")).isEqualTo(0);
     assertThat(lowerHexToUnsignedLong(Long.toHexString(Long.MAX_VALUE))).isEqualTo(Long.MAX_VALUE);
 
     try {
-      lowerHexToUnsignedLong("fffffffffffffffff"); // too long
+      lowerHexToUnsignedLong("fffffffffffffffffffffffffffffffff"); // too long
       failBecauseExceptionWasNotThrown(NumberFormatException.class);
     } catch (NumberFormatException e) {
 


### PR DESCRIPTION
This bridges support for 128bit trace ids by not failing on their
receipt. Basically, this throws out any hex characters to the left
of the 16 needed for the 64bit trace id.

See #1262
