### PR TITLE
Unbreaks ElasticsearchStorage.Builder; reduces scope of internal client

### DIFF
--- a/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -17,13 +17,12 @@ import java.util.Collections;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.storage.elasticsearch.ElasticsearchStorage;
-import zipkin.storage.elasticsearch.NativeClient;
 
 @ConfigurationProperties("zipkin.storage.elasticsearch")
 public class ZipkinElasticsearchStorageProperties {
-  /** @see NativeClient.Builder#cluster(String) */
+  /** @see ElasticsearchStorage.Builder#cluster(String) */
   private String cluster = "elasticsearch";
-  /** @see NativeClient.Builder#hosts(List) */
+  /** @see ElasticsearchStorage.Builder#hosts(List) */
   private List<String> hosts = Collections.singletonList("localhost:9300");
   /** @see ElasticsearchStorage.Builder#index(String) */
   private String index = "zipkin";
@@ -77,9 +76,8 @@ public class ZipkinElasticsearchStorageProperties {
 
   public ElasticsearchStorage.Builder toBuilder() {
     return ElasticsearchStorage.builder()
-        .client(NativeClient.builder()
-            .cluster(cluster)
-            .hosts(hosts).build())
+        .cluster(cluster)
+        .hosts(hosts)
         .index(index)
         .indexShards(indexShards)
         .indexReplicas(indexReplicas);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/IndexNameFormatter.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/IndexNameFormatter.java
@@ -40,7 +40,7 @@ final class IndexNameFormatter {
     return index + "-" + dateFormat.get().format(new Date(timestampMillis));
   }
 
-  String[] catchAll() {
-    return new String[] {index + "-*"};
+  String catchAll() {
+    return index + "-*";
   }
 }

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
@@ -14,9 +14,9 @@
 package zipkin.storage.elasticsearch;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -27,24 +27,55 @@ import zipkin.Span;
 /**
  * Common interface for different protocol implementations communicating with Elasticsearch.
  *
- * Due to the difficulties of shoehorning auth over the native Elasticsearch protocol, many PaaS
+ * <p>Due to the difficulties of shoehorning auth over the native Elasticsearch protocol, many PaaS
  * providers (like AWS) only offer REST interfaces to ElasticSearch (presumably they meet their
  * security requirements with an HTTP proxy layer).
  *
- * That means, in order to support both aaS elasticsearch and "native" elasticsearch, we require a
- * shim.
+ * <p>That means, in order to support both aaS elasticsearch and "native" elasticsearch, we require
+ * a shim.
  */
-interface InternalElasticsearchClient extends AutoCloseable {
-
+public abstract class InternalElasticsearchClient implements Closeable {
   /**
-   * Ensures the existence of a template, creating it if it does not exist.
+   * The maximum count of raw spans returned in a trace query.
+   *
+   * <p>Not configurable as it implies adjustments to the index template (index.max_result_window)
+   * and user settings
+   *
+   * <p> See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html
    */
-  void ensureTemplate(String name, String indexTemplate);
+  protected static final int MAX_RAW_SPANS = 10000; // the default elasticsearch allowed limit
+  protected static final String SPAN = "span";
+  protected static final String DEPENDENCY_LINK = "dependencylink";
 
-  /**
-   * Deletes the specified index (or indices, if a pattern is supplied)
-   */
-  void clear(String index);
+  protected interface Factory {
+    InternalElasticsearchClient create();
+  }
+
+  // abstract class so we can hide flushOnWrites
+  protected interface Builder {
+    /** The elasticsearch cluster to connect to, defaults to "elasticsearch". */
+    Builder cluster(String cluster);
+
+    /**
+     * A comma separated list of elasticsearch host to connect to, in a transport-specific format.
+     * For example, for the native client, this would default to "localhost:9300".
+     */
+    Builder hosts(List<String> hosts);
+
+    /**
+     * Internal flag that allows you read-your-writes consistency during tests. With Elasticsearch,
+     * it is not sufficient to block on futures since the index also needs to be flushed.
+     */
+    Builder flushOnWrites(boolean flushOnWrites);
+
+    Factory buildFactory();
+  }
+
+  /** Ensures the existence of a template, creating it if it does not exist. */
+  protected abstract void ensureTemplate(String name, String indexTemplate);
+
+  /** Deletes the specified index pattern is supplied */
+  protected abstract void clear(String index);
 
   /**
    * Scans the given indices with the given query and aggregates. If aggregating all traces,
@@ -55,10 +86,10 @@ interface InternalElasticsearchClient extends AutoCloseable {
    *
    * Will never return results; this interface is for aggregation only.
    */
-  ListenableFuture<Buckets> scanTraces(String[] indices, QueryBuilder query,
+  protected abstract ListenableFuture<Buckets> scanTraces(String[] indices, QueryBuilder query,
       AbstractAggregationBuilder... aggregations);
 
-  interface Buckets {
+  protected interface Buckets {
     /**
      * Retrieves the aggregation bucket keys from the aggregation at name[>nestedPath]
      *
@@ -66,6 +97,7 @@ interface InternalElasticsearchClient extends AutoCloseable {
      * interface wraps the ugliness of dealing with different aggregation APIs while leaving control
      * of the aggregation keys in the hands of the caller.
      */
+    // TODO(adrian): revisit once the other implementation is in: can we avoid varags?
     List<String> getBucketKeys(String name, String... nestedPath);
   }
 
@@ -76,7 +108,7 @@ interface InternalElasticsearchClient extends AutoCloseable {
    * NB: This call is _lenient_ in its index selection, and only will match open indexes, cf.
    * {@link IndicesOptions#lenientExpandOpen()}.
    */
-  ListenableFuture<List<Span>> findSpans(String[] indices, QueryBuilder query);
+  protected abstract ListenableFuture<List<Span>> findSpans(String[] indices, QueryBuilder query);
 
   /**
    * Retrieves all dependency links in the given indices. Useful for gathering dependencies from
@@ -85,32 +117,18 @@ interface InternalElasticsearchClient extends AutoCloseable {
    * NB: This call is _lenient_ in its index selection, and only will match open indexes, cf.
    * {@link IndicesOptions#lenientExpandOpen()} }.
    */
-  ListenableFuture<Collection<DependencyLink>> findDependencies(String[] indices);
-
-  /**
-   * Indexes the given dependency links, flushing unconditionally.
-   */
-  void indexDependencies(String index, List<IndexableLink> links);
-
-  final class IndexableLink {
-    final String id;
-    final Map<String, ?> data;
-
-    public IndexableLink(String id, Map<String, ?> data) {
-      this.id = id;
-      this.data = data;
-    }
-  }
+  // TODO(adrian): revisit once the other implementation is in: why we are using arrays vs lists?
+  protected abstract ListenableFuture<Collection<DependencyLink>> findDependencies(String[] indices);
 
   /**
    * Indexes the given spans, flushing depending on the value of
-   * {@link ElasticsearchStorage#FLUSH_ON_WRITES}
+   * {@link Builder#flushOnWrites(boolean)}
    */
-  ListenableFuture<Void> indexSpans(List<IndexableSpan> spans);
+  protected abstract ListenableFuture<Void> indexSpans(List<IndexableSpan> spans);
 
-  final class IndexableSpan {
-    final String index;
-    final byte[] data;
+  protected static final class IndexableSpan {
+    public final String index;
+    public final byte[] data;
 
     IndexableSpan(String index, byte[] data) {
       this.index = index;
@@ -119,23 +137,13 @@ interface InternalElasticsearchClient extends AutoCloseable {
   }
 
   /**
-   * Cluster health status
-   */
-  HealthStatus clusterHealth(String... indices);
-
-  @SuppressWarnings("unused") enum HealthStatus {
-    GREEN, YELLOW, RED
-  }
-
-  /**
-   * See {@link AutoCloseable#close()}
+   * Throws an exception if the health status is red, or a connection couldn't be made.
    *
-   * Overridden to remove checked exceptions.
+   * @param catchAll See {@link IndexNameFormatter#catchAll()}
    */
-  @Override
-  void close();
+  protected abstract void ensureClusterReady(String catchAll);
 
-  interface ClientFactory {
-    InternalElasticsearchClient create(String[] allIndices);
-  }
+  /** Overridden to remove checked exceptions. */
+  @Override
+  public abstract void close();
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
@@ -14,9 +14,10 @@
 package zipkin.storage.elasticsearch;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import java.util.List;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.client.transport.TransportClient;
 import zipkin.DependencyLink;
 import zipkin.Span;
 import zipkin.internal.MergeById;
@@ -66,14 +67,19 @@ public class ElasticsearchDependenciesTest extends DependenciesTest {
 
   @VisibleForTesting void writeDependencyLinks(List<DependencyLink> links, long timestampMillis) {
     long midnight = Util.midnightUTC(timestampMillis);
-    storage.client().indexDependencies(storage.indexNameFormatter.indexNameForTimestamp(midnight),
-        Lists.transform(links, link -> new InternalElasticsearchClient.IndexableLink(
-                link.parent + "|" + link.child, // unique constraint
-                ImmutableMap.of(
-                    "parent", link.parent,
-                    "child", link.child,
-                    "callCount", link.callCount
-                )
-            )));
+    TransportClient client = ((NativeClient) storage.client()).client;
+    BulkRequestBuilder request = client.prepareBulk();
+    for (DependencyLink link : links) {
+      request.add(client.prepareIndex(
+          storage.indexNameFormatter.indexNameForTimestamp(midnight),
+          ElasticsearchConstants.DEPENDENCY_LINK)
+          .setId(link.parent + "|" + link.child) // Unique constraint
+          .setSource(
+              "parent", link.parent,
+              "child", link.child,
+              "callCount", link.callCount));
+    }
+    request.execute().actionGet();
+    client.admin().indices().flush(new FlushRequest()).actionGet();
   }
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchStorageTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchStorageTest.java
@@ -24,8 +24,7 @@ public class ElasticsearchStorageTest {
   @Test
   public void check_failsInsteadOfThrowing() {
     CheckResult result =
-        ElasticsearchStorage.builder().client(NativeClient.builder().cluster("1.1.1.1").build())
-            .build().check();
+        ElasticsearchStorage.builder().cluster("1.1.1.1").build().check();
 
     assertThat(result.ok).isFalse();
     assertThat(result.exception)

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
@@ -13,27 +13,25 @@
  */
 package zipkin.storage.elasticsearch;
 
+import java.util.List;
 import org.junit.AssumptionViolatedException;
 import zipkin.Component.CheckResult;
+import zipkin.DependencyLink;
 import zipkin.internal.LazyCloseable;
 
 enum ElasticsearchTestGraph {
   INSTANCE;
-
-  static {
-    ElasticsearchStorage.FLUSH_ON_WRITES = true;
-  }
 
   final LazyCloseable<ElasticsearchStorage> storage = new LazyCloseable<ElasticsearchStorage>() {
     public AssumptionViolatedException ex;
 
     @Override protected ElasticsearchStorage compute() {
       if (ex != null) throw ex;
-      ElasticsearchStorage result =
-          new ElasticsearchStorage.Builder().index("test_zipkin_native").build();
+      ElasticsearchStorage result = ElasticsearchStorage.builder()
+          .index("test_zipkin_native").flushOnWrites(true).build();
       CheckResult check = result.check();
       if (check.ok) return result;
-      throw ex = new AssumptionViolatedException("cluster was not healthy", check.exception);
+      throw ex = new AssumptionViolatedException(check.exception.getMessage());
     }
   };
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/LazyClientTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/LazyClientTest.java
@@ -25,20 +25,17 @@ public class LazyClientTest {
 
   @Test
   public void testToString() {
-    LazyClient lazyClient = new LazyClient(new ElasticsearchStorage.Builder()
-        .client(new NativeClient.Builder()
+    LazyClient lazyClient = new LazyClient(ElasticsearchStorage.builder()
         .cluster("cluster")
-        .hosts(asList("host1", "host2"))
-        .build()));
+        .hosts(asList("host1", "host2")));
 
     assertThat(lazyClient)
-        .hasToString("{\"clientFactory\": "
-            + "{\"clusterName\": \"cluster\", \"hosts\": [\"host1\", \"host2\"]}}");
+        .hasToString("{\"clusterName\": \"cluster\", \"hosts\": [\"host1\", \"host2\"]}");
   }
 
   @Test
   public void defaultShardAndReplicaCount() {
-    LazyClient lazyClient = new LazyClient(new ElasticsearchStorage.Builder());
+    LazyClient lazyClient = new LazyClient(ElasticsearchStorage.builder());
 
     assertThat(lazyClient.indexTemplate)
         .contains("    \"index.number_of_shards\": 5,\n"
@@ -47,7 +44,7 @@ public class LazyClientTest {
 
   @Test
   public void overrideShardAndReplicaCount() {
-    LazyClient lazyClient = new LazyClient(new ElasticsearchStorage.Builder()
+    LazyClient lazyClient = new LazyClient(ElasticsearchStorage.builder()
         .indexShards(30)
         .indexReplicas(0));
 
@@ -57,13 +54,14 @@ public class LazyClientTest {
   }
 
   @Test
-  public void nativePortDefaultsTo9300() {
-    try (LazyClient lazyClient = new LazyClient(new ElasticsearchStorage.Builder()
-        .client(new NativeClient.Builder().hosts(asList("localhost")).build()))) {
+  public void portDefaultsTo9300() {
+    try (LazyClient lazyClient = new LazyClient(ElasticsearchStorage.builder()
+        .hosts(asList("localhost")))) {
 
-      assertThat(((NativeClient) lazyClient.get()).transportAddresses())
+      assertThat(((NativeClient) lazyClient.get()).client.transportAddresses())
           .extracting(TransportAddress::getPort)
           .containsOnly(9300);
+
     } catch (NoNodeAvailableException e) {
       throw new AssumptionViolatedException(e.getMessage());
     }


### PR DESCRIPTION
This does a few things to make the recently refactored Elasticsearch
component more maintainable:
- Unbreaks api changes to ElasticsearchStorage.Builder
  - This now delegates to InternalElasticsearchClient.Builder
- Reduces scope of InternalElasticsearchClient
  - Removes dependency writes as this is only used in tests
- Various small cleanups.

See #1303
