### PR TITLE
Adds cause to test skip exception

### DIFF
--- a/zipkin-collector/kafka/src/test/java/zipkin/collector/kafka/KafkaTestGraph.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin/collector/kafka/KafkaTestGraph.java
@@ -40,7 +40,7 @@ enum KafkaTestGraph {
         new ZkClient("127.0.0.1:2181", 1000);
         producer.send(new KeyedMessage<>("test", new byte[0]));
       } catch (FailedToSendMessageException | ZkTimeoutException e) {
-        throw ex = new AssumptionViolatedException(e.getMessage());
+        throw ex = new AssumptionViolatedException(e.getMessage(), e);
       }
     }
     return producer;

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
@@ -28,7 +28,7 @@ enum CassandraTestGraph {
       CassandraStorage result = CassandraStorage.builder().keyspace("test_zipkin").build();
       CheckResult check = result.check();
       if (check.ok) return result;
-      throw ex = new AssumptionViolatedException(check.exception.getMessage());
+      throw ex = new AssumptionViolatedException(check.exception.getMessage(), check.exception);
     }
   };
 }

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaTestGraph.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraWithOriginalSchemaTestGraph.java
@@ -38,12 +38,12 @@ enum CassandraWithOriginalSchemaTestGraph {
            Session session = cluster.newSession()) {
         Schema.applyCqlFile(result.keyspace, session, "/cassandra-schema-cql3-original.txt");
       } catch (RuntimeException e) {
-        throw ex = new AssumptionViolatedException(e.getMessage());
+        throw ex = new AssumptionViolatedException(e.getMessage(), e);
       }
 
       CheckResult check = result.check();
       if (check.ok) return result;
-      throw ex = new AssumptionViolatedException(check.exception.getMessage());
+      throw ex = new AssumptionViolatedException(check.exception.getMessage(), check.exception);
     }
   };
 }

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/Cassandra3TestGraph.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/Cassandra3TestGraph.java
@@ -28,7 +28,7 @@ enum Cassandra3TestGraph {
       Cassandra3Storage result = Cassandra3Storage.builder().keyspace("test_zipkin3").build();
       CheckResult check = result.check();
       if (check.ok) return result;
-      throw ex = new AssumptionViolatedException(check.exception.getMessage());
+      throw ex = new AssumptionViolatedException(check.exception.getMessage(), check.exception);
     }
   };
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
@@ -31,7 +31,7 @@ enum ElasticsearchTestGraph {
           .index("test_zipkin_native").flushOnWrites(true).build();
       CheckResult check = result.check();
       if (check.ok) return result;
-      throw ex = new AssumptionViolatedException(check.exception.getMessage());
+      throw ex = new AssumptionViolatedException(check.exception.getMessage(), check.exception);
     }
   };
 }

--- a/zipkin-storage/mysql/src/test/java/zipkin/storage/mysql/MySQLTestGraph.java
+++ b/zipkin-storage/mysql/src/test/java/zipkin/storage/mysql/MySQLTestGraph.java
@@ -36,7 +36,7 @@ enum MySQLTestGraph {
         dataSource.setUrl(mysqlUrl);
         return new MySQLStorage.Builder().datasource(dataSource).executor(Runnable::run).build();
       } catch (SQLException e) {
-        throw new AssumptionViolatedException(e.getMessage());
+        throw new AssumptionViolatedException(e.getMessage(), e);
       }
     }
   };


### PR DESCRIPTION
When the environment isn't available, we used to log the reason, but not
the root cause. @sethp-jive noticed it is easier to debug new components
if we log the cause. This does that!

See https://github.com/openzipkin/zipkin/pull/1304#r79512516
