### PR TITLE
Makes it possible to display annotations who are a json value

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -22,7 +22,10 @@ export default component(function spanPanel() {
       }
       $row.find('td').each(function() {
         const $this = $(this);
-        $this.text(anno[$this.data('key')]);
+        const maybeObject = anno[$this.data('key')];
+        // In case someone is storing escaped json as an annotation value
+        // TODO: this class is not testable at the moment
+        $this.text($.type(maybeObject) === 'object' ? JSON.stringify(maybeObject) : maybeObject);
       });
       $annoBody.append($row);
     });


### PR DESCRIPTION
Tested by making an annotation have a json value

![screen shot 2016-09-20 at 9 58 26 am](https://cloud.githubusercontent.com/assets/64215/18660490/4e3a7a3e-7f43-11e6-975d-76dbc06b791d.png)

See https://github.com/uber/jaeger-client-go/pull/42/files#diff-0c86eb97f3a2f8a9893cb60c27e21dd7R33
See dfcd6c120436c3a6b341f136dc7c634d78b59f4a
