### PR TITLE
Deprecates Endpoint.create(String,int,int) as it leads to null pointers

### DIFF
--- a/benchmarks/src/main/java/zipkin/benchmarks/SpanBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/SpanBenchmarks.java
@@ -44,8 +44,10 @@ import zipkin.Span;
 public class SpanBenchmarks {
   // endpoints are almost always cached, so caching here to record more accurate performance
   static final Endpoint web = Endpoint.create("web", 124 << 24 | 13 << 16 | 90 << 8 | 3);
-  static final Endpoint app = Endpoint.create("app", 172 << 24 | 17 << 16 | 2, 8080);
-  static final Endpoint db = Endpoint.create("db", 172 << 24 | 17 << 16 | 2, 3306);
+  static final Endpoint app =
+      Endpoint.builder().serviceName("app").ipv4(172 << 24 | 17 << 16 | 2).port(8080).build();
+  static final Endpoint db =
+      Endpoint.builder().serviceName("db").ipv4(172 << 24 | 17 << 16 | 2).port(3306).build();
 
   @Benchmark
   public Span buildLocalSpan() {

--- a/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/brave/TraceZipkinMySQLStorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/brave/TraceZipkinMySQLStorageAutoConfiguration.java
@@ -70,7 +70,7 @@ public class TraceZipkinMySQLStorageAutoConfiguration extends DefaultExecuteList
   @Bean
   @Qualifier("mysql") Endpoint mysql() throws UnknownHostException {
     int ipv4 = ByteBuffer.wrap(InetAddress.getByName(mysql.getHost()).getAddress()).getInt();
-    return Endpoint.create("mysql", ipv4, mysql.getPort());
+    return Endpoint.builder().serviceName("mysql").ipv4(ipv4).port(mysql.getPort()).build();
   }
 
   @Autowired

--- a/zipkin-collector/scribe/src/test/java/zipkin/collector/scribe/ScribeSpanConsumerTest.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin/collector/scribe/ScribeSpanConsumerTest.java
@@ -162,8 +162,9 @@ public class ScribeSpanConsumerTest {
     Arrays.fill(as, 'a');
     String reallyLongAnnotation = new String(as);
 
-    Endpoint zipkinQuery = Endpoint.create("zipkin-query", (127 << 24) | 1, 9411);
-    Endpoint zipkinQuery0 = Endpoint.create("zipkin-query", (127 << 24) | 1);
+    Endpoint zipkinQuery =
+        Endpoint.builder().serviceName("zipkin-query").ipv4(127 << 24 | 1).port(9411).build();
+    Endpoint zipkinQuery0 = zipkinQuery.toBuilder().port(null).build();
 
     assertThat(consumed).containsExactly(
         Span.builder()
@@ -182,7 +183,7 @@ public class ScribeSpanConsumerTest {
             .addBinaryAnnotation(binaryAnnotation("srv/mux/enabled", true, zipkinQuery0))
             .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, zipkinQuery))
             .addBinaryAnnotation(BinaryAnnotation.address(Constants.CLIENT_ADDR,
-                Endpoint.create("zipkin-query", (127 << 24) | 1, 63840)))
+                zipkinQuery.toBuilder().port(63840).build()))
             .addBinaryAnnotation(binaryAnnotation("numIds", 1, zipkinQuery))
             .debug(false)
             .build());

--- a/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
@@ -56,7 +56,7 @@ public class BraveConfiguration {
     } catch (Exception ignored) {
       ipv4 = 127 << 24 | 1;
     }
-    return Endpoint.create("zipkin-server", ipv4, port);
+    return Endpoint.builder().serviceName("zipkin-server").ipv4(ipv4).port(port).build();
   }
 
   @Bean LocalSpanCollector spanCollector(StorageComponent storage,

--- a/zipkin/src/main/java/zipkin/Endpoint.java
+++ b/zipkin/src/main/java/zipkin/Endpoint.java
@@ -31,6 +31,10 @@ import static zipkin.internal.Util.checkNotNull;
  */
 public final class Endpoint {
 
+  /**
+   * @deprecated as leads to null pointer exceptions on port. Use {@link #builder()} instead.
+   */
+  @Deprecated
   public static Endpoint create(String serviceName, int ipv4, int port) {
     return new Endpoint(serviceName, ipv4, null, port == 0 ? null : (short) (port & 0xffff));
   }
@@ -133,6 +137,21 @@ public final class Endpoint {
         checkArgument(ipv6.length == 16, "ipv6 addresses are 16 bytes: " + ipv6.length);
         this.ipv6 = ipv6;
       }
+      return this;
+    }
+
+    /**
+     * Use this to set the port to an externally defined value.
+     *
+     * <p>Don't pass {@link Endpoint#port} to this method, as it may result in a
+     * NullPointerException. Instead, use {@link Endpoint#toBuilder()} or {@link #port(Short)}.
+     *
+     * @param port port associated with the endpoint. zero coerces to null (unknown)
+     * @see Endpoint#port
+     */
+    public Builder port(int port) {
+      checkArgument(port >= 0 && port <= 0xffff, "invalid port %s", port);
+      this.port = port == 0 ? null : (short) (port & 0xffff);
       return this;
     }
 

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -81,7 +81,7 @@ public final class JsonCodec implements Codec {
           // Shouldn't hit DNS, because it's an IP string literal.
           result.ipv6(Inet6Address.getByName(input).getAddress());
         } else if (nextName.equals("port")) {
-          result.port((short) reader.nextInt());
+          result.port(reader.nextInt());
         } else {
           reader.skipValue();
         }

--- a/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
@@ -124,7 +124,7 @@ public final class ThriftCodec implements Codec {
         if (field.isEqualTo(IPV4)) {
           result.ipv4(bytes.getInt());
         } else if (field.isEqualTo(PORT)) {
-          result.port(bytes.getShort());
+          result.port(Short.valueOf(bytes.getShort()));
         } else if (field.isEqualTo(SERVICE_NAME)) {
           result.serviceName(readUtf8(bytes));
         } else if (field.isEqualTo(IPV6)) {

--- a/zipkin/src/test/java/zipkin/EndpointTest.java
+++ b/zipkin/src/test/java/zipkin/EndpointTest.java
@@ -38,6 +38,36 @@ public class EndpointTest {
   }
 
   @Test
+  public void builderWithPort_0CoercesToNull() {
+    assertThat(Endpoint.builder().serviceName("foo").port(0).build().port)
+        .isNull();
+  }
+
+  @Test
+  public void builderWithPort_highest() {
+    assertThat(Endpoint.builder().serviceName("foo").port(65535).build().port)
+        .isEqualTo((short) -1); // an unsigned short of 65535 is the same as -1
+  }
+
+  /** The integer arg of port should be a whole number */
+  @Test
+  public void builderWithPort_negativeIsInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("invalid port -1");
+
+    assertThat(Endpoint.builder().serviceName("foo").port(-1).build().port);
+  }
+
+  /** The integer arg of port should fit in a 16bit unsigned value */
+  @Test
+  public void builderWithPort_tooHighIsInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("invalid port 65536");
+
+    assertThat(Endpoint.builder().serviceName("foo").port(65536).build().port);
+  }
+
+  @Test
   public void lowercasesServiceName() {
     assertThat(Endpoint.builder().serviceName("fFf").ipv4(127 << 24 | 1).build().serviceName)
         .isEqualTo("fff");

--- a/zipkin/src/test/java/zipkin/TestObjects.java
+++ b/zipkin/src/test/java/zipkin/TestObjects.java
@@ -46,9 +46,9 @@ public final class TestObjects {
       .ipv6(sun.net.util.IPAddressUtil.textToNumericFormatV6("2001:db8::c001"))
       .port((short) 80).build();
   public static final Endpoint APP_ENDPOINT =
-      Endpoint.create("app", 172 << 24 | 17 << 16 | 2, 8080);
+      Endpoint.builder().serviceName("app").ipv4(172 << 24 | 17 << 16 | 2).port(8080).build();
   public static final Endpoint DB_ENDPOINT =
-      Endpoint.create("db", 172 << 24 | 17 << 16 | 2, 3306);
+      Endpoint.builder().serviceName("db").ipv4(172 << 24 | 17 << 16 | 2).port(3306).build();
   public static final Endpoint NO_IP_ENDPOINT = Endpoint.builder().serviceName("no_ip").build();
 
   static final long WEB_SPAN_ID = -692101025335252320L;
@@ -88,7 +88,7 @@ public final class TestObjects {
 
   /** Reuse a builder as it is significantly slows tests to create 100000 of these! */
   static Span.Builder spanBuilder() {
-    Endpoint e = Endpoint.create("service", 127 << 24 | 1, 8080);
+    Endpoint e = Endpoint.builder().serviceName("service").ipv4(127 << 24 | 1).port(8080).build();
     Annotation sr = Annotation.create(System.currentTimeMillis() * 1000, SERVER_RECV, e);
     Annotation ss = Annotation.create(sr.timestamp + 1000, SERVER_SEND, e);
     BinaryAnnotation ba = BinaryAnnotation.create(TraceKeys.HTTP_METHOD, "GET", e);

--- a/zipkin/src/test/java/zipkin/internal/ApplyTimestampAndDurationTest.java
+++ b/zipkin/src/test/java/zipkin/internal/ApplyTimestampAndDurationTest.java
@@ -25,10 +25,12 @@ import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
 
 public class ApplyTimestampAndDurationTest {
 
-  Endpoint frontend = Endpoint.create("frontend", 192 << 24 | 168 << 16 | 2, 8080);
+  Endpoint frontend =
+      Endpoint.builder().serviceName("frontend").ipv4(192 << 24 | 12 << 16 | 1).port(8080).build();
   Annotation cs = Annotation.create((50) * 1000, CLIENT_SEND, frontend);
 
-  Endpoint backend = Endpoint.create("backend", 192 << 24 | 168 << 16 | 2, 8080);
+  Endpoint backend =
+        Endpoint.builder().serviceName("backend").ipv4(192 << 24 | 12 << 16 | 2).port(8080).build();
   Annotation sr = Annotation.create((95) * 1000, SERVER_RECV, backend);
 
   Span.Builder span = Span.builder().traceId(1).name("method1").id(666);

--- a/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
@@ -124,11 +124,11 @@ public abstract class DependenciesTest {
    */
   @Test
   public void getDependenciesAllInstrumented() {
-    Endpoint one = Endpoint.create("trace-producer-one", 127 << 24 | 1, 9410);
+    Endpoint one = Endpoint.create("trace-producer-one", 127 << 24 | 1);
     Endpoint onePort3001 = one.toBuilder().port((short) 3001).build();
-    Endpoint two = Endpoint.create("trace-producer-two", 127 << 24 | 2, 9410);
+    Endpoint two = Endpoint.create("trace-producer-two", 127 << 24 | 2);
     Endpoint twoPort3002 = two.toBuilder().port((short) 3002).build();
-    Endpoint three = Endpoint.create("trace-producer-three", 127 << 24 | 3, 9410);
+    Endpoint three = Endpoint.create("trace-producer-three", 127 << 24 | 3);
 
     List<Span> trace = asList(
         Span.builder().traceId(10L).id(10L).name("get")
@@ -168,11 +168,11 @@ public abstract class DependenciesTest {
    */
   @Test
   public void getDependencies_noTimestamps() {
-    Endpoint one = Endpoint.create("trace-producer-one", 127 << 24 | 1, 9410);
+    Endpoint one = Endpoint.create("trace-producer-one", 127 << 24 | 1);
     Endpoint onePort3001 = one.toBuilder().port((short) 3001).build();
-    Endpoint two = Endpoint.create("trace-producer-two", 127 << 24 | 2, 9410);
+    Endpoint two = Endpoint.create("trace-producer-two", 127 << 24 | 2);
     Endpoint twoPort3002 = two.toBuilder().port((short) 3002).build();
-    Endpoint three = Endpoint.create("trace-producer-three", 127 << 24 | 3, 9410);
+    Endpoint three = Endpoint.create("trace-producer-three", 127 << 24 | 3);
 
     List<Span> trace = asList(
         Span.builder().traceId(10L).id(10L).name("get")
@@ -286,7 +286,7 @@ public abstract class DependenciesTest {
    */
   @Test
   public void notInstrumentedClientAndServer() {
-    Endpoint someClient = Endpoint.create("some-client", 172 << 24 | 17 << 16 | 4, 80);
+    Endpoint someClient = Endpoint.create("some-client", 172 << 24 | 17 << 16 | 4);
 
     List<Span> trace = asList(
         Span.builder().traceId(20L).id(20L).name("get")
@@ -418,7 +418,7 @@ public abstract class DependenciesTest {
   /** This test confirms that core ("sr", "cs", "cr", "ss") annotations are not required. */
   @Test
   public void noCoreAnnotations() {
-    Endpoint someClient = Endpoint.create("some-client", 172 << 24 | 17 << 16 | 4, 80);
+    Endpoint someClient = Endpoint.create("some-client", 172 << 24 | 17 << 16 | 4);
     List<Span> trace = asList(
         Span.builder().traceId(20L).id(20L).name("get")
             .timestamp(TODAY * 1000).duration(350L * 1000)

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -85,7 +85,7 @@ public abstract class SpanStoreTest {
   // Use real time, as most span-stores have TTL logic which looks back several days.
   long today = midnight();
 
-  Endpoint ep = Endpoint.create("service", 127 << 24 | 1, 8080);
+  Endpoint ep = Endpoint.create("service", 127 << 24 | 1);
 
   long spanId = 456;
   Annotation ann1 = Annotation.create((today + 1) * 1000, "cs", ep);
@@ -205,7 +205,7 @@ public abstract class SpanStoreTest {
 
   @Test
   public void getAllServiceNames() {
-    BinaryAnnotation yak = BinaryAnnotation.address("sa", Endpoint.create("yak", 127 << 24 | 1, 8080));
+    BinaryAnnotation yak = BinaryAnnotation.address("sa", Endpoint.create("yak", 127 << 24 | 1));
     accept(span1.toBuilder().addBinaryAnnotation(yak).build(), span4);
 
     // should be in order
@@ -220,7 +220,7 @@ public abstract class SpanStoreTest {
     for (int i = 0; i < 50; i++) {
       String suffix = i < 10 ? "0" + i : String.valueOf(i);
       BinaryAnnotation yak =
-          BinaryAnnotation.address("sa", Endpoint.create("yak" + suffix, 127 << 24 | 1, 8080));
+          BinaryAnnotation.address("sa", Endpoint.create("yak" + suffix, 127 << 24 | 1));
       accept(span1.toBuilder().id(i).addBinaryAnnotation(yak).build());
       serviceNames.add("yak" + suffix);
     }
@@ -312,9 +312,9 @@ public abstract class SpanStoreTest {
   /** Shows that duration queries go against the root span, not the child */
   @Test
   public void getTraces_duration() {
-    Endpoint service1 = Endpoint.create("service1", 127 << 24 | 1, 8080);
-    Endpoint service2 = Endpoint.create("service2", 127 << 24 | 2, 8080);
-    Endpoint service3 = Endpoint.create("service3", 127 << 24 | 3, 8080);
+    Endpoint service1 = Endpoint.create("service1", 127 << 24 | 1);
+    Endpoint service2 = Endpoint.create("service2", 127 << 24 | 2);
+    Endpoint service3 = Endpoint.create("service3", 127 << 24 | 3);
 
     BinaryAnnotation.Builder component = BinaryAnnotation.builder().key(LOCAL_COMPONENT).value("archiver");
     BinaryAnnotation archiver1 = component.endpoint(service1).build();
@@ -628,9 +628,9 @@ public abstract class SpanStoreTest {
    */
   @Test
   public void correctsClockSkew() {
-    Endpoint client = Endpoint.create("client", 192 << 24 | 168 << 16 | 1, 8080);
-    Endpoint frontend = Endpoint.create("frontend", 192 << 24 | 168 << 16 | 2, 8080);
-    Endpoint backend = Endpoint.create("backend", 192 << 24 | 168 << 16 | 3, 8080);
+    Endpoint client = Endpoint.create("client", 192 << 24 | 168 << 16 | 1);
+    Endpoint frontend = Endpoint.create("frontend", 192 << 24 | 168 << 16 | 2);
+    Endpoint backend = Endpoint.create("backend", 192 << 24 | 168 << 16 | 3);
 
     /** Intentionally not setting span.timestamp, duration */
     Span parent = Span.builder()
@@ -696,8 +696,8 @@ public abstract class SpanStoreTest {
    */
   @Test
   public void clientTimestampAndDurationWinInSharedSpan() {
-    Endpoint client = Endpoint.create("client", 192 << 24 | 168 << 16 | 1, 8080);
-    Endpoint server = Endpoint.create("server", 192 << 24 | 168 << 16 | 2, 8080);
+    Endpoint client = Endpoint.create("client", 192 << 24 | 168 << 16 | 1);
+    Endpoint server = Endpoint.create("server", 192 << 24 | 168 << 16 | 2);
 
     long clientTimestamp = (today + 100) * 1000;
     long clientDuration = 35 * 1000;
@@ -769,11 +769,11 @@ public abstract class SpanStoreTest {
    */
   @Test
   public void whenSpanTimestampIsMissingClientSendIsPreferred() {
-    Endpoint frontend = Endpoint.create("frontend", 192 << 24 | 168 << 16 | 2, 8080);
+    Endpoint frontend = Endpoint.create("frontend", 192 << 24 | 168 << 16 | 2);
     Annotation cs = Annotation.create((today + 50) * 1000, CLIENT_SEND, frontend);
     Annotation cr = Annotation.create((today + 150) * 1000, CLIENT_RECV, frontend);
 
-    Endpoint backend = Endpoint.create("backend", 192 << 24 | 168 << 16 | 2, 8080);
+    Endpoint backend = Endpoint.create("backend", 192 << 24 | 168 << 16 | 2);
     Annotation sr = Annotation.create((today + 95) * 1000, SERVER_RECV, backend);
     Annotation ss = Annotation.create((today + 100) * 1000, SERVER_SEND, backend);
 
@@ -794,10 +794,10 @@ public abstract class SpanStoreTest {
   // This supports the "raw trace" feature, which skips application-level data cleaning
   @Test
   public void rawTrace_doesntPerformQueryTimeAdjustment() {
-    Endpoint producer = Endpoint.create("producer", 192 << 24 | 168 << 16 | 1, 8080);
+    Endpoint producer = Endpoint.create("producer", 192 << 24 | 168 << 16 | 1);
     Annotation ms = Annotation.create((today + 95) * 1000, "ms", producer);
 
-    Endpoint consumer = Endpoint.create("consumer", 192 << 24 | 168 << 16 | 2, 8080);
+    Endpoint consumer = Endpoint.create("consumer", 192 << 24 | 168 << 16 | 2);
     Annotation mr = Annotation.create((today + 100) * 1000, "mr", consumer);
 
     Span span = Span.builder().traceId(1).name("message").id(666).build();
@@ -824,7 +824,7 @@ public abstract class SpanStoreTest {
   @Test public void getTraces_acrossServices() {
     List<BinaryAnnotation> annotations = IntStream.rangeClosed(1, 10).mapToObj(i ->
         BinaryAnnotation.create(LOCAL_COMPONENT, "serviceAnnotation",
-            Endpoint.create("service" + i, 127 << 24 | i, 8080)))
+            Endpoint.create("service" + i, 127 << 24 | i)))
         .collect(Collectors.toList());
 
     long gapBetweenSpans = 100;


### PR DESCRIPTION
Multiple people have been bitten by `Endpoint.create(String,int,int)` as
`Endpoint.port` is nullable. This deprecates that method and advises to
use a better documented builder method or simply `Endpoint.toBuilder()`
when copying an endpoint.
