### PR TITLE
Fixes thread safety issues and improves health checks on elasticsearch

### DIFF
--- a/zipkin-autoconfigure/storage-elasticsearch-aws/pom.xml
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/pom.xml
@@ -65,5 +65,18 @@
       <artifactId>aws-java-sdk-sts</artifactId>
       <version>${aws.sdk.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/zipkin-autoconfigure/storage-elasticsearch-aws/src/main/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/src/main/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageProperties.java
@@ -128,10 +128,9 @@ public class ZipkinElasticsearchAwsStorageProperties {
     } else {
       region = ZipkinElasticsearchHttpStorageAutoConfiguration.regionFromAwsUrls(hosts).get();
     }
-    HttpClient.Builder httpBuilder = new HttpClient.Builder()
-        .addPostInterceptor(
-            new AwsSignatureInterceptor("es", region, new DefaultAWSCredentialsProviderChain())
-        );
+    ElasticsearchAwsRequestSigner signer =
+        new ElasticsearchAwsRequestSigner(region, new DefaultAWSCredentialsProviderChain());
+    HttpClient.Builder httpBuilder = new HttpClient.Builder().addPostInterceptor(signer);
 
     if (aws.domain != null) {
       httpBuilder.hosts(new ElasticsearchDomainEndpoint(aws.domain, region));

--- a/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/java/zipkin/autoconfigure/storage/elasticsearch/aws/AwsElasticsearchStorageTest.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/java/zipkin/autoconfigure/storage/elasticsearch/aws/AwsElasticsearchStorageTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.elasticsearch.aws;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.function.Supplier;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import zipkin.storage.elasticsearch.ElasticsearchStorage;
+import zipkin.storage.elasticsearch.http.HttpClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AwsElasticsearchStorageTest {
+  @Rule
+  public MockWebServer es = new MockWebServer();
+
+  String region = "us-east-1";
+  Supplier<AWSCredentials> credentials = () -> new BasicAWSCredentials("access-key", "secret-key");
+
+  ElasticsearchAwsRequestSigner signer =
+      new ElasticsearchAwsRequestSigner(region, new AWSCredentialsProvider() {
+        @Override public AWSCredentials getCredentials() {
+          return credentials.get();
+        }
+
+        @Override public void refresh() {
+        }
+      });
+
+  ElasticsearchStorage storage = ElasticsearchStorage.builder(new HttpClient.Builder()
+      .addPostInterceptor(signer)
+      .hosts(ImmutableList.of(es.url("/").toString()))).build();
+
+  @After
+  public void close() throws IOException {
+    storage.close();
+  }
+
+  @Test
+  public void check_failsOnCredentialException() throws InterruptedException {
+    credentials = () -> {
+      throw new AmazonClientException(
+          "Unable to load AWS credentials from any provider in the chain");
+    };
+
+    assertThat(storage.check().ok).isFalse();
+    assertThat(storage.check().exception) // notably, this isn't wrapped
+        .isInstanceOf(AmazonClientException.class);
+  }
+
+  @Test
+  public void signsRequestsForRegionAndEsService() throws InterruptedException {
+    // check lazy calls get template, then checks cluster status.
+    // We need to enqueue both or the test will hang.
+    es.enqueue(new MockResponse()); // GET /_template/zipkin_template
+    es.enqueue(new MockResponse().setBody("{\n"
+        + "  \"cluster_name\" : \"zipkin\",\n"
+        + "  \"status\" : \"green\"\n"
+        + "}")); // GET /_cluster/health/zipkin-*
+
+    assertThat(storage.check().ok).isTrue();
+
+    RecordedRequest request = es.takeRequest(); // spot-check the first request
+    assertThat(request.getHeader("Authorization"))
+        .startsWith("AWS4-HMAC-SHA256 Credential=" + credentials.get().getAWSAccessKeyId())
+        .contains(region + "/es/aws4_request"); // for the region and service
+  }
+}

--- a/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/resources/logback.xml
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/zipkin-storage/elasticsearch-http/pom.xml
+++ b/zipkin-storage/elasticsearch-http/pom.xml
@@ -67,9 +67,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
@@ -44,7 +44,7 @@ public class ElasticsearchDependenciesTest extends DependenciesTest {
     return storage;
   }
 
-  @Override public void clear() {
+  @Override public void clear() throws IOException {
     storage.clear();
   }
 

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
@@ -15,6 +15,7 @@ package zipkin.storage.elasticsearch;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.Before;
@@ -43,7 +44,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Before
-  public void clear() {
+  public void clear() throws IOException {
     storage.clear();
   }
 

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanStoreTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanStoreTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin.storage.elasticsearch;
 
+import java.io.IOException;
 import zipkin.storage.SpanStoreTest;
 import zipkin.storage.StorageComponent;
 
@@ -30,7 +31,7 @@ public class ElasticsearchSpanStoreTest extends SpanStoreTest {
     return storage;
   }
 
-  @Override public void clear() {
+  @Override public void clear() throws IOException {
     storage.clear();
   }
 }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpElasticsearchStorageTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpElasticsearchStorageTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch.http;
+
+import com.google.common.collect.ImmutableList;
+import io.searchbox.client.config.exception.CouldNotConnectException;
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import zipkin.storage.elasticsearch.ElasticsearchStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpElasticsearchStorageTest {
+  @Rule
+  public MockWebServer es = new MockWebServer();
+
+  ElasticsearchStorage storage = ElasticsearchStorage.builder(new HttpClient.Builder()
+      .hosts(ImmutableList.of(es.url("/").toString()))).build();
+
+  @After
+  public void close() throws IOException {
+    storage.close();
+  }
+
+  /** Very important that we don't return wrapped exceptions as otherwise /health endpoint is useless */
+  @Test
+  public void check_fail_doesntWrapExceptions() throws IOException {
+    es.shutdown();
+
+    assertThat(storage.check().ok).isFalse();
+    assertThat(storage.check().exception)
+        .isInstanceOf(CouldNotConnectException.class);
+  }
+
+  @Test
+  public void check_ensuresTemplateExistsAndClusterGreen() throws InterruptedException {
+    es.enqueue(new MockResponse());
+    es.enqueue(new MockResponse().setBody("{\n"
+        + "  \"cluster_name\" : \"zipkin\",\n"
+        + "  \"status\" : \"green\"\n"
+        + "}"));
+
+    assertThat(storage.check().ok).isTrue();
+
+    assertThat(es.takeRequest().getPath()).isEqualTo("/_template/zipkin_template");
+    assertThat(es.takeRequest().getPath()).isEqualTo("/_cluster/health/zipkin-*");
+  }
+}

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
@@ -15,6 +15,7 @@ package zipkin.storage.elasticsearch;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -83,10 +84,10 @@ public abstract class InternalElasticsearchClient implements Closeable {
   }
 
   /** Ensures the existence of a template, creating it if it does not exist. */
-  protected abstract void ensureTemplate(String name, String indexTemplate);
+  protected abstract void ensureTemplate(String name, String indexTemplate) throws IOException;
 
   /** Deletes the specified index pattern is supplied */
-  protected abstract void clear(String index);
+  protected abstract void clear(String index) throws IOException;
 
   /**
    * Scans the given indices with the given query and aggregates. If aggregating all traces,
@@ -152,7 +153,7 @@ public abstract class InternalElasticsearchClient implements Closeable {
    *
    * @param catchAll See {@link IndexNameFormatter#catchAll()}
    */
-  protected abstract void ensureClusterReady(String catchAll);
+  protected abstract void ensureClusterReady(String catchAll) throws IOException;
 
   /** Overridden to remove checked exceptions. */
   @Override

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
@@ -14,6 +14,7 @@
 package zipkin.storage.elasticsearch;
 
 import com.google.common.io.Resources;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import zipkin.internal.LazyCloseable;
@@ -42,7 +43,12 @@ final class LazyClient extends LazyCloseable<InternalElasticsearchClient> {
 
   @Override protected InternalElasticsearchClient compute() {
     InternalElasticsearchClient client = clientFactory.create(allIndices);
-    client.ensureTemplate(indexTemplateName, indexTemplate);
+    try {
+      client.ensureTemplate(indexTemplateName, indexTemplate);
+    } catch (IOException e) {
+      client.close();
+      throw new UncheckedExecutionException(e);
+    }
     return client;
   }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
@@ -14,6 +14,7 @@
 package zipkin.storage.elasticsearch;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
 import java.util.List;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -43,7 +44,7 @@ public class ElasticsearchDependenciesTest extends DependenciesTest {
     return storage;
   }
 
-  @Override public void clear() {
+  @Override public void clear() throws IOException {
     storage.clear();
   }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
@@ -16,6 +16,7 @@ package zipkin.storage.elasticsearch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ObjectArrays;
 import com.google.common.util.concurrent.Futures;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -53,7 +54,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Before
-  public void clear() {
+  public void clear() throws IOException {
     storage.clear();
   }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanStoreTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanStoreTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin.storage.elasticsearch;
 
+import java.io.IOException;
 import zipkin.storage.SpanStoreTest;
 import zipkin.storage.StorageComponent;
 
@@ -28,7 +29,7 @@ public class ElasticsearchSpanStoreTest extends SpanStoreTest {
     return storage;
   }
 
-  @Override public void clear() {
+  @Override public void clear() throws IOException {
     storage.clear();
   }
 }

--- a/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin.storage;
 
+import java.io.IOException;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +61,7 @@ public abstract class DependenciesTest {
 
   /** Clears store between tests. */
   @Before
-  public abstract void clear();
+  public abstract void clear() throws IOException;
 
   /**
    * Override if dependency processing is a separate job: it should complete before returning from

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin.storage;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -69,7 +70,7 @@ public abstract class SpanStoreTest {
 
   /** Clears store between tests. */
   @Before
-  public abstract void clear();
+  public abstract void clear() throws IOException;
 
   /** Notably, the cassandra implementation has day granularity */
   static long midnight(){


### PR DESCRIPTION
This fixes a thread-safety concern raised by @sethp-jive on AWS signing.

It also improves health check by not wrapping exceptions. This will
allow users to troubleshoot the system easier.

Finally, this throws on misconfigured credentials vs swallowing the
exception. This will help people use health checks also, as it makes
this configuration error visible without enabling debug logging.

See #1310
