### PR TITLE
README polish

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,6 +21,6 @@ in mind when choosing version numbers.
    (Note: Javaocs are also published on all builds of master; due to versioning, it doesn't overwrite docs built
    for releases.)
 
-1. **Publish `docker-zipkin-java`**
+1. **Publish `docker-zipkin`**
 
-   Refer to [docker-zipkin-java/RELEASE.md](https://github.com/openzipkin/docker-zipkin-java/blob/master/RELEASE.md).
+   Refer to [docker-zipkin/RELEASE.md](https://github.com/openzipkin/docker-zipkin/blob/master/RELEASE.md).

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -19,7 +19,7 @@ Once you've started, browse to http://your_host:9411 to find traces!
 ## Endpoints
 
 The following endpoints are defined under the base url http://your_host:9411
-* / - [UI](https://github.com/openzipkin/zipkin/tree/master/zipkin-ui)
+* / - [UI](../zipkin-ui)
 * /config.json - [Configuration for the UI](#configuration-for-the-ui)
 * /api/v1 - [Api](http://zipkin.io/zipkin-api/#/)
 * /health - Returns 200 status if OK
@@ -81,7 +81,7 @@ who enable self-tracing should lower the sample rate from 1.0 (100%) to a much s
 When Brave dependencies are in the classpath, and `zipkin.self-tracing.enabled=true`,
 Zipkin will self-trace calls to the api.
 
-[yaml configuration](zipkin-server/src/main/resources/zipkin-server.yml) binds the following environment variables to spring properties:
+[yaml configuration](src/main/resources/zipkin-server.yml) binds the following environment variables to spring properties:
 
 Variable | Property | Description
 --- | --- | ---
@@ -104,9 +104,9 @@ instrumented | zipkin.ui.instrumented | Which sites this Zipkin UI covers. Regex
 For example, if using docker you can set `ZIPKIN_UI_QUERY_LIMIT=100` to affect `$.queryLimit` in `/config.json`.
 
 ## Environment Variables
-zipkin-server is a drop-in replacement for the [scala query service](https://github.com/openzipkin/zipkin/tree/master/zipkin-query-service).
+zipkin-server is a drop-in replacement for the [scala query service](https://github.com/openzipkin/zipkin/tree/scala/zipkin-query-service).
 
-[yaml configuration](zipkin-server/src/main/resources/zipkin-server.yml) binds the following environment variables from zipkin-scala:
+[yaml configuration](src/main/resources/zipkin-server.yml) binds the following environment variables from zipkin-scala:
 
     * `QUERY_PORT`: Listen port for the http api and web ui; Defaults to 9411
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
@@ -250,7 +250,7 @@ $ java -jar zipkin.jar
 
 ## Running with Docker
 Released versions of zipkin-server are published to Docker Hub as `openzipkin/zipkin`.
-See [docker-zipkin-java](https://github.com/openzipkin/docker-zipkin-java) for details.
+See [docker-zipkin](https://github.com/openzipkin/docker-zipkin) for details.
 
 ## Building locally
 

--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -42,7 +42,7 @@ Redundant requests to store service or span names are ignored for an hour to red
 Indexing of traces are optimized by default. This reduces writes to Cassandra at the cost of memory
 needed to cache state. This cache is tunable based on your typical trace duration and span count.
 
-[Core annotations](https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin/Constants.java#L184),
+[Core annotations](../../zipkin/src/main/java/zipkin/Constants.java#L186-L188),
 ex "sr", are not written to `annotations_index`, as they aren't intended for use in user queries.
 Also, binary annotation values longer than 256 characters are not indexed. These optimizations
 significantly limit writes per trace.

--- a/zipkin-storage/cassandra3/README.md
+++ b/zipkin-storage/cassandra3/README.md
@@ -48,7 +48,7 @@ A SASI index on its 'all_annotations' column permits full-text searches against 
 A SASI index on the 'duration' column.
 A materialized view of the 'trace_by_service_span' table exists as 'trace_by_service'.
 
-[Core annotations](../zipkin/src/main/java/zipkin/Constants.java#L184),
+[Core annotations](../../zipkin/src/main/java/zipkin/Constants.java#L186-L188),
 ex "sr", and non-string annotations, are not written to the `all_annotations` SASI, as they aren't intended for use in user queries.
 
 ### Time-To_live

--- a/zipkin-storage/mysql/README.md
+++ b/zipkin-storage/mysql/README.md
@@ -5,7 +5,7 @@ This MySQL storage component includes a blocking `SpanStore` and span consumer f
 
 The implementation uses JOOQ to generate MySQL SQL commands. It is only tested on MySQL 5.6-5.7.
 
-The schema is the same as [zipkin-scala](https://github.com/openzipkin/zipkin/tree/master/zipkin-anormdb).
+See the [schema DDL](src/main/resources/mysql.sql).
 
 `zipkin.storage.mysql.MySQLStorage.Builder` includes defaults that will
 operate against a given Datasource.

--- a/zipkin-zookeeper/README.md
+++ b/zipkin-zookeeper/README.md
@@ -46,6 +46,6 @@ Path | Owner | Description
 /election | each sampler | This path is used to determine or elect a new leader.
 
 ## More information
-More details are available in the [javadoc](./src/main/java/zipkin/sampler/zookeeper/ZooKeeperSampler.java)
-The sampling implementation was initially based on [zipkin-scala](https://github.com/openzipkin/zipkin/tree/1.39.7/zipkin-sampler).
+More details are available in the [javadoc](src/main/java/zipkin/collector/zookeeper/ZooKeeperCollectorSampler.java)
+The sampling implementation was initially based on [zipkin-scala](https://github.com/openzipkin/zipkin/tree/scala/zipkin-sampler).
 


### PR DESCRIPTION
Use relative links instead of absolute links where possible.
Fix some broken links in the READMEs.
