### PR TITLE
Defaults UI to expand all

### DIFF
--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -9,8 +9,8 @@
 
   <form class='form-inline' role='form'>
     <div class='btn-group btn-group-sm' id='filterAllServices'>
-      <button type='button' class='btn btn-default' value='uiExpandAllSpans'>Expand All</button>
-      <button type='button' class='btn btn-default active' value='uiCollapseAllSpans'>Collapse All</button>
+      <button type='button' class='btn btn-default active' value='uiExpandAllSpans'>Expand All</button>
+      <button type='button' class='btn btn-default' value='uiCollapseAllSpans'>Collapse All</button>
     </div>
     <select data-placeholder='Filter Service Search' class='form-control input-sm' name='serviceFilterSearch' id='serviceFilterSearch'>
       <option value=''></option>


### PR DESCRIPTION
Routinely, we ask users to click "Expand All" when they are having
trouble with the UI. This sometimes is the only thing they need to do.

The default to "Collapse All" optimizes for very large traces, but we've
no history of what a good number would be (or even a nice place to code
that number). Also, we've never heard anyone defend the "Collapse All"
default despite multiple complaints asking to change it.

This changes the default trace view to expand all traces, optimizing for
those who are starting with Zipkin or have traces that aren't huge. The
impact is that those who have huge traces might want to click "Collapse
All" and/or report back or raise a pull request to have an appropriate
behavior with a default backed up by some user experience.

Fixes #1046
