### PR TITLE
Adds collector_timestamp_millis to spans stored in elasticsearch

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkSpanIndexer.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkSpanIndexer.java
@@ -29,10 +29,6 @@ final class HttpBulkSpanIndexer extends HttpBulkIndexer<Span> implements
 
   @Override public void add(String index, Span span, Long timestampMillis) throws IOException {
     String id = null; // Allow ES to choose an ID
-    if (timestampMillis == null) {
-      super.add(index, span, id);
-      return;
-    }
     writeIndexMetadata(index, id);
     body.write(toSpanBytes(span, timestampMillis));
     body.writeByte('\n');

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin.Annotation;
-import zipkin.Codec;
 import zipkin.Span;
 import zipkin.storage.elasticsearch.http.HttpElasticsearchTestGraph;
 
@@ -119,22 +118,6 @@ public class ElasticsearchSpanConsumerTest {
 
     assertThat(indexFromToday.size())
         .isEqualTo(1);
-  }
-
-  @Test
-  public void prefixWithTimestampMillis() {
-    Span span = Span.builder().traceId(20L).id(20L).name("get")
-        .timestamp(TODAY * 1000).build();
-
-    byte[] result =
-        ElasticsearchSpanConsumer.prefixWithTimestampMillis(Codec.JSON.writeSpan(span), TODAY);
-
-    String json = new String(result);
-    assertThat(json)
-        .startsWith("{\"timestamp_millis\":" + Long.toString(TODAY) + ",\"traceId\":");
-
-    assertThat(Codec.JSON.readSpan(json.getBytes()))
-        .isEqualTo(span); // ignores timestamp_millis field
   }
 
   void accept(Span span) {

--- a/zipkin-storage/elasticsearch/README.md
+++ b/zipkin-storage/elasticsearch/README.md
@@ -14,6 +14,13 @@ Zipkin's timestamps are in epoch microseconds, which is not a supported date typ
 In consideration of tools like like Kibana, this component adds "timestamp_millis" when writing
 spans. This is mapped to the Elasticsearch date type, so can be used to any date-based queries.
 
+If you are investigating a span, you'll also notice the "collector_timestamp_millis" field. This
+is the epoch timestamp that the collector wrote before sending to storage. A gap between
+"timestamp_millis" and "collector_timestamp_millis" is normal. For example, a span cannot be reported
+until it is complete (span.timestamp + span.duration). Next, reporters often buffer for a second
+or so before sending a message onto the transport. Also, there is transport delay prior to a collector
+receiving that message. Finally, there may be clock skew between the reporter and the collector.
+
 `zipkin.storage.elasticsearch.ElasticsearchStorage.Builder` includes defaults
 that will operate against a local Elasticsearch installation.
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
@@ -27,7 +27,7 @@ import zipkin.Span;
 import zipkin.internal.Lazy;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static zipkin.storage.elasticsearch.ElasticsearchSpanConsumer.prefixWithTimestampMillis;
+import static zipkin.storage.elasticsearch.ElasticsearchSpanConsumer.prefixWithTimestamps;
 
 /**
  * Common interface for different protocol implementations communicating with Elasticsearch.
@@ -148,9 +148,8 @@ public abstract class InternalElasticsearchClient implements Closeable {
   }
 
   public static byte[] toSpanBytes(Span span, Long timestampMillis) {
-    return timestampMillis != null
-        ? prefixWithTimestampMillis(Codec.JSON.writeSpan(span), timestampMillis)
-        : Codec.JSON.writeSpan(span);
+    return prefixWithTimestamps(Codec.JSON.writeSpan(span), timestampMillis,
+        System.currentTimeMillis());
   }
 
   /**


### PR DESCRIPTION
Zipkin's timestamps are in epoch microseconds, which is not a supported date type in Elasticsearch.
In consideration of tools like like Kibana, this component adds "timestamp_millis" when writing
spans. This is mapped to the Elasticsearch date type, so can be used to any date-based queries.

If you are investigating a span, you'll also notice the "collector_timestamp_millis" field. This
is the epoch timestamp that the collector wrote before sending to storage. A gap between
"timestamp_millis" and "collector_timestamp_millis" is normal. For example, a span cannot be reported until it is complete (span.timestamp + span.duration). Next, reporters often buffer for a second or so before sending a message onto the transport. Also, there is transport delay prior to a collector receiving that message. Finally, there may be clock skew between the reporter and the collector.

Fixes #1318
