### PR TITLE
README broken link

### DIFF
--- a/zipkin-storage/elasticsearch-http/README.md
+++ b/zipkin-storage/elasticsearch-http/README.md
@@ -4,4 +4,4 @@ This is is a plugin to the Elasticsearch storage component, which uses
 HTTP by way of [OkHttp 3](https://github.com/square/okttp) and
 [Moshi](https://github.com/square/moshi). 
 
-See [storage-elasticsearch](../storage-elasticsearch) for more details.
+See [storage-elasticsearch](../elasticsearch) for more details.


### PR DESCRIPTION
Fixes the link to the storage-elasticsearch component from the elasticsearch-http README.
