### PR TITLE
Fixes missing CORS config

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
@@ -20,6 +20,7 @@ import java.util.zip.GZIPInputStream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,6 +41,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
  * Implements the POST /api/v1/spans endpoint used by instrumentation.
  */
 @RestController
+@CrossOrigin("${zipkin.query.allowed-origins:*}")
 public class ZipkinHttpCollector {
   static final ResponseEntity<?> SUCCESS = ResponseEntity.accepted().build();
   static final String APPLICATION_THRIFT = "application/x-thrift";

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerCORSTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerCORSTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -56,6 +57,11 @@ public class ZipkinServerCORSTest {
     mockMvc.perform(get("/api/v1/traces")
         .header(HttpHeaders.ORIGIN, "foo.example.com"))
            .andExpect(status().isOk());
+
+    mockMvc.perform(post("/api/v1/spans")
+        .content("[]")
+        .header(HttpHeaders.ORIGIN, "foo.example.com"))
+          .andExpect(status().isAccepted());
   }
 
   @Test
@@ -64,5 +70,10 @@ public class ZipkinServerCORSTest {
     mockMvc.perform(get("/api/v1/traces")
         .header(HttpHeaders.ORIGIN, "bar.example.com"))
            .andExpect(status().isForbidden());
+
+    mockMvc.perform(post("/api/v1/spans")
+        .content("[]")
+        .header(HttpHeaders.ORIGIN, "bar.example.com"))
+         .andExpect(status().isForbidden());
   }
 }


### PR DESCRIPTION
We forgot one of the endpoints when adding CORS config. With this change
zipkin-js can send spans directly to Zipkin via HTTP.

See #1234
