### PR TITLE
Unwinds elasticsearch-http configuration by using List<Interceptor>

### DIFF
--- a/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageAutoConfigurationTest.java
@@ -13,7 +13,7 @@
  */
 package zipkin.autoconfigure.storage.elasticsearch.aws;
 
-import okhttp3.OkHttpClient;
+import okhttp3.Interceptor;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,9 +62,8 @@ public class ZipkinElasticsearchAwsStorageAutoConfigurationTest {
         ZipkinElasticsearchAwsStorageAutoConfiguration.class);
     context.refresh();
 
-    assertThat(context.getBean(OkHttpClient.class).networkInterceptors())
-        .extracting(i -> i.getClass())
-        .contains((Class) AWSSignatureVersion4.class);
+    assertThat(context.getBean(Interceptor.class))
+        .isInstanceOf(AWSSignatureVersion4.class);
   }
 
   @Test
@@ -79,9 +78,8 @@ public class ZipkinElasticsearchAwsStorageAutoConfigurationTest {
         ZipkinElasticsearchAwsStorageAutoConfiguration.class);
     context.refresh();
 
-    assertThat(context.getBean(OkHttpClient.class).networkInterceptors())
-        .extracting(i -> i.getClass())
-        .contains((Class) AWSSignatureVersion4.class);
+    assertThat(context.getBean(Interceptor.class))
+        .isInstanceOf(AWSSignatureVersion4.class);
   }
 
   @Test

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
@@ -13,6 +13,8 @@
  */
 package zipkin.autoconfigure.storage.elasticsearch.http;
 
+import java.util.Collections;
+import java.util.List;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,8 +36,8 @@ import zipkin.storage.elasticsearch.http.HttpClientBuilder;
 public class ZipkinElasticsearchHttpStorageAutoConfiguration {
 
   @Autowired(required = false)
-  @Qualifier("zipkinElasticsearchHttpAuthentication")
-  Interceptor zipkinElasticsearchHttpAuthentication;
+  @Qualifier("zipkinElasticsearchHttp")
+  List<Interceptor> networkInterceptors = Collections.emptyList();
 
   @Autowired(required = false)
   @Qualifier("zipkinElasticsearchHttp")
@@ -49,8 +51,8 @@ public class ZipkinElasticsearchHttpStorageAutoConfiguration {
         ? elasticsearchOkHttpClientBuilder
         : new OkHttpClient.Builder();
 
-    if (zipkinElasticsearchHttpAuthentication != null) {
-      builder.addNetworkInterceptor(zipkinElasticsearchHttpAuthentication);
+    for (Interceptor interceptor : networkInterceptors) {
+      builder.addNetworkInterceptor(interceptor);
     }
     return builder.build();
   }


### PR DESCRIPTION
Before, we had to pass around more state in order to set OkHttp
interceptors used in elasticsearch (ex AWS authentication). This
injects `List<Interceptor>` so that the process is a bit easier.
