### PR TITLE
When a LazyCloseable delegates to a Closeable, prefer default close()

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
@@ -55,10 +55,4 @@ final class LazyClient extends LazyCloseable<InternalElasticsearchClient> {
   @Override public String toString() {
     return clientFactory.toString();
   }
-
-  @Override
-  public void close() {
-    InternalElasticsearchClient maybeNull = maybeNull();
-    if (maybeNull != null) maybeNull.close();
-  }
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/LazyClientTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/LazyClientTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin.storage.elasticsearch;
 
+import java.io.IOException;
 import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.junit.AssumptionViolatedException;
@@ -54,7 +55,7 @@ public class LazyClientTest {
   }
 
   @Test
-  public void portDefaultsTo9300() {
+  public void portDefaultsTo9300() throws IOException {
     try (LazyClient lazyClient = new LazyClient(ElasticsearchStorage.builder()
         .hosts(asList("localhost")))) {
 


### PR DESCRIPTION
`LazyCloseable.close()` is not final as there's no requirement that its
delegate implements Closeable (ex it could just have a `shutdown()`
method. Due to copy/pasta, we redudantly did the same thing in a
subtype.

Thanks to @autoletics for pointing out this possibility.
