### PR TITLE
Adds an example to Endpoint.port note

### DIFF
--- a/zipkin/src/main/java/zipkin/Endpoint.java
+++ b/zipkin/src/main/java/zipkin/Endpoint.java
@@ -84,6 +84,10 @@ public final class Endpoint {
    * Port of the IP's socket or null, if not known.
    *
    * <p>Note: this is to be treated as an unsigned integer, so watch for negatives.
+   * <p>Ex.
+   * <pre>{@code
+   * Integer unsignedPort = endpoint.port == null ? null : endpoint.port & 0xffff;
+   * }</pre>
    *
    * @see java.net.InetSocketAddress#getPort()
    */

--- a/zipkin/src/test/java/zipkin/EndpointTest.java
+++ b/zipkin/src/test/java/zipkin/EndpointTest.java
@@ -45,8 +45,13 @@ public class EndpointTest {
 
   @Test
   public void builderWithPort_highest() {
-    assertThat(Endpoint.builder().serviceName("foo").port(65535).build().port)
+    short port = Endpoint.builder().serviceName("foo").port(65535).build().port;
+
+    assertThat(port)
         .isEqualTo((short) -1); // an unsigned short of 65535 is the same as -1
+
+    assertThat(port & 0xffff)
+        .isEqualTo(65535);
   }
 
   /** The integer arg of port should be a whole number */


### PR DESCRIPTION
This adds a code example to Endpoint.port javadoc to help explain what
the watch for negatives comment was about.

Fixes #1350
