### PR TITLE
128-bit trace ID part 2: store 128-bit trace ids, but retrieve by lower 64-bits

### DIFF
--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
@@ -364,10 +364,15 @@ final class CassandraSpanStore implements GuavaSpanStore {
                   spans.put(traceId, new ArrayList<Span>());
                 }
                 Span.Builder builder = Span.builder()
-                    .traceId(row.getVarint("trace_id").longValue())
                     .id(row.getLong("id"))
                     .name(row.getString("span_name"))
                     .duration(row.getLong("duration"));
+
+                // Sets a 64 bit trace id, or split a 128-bit one into high and low bits
+                if (traceId.bitLength() > 63) {
+                  builder.traceIdHigh(traceId.shiftRight(64).longValue());
+                }
+                builder.traceId(traceId.longValue());
 
                 if (!row.isNull("ts")) {
                   builder = builder.timestamp(row.getLong("ts"));

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanStoreTest.java
@@ -15,6 +15,7 @@ package zipkin.storage.cassandra3;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -95,6 +96,17 @@ public class CassandraSpanStoreTest extends SpanStoreTest {
     assertThat(
         store().getTraces(QueryRequest.builder().lookback(86400000L).limit(traceCount).build()))
         .hasSize(traceCount);
+  }
+
+  /**
+   * Currently, trace ids are stored as a variable-length number (as opposed to a 2 part hi/lo
+   * 128bit id). In order to support query by low 64 bits, we need to split this up somehow or add a
+   * separate index.
+   */
+  @Override
+  @Test
+  @Ignore("fetch by lower 64-bit isn't supported in cassandra3")
+  public void getTrace_retrieves128bitTraceIdByLower64Bits() {
   }
 
   long rowCount(String table) {

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ZipkinAdapters.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ZipkinAdapters.java
@@ -29,6 +29,7 @@ import zipkin.Span;
 import zipkin.internal.Util;
 
 import static zipkin.internal.Util.UTF_8;
+import static zipkin.internal.Util.lowerHexToUnsignedLong;
 
 /**
  * Read-only json adapters resurrected from before we switched to Java 6 as storage components can
@@ -48,7 +49,11 @@ final class ZipkinAdapters {
         }
         switch (nextName) {
           case "traceId":
-            result.traceId(Util.lowerHexToUnsignedLong(reader.nextString()));
+            String traceId = reader.nextString();
+            if (traceId.length() == 32) {
+              result.traceIdHigh(lowerHexToUnsignedLong(traceId, 0));
+            }
+            result.traceId(lowerHexToUnsignedLong(traceId));
             break;
           case "name":
             result.name(reader.nextString());

--- a/zipkin-storage/elasticsearch/README.md
+++ b/zipkin-storage/elasticsearch/README.md
@@ -5,17 +5,46 @@ Until [zipkin-dependencies](https://github.com/openzipkin/zipkin-dependencies) i
 
 The implementation uses Elasticsearch Java API's [transport client](https://www.elastic.co/guide/en/elasticsearch/guide/master/_talking_to_elasticsearch.html#_java_api) for optimal performance.
 
+`zipkin.storage.elasticsearch.ElasticsearchStorage.Builder` includes defaults
+that will operate against a local Elasticsearch installation.
+
+## Indexes
 Spans are stored into daily indices, for example spans with a timestamp falling on 2016/03/19
 will be stored in an index like zipkin-2016-03-19. There is no support for TTL through this SpanStore.
 It is recommended instead to use [Elastic Curator](https://www.elastic.co/guide/en/elasticsearch/client/curator/current/about.html)
 to remove indices older than the point you are interested in.
 
+### Timestamps
 Zipkin's timestamps are in epoch microseconds, which is not a supported date type in Elasticsearch.
 In consideration of tools like like Kibana, this component adds "timestamp_millis" when writing
 spans. This is mapped to the Elasticsearch date type, so can be used to any date-based queries.
 
-`zipkin.storage.elasticsearch.ElasticsearchStorage.Builder` includes defaults
-that will operate against a local Elasticsearch installation.
+### Trace Identifiers
+The index template tokenizes trace identifiers to match on either 64-bit
+or 128-bit length. This allows span lookup by 64-bit trace ID to include
+spans reported with 128-bit variants of the same id. This allows interop
+with tools who only support 64-bit ids, and buys time for applications
+to upgrade to 128-bit instrumentation.
+
+For example, application A starts a trace with a 128-bit `traceId`
+"48485a3953bb61246b221d5bc9e6496c". The next hop, application B, doesn't
+yet support 128-bit ids, B truncates `traceId` to "6b221d5bc9e6496c".
+When `SpanStore.getTrace(toLong("6b221d5bc9e6496c"))` executes, it
+is able to retrieve spans with the longer `traceId`, due to tokenization
+setup in the index template.
+
+To see this in action, you can run a test command like so against one of
+your indexes:
+
+```bash
+# the output below shows which tokens will match on the trace id supplied.
+$ curl -s localhost:9200/test_zipkin_http-2016-10-26/_analyze -d '{
+      "text": "48485a3953bb61246b221d5bc9e6496c",
+      "analyzer": "traceId_analyzer"
+  }'|jq '.tokens|.[]|.token'
+  "48485a3953bb61246b221d5bc9e6496c"
+  "6b221d5bc9e6496c"
+```
 
 ## Testing this component
 This module conditionally runs integration tests against a local Elasticsearch instance.

--- a/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
+++ b/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
@@ -12,6 +12,18 @@
           "filter": [
             "lowercase"
           ]
+        },
+        "traceId_analyzer": {
+          "type": "custom",
+          "tokenizer": "keyword",
+          "filter": "traceId_filter"
+        }
+      },
+      "filter": {
+        "traceId_filter": {
+          "type": "pattern_capture",
+          "patterns": ["([0-9a-f]{1,16})$"],
+          "preserve_original": true
         }
       }
     }
@@ -72,6 +84,10 @@
     },
     "span": {
       "properties": {
+        "traceId": {
+          "type": "string",
+          "analyzer": "traceId_analyzer"
+        },
         "timestamp_millis": {
           "type":   "date",
           "format": "epoch_millis"

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/HasTraceIdHigh.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/HasTraceIdHigh.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.mysql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+import zipkin.internal.Lazy;
+
+import static zipkin.storage.mysql.internal.generated.tables.ZipkinSpans.ZIPKIN_SPANS;
+
+final class HasTraceIdHigh extends Lazy<Boolean> {
+  private static final Logger LOG = Logger.getLogger(HasTraceIdHigh.class.getName());
+
+  final DataSource datasource;
+  final DSLContexts context;
+
+  HasTraceIdHigh(DataSource datasource, DSLContexts context) {
+    this.datasource = datasource;
+    this.context = context;
+  }
+
+  @Override protected Boolean compute() {
+    try (Connection conn = datasource.getConnection()) {
+      DSLContext dsl = context.get(conn);
+      dsl.select(ZIPKIN_SPANS.TRACE_ID_HIGH).from(ZIPKIN_SPANS).limit(1).fetchAny();
+      return true;
+    } catch (DataAccessException e) {
+      if (e.sqlState().equals("42S22")) {
+        LOG.warning(
+            "zipkin_spans.trace_id_high doesn't exist, so 128-bit trace ids are not supported. " +
+                "Execute: alter table zipkin_spans add `trace_id_high` BIGINT NOT NULL DEFAULT 0");
+        return false;
+      }
+      problemReading(e);
+    } catch (SQLException | RuntimeException e) {
+      problemReading(e);
+    }
+    return false;
+  }
+
+  static void problemReading(Exception e) {
+    LOG.log(Level.WARNING, "problem reading zipkin_spans.trace_id_high", e);
+  }
+}

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLStorage.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLStorage.java
@@ -80,6 +80,7 @@ public final class MySQLStorage implements StorageComponent {
   private final Executor executor;
   private final DSLContexts context;
   final Lazy<Boolean> hasIpv6;
+  final Lazy<Boolean> hasTraceIdHigh;
   final Lazy<Boolean> hasPreAggregatedDependencies;
   private final SpanStore spanStore;
   private final AsyncSpanStore asyncSpanStore;
@@ -90,10 +91,13 @@ public final class MySQLStorage implements StorageComponent {
     this.executor = checkNotNull(builder.executor, "executor");
     this.context = new DSLContexts(builder.settings, builder.listenerProvider);
     this.hasIpv6 = new HasIpv6(datasource, context);
+    this.hasTraceIdHigh = new HasTraceIdHigh(datasource, context);
     this.hasPreAggregatedDependencies = new HasPreAggregatedDependencies(datasource, context);
-    this.spanStore = new MySQLSpanStore(datasource, context, hasIpv6, hasPreAggregatedDependencies);
+    this.spanStore = new MySQLSpanStore(datasource, context, hasTraceIdHigh, hasIpv6,
+        hasPreAggregatedDependencies);
     this.asyncSpanStore = blockingToAsync(spanStore, executor);
-    MySQLSpanConsumer spanConsumer = new MySQLSpanConsumer(datasource, context, hasIpv6);
+    MySQLSpanConsumer spanConsumer =
+        new MySQLSpanConsumer(datasource, context, hasTraceIdHigh, hasIpv6);
     this.asyncSpanConsumer = blockingToAsync(spanConsumer, executor);
   }
 

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/internal/generated/tables/ZipkinSpans.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/internal/generated/tables/ZipkinSpans.java
@@ -42,7 +42,7 @@ import zipkin.storage.mysql.internal.generated.Zipkin;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class ZipkinSpans extends TableImpl<Record> {
 
-    private static final long serialVersionUID = 1408994496;
+    private static final long serialVersionUID = -709545889;
 
     /**
      * The reference instance of <code>zipkin.zipkin_spans</code>
@@ -56,6 +56,11 @@ public class ZipkinSpans extends TableImpl<Record> {
     public Class<Record> getRecordType() {
         return Record.class;
     }
+
+    /**
+     * The column <code>zipkin.zipkin_spans.trace_id_high</code>. If non zero, this means the trace uses 128 bit traceIds instead of 64 bit
+     */
+    public final TableField<Record, Long> TRACE_ID_HIGH = createField("trace_id_high", org.jooq.impl.SQLDataType.BIGINT.nullable(false).defaultValue(org.jooq.impl.DSL.inline("0", org.jooq.impl.SQLDataType.BIGINT)), this, "If non zero, this means the trace uses 128 bit traceIds instead of 64 bit");
 
     /**
      * The column <code>zipkin.zipkin_spans.trace_id</code>.

--- a/zipkin-storage/mysql/src/main/resources/mysql.sql
+++ b/zipkin-storage/mysql/src/main/resources/mysql.sql
@@ -1,4 +1,5 @@
 CREATE TABLE IF NOT EXISTS zipkin_spans (
+  `trace_id_high` BIGINT NOT NULL DEFAULT 0 COMMENT 'If non zero, this means the trace uses 128 bit traceIds instead of 64 bit',
   `trace_id` BIGINT NOT NULL,
   `id` BIGINT NOT NULL,
   `name` VARCHAR(255) NOT NULL,

--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -102,11 +102,19 @@ public final class Util {
     if (length < 1 || length > 32) throw isntLowerHexLong(lowerHex);
 
     // trim off any high bits
-    int i = length > 16 ? length - 16 : 0;
+    int beginIndex = length > 16 ? length - 16 : 0;
 
+    return lowerHexToUnsignedLong(lowerHex, beginIndex);
+  }
+
+  /**
+   * Parses a 16 character lower-hex string with no prefix into an unsigned long, starting at the
+   * spe index.
+   */
+  public static long lowerHexToUnsignedLong(String lowerHex, int index) {
     long result = 0;
-    for (; i < length; i++) {
-      char c = lowerHex.charAt(i);
+    for (int endIndex = Math.min(index + 16, lowerHex.length()); index < endIndex; index++) {
+      char c = lowerHex.charAt(index);
       result <<= 4;
       if (c >= '0' && c <= '9') {
         result |= c - '0';

--- a/zipkin/src/test/java/zipkin/CodecTest.java
+++ b/zipkin/src/test/java/zipkin/CodecTest.java
@@ -47,6 +47,25 @@ public abstract class CodecTest {
   }
 
   @Test
+  public void spanRoundTrip_128bitTraceId() throws IOException {
+    for (Span span : TestObjects.TRACE) {
+      span = span.toBuilder().traceIdHigh(12345L).build();
+      byte[] bytes = codec().writeSpan(span);
+      assertThat(codec().readSpan(bytes))
+          .isEqualTo(span);
+    }
+  }
+
+  @Test
+  public void sizeInBytes_128bitTraceId() throws IOException {
+    for (Span span : TestObjects.TRACE) {
+      span = span.toBuilder().traceIdHigh(12345L).build();
+      assertThat(codec().sizeInBytes(span))
+          .isEqualTo(codec().writeSpan(span).length);
+    }
+  }
+
+  @Test
   public void binaryAnnotation_long() throws IOException {
     Span span = TestObjects.LOTS_OF_SPANS[0].toBuilder().binaryAnnotations(asList(
         BinaryAnnotation.builder()

--- a/zipkin/src/test/java/zipkin/SpanTest.java
+++ b/zipkin/src/test/java/zipkin/SpanTest.java
@@ -19,11 +19,24 @@ import java.util.Arrays;
 import okio.Buffer;
 import okio.ByteString;
 import org.junit.Test;
+import zipkin.internal.Util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin.TestObjects.APP_ENDPOINT;
 
 public class SpanTest {
+
+  @Test
+  public void traceIdHigh() {
+    Span with128BitId = Span.builder()
+        .traceId(Util.lowerHexToUnsignedLong("48485a3953bb6124"))
+        .traceIdHigh(Util.lowerHexToUnsignedLong("463ac35c9f6413ad"))
+        .id(1)
+        .name("foo").build();
+
+    assertThat(with128BitId.idString())
+        .isEqualTo("463ac35c9f6413ad48485a3953bb6124.0000000000000001<:0000000000000001");
+  }
 
   @Test
   public void idString_withParent() {

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -523,6 +523,28 @@ public abstract class SpanStoreTest {
         .containsExactly(span);
   }
 
+  /** This tests that the 128bit trace id is read back from storage. */
+  @Test
+  public void getTraces_128BitTraceId() {
+    Span span = span1.toBuilder().traceIdHigh(1).build();
+
+    accept(span);
+
+    assertThat(store().getTraces(QueryRequest.builder().build()))
+        .containsExactly(asList(span));
+  }
+
+  /** This tests that the existing getTrace api can read traces which reported 128bit trace ids. */
+  @Test
+  public void getTrace_retrieves128bitTraceIdByLower64Bits() {
+    Span span = span1.toBuilder().traceIdHigh(1).build();
+
+    accept(span);
+
+    assertThat(store().getTrace(span.traceId))
+        .containsExactly(span);
+  }
+
   /**
    * It is expected that [[com.twitter.zipkin.storage.SpanStore.apply]] will receive the same span
    * id multiple times with different annotations. At query time, these must be merged.


### PR DESCRIPTION
This supports storage of 128-bit ids. Once this in, instrumentation can report 128-bit trace ids to zipkin. Understanding deployments will be mixed and not support 128-bit for a while, query remains 64-bit.
- Adds traceIdHigh (default 0) to zipkin.Span and implement it in codecs
  - in json, it is simply a longer traceId field to accommodate the extra 16 hex characters
- Ensures supported storage components are not lossy with regards to 128-bit ids
- Ensures supported storage can query by 64-bit trace ids
#### Notes on storage of 128-bit trace id:
- mysql needs the following schema update:

``` mysql
mysql> alter table zipkin_spans add `trace_id_high` BIGINT NOT NULL DEFAULT 0;
```

Notes on retrieval by lower-64 bit:
- cassandra3 doesn't support retrieval by lower-64 bit
  - This is likely solvable but too much for this PR.
- elasticsearch requires an index template update
  - This automatically applies when the day rolls over.

See #1298
