### PR TITLE
Disables cassandra in travis to avoid perpetual build fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,8 @@ services:
   - mysql
 
 before_install:
-  # Manually install very recent version of cassandra; unless we create a user we have to run it as root
-  - curl -SL http://www-us.apache.org/dist/cassandra/3.9/apache-cassandra-3.9-bin.tar.gz | tar xz
-  - sed -i -e 's/INFO/WARN/g' apache-cassandra-*/conf/logback.xml
-  - sudo apache-cassandra-*/bin/cassandra -R
+  # We don't install cassandra as it flakes too much. Instead we defer to circleci to test it
+  # See https://github.com/openzipkin/zipkin/issues/1356
   # install mysql schema
   - mysql -uroot -e 'SET GLOBAL innodb_file_format=Barracuda'
   - mysql -uroot -e 'create database if not exists zipkin'


### PR DESCRIPTION
Cassandra recently started crashing only in Travis (not CircleCI).
This removes cassandra from travis so that it doesn't keep breaking
the build.

fixes #1356
