### PR TITLE
Fixes bad high port read on Elasticsearch

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ZipkinAdapters.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ZipkinAdapters.java
@@ -156,7 +156,7 @@ final class ZipkinAdapters {
             result.ipv6(ipv6);
             break;
           case "port":
-            result.port((short) reader.nextInt());
+            result.port(reader.nextInt());
             break;
           default:
             reader.skipValue();

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ZipkinAdaptersTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ZipkinAdaptersTest.java
@@ -260,6 +260,29 @@ public class ZipkinAdaptersTest {
   }
 
   @Test
+  public void endpointHighPort() throws IOException {
+    String json = "{\n"
+        + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+        + "  \"name\": \"get-traces\",\n"
+        + "  \"id\": \"6b221d5bc9e6496c\",\n"
+        + "  \"binaryAnnotations\": [\n"
+        + "    {\n"
+        + "      \"key\": \"foo\",\n"
+        + "      \"value\": \"bar\",\n"
+        + "      \"endpoint\": {\n"
+        + "        \"serviceName\": \"service\",\n"
+        + "        \"port\": 65535\n"
+        + "      }\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    assertThat(SPAN_ADAPTER.fromJson(json).binaryAnnotations)
+        .containsExactly(BinaryAnnotation.create("foo", "bar",
+            Endpoint.builder().serviceName("service").port(65535).build()));
+  }
+
+  @Test
   public void dependencyLinkRoundTrip() throws IOException {
     DependencyLink link = DependencyLink.create("foo", "bar", 2);
 

--- a/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import zipkin.BinaryAnnotation;
 import zipkin.Codec;
 import zipkin.CodecTest;
+import zipkin.Endpoint;
 import zipkin.Span;
 import zipkin.TestObjects;
 
@@ -239,6 +240,33 @@ public final class JsonCodecTest extends CodecTest {
             .type(BinaryAnnotation.Type.DOUBLE)
             .value(toBytes(Double.doubleToRawLongBits(1.23456789)))
             .build());
+
+    assertThat(Codec.JSON.readSpan(Codec.JSON.writeSpan(span)))
+        .isEqualTo(span);
+  }
+
+  @Test
+  public void endpointHighPort() {
+    String json = "{\n"
+        + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+        + "  \"name\": \"get-traces\",\n"
+        + "  \"id\": \"6b221d5bc9e6496c\",\n"
+        + "  \"binaryAnnotations\": [\n"
+        + "    {\n"
+        + "      \"key\": \"foo\",\n"
+        + "      \"value\": \"bar\",\n"
+        + "      \"endpoint\": {\n"
+        + "        \"serviceName\": \"service\",\n"
+        + "        \"port\": 65535\n"
+        + "      }\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    Span span = Codec.JSON.readSpan(json.getBytes(UTF_8));
+    assertThat(span.binaryAnnotations)
+        .containsExactly(BinaryAnnotation.create("foo", "bar",
+            Endpoint.builder().serviceName("service").port(65535).build()));
 
     assertThat(Codec.JSON.readSpan(Codec.JSON.writeSpan(span)))
         .isEqualTo(span);


### PR DESCRIPTION
We had a bug fixed only in the normal json codec around high ports. This
backfills tests to make sure it doesn't arise again.

Thanks to @nollbit for finding this!

Fixes #1350
