### PR TITLE
Fix annotation query parsing

### DIFF
--- a/zipkin/src/main/java/zipkin/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin/storage/QueryRequest.java
@@ -225,7 +225,7 @@ public final class QueryRequest {
             addAnnotation(ann);
           } else {
             String[] keyValue = ann.split("=");
-            addBinaryAnnotation(ann.substring(0, idx - 1), keyValue.length < 2 ? "" : ann.substring(idx+1));
+            addBinaryAnnotation(ann.substring(0, idx), keyValue.length < 2 ? "" : ann.substring(idx+1));
           }
         }
       }

--- a/zipkin/src/main/java/zipkin/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin/storage/QueryRequest.java
@@ -220,11 +220,12 @@ public final class QueryRequest {
     public Builder parseAnnotationQuery(String annotationQuery) {
       if (annotationQuery != null && !annotationQuery.isEmpty()) {
         for (String ann : annotationQuery.split(" and ")) {
-          if (ann.indexOf('=') == -1) {
+          int idx = ann.indexOf('=');
+          if (idx == -1) {
             addAnnotation(ann);
           } else {
             String[] keyValue = ann.split("=");
-            addBinaryAnnotation(keyValue[0], keyValue.length < 2 ? "" :keyValue[1]);
+            addBinaryAnnotation(ann.substring(0, idx - 1), keyValue.length < 2 ? "" : ann.substring(idx+1));
           }
         }
       }

--- a/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
@@ -105,9 +105,26 @@ public class QueryRequestTest {
 
     QueryRequest request =
         QueryRequest.builder().serviceName("security-service").parseAnnotationQuery(annotationQuery).build();
-
+    
     assertThat(request.binaryAnnotations)
         .containsEntry(HTTP_METHOD, "GET")
+        .hasSize(1);
+    assertThat(request.annotations)
+        .containsExactly(Constants.ERROR);
+
+    assertThat(request.toAnnotationQuery())
+        .isEqualTo(annotationQuery);
+  }
+
+  @Test
+  public void annotationQuery_complexValue() {
+    String annotationQuery = "http.method=GET=1 and error";
+
+    QueryRequest request =
+        QueryRequest.builder().serviceName("security-service").parseAnnotationQuery(annotationQuery).build();
+    
+    assertThat(request.binaryAnnotations)
+        .containsEntry(HTTP_METHOD, "GET=1")
         .hasSize(1);
     assertThat(request.annotations)
         .containsExactly(Constants.ERROR);


### PR DESCRIPTION
The current annotation query parser only returns value if a value contains an '=' sign. Fixed the parser to return the complete value even if they are '=' sign in the value.

Fixes #1366
