### PR TITLE
Serializes I64 numbers greater than 53bits as strings in json

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ZipkinAdapters.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ZipkinAdapters.java
@@ -235,6 +235,7 @@ final class ZipkinAdapters {
           break;
         case I64:
         case DOUBLE:
+          if (number == null) number = string;
           long v = type == BinaryAnnotation.Type.I64
               ? Long.parseLong(number)
               : Double.doubleToRawLongBits(Double.parseDouble(number));

--- a/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
@@ -219,6 +219,26 @@ public final class JsonCodecTest extends CodecTest {
   }
 
   @Test
+  public void binaryAnnotation_long_max() {
+    String json = ("{"
+        + "  \"traceId\": \"6b221d5bc9e6496c\","
+        + "  \"id\": \"6b221d5bc9e6496c\","
+        + "  \"name\": \"get-traces\","
+        + "  \"binaryAnnotations\": ["
+        + "    {"
+        + "      \"key\": \"num\","
+        + "      \"value\": \"9223372036854775807\","
+        + "      \"type\": \"I64\""
+        + "    }"
+        + "  ]"
+        + "}").replaceAll("\\s", "");
+
+    Span span = Codec.JSON.readSpan(json.getBytes(UTF_8));
+    assertThat(new String(Codec.JSON.writeSpan(span), UTF_8))
+        .isEqualTo(json);
+  }
+
+  @Test
   public void binaryAnnotation_double() {
     String json = "{\n"
         + "  \"traceId\": \"6b221d5bc9e6496c\",\n"


### PR DESCRIPTION
While usage of binary annotation type I64 is discouraged, Finagle lets you do it

Fixes #1372