### PR TITLE
Fixes elasticsearch wiring when using AWS and ES_HOSTS

### DIFF
--- a/zipkin-autoconfigure/storage-elasticsearch-aws/src/main/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/src/main/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageAutoConfiguration.java
@@ -38,7 +38,6 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import zipkin.autoconfigure.storage.elasticsearch.ZipkinElasticsearchStorageProperties;
-import zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchHttpStorageAutoConfiguration;
 import zipkin.storage.elasticsearch.InternalElasticsearchClient;
 import zipkin.storage.elasticsearch.http.HttpClientBuilder;
 
@@ -51,8 +50,7 @@ import static java.lang.String.format;
     ZipkinElasticsearchAwsStorageProperties.class
 })
 @Conditional(ZipkinElasticsearchAwsStorageAutoConfiguration.AwsMagic.class)
-public class ZipkinElasticsearchAwsStorageAutoConfiguration extends
-    ZipkinElasticsearchHttpStorageAutoConfiguration {
+public class ZipkinElasticsearchAwsStorageAutoConfiguration {
   static final Pattern AWS_URL =
       Pattern.compile("^https://[^.]+\\.([^.]+)\\.es\\.amazonaws\\.com", Pattern.CASE_INSENSITIVE);
   static final Logger log =

--- a/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageAutoConfigurationTest.java
@@ -13,7 +13,6 @@
  */
 package zipkin.autoconfigure.storage.elasticsearch.aws;
 
-import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import org.junit.After;
 import org.junit.Rule;
@@ -22,6 +21,7 @@ import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchOkHttpAutoConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
@@ -60,6 +60,7 @@ public class ZipkinElasticsearchAwsStorageAutoConfigurationTest {
         "zipkin.storage.elasticsearch.hosts:https://search-domain-xyzzy.us-west-2.es.amazonaws.com"
     );
     context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinElasticsearchOkHttpAutoConfiguration.class,
         ZipkinElasticsearchAwsStorageAutoConfiguration.class);
     context.refresh();
 
@@ -77,6 +78,7 @@ public class ZipkinElasticsearchAwsStorageAutoConfigurationTest {
         "zipkin.storage.elasticsearch.aws.region:us-west-2"
     );
     context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinElasticsearchOkHttpAutoConfiguration.class,
         ZipkinElasticsearchAwsStorageAutoConfiguration.class);
     context.refresh();
 

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
@@ -13,11 +13,7 @@
  */
 package zipkin.autoconfigure.storage.elasticsearch.http;
 
-import java.util.Collections;
-import java.util.List;
-import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,28 +30,6 @@ import zipkin.storage.elasticsearch.http.HttpClientBuilder;
 @ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "elasticsearch")
 @Conditional(ZipkinElasticsearchHttpStorageAutoConfiguration.HostsAreUrls.class)
 public class ZipkinElasticsearchHttpStorageAutoConfiguration {
-
-  @Autowired(required = false)
-  @Qualifier("zipkinElasticsearchHttp")
-  List<Interceptor> networkInterceptors = Collections.emptyList();
-
-  @Autowired(required = false)
-  @Qualifier("zipkinElasticsearchHttp")
-  OkHttpClient.Builder elasticsearchOkHttpClientBuilder;
-
-  @Bean
-  @Qualifier("zipkinElasticsearchHttp")
-  @ConditionalOnMissingBean
-  OkHttpClient elasticsearchOkHttpClient() {
-    OkHttpClient.Builder builder = elasticsearchOkHttpClientBuilder != null
-        ? elasticsearchOkHttpClientBuilder
-        : new OkHttpClient.Builder();
-
-    for (Interceptor interceptor : networkInterceptors) {
-      builder.addNetworkInterceptor(interceptor);
-    }
-    return builder.build();
-  }
 
   @Bean
   @ConditionalOnMissingBean

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchOkHttpAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchOkHttpAutoConfiguration.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.elasticsearch.http;
+
+import java.util.Collections;
+import java.util.List;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This is auto-configures the {@linkplain OkHttpClient} used for Elasticsearch.
+ *
+ * <p>Here are the major features:
+ * <pre><ul>
+ *   <li>The {@linkplain OkHttpClient.Builder} can be pre-configured (ex self-tracing)</li>
+ *   <li>{@linkplain Interceptor} beans will be added before returning (ex auth or logging)</li>
+ * </ul></pre>
+ *
+ * <p>This bean will register even if the http transport isn't in use (ex using Elasticsearch's
+ * native api). This is a complexity tradeoff as detecting if http is strictly needed is not
+ * straight-forward. For example, eventhough the hosts might contain http urls, in the case
+ * of Amazon, the hosts collection can be blank (lookup host by domain name).
+ */
+@Configuration
+@ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "elasticsearch")
+public class ZipkinElasticsearchOkHttpAutoConfiguration {
+
+  @Autowired(required = false)
+  @Qualifier("zipkinElasticsearchHttp")
+  List<Interceptor> networkInterceptors = Collections.emptyList();
+
+  @Autowired(required = false)
+  @Qualifier("zipkinElasticsearchHttp")
+  OkHttpClient.Builder elasticsearchOkHttpClientBuilder;
+
+  @Bean
+  @Qualifier("zipkinElasticsearchHttp")
+  @ConditionalOnMissingBean
+  OkHttpClient elasticsearchOkHttpClient() {
+    OkHttpClient.Builder builder = elasticsearchOkHttpClientBuilder != null
+        ? elasticsearchOkHttpClientBuilder
+        : new OkHttpClient.Builder();
+
+    for (Interceptor interceptor : networkInterceptors) {
+      builder.addNetworkInterceptor(interceptor);
+    }
+    return builder.build();
+  }
+}

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/resources/META-INF/spring.factories
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchOkHttpAutoConfiguration,\
 zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchHttpStorageAutoConfiguration,\
 zipkin.autoconfigure.storage.elasticsearch.http.brave.TraceZipkinElasticsearchHttpStorageAutoConfiguration

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/test/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchHttpStorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/test/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchHttpStorageAutoConfigurationTest.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchHttpStorageAutoConfiguration;
+import zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchOkHttpAutoConfiguration;
 import zipkin.storage.elasticsearch.InternalElasticsearchClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,6 +66,7 @@ public class ZipkinElasticsearchHttpStorageAutoConfigurationTest {
         "zipkin.storage.elasticsearch.hosts:http://host1:9200"
     );
     context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinElasticsearchOkHttpAutoConfiguration.class,
         ZipkinElasticsearchHttpStorageAutoConfiguration.class);
     context.refresh();
 
@@ -108,6 +110,7 @@ public class ZipkinElasticsearchHttpStorageAutoConfigurationTest {
         "zipkin.storage.elasticsearch.hosts:http://host1:9200"
     );
     context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinElasticsearchOkHttpAutoConfiguration.class,
         ZipkinElasticsearchHttpStorageAutoConfiguration.class,
         InterceptorConfiguration.class);
     context.refresh();


### PR DESCRIPTION
Previously, when `ES_HOSTS` was used for an Amazon Elasticsearch domain,
the following error would result:

```
There is a circular dependency between 4 beans in the application context:
    - zipkinHttpCollector defined in file [/zipkin/BOOT-INF/classes/zipkin/server/ZipkinHttpCollector.class]
    - zipkin.autoconfigure.storage.elasticsearch.ZipkinElasticsearchStorageAutoConfiguration (field zipkin.storage.elasticsearch.InternalElasticsearchClient$Builder zipkin.autoconfigure.storage.elasticsearch.ZipkinElasticsearchStorageAutoConfiguration.clientBuilder)
    - zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchHttpStorageAutoConfiguration (field java.util.List zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchHttpStorageAutoConfiguration.networkInterceptors)
    - zipkin.autoconfigure.storage.elasticsearch.aws.ZipkinElasticsearchAwsStorageAutoConfiguration (field java.util.List zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchHttpStorageAutoConfiguration.networkInterceptors)
    - awsSignatureVersion4
```

This fixes that by unwinding an initialization concern around the OkHttp
client used.