### PR TITLE
Compresses indexes to search based on date expression

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
@@ -62,9 +62,6 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
     }
   });
 
-  /** To not produce unnecessarily long queries, we don't look back further than first ES support */
-  static final long EARLIEST_MS = 1456790400000L; // March 2016
-
   private final InternalElasticsearchClient client;
   private final IndexNameFormatter indexNameFormatter;
   private final String[] catchAll;
@@ -78,7 +75,7 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
 
   @Override public ListenableFuture<List<List<Span>>> getTraces(QueryRequest request) {
     long endMillis = request.endTs;
-    long beginMillis = Math.max(endMillis - request.lookback, EARLIEST_MS);
+    long beginMillis = endMillis - request.lookback;
 
     BoolQueryBuilder filter = boolQuery()
         .must(rangeQuery("timestamp_millis")
@@ -235,7 +232,7 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
 
   @Override public ListenableFuture<List<DependencyLink>> getDependencies(long endMillis,
       @Nullable Long lookback) {
-    long beginMillis = lookback != null ? Math.max(endMillis - lookback, EARLIEST_MS) : EARLIEST_MS;
+    long beginMillis = lookback != null ? endMillis - lookback : 0;
     // We just return all dependencies in the days that fall within endTs and lookback as
     // dependency links themselves don't have timestamps.
     Set<String> indices = indexNameFormatter.indexNamePatternsForRange(beginMillis, endMillis);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/IndexNameFormatter.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/IndexNameFormatter.java
@@ -14,12 +14,18 @@
 package zipkin.storage.elasticsearch;
 
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.TimeZone;
+import zipkin.internal.Util;
 
 final class IndexNameFormatter {
-
   private static final String DAILY_INDEX_FORMAT = "yyyy-MM-dd";
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
   private final String index;
   // SimpleDateFormat isn't thread-safe
@@ -34,6 +40,58 @@ final class IndexNameFormatter {
         return result;
       }
     };
+  }
+
+  /**
+   * Returns a set of index patterns that represent the range provided. Notably, this compresses
+   * months or years using wildcards (in order to send smaller API calls).
+   *
+   * <p>For example, if {@code beginMillis} is 2016-11-30 and {@code endMillis} is 2017-01-02, the
+   * result will be 2016-11-30, 2016-12-*, 2017-01-01 and 2017-01-02.
+   */
+  Set<String> indexNamePatternsForRange(long beginMillis, long endMillis) {
+    GregorianCalendar current = midnightUTC(beginMillis);
+    GregorianCalendar end = midnightUTC(endMillis);
+    if (current.equals(end)) {
+      return Collections.singleton(indexNameForTimestamp(current.getTimeInMillis()));
+    }
+
+    Set<String> indices = new LinkedHashSet<>();
+    while (current.compareTo(end) <= 0) {
+      if (current.get(Calendar.MONTH) == 0 && current.get(Calendar.DATE) == 1) {
+        // attempt to compress a year
+        current.set(Calendar.DAY_OF_YEAR, current.getActualMaximum(Calendar.DAY_OF_YEAR));
+        if (current.compareTo(end) <= 0) {
+          indices.add(String.format("%s-%s-*", index, current.get(Calendar.YEAR)));
+          current.add(Calendar.DATE, 1); // rollover to next year
+          continue;
+        } else {
+          current.set(Calendar.DAY_OF_YEAR, 1); // rollback to first of the year
+        }
+      } else if (current.get(Calendar.DATE) == 1) {
+        // attempt to compress a month
+        current.set(Calendar.DATE, current.getActualMaximum(Calendar.DATE));
+        if (current.compareTo(end) <= 0) {
+          indices.add(String.format("%s-%s-%02d-*", index,
+              current.get(Calendar.YEAR),
+              current.get(Calendar.MONTH) + 1
+          ));
+          current.add(Calendar.DATE, 1); // rollover to next month
+          continue;
+        } else {
+          current.set(Calendar.DATE, 1); // rollback to first of the month
+        }
+      }
+      indices.add(indexNameForTimestamp(current.getTimeInMillis()));
+      current.add(Calendar.DATE, 1);
+    }
+    return indices;
+  }
+
+  static GregorianCalendar midnightUTC(long epochMillis) {
+    GregorianCalendar result = new GregorianCalendar(UTC);
+    result.setTimeInMillis(Util.midnightUTC(epochMillis));
+    return result;
   }
 
   String indexNameForTimestamp(long timestampMillis) {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/IndexNameFormatterTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/IndexNameFormatterTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IndexNameFormatterTest {
+  IndexNameFormatter formatter = new IndexNameFormatter("zipkin");
+  DateFormat iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
+
+  public IndexNameFormatterTest() {
+    iso8601.setTimeZone(TimeZone.getTimeZone("UTC"));
+  }
+
+  @Test
+  public void indexNameForTimestampRange_sameDay() throws ParseException {
+    long start = iso8601.parse("2016-11-01T01:01:01Z").getTime();
+    long end = iso8601.parse("2016-11-01T23:59:59Z").getTime();
+
+    assertThat(formatter.indexNamePatternsForRange(start, end))
+        .containsExactly("zipkin-2016-11-01");
+  }
+
+  @Test
+  public void indexNameForTimestampRange_sameMonth() throws ParseException {
+    long start = iso8601.parse("2016-11-15T01:01:01Z").getTime();
+    long end = iso8601.parse("2016-11-16T23:59:59Z").getTime();
+
+    assertThat(formatter.indexNamePatternsForRange(start, end))
+        .containsExactly("zipkin-2016-11-15", "zipkin-2016-11-16");
+  }
+
+  @Test
+  public void indexNameForTimestampRange_sameMonth_startingAtOne() throws ParseException {
+    long start = iso8601.parse("2016-11-1T01:01:01Z").getTime();
+    long end = iso8601.parse("2016-11-3T23:59:59Z").getTime();
+
+    assertThat(formatter.indexNamePatternsForRange(start, end))
+        .containsExactly("zipkin-2016-11-01", "zipkin-2016-11-02", "zipkin-2016-11-03");
+  }
+
+  @Test
+  public void indexNameForTimestampRange_nextMonth() throws ParseException {
+    long start = iso8601.parse("2016-10-31T01:01:01Z").getTime();
+    long end = iso8601.parse("2016-11-01T23:59:59Z").getTime();
+
+    assertThat(formatter.indexNamePatternsForRange(start, end))
+        .containsExactly("zipkin-2016-10-31", "zipkin-2016-11-01");
+  }
+
+  @Test
+  public void indexNameForTimestampRange_compressesMonth() throws ParseException {
+    long start = iso8601.parse("2016-10-01T01:01:01Z").getTime();
+    long end = iso8601.parse("2016-10-31T23:59:59Z").getTime();
+
+    assertThat(formatter.indexNamePatternsForRange(start, end))
+        .containsExactly("zipkin-2016-10-*");
+  }
+
+  @Test
+  public void indexNameForTimestampRange_skipMonths() throws ParseException {
+    long start = iso8601.parse("2016-10-31T01:01:01Z").getTime();
+    long end = iso8601.parse("2016-12-01T23:59:59Z").getTime();
+
+    assertThat(formatter.indexNamePatternsForRange(start, end))
+        .containsExactly("zipkin-2016-10-31", "zipkin-2016-11-*", "zipkin-2016-12-01");
+  }
+
+  @Test
+  public void indexNameForTimestampRange_skipMonths_leapYear() throws ParseException {
+    long start = iso8601.parse("2016-02-28T01:01:01Z").getTime();
+    long end = iso8601.parse("2016-04-01T23:59:59Z").getTime();
+
+    assertThat(formatter.indexNamePatternsForRange(start, end)).containsExactly(
+        "zipkin-2016-02-28",
+        "zipkin-2016-02-29",
+        "zipkin-2016-03-*",
+        "zipkin-2016-04-01"
+    );
+  }
+
+  @Test
+  public void indexNameForTimestampRange_compressesYear() throws ParseException {
+    long start = iso8601.parse("2016-01-01T01:01:01Z").getTime();
+    long end = iso8601.parse("2016-12-31T23:59:59Z").getTime();
+
+    assertThat(formatter.indexNamePatternsForRange(start, end))
+        .containsExactly("zipkin-2016-*");
+  }
+
+  @Test
+  public void indexNameForTimestampRange_skipYears() throws ParseException {
+    long start = iso8601.parse("2016-10-31T01:01:01Z").getTime();
+    long end = iso8601.parse("2018-01-01T23:59:59Z").getTime();
+
+    assertThat(formatter.indexNamePatternsForRange(start, end)).containsExactly(
+        "zipkin-2016-10-31",
+        "zipkin-2016-11-*",
+        "zipkin-2016-12-*",
+        "zipkin-2017-*",
+        "zipkin-2018-01-01"
+    );
+  }
+}

--- a/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
@@ -149,23 +149,23 @@ public abstract class DependenciesTest {
 
     List<Span> trace = asList(
         Span.builder().traceId(10L).id(10L).name("get")
-            .timestamp(1477898539256150L).duration(1152579L)
-            .addAnnotation(Annotation.create(1477898539256150L, SERVER_RECV, one))
-            .addAnnotation(Annotation.create(1477898540408729L, SERVER_SEND, one))
+            .timestamp(1445136539256150L).duration(1152579L)
+            .addAnnotation(Annotation.create(1445136539256150L, SERVER_RECV, one))
+            .addAnnotation(Annotation.create(1445136540408729L, SERVER_SEND, one))
             .build(),
         Span.builder().traceId(10L).parentId(10L).id(20L).name("get")
-            .timestamp(1477898539764798L).duration(639337L)
-            .addAnnotation(Annotation.create(1477898539764798L, CLIENT_SEND, onePort3001))
-            .addAnnotation(Annotation.create(1477898539816432L, SERVER_RECV, two))
-            .addAnnotation(Annotation.create(1477898540401414L, SERVER_SEND, two))
-            .addAnnotation(Annotation.create(1477898540404135L, CLIENT_RECV, onePort3001))
+            .timestamp(1445136539764798L).duration(639337L)
+            .addAnnotation(Annotation.create(1445136539764798L, CLIENT_SEND, onePort3001))
+            .addAnnotation(Annotation.create(1445136539816432L, SERVER_RECV, two))
+            .addAnnotation(Annotation.create(1445136540401414L, SERVER_SEND, two))
+            .addAnnotation(Annotation.create(1445136540404135L, CLIENT_RECV, onePort3001))
             .build(),
         Span.builder().traceId(10L).parentId(20L).id(30L).name("get")
-            .timestamp(1477898540025751L).duration(371298L)
-            .addAnnotation(Annotation.create(1477898540025751L, CLIENT_SEND, twoPort3002))
-            .addAnnotation(Annotation.create(1477898540072846L, SERVER_RECV, three))
-            .addAnnotation(Annotation.create(1477898540394644L, SERVER_SEND, three))
-            .addAnnotation(Annotation.create(1477898540397049L, CLIENT_RECV, twoPort3002))
+            .timestamp(1445136540025751L).duration(371298L)
+            .addAnnotation(Annotation.create(1445136540025751L, CLIENT_SEND, twoPort3002))
+            .addAnnotation(Annotation.create(1445136540072846L, SERVER_RECV, three))
+            .addAnnotation(Annotation.create(1445136540394644L, SERVER_SEND, three))
+            .addAnnotation(Annotation.create(1445136540397049L, CLIENT_RECV, twoPort3002))
             .build()
     );
     processDependencies(trace);
@@ -193,20 +193,20 @@ public abstract class DependenciesTest {
 
     List<Span> trace = asList(
         Span.builder().traceId(10L).id(10L).name("get")
-            .addAnnotation(Annotation.create(1477898539256150L, SERVER_RECV, one))
-            .addAnnotation(Annotation.create(1477898540408729L, SERVER_SEND, one))
+            .addAnnotation(Annotation.create(1445136539256150L, SERVER_RECV, one))
+            .addAnnotation(Annotation.create(1445136540408729L, SERVER_SEND, one))
             .build(),
         Span.builder().traceId(10L).parentId(10L).id(20L).name("get")
-            .addAnnotation(Annotation.create(1477898539764798L, CLIENT_SEND, onePort3001))
-            .addAnnotation(Annotation.create(1477898539816432L, SERVER_RECV, two))
-            .addAnnotation(Annotation.create(1477898540401414L, SERVER_SEND, two))
-            .addAnnotation(Annotation.create(1477898540404135L, CLIENT_RECV, onePort3001))
+            .addAnnotation(Annotation.create(1445136539764798L, CLIENT_SEND, onePort3001))
+            .addAnnotation(Annotation.create(1445136539816432L, SERVER_RECV, two))
+            .addAnnotation(Annotation.create(1445136540401414L, SERVER_SEND, two))
+            .addAnnotation(Annotation.create(1445136540404135L, CLIENT_RECV, onePort3001))
             .build(),
         Span.builder().traceId(10L).parentId(20L).id(30L).name("get")
-            .addAnnotation(Annotation.create(1477898540025751L, CLIENT_SEND, twoPort3002))
-            .addAnnotation(Annotation.create(1477898540072846L, SERVER_RECV, three))
-            .addAnnotation(Annotation.create(1477898540394644L, SERVER_SEND, three))
-            .addAnnotation(Annotation.create(1477898540397049L, CLIENT_RECV, twoPort3002))
+            .addAnnotation(Annotation.create(1445136540025751L, CLIENT_SEND, twoPort3002))
+            .addAnnotation(Annotation.create(1445136540072846L, SERVER_RECV, three))
+            .addAnnotation(Annotation.create(1445136540394644L, SERVER_SEND, three))
+            .addAnnotation(Annotation.create(1445136540397049L, CLIENT_RECV, twoPort3002))
             .build()
     );
     processDependencies(trace);


### PR DESCRIPTION
This adds `IndexNameFormatter.indexNamePatternsForRange` which 
compresses api requests by using wildcard expressions for months or 
years.

For example, if begin is 2016-11-30 and end is 2017-01-02, the result 
will be 2016-11-30, 2016-12-*, 2017-01-01 and 2017-01-02 as opposed to
a set of >30 individual index names.

As a side effect, we no longer need special http configuration as we
won't create request lines larger than 4096 on account of index names.

Fixes #1327
Obviates #1371
