### PR TITLE
Adds tests for mixed trace ID length and fixes cassandra3 trace ID codec

### DIFF
--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanConsumer.java
@@ -92,7 +92,7 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
     for (Span span : rawSpans) {
       // indexing occurs by timestamp, so derive one if not present.
       Long timestamp = guessTimestamp(span);
-      BigInteger traceId = traceId(span);
+      BigInteger traceId = CassandraUtil.extractTraceId(span);
       futures.add(storeSpan(span, traceId, timestamp));
 
       for (String serviceName : span.serviceNames()) {
@@ -189,11 +189,5 @@ final class CassandraSpanConsumer implements GuavaSpanConsumer {
     } catch (RuntimeException ex) {
       return Futures.immediateFailedFuture(ex);
     }
-  }
-
-  static BigInteger traceId(Span span) {
-    return span.traceIdHigh != 0
-        ? BigInteger.valueOf(span.traceIdHigh).shiftLeft(64).or(BigInteger.valueOf(span.traceId))
-        : BigInteger.valueOf(span.traceId);
   }
 }

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanStoreTest.java
@@ -109,6 +109,12 @@ public class CassandraSpanStoreTest extends SpanStoreTest {
   public void getTrace_retrieves128bitTraceIdByLower64Bits() {
   }
 
+  @Override
+  @Test
+  @Ignore("fetch by lower 64-bit isn't supported in cassandra3")
+  public void getTrace_retrieves128bitTraceIdByLower64Bits_mixed() {
+  }
+
   long rowCount(String table) {
     return storage.session().execute("SELECT COUNT(*) from " + table).one().getLong(0);
   }

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -534,6 +534,18 @@ public abstract class SpanStoreTest {
         .containsExactly(asList(span));
   }
 
+  @Test
+  public void getTraces_128BitTraceId_mixed() {
+    List<Span> trace = new ArrayList<>(TestObjects.TRACE);
+    trace.set(0, trace.get(0).toBuilder().traceIdHigh(1).build());
+    // pretend the others downgraded to 64-bit trace IDs
+
+    accept(trace.toArray(new Span[0]));
+
+    assertThat(store().getTraces(QueryRequest.builder().build()))
+        .containsExactly(trace);
+  }
+
   /** This tests that the existing getTrace api can read traces which reported 128bit trace ids. */
   @Test
   public void getTrace_retrieves128bitTraceIdByLower64Bits() {
@@ -543,6 +555,18 @@ public abstract class SpanStoreTest {
 
     assertThat(store().getTrace(span.traceId))
         .containsExactly(span);
+  }
+
+  @Test
+  public void getTrace_retrieves128bitTraceIdByLower64Bits_mixed() {
+    List<Span> trace = new ArrayList<>(TestObjects.TRACE);
+    trace.set(0, trace.get(0).toBuilder().traceIdHigh(1).build());
+    // pretend the others downgraded to 64-bit trace IDs
+
+    accept(trace.toArray(new Span[0]));
+
+    assertThat(store().getTrace(trace.get(0).traceId))
+        .containsExactlyElementsOf(trace);
   }
 
   /**


### PR DESCRIPTION
This adds tests to ensure we can retrieve mixed length trace IDs. Along
the way, I noticed the cassandra3 trace ID codec was incorrect. I fixed
this, although I hope we can change the model to not use BigInteger in
the future.

See https://github.com/openzipkin/zipkin/issues/1364#issuecomment-257790635