### PR TITLE
Zipkin #1387 - Support for MySQL 5.7 with SQL_MODE=ONLY_FULL_GROUP_BY

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -56,7 +56,6 @@ dependencies:
 database:
   override:
     - mysql -u ubuntu -e 'SET GLOBAL innodb_file_format=Barracuda'
-    - mysql -u ubuntu -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
     - mysql -u ubuntu circle_test < zipkin-storage/mysql/src/main/resources/mysql.sql
 
 test:

--- a/zipkin-storage/mysql/README.md
+++ b/zipkin-storage/mysql/README.md
@@ -46,8 +46,6 @@ For example, all the below query the same trace using different tools:
 ```bash
 # Barracuda supports compression (In AWS RDS, this must be assigned in a parameter group)
 $ mysql -uroot -e "SET GLOBAL innodb_file_format=Barracuda"
-# If using MySQL 5.7, you'll need to disable ONLY_FULL_GROUP_BY
-$ mysql -uroot -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
 # This command should work even in RDS, and return "Barracuda"
 $ mysql -uroot -e "show global variables like 'innodb_file_format'"
 

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanStore.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanStore.java
@@ -330,7 +330,7 @@ final class MySQLSpanStore implements SpanStore {
             ZIPKIN_SPANS.START_TS.lessOrEqual(endTs) :
             ZIPKIN_SPANS.START_TS.between(endTs - lookback * 1000, endTs))
         // Grouping so that later code knows when a span or trace is finished.
-        .groupBy(ZIPKIN_SPANS.TRACE_ID, ZIPKIN_SPANS.ID, ZIPKIN_ANNOTATIONS.A_KEY).fetchLazy();
+        .groupBy(ZIPKIN_SPANS.TRACE_ID, ZIPKIN_SPANS.ID, ZIPKIN_ANNOTATIONS.A_KEY, ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME).fetchLazy();
 
     Iterator<Iterator<DependencyLinkSpan>> traces =
         new DependencyLinkSpanIterator.ByTraceId(cursor.iterator(), hasTraceIdHigh.get());


### PR DESCRIPTION
### Summary
As documented in #1387, this pull request will correct the ambiguous SQL query for MySQL backends. 

### Change
This changes the SQL query used to get a list of the traces to one that is now MySQL 5.7 compatible.
Previously the query was:
```
select distinct `zipkin_spans`.`trace_id` from `zipkin_spans` [...] order by `zipkin_spans`.`start_ts`
```
This query is ambiguous because it does not specify how to order along the start_ts when there's multiple records with the same trace_id.

It's now:
```
select `zipkin_spans`.`trace_id`, MAX(`zipkin_spans`.`start_ts`) [...] group by `zipkin_spans`.`trace_id` order by MAX(`zipkin_spans`.`start_ts`) desc limit 10
```

This forces MySQL to order along the last start_ts.

### Testing Done
Verified unit tests still succeed [Travis CI](https://travis-ci.org/ajacques/zipkin/builds/173357222)
I've also uploaded this change to my own testing server and verified that I can now view spans. Previously the index page would fail to load with a 500 with the previously mentioned failure.

### Notes
We may also want to remove the comment in zipkin\zipkin-storage\mysql\README.md that references the SQL_MODE required change, but I haven't done enough testing to verify that it's completely unnecessary everywhere. In my use case, it's not needed anymore in this repository. The aforementioned issue does note there might be an issue in the zipkin-dependencies repository.