### PR TITLE
Moves cassandra3 traceId from BigInteger to TraceIdUDT(high,low)

### DIFF
--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Schema.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Schema.java
@@ -37,6 +37,8 @@ import zipkin.Annotation;
 import zipkin.BinaryAnnotation;
 import zipkin.Endpoint;
 
+import static zipkin.internal.Util.writeHexLong;
+
 final class Schema {
   private static final Logger LOG = LoggerFactory.getLogger(Schema.class);
 
@@ -107,6 +109,71 @@ final class Schema {
       }
     } catch (IOException ex) {
       LOG.error(ex.getMessage(), ex);
+    }
+  }
+
+  @UDT(keyspace = DEFAULT_KEYSPACE + "_udts", name = "trace_id")
+  static final class TraceIdUDT {
+
+    private long high;
+    private long low;
+
+    TraceIdUDT() {
+      this.high = 0L;
+      this.low = 0L;
+    }
+
+    TraceIdUDT(long high, long low) {
+        this.high = high;
+        this.low = low;
+    }
+
+    Long getHigh() {
+      return high;
+    }
+
+    long getLow() {
+      return low;
+    }
+
+    void setHigh(Long high) {
+      this.high = high;
+    }
+
+    void setLow(long low) {
+      this.low = low;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) return true;
+      if (o instanceof TraceIdUDT) {
+        TraceIdUDT that = (TraceIdUDT) o;
+        return (this.high == that.high) && (this.low == that.low);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      int h = 1;
+      h *= 1000003;
+      h ^= (high >>> 32) ^ high;
+      h *= 1000003;
+      h ^= (low >>> 32) ^ low;
+      return h;
+    }
+
+    @Override
+    public String toString() {
+      char[] result = new char[high != 0 ? 32 : 16];
+      int pos = 0;
+      if (high != 0) {
+        writeHexLong(result, pos, high);
+        pos += 16;
+      }
+      writeHexLong(result, pos, low);
+      return new String(result);
     }
   }
 

--- a/zipkin-storage/cassandra3/src/main/resources/cassandra3-schema.cql
+++ b/zipkin-storage/cassandra3/src/main/resources/cassandra3-schema.cql
@@ -1,5 +1,10 @@
 CREATE KEYSPACE IF NOT EXISTS zipkin3 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
 
+CREATE TYPE IF NOT EXISTS zipkin3.trace_id (
+    high    bigint,
+    low     bigint
+);
+
 CREATE TYPE IF NOT EXISTS zipkin3.endpoint (
     service_name text,
     ipv4         inet,
@@ -21,7 +26,7 @@ CREATE TYPE IF NOT EXISTS zipkin3.binary_annotation (
 );
 
 CREATE TABLE IF NOT EXISTS zipkin3.traces (
-    trace_id            varint,
+    trace_id            frozen<trace_id>,
     ts_uuid             timeuuid,
     id                  bigint,
     ts                  bigint,
@@ -39,12 +44,12 @@ CREATE TABLE IF NOT EXISTS zipkin3.traces (
 
 
 CREATE TABLE IF NOT EXISTS zipkin3.trace_by_service_span (
-    service_name  text,      //-- service name
-    span_name     text,      //-- span name, or blank for queries without span name
-    bucket        int,       //-- time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1 day.
-    ts            timeuuid,  //-- start timestamp of the span, truncated to millisecond precision
-    trace_id      varint,    //-- trace ID
-    duration      bigint,    //-- span duration, in microseconds
+    service_name  text,             //-- service name
+    span_name     text,             //-- span name, or blank for queries without span name
+    bucket        int,              //-- time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1 day.
+    ts            timeuuid,         //-- start timestamp of the span, truncated to millisecond precision
+    trace_id      frozen<trace_id>, //-- trace ID
+    duration      bigint,           //-- span duration, in microseconds
     PRIMARY KEY ((service_name, span_name, bucket), ts)
 )
    WITH CLUSTERING ORDER BY (ts DESC)

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
@@ -14,26 +14,18 @@
 package zipkin.storage.cassandra3;
 
 import com.google.common.collect.ImmutableList;
-import java.math.BigInteger;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import zipkin.BinaryAnnotation;
 import zipkin.Constants;
 import zipkin.Span;
 import zipkin.TestObjects;
 import zipkin.TraceKeys;
-import zipkin.internal.Util;
 import zipkin.storage.QueryRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Enclosed.class)
 public class CassandraUtilTest {
 
   @Rule
@@ -104,31 +96,5 @@ public class CassandraUtilTest {
 
     assertThat(CassandraUtil.annotationKeys(span))
         .containsOnly("web;aws.arn;" + arn);
-  }
-
-  @RunWith(Parameterized.class)
-  public static class TraceIdCodecTest {
-    @Parameters(name = "traceId={0}")
-    public static Object[] traceIds() {
-      return new Object[] {
-          "0000000000000000ff1c4625acae1983",
-          "032142b8731f3226ff1c4625acae1983",
-          "f26275921cef644dffb092c15b079cda",
-          "5a3b4868cea01275de309d96c358cea9",
-      };
-    }
-
-    @Parameter
-    public String traceId;
-
-    @Test public void extractAndInject() {
-      Span span = TestObjects.TRACE.get(0).toBuilder()
-          .traceIdHigh(Util.lowerHexToUnsignedLong(traceId, 0))
-          .traceId(Util.lowerHexToUnsignedLong(traceId))
-          .build();
-      BigInteger traceId = CassandraUtil.extractTraceId(span);
-      Span copy = CassandraUtil.injectTraceId(span.toBuilder(), traceId).build();
-      assertThat(copy).isEqualTo(span);
-    }
   }
 }

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/SchemaTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/SchemaTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.cassandra3;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import zipkin.storage.cassandra3.Schema.TraceIdUDT;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Enclosed.class)
+public class SchemaTest {
+
+  public static class TraceIdUDTTest {
+
+    @Test public void toString_whenNotHigh_16Chars() {
+      assertThat(new TraceIdUDT(0L, 12345678L))
+          .hasToString("0000000000bc614e");
+    }
+
+    @Test public void toString_whenHigh_32Chars() {
+      assertThat(new TraceIdUDT(1234L, 5678L))
+          .hasToString("00000000000004d2000000000000162e");
+    }
+  }
+}


### PR DESCRIPTION
This moves cassandra3's schema to high/low which is more precise and
allows us more options on how to index by only the low 64-bits of the
trace ID.

See #1364