### PR TITLE
Add support for specifying a trusted cert via env

### DIFF
--- a/zipkin-storage/cassandra3/pom.xml
+++ b/zipkin-storage/cassandra3/pom.xml
@@ -52,6 +52,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.jkutner</groupId>
+      <artifactId>env-keystore</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin</artifactId>
       <type>test-jar</type>

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
@@ -104,8 +104,6 @@ final class DefaultSessionFactory implements Cassandra3Storage.SessionFactory {
 
   // Visible for testing
   static Cluster buildCluster(Cassandra3Storage cassandra) {
-    LOG.error("building cassandra3 cluster");
-
     Cluster.Builder builder = Cluster.builder();
     List<InetSocketAddress> contactPoints = parseContactPoints(cassandra);
     int defaultPort = findConnectPort(contactPoints);
@@ -125,9 +123,7 @@ final class DefaultSessionFactory implements Cassandra3Storage.SessionFactory {
         HostDistance.LOCAL, cassandra.maxConnections
     ));
     // https://github.com/datastax/java-driver/tree/3.x/manual/ssl#driver-configuration
-    LOG.error("building cassandra3 ssl options");
     SSLOptions sslOptions = buildSSLOptions();
-    LOG.error("built cassandra3 ssl options; {}", sslOptions);
     return builder.withSSL(sslOptions).build();
   }
 
@@ -137,8 +133,6 @@ final class DefaultSessionFactory implements Cassandra3Storage.SessionFactory {
       String tmfAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
       TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlgorithm);
       tmf.init(ts);
-
-      LOG.error("using keystore; {}", ts);
 
       SSLContext sslContext = SSLContext.getInstance("TLS");
       sslContext.init(null, tmf.getTrustManagers(), new SecureRandom());


### PR DESCRIPTION
This adds support for specifying a trusted cert via an environment variable.

This may not be quite up to standard, but wanted to start a conversation and confirm that there was interest in merging this support into the mainline before pursuing hygienic improvements.