### PR TITLE
Fixed Navbar in Zipkin UI

### DIFF
--- a/zipkin-ui/css/main.scss
+++ b/zipkin-ui/css/main.scss
@@ -14,10 +14,6 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 @import "trace";
 @import "traces";
 
-body {
-  padding-top: 50px;
-}
-
 .container {
   width: 90%;
   margin: 0 5%;

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -1,4 +1,4 @@
-    <div id='navbar' class='navbar navbar-inverse navbar-fixed-top' role='navigation'>
+    <div id='navbar' class='navbar navbar-inverse' role='navigation'>
       <div class='container'>
         <div class='navbar-header'>
           <a class='navbar-brand' href='/'>


### PR DESCRIPTION
Currently, on narrow screens or when the window is resized on wide screens, the nav bar in zipkin UI covers the content (can be simulated by resizing the browser window size). The ideal solution is to move the content down after the navbar when the screen is resized.

In the current UI, this happens because the navbar is fixed and is always displayed. This behavior has a few issues:

a) In the zipkin UI there is no need to show the navbar always. If a user wants to use the navbar he can scroll up.
b) On the trace page, displaying the navbar not only covers the content but also covers the spans when the trace is large. If the nav bar can be scrolled up we can use that screen real estate to see more spans.
c) On home page, the nav bar would cover the trace selection form when the browser window is resized.

I have tested this change in-browser.You can experiment with the navbar behavior here: https://getbootstrap.com/examples/navbar-static-top/

In the long term the navbar should be redone to have a better layout of it's contents. Further, on small screens, the nav-bar should collapse into a hamburger menu. 