### PR TITLE
Limit some ES indexing overhead and document C* limits

### DIFF
--- a/zipkin-storage/elasticsearch/README.md
+++ b/zipkin-storage/elasticsearch/README.md
@@ -14,12 +14,31 @@ will be stored in an index like zipkin-2016-03-19. There is no support for TTL t
 It is recommended instead to use [Elastic Curator](https://www.elastic.co/guide/en/elasticsearch/client/curator/current/about.html)
 to remove indices older than the point you are interested in.
 
+### String Mapping
+The Zipkin api implies aggregation and exact match (keyword) on string
+fields named `traceId` and `name`, as well nested fields named
+`serviceName`, `key` and `value`. Indexing on these fields is limited to
+256 characters eventhough storage is currently unbounded.
+
 ### Timestamps
 Zipkin's timestamps are in epoch microseconds, which is not a supported date type in Elasticsearch.
 In consideration of tools like like Kibana, this component adds "timestamp_millis" when writing
 spans. This is mapped to the Elasticsearch date type, so can be used to any date-based queries.
 
 ### Trace Identifiers
+Unless `ElasticsearchStorage.Builder.strictTraceId` is set to false,
+trace identifiers are unanalyzed keywords (exact string match). This
+means that trace IDs should be written fixed length as either 16 or 32
+lowercase hex characters, corresponding to 64 or 128 bit length. If
+writing a custom collector in a different language, make sure you trace
+identifiers the same way.
+
+#### Migrating from 64 to 128-bit trace IDs
+When [migrating from 64 to 128-bit trace IDs](../../zipkin-server/README.md#migrating-from-64-to-128-bit-trace-ids),
+`ElasticsearchStorage.Builder.strictTraceId` will be false, and traceId
+fields will be tokenized to support mixed lookup. This setting should
+only be used temporarily, but is explained below.
+
 The index template tokenizes trace identifiers to match on either 64-bit
 or 128-bit length. This allows span lookup by 64-bit trace ID to include
 spans reported with 128-bit variants of the same id. This allows interop
@@ -45,6 +64,13 @@ $ curl -s localhost:9200/test_zipkin_http-2016-10-26/_analyze -d '{
   "48485a3953bb61246b221d5bc9e6496c"
   "6b221d5bc9e6496c"
 ```
+
+### Span and service Names
+Zipkin defines span and service names as lowercase. At write time, any
+mixed case span or service names are downcased. If writing a custom
+collector in a different language, make sure you write span and service
+names in lowercase. Also, if there are any custom query tools, ensure
+inputs are downcased.
 
 ## Testing this component
 This module conditionally runs integration tests against a local Elasticsearch instance.

--- a/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
+++ b/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
@@ -6,13 +6,6 @@
     "index.requests.cache.enable": true,
     "analysis": {
       "analyzer": {
-        "lowercase": {
-          "type": "custom",
-          "tokenizer": "keyword",
-          "filter": [
-            "lowercase"
-          ]
-        },
         "traceId_analyzer": {
           "type": "custom",
           "tokenizer": "keyword",
@@ -34,8 +27,9 @@
         {
           "strings": {
             "mapping": {
+              "type": "string",
               "index": "not_analyzed",
-              "type": "string"
+              "ignore_above": 256
             },
             "match_mapping_type": "string",
             "match": "*"
@@ -45,19 +39,11 @@
           "value": {
             "match": "value",
             "mapping": {
+              "type": "string",
               "match_mapping_type": "string",
               "index": "not_analyzed",
-              "ignore_malformed": true,
-              "type": "string"
-            }
-          }
-        },
-        {
-          "serviceName": {
-            "match": "serviceName",
-            "mapping": {
-              "type": "string",
-              "analyzer": "lowercase"
+              "ignore_above": 256,
+              "ignore_malformed": true
             }
           }
         },


### PR DESCRIPTION
This removes the explicit mixed-case support in the ES index because it
adds overhead. For example, service and span names are downcased prior
to storage already. This also limits string indexing to the same as C*:
256 characters or less.

This also clarifies the cassandra3 README and backfills a test to make
sure we don't accidentally drop large annotations when we choose to not
index them.