### PR TITLE
Use default withSSL() settings for cassandra

### DIFF
--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
@@ -24,6 +24,7 @@ public class ZipkinCassandraStorageProperties {
   private String localDc;
   private int maxConnections = 8;
   private boolean ensureSchema = true;
+  private boolean useSSL = false;
   private String username;
   private String password;
   private int spanTtl = (int) TimeUnit.DAYS.toSeconds(7);
@@ -73,6 +74,14 @@ public class ZipkinCassandraStorageProperties {
 
   public void setEnsureSchema(boolean ensureSchema) {
     this.ensureSchema = ensureSchema;
+  }
+
+  public boolean isUseSSL() {
+    return useSSL;
+  }
+
+  public void setUseSSL(boolean useSSL) {
+    this.useSSL = useSSL;
   }
 
   public String getUsername() {

--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
@@ -163,6 +163,7 @@ public class ZipkinCassandraStorageProperties {
         .localDc(localDc)
         .maxConnections(maxConnections)
         .ensureSchema(ensureSchema)
+        .useSsl(useSsl)
         .username(username)
         .password(password)
         .spanTtl(spanTtl)

--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
@@ -24,7 +24,7 @@ public class ZipkinCassandraStorageProperties {
   private String localDc;
   private int maxConnections = 8;
   private boolean ensureSchema = true;
-  private boolean useSSL = false;
+  private boolean useSsl = false;
   private String username;
   private String password;
   private int spanTtl = (int) TimeUnit.DAYS.toSeconds(7);
@@ -76,12 +76,12 @@ public class ZipkinCassandraStorageProperties {
     this.ensureSchema = ensureSchema;
   }
 
-  public boolean isUseSSL() {
-    return useSSL;
+  public boolean isUseSsl() {
+    return useSsl;
   }
 
-  public void setUseSSL(boolean useSSL) {
-    this.useSSL = useSSL;
+  public void setUseSsl(boolean useSsl) {
+    this.useSsl = useSsl;
   }
 
   public String getUsername() {

--- a/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageProperties.java
@@ -26,6 +26,7 @@ public class ZipkinCassandra3StorageProperties {
   private String localDc;
   private int maxConnections = 8;
   private boolean ensureSchema = true;
+  private boolean useSsl = false;
   private String username;
   private String password;
   /** See {@link Cassandra3Storage.Builder#indexFetchMultiplier(int)} */
@@ -71,6 +72,14 @@ public class ZipkinCassandra3StorageProperties {
     this.ensureSchema = ensureSchema;
   }
 
+  public boolean isUseSsl() {
+    return useSsl;
+  }
+
+  public void setUseSsl(boolean useSsl) {
+    this.useSsl = useSsl;
+  }
+
   public String getUsername() {
     return username;
   }
@@ -102,6 +111,7 @@ public class ZipkinCassandra3StorageProperties {
         .localDc(localDc)
         .maxConnections(maxConnections)
         .ensureSchema(ensureSchema)
+        .useSsl(useSsl)
         .username(username)
         .password(password)
         .indexFetchMultiplier(indexFetchMultiplier);

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -24,7 +24,7 @@ The following endpoints are defined under the base url http://your_host:9411
 * /api/v1 - [Api](http://zipkin.io/zipkin-api/#/)
 * /health - Returns 200 status if OK
 * /info - Provides the version of the running instance
-* /metrics - Includes collector metrics broken down by transport type 
+* /metrics - Includes collector metrics broken down by transport type
 
 There are more [built-in endpoints](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) provided by Spring Boot, such as `/metrics`. To comprehensively list endpoints, `GET /mappings`.
 
@@ -112,7 +112,7 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
     * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 7 days
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`
-    * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410 
+    * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 
 ### Cassandra Storage
@@ -124,6 +124,7 @@ supports version 2.2+ and applies when `STORAGE_TYPE` is set to `cassandra`:
     * `CASSANDRA_LOCAL_DC`: Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
     * `CASSANDRA_ENSURE_SCHEMA`: Ensuring cassandra has the latest schema. If enabled tries to execute scripts in the classpath prefixed with `cassandra-schema-cql3`. Defaults to true
     * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails. No default
+    * `CASSANDRA_USE_SSL`: Requires `javax.net.ssl.trustStore` and `javax.net.ssl.trustStorePassword`, defaults to false.
 
 The following are tuning parameters which may not concern all users:
 
@@ -162,16 +163,16 @@ The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
                   base urls, ex. http://host:9200. Defaults to "localhost:9300". When not using http,
                   Only one of the hosts needs to be available to fetch the remaining nodes in the
                   cluster. It is recommended to set this to all the master nodes of the cluster.
-                  
+
                   If the http URL is an AWS-hosted elasticsearch installation (e.g.
-                  https://search-domain-xyzzy.us-west-2.es.amazonaws.com) then Zipkin will attempt to 
+                  https://search-domain-xyzzy.us-west-2.es.amazonaws.com) then Zipkin will attempt to
                   use the default AWS credential provider (env variables, system properties, config
                   files, or ec2 profiles) to sign outbound requests to the cluster.
-    * `ES_AWS_DOMAIN`: The name of the AWS-hosted elasticsearch domain to use. Supercedes any set 
+    * `ES_AWS_DOMAIN`: The name of the AWS-hosted elasticsearch domain to use. Supercedes any set
                        `ES_HOSTS`. Triggers the same request signing behavior as with `ES_HOSTS`, but
                        requires the additional IAM permission to describe the given domain.
-    * `ES_AWS_REGION`: An optional override to the default region lookup to search for the domain 
-                       given in `ES_AWS_DOMAIN`. Ignored if only `ES_HOSTS` is present. 
+    * `ES_AWS_REGION`: An optional override to the default region lookup to search for the domain
+                       given in `ES_AWS_DOMAIN`. Ignored if only `ES_HOSTS` is present.
     * `ES_INDEX`: The index prefix to use when generating daily index names. Defaults to zipkin.
     * `ES_INDEX_SHARDS`: The number of shards to split the index into. Each shard and its replicas
                          are assigned to a machine in the cluster. Increasing the number of shards

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -75,6 +75,8 @@ zipkin:
       ensure-schema: ${CASSANDRA3_ENSURE_SCHEMA:true}
       # how many more index rows to fetch than the user-supplied query limit
       index-fetch-multiplier: ${CASSANDRA3_INDEX_FETCH_MULTIPLIER:3}
+      # Using ssl for connection, rely on Keystore
+      use-ssl: ${CASSANDRA3_USE_SSL:false}
     elasticsearch:
       cluster: ${ES_CLUSTER:elasticsearch}
       # host is left unset intentionally, to defer the decision

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -58,6 +58,8 @@ zipkin:
       index-cache-ttl: ${CASSANDRA_INDEX_CACHE_TTL:60}
       # how many more index rows to fetch than the user-supplied query limit
       index-fetch-multiplier: ${CASSANDRA_INDEX_FETCH_MULTIPLIER:3}
+      # Using ssl for connection, rely on Keystore
+      use-ssl: ${CASSANDRA_USE_SSL:false}
     cassandra3:
       # Comma separated list of hosts / ip addresses part of Cassandra cluster.
       contact-points: ${CASSANDRA3_CONTACT_POINTS:localhost}

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
@@ -58,6 +58,7 @@ public final class CassandraStorage
     String localDc;
     int maxConnections = 8;
     boolean ensureSchema = true;
+    boolean useSSL = false;
     String username;
     String password;
     int maxTraceCols = 100000;
@@ -124,6 +125,15 @@ public final class CassandraStorage
      */
     public Builder ensureSchema(boolean ensureSchema) {
       this.ensureSchema = ensureSchema;
+      return this;
+    }
+
+    /**
+     * Use ssl for connection.
+     * Defaults to false.
+     */
+    public Builder useSSL(boolean useSSL) {
+      this.useSSL = useSSL;
       return this;
     }
 
@@ -240,6 +250,7 @@ public final class CassandraStorage
   final String username;
   final String password;
   final boolean ensureSchema;
+  final boolean useSSL;
   final String keyspace;
   final CacheBuilderSpec indexCacheSpec;
   final int indexFetchMultiplier;
@@ -253,6 +264,7 @@ public final class CassandraStorage
     this.username = builder.username;
     this.password = builder.password;
     this.ensureSchema = builder.ensureSchema;
+    this.useSSL = builder.useSSL;
     this.keyspace = builder.keyspace;
     this.maxTraceCols = builder.maxTraceCols;
     this.strictTraceId = builder.strictTraceId;

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
@@ -58,7 +58,7 @@ public final class CassandraStorage
     String localDc;
     int maxConnections = 8;
     boolean ensureSchema = true;
-    boolean useSSL = false;
+    boolean useSsl = false;
     String username;
     String password;
     int maxTraceCols = 100000;
@@ -132,8 +132,8 @@ public final class CassandraStorage
      * Use ssl for connection.
      * Defaults to false.
      */
-    public Builder useSSL(boolean useSSL) {
-      this.useSSL = useSSL;
+    public Builder useSsl(boolean useSsl) {
+      this.useSsl = useSsl;
       return this;
     }
 
@@ -250,7 +250,7 @@ public final class CassandraStorage
   final String username;
   final String password;
   final boolean ensureSchema;
-  final boolean useSSL;
+  final boolean useSsl;
   final String keyspace;
   final CacheBuilderSpec indexCacheSpec;
   final int indexFetchMultiplier;
@@ -264,7 +264,7 @@ public final class CassandraStorage
     this.username = builder.username;
     this.password = builder.password;
     this.ensureSchema = builder.ensureSchema;
-    this.useSSL = builder.useSSL;
+    this.useSsl = builder.useSsl;
     this.keyspace = builder.keyspace;
     this.maxTraceCols = builder.maxTraceCols;
     this.strictTraceId = builder.strictTraceId;

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/SessionFactory.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/SessionFactory.java
@@ -87,7 +87,7 @@ public interface SessionFactory {
       builder.withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(
           HostDistance.LOCAL, cassandra.maxConnections
       ));
-      if (cassandra.useSSL) {
+      if (cassandra.useSsl) {
         builder = builder.withSSL();
       }
       return builder.build();

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/SessionFactory.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/SessionFactory.java
@@ -87,6 +87,9 @@ public interface SessionFactory {
       builder.withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(
           HostDistance.LOCAL, cassandra.maxConnections
       ));
+      if (cassandra.useSSL) {
+        builder = builder.withSSL();
+      }
       return builder.build();
     }
 

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Cassandra3Storage.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Cassandra3Storage.java
@@ -63,6 +63,7 @@ public final class Cassandra3Storage
     String localDc;
     int maxConnections = 8;
     boolean ensureSchema = true;
+    boolean useSsl = false;
     String username;
     String password;
     int maxTraceCols = 100000;
@@ -114,6 +115,15 @@ public final class Cassandra3Storage
      */
     public Builder ensureSchema(boolean ensureSchema) {
       this.ensureSchema = ensureSchema;
+      return this;
+    }
+
+    /**
+     * Use ssl for driver
+     * Defaults to false.
+     */
+    public Builder useSsl(boolean useSsl) {
+      this.useSsl = useSsl;
       return this;
     }
 
@@ -170,6 +180,7 @@ public final class Cassandra3Storage
   final String username;
   final String password;
   final boolean ensureSchema;
+  final boolean useSsl;
   final String keyspace;
   final int indexFetchMultiplier;
   final boolean strictTraceId;
@@ -182,6 +193,7 @@ public final class Cassandra3Storage
     this.username = builder.username;
     this.password = builder.password;
     this.ensureSchema = builder.ensureSchema;
+    this.useSsl = builder.useSsl;
     this.keyspace = builder.keyspace;
     this.maxTraceCols = builder.maxTraceCols;
     this.indexFetchMultiplier = builder.indexFetchMultiplier;

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
@@ -123,6 +123,10 @@ final class DefaultSessionFactory implements Cassandra3Storage.SessionFactory {
     builder.withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(
         HostDistance.LOCAL, cassandra.maxConnections
     ));
+    if (cassandra.useSsl) {
+      builder = builder.withSSL();
+    }
+
     return builder.build();
   }
 


### PR DESCRIPTION
This is an optin to use `withSSL` for the cassandra driver.

This will require the java keystore and so on to be configured correctly on the server so that the cassandra certificate is present.

I have not tested this yet but wanted more feedback.

This is a simplification of #1396 