### PR TITLE
Adds Elasticsearch 5.x support via storage type: elasticsearch-http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ _site/
 *.iml
 *.swp
 # .travis.yml installs things
-apache-cassandra-*
-elasticsearch-2*
-kafka_*
+/apache-cassandra-*
+/elasticsearch-*
+/kafka_*
 # temporary directory used by travis/publish.sh for building gh-pages
 /javadoc-builddir

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ before_install:
   - git config credential.helper "store --file=.git/credentials"
   - echo "https://$GH_TOKEN:@github.com" > .git/credentials
 
-  # Manually install elasticsearch until https://github.com/travis-ci/apt-source-whitelist/issues/190
-  - curl -SL https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.2.1/elasticsearch-2.2.1.tar.gz | tar xz
+  # Manually install elasticsearch 5 (since 2.x is default in travis)
+  - curl -SL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz | tar xz
   - elasticsearch-*/bin/elasticsearch -d > /dev/null
 
   # Manually install and run zk+kafka as it isn't an available service

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The [CassandraStorage](zipkin-storage/cassandra) component is tested against Cas
 ### Elasticsearch
 The [ElasticsearchStorage](zipkin-storage/elasticsearch) component is tested against Elasticsearch 2.3. It stores spans as json and has been designed for larger scale. This store requires a [spark job](https://github.com/openzipkin/zipkin-dependencies) to aggregate dependency links.
 
+Note: The storage type `elasticsearch-http` supports both 2.x and 5.x versions of Elasticsearch.
+
 ## Running the server from source
 The [zipkin server](zipkin-server)
 receives spans via HTTP POST and respond to queries from its UI. It can also run collectors, such as Scribe or Kafka.

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     -->
     <mariadb-java-client.version>1.4.6</mariadb-java-client.version>
     <HikariCP.version>2.4.7</HikariCP.version>
-    <elasticsearch.version>2.4.0</elasticsearch.version>
+    <elasticsearch.version>2.4.1</elasticsearch.version>
     <slf4j.version>1.7.21</slf4j.version>
     <logback.version>1.1.7</logback.version>
     <!-- be careful to not eagerly update as we can break other storage or transports!
@@ -539,7 +539,7 @@
             <exclude>LICENSE</exclude>
             <exclude>**/*.md</exclude>
             <exclude>apache-cassandra-*/**</exclude>
-            <exclude>elasticsearch-2*/**</exclude>
+            <exclude>elasticsearch-*/**</exclude>
             <exclude>kafka_*/**</exclude>
             <exclude>src/test/resources/**</exclude>
             <exclude>src/main/resources/**</exclude>

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
@@ -15,6 +15,7 @@ package zipkin.autoconfigure.storage.elasticsearch.http;
 
 import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -34,8 +35,9 @@ public class ZipkinElasticsearchHttpStorageAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   InternalElasticsearchClient.Builder clientBuilder(
-      @Qualifier("zipkinElasticsearchHttp") OkHttpClient client) {
-    return HttpClientBuilder.create(client);
+      @Qualifier("zipkinElasticsearchHttp") OkHttpClient client,
+      @Value("${zipkin.storage.elasticsearch.pipeline:}") String pipeline) {
+    return HttpClientBuilder.create(client).pipeline(pipeline.isEmpty() ? null : pipeline);
   }
 
   /** cheap check to see if we are likely to include urls */

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -168,7 +168,9 @@ The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
                   https://search-domain-xyzzy.us-west-2.es.amazonaws.com) then Zipkin will attempt to
                   use the default AWS credential provider (env variables, system properties, config
                   files, or ec2 profiles) to sign outbound requests to the cluster.
-    * `ES_AWS_DOMAIN`: The name of the AWS-hosted elasticsearch domain to use. Supercedes any set
+    * `ES_PIPELINE`: Only valid when the destination is Elasticsearch 5.x. Indicates the ingest
+                     pipeline used before spans are indexed. No default.
+    * `ES_AWS_DOMAIN`: The name of the AWS-hosted elasticsearch domain to use. Supercedes any set 
                        `ES_HOSTS`. Triggers the same request signing behavior as with `ES_HOSTS`, but
                        requires the additional IAM permission to describe the given domain.
     * `ES_AWS_REGION`: An optional override to the default region lookup to search for the domain

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -81,6 +81,7 @@ zipkin:
       cluster: ${ES_CLUSTER:elasticsearch}
       # host is left unset intentionally, to defer the decision
       hosts: ${ES_HOSTS:}
+      pipeline: ${ES_PIPELINE:}
       aws:
         domain: ${ES_AWS_DOMAIN:}
         region: ${ES_AWS_REGION:}

--- a/zipkin-storage/elasticsearch-http/README.md
+++ b/zipkin-storage/elasticsearch-http/README.md
@@ -2,6 +2,31 @@
 
 This is is a plugin to the Elasticsearch storage component, which uses
 HTTP by way of [OkHttp 3](https://github.com/square/okttp) and
-[Moshi](https://github.com/square/moshi). 
+[Moshi](https://github.com/square/moshi). This currently supports both
+2.x and 5.x version families.
 
 See [storage-elasticsearch](../elasticsearch) for more details.
+
+## Customizing the ingest pipeline
+
+When using Elasticsearch 5.x, you can setup an [ingest pipeline](https://www.elastic.co/guide/en/elasticsearch/reference/master/pipeline.html)
+to perform custom processing.
+
+Here's an example, which you'd setup prior to configuring Zipkin to use
+it via `zipkin.storage.elasticsearch.http.HttpClientBuilder.pipeline`
+
+
+```
+PUT _ingest/pipeline/zipkin
+{
+  "description" : "add collector_timestamp_millis",
+  "processors" : [
+    {
+      "set" : {
+        "field": "collector_timestamp_millis",
+        "value": "{{_ingest.timestamp}}"
+      }
+    }
+  ]
+}
+```

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkSpanIndexer.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkSpanIndexer.java
@@ -27,17 +27,19 @@ final class HttpBulkSpanIndexer extends HttpBulkIndexer<Span> implements
     super(delegate, spanType);
   }
 
-  @Override public void add(String index, Span span, Long timestampMillis) throws IOException {
+  @Override
+  public HttpBulkSpanIndexer add(String index, Span span, Long timestampMillis) throws IOException {
     String id = null; // Allow ES to choose an ID
     if (timestampMillis == null) {
       super.add(index, span, id);
-      return;
+      return this;
     }
     writeIndexMetadata(index, id);
     body.write(toSpanBytes(span, timestampMillis));
     body.writeByte('\n');
 
     if (client.flushOnWrites) indices.add(index);
+    return this;
   }
 
   @Override byte[] toJsonBytes(Span span) {

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClientBuilder.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClientBuilder.java
@@ -19,12 +19,12 @@ import okhttp3.OkHttpClient;
 import zipkin.internal.Lazy;
 import zipkin.storage.elasticsearch.InternalElasticsearchClient;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static zipkin.internal.Util.checkNotNull;
 
 public final class HttpClientBuilder extends InternalElasticsearchClient.Builder {
   final OkHttpClient client;
   Lazy<List<String>> hosts;
-  boolean compressionEnabled = true;
+  String pipeline;
   boolean flushOnWrites;
 
   public static HttpClientBuilder create(OkHttpClient client) {
@@ -53,9 +53,14 @@ public final class HttpClientBuilder extends InternalElasticsearchClient.Builder
     return this;
   }
 
-  /** Default true. true implies that spans will be gzipped before transport. */
-  public HttpClientBuilder compressionEnabled(boolean compressionEnabled) {
-    this.compressionEnabled = compressionEnabled;
+  /**
+   * Only valid when the destination is Elasticsearch 5.x. Indicates the ingest pipeline used before
+   * spans are indexed. No default.
+   *
+   * <p>See https://www.elastic.co/guide/en/elasticsearch/reference/master/pipeline.html
+   */
+  public HttpClientBuilder pipeline(String pipeline) {
+    this.pipeline = pipeline;
     return this;
   }
 

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/moshi/JsonReadersTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/moshi/JsonReadersTest.java
@@ -24,6 +24,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JsonReadersTest {
 
   @Test
+  public void enterPath_nested() throws IOException {
+    assertThat(JsonReaders.enterPath(JsonReader.of(new Buffer().writeUtf8("{\n"
+        + "  \"name\" : \"Kamal\",\n"
+        + "  \"cluster_name\" : \"elasticsearch\",\n"
+        + "  \"version\" : {\n"
+        + "    \"number\" : \"2.4.0\",\n"
+        + "    \"build_hash\" : \"ce9f0c7394dee074091dd1bc4e9469251181fc55\",\n"
+        + "    \"build_timestamp\" : \"2016-08-29T09:14:17Z\",\n"
+        + "    \"build_snapshot\" : false,\n"
+        + "    \"lucene_version\" : \"5.5.2\"\n"
+        + "  },\n"
+        + "  \"tagline\" : \"You Know, for Search\"\n"
+        + "}")), "version", "number").nextString())
+        .isEqualTo("2.4.0");
+  }
+
+  @Test
   public void enterPath_nullOnNoInput() throws IOException {
     assertThat(JsonReaders.enterPath(JsonReader.of(new Buffer()), "message"))
         .isNull();

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
@@ -14,10 +14,8 @@
 package zipkin.storage.elasticsearch;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin.Annotation;
@@ -48,8 +46,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Test
-  public void spanGoesIntoADailyIndex_whenTimestampIsDerived()
-      throws ExecutionException, InterruptedException {
+  public void spanGoesIntoADailyIndex_whenTimestampIsDerived() throws Exception {
     long twoDaysAgo = (TODAY - 2 * DAY);
 
     Span span = Span.builder().traceId(20L).id(20L).name("get")
@@ -70,8 +67,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Test
-  public void spanGoesIntoADailyIndex_whenTimestampIsExplicit()
-      throws ExecutionException, InterruptedException {
+  public void spanGoesIntoADailyIndex_whenTimestampIsExplicit() throws Exception {
     long twoDaysAgo = (TODAY - 2 * DAY);
 
     Span span = Span.builder().traceId(20L).id(20L).name("get")
@@ -90,8 +86,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Test
-  public void spanGoesIntoADailyIndex_fallsBackToTodayWhenNoTimestamps()
-      throws ExecutionException, InterruptedException {
+  public void spanGoesIntoADailyIndex_fallsBackToTodayWhenNoTimestamps() throws Exception {
     Span span = Span.builder().traceId(20L).id(20L).name("get").build();
 
     accept(span);
@@ -107,7 +102,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Test
-  public void searchByTimestampMillis() throws ExecutionException, InterruptedException {
+  public void searchByTimestampMillis() throws Exception {
     Span span = Span.builder().timestamp(TODAY * 1000).traceId(20L).id(20L).name("get").build();
 
     accept(span);
@@ -137,7 +132,7 @@ public class ElasticsearchSpanConsumerTest {
         .isEqualTo(span); // ignores timestamp_millis field
   }
 
-  void accept(Span span) {
-    Futures.getUnchecked(storage.computeGuavaSpanConsumer().accept(ImmutableList.of(span)));
+  void accept(Span span) throws Exception {
+    storage.guavaSpanConsumer().accept(ImmutableList.of(span)).get();
   }
 }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/CallbackListenableFutureTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/CallbackListenableFutureTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch.http;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class CallbackListenableFutureTest {
+  @Rule
+  public MockWebServer mws = new MockWebServer();
+
+  OkHttpClient client = new OkHttpClient();
+  Call call = client.newCall(new Request.Builder().url(mws.url("")).build());
+
+  @After
+  public void close() throws IOException {
+    client.dispatcher().executorService().shutdownNow();
+  }
+
+  @Test
+  public void propagatesOnDispatcherThreadWhenFatal() throws Exception {
+    mws.enqueue(new MockResponse());
+
+    ListenableFuture<Void> future = new CallbackListenableFuture<Void>(call) {
+      @Override Void convert(ResponseBody responseBody) throws IOException {
+        throw new LinkageError();
+      }
+    }.enqueue();
+
+    try {
+      future.get(100, TimeUnit.MILLISECONDS);
+      failBecauseExceptionWasNotThrown(TimeoutException.class);
+    } catch (TimeoutException expected) {
+    }
+  }
+
+  @Test
+  public void executionException_conversionException() throws Exception {
+    mws.enqueue(new MockResponse());
+
+    ListenableFuture<Void> future = new CallbackListenableFuture<Void>(call) {
+      @Override Void convert(ResponseBody responseBody) throws IOException {
+        throw new IllegalArgumentException("eeek");
+      }
+    }.enqueue();
+
+    try {
+      future.get();
+      failBecauseExceptionWasNotThrown(ExecutionException.class);
+    } catch (ExecutionException expected) {
+      assertThat(expected).hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  public void executionException_httpFailure() throws Exception {
+    mws.enqueue(new MockResponse().setResponseCode(500));
+
+    ListenableFuture<Void> future = new CallbackListenableFuture<Void>(call).enqueue();
+
+    try {
+      future.get();
+      failBecauseExceptionWasNotThrown(ExecutionException.class);
+    } catch (ExecutionException expected) {
+      assertThat(expected).hasCauseInstanceOf(IllegalStateException.class);
+    }
+  }
+}

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpClientTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpClientTest.java
@@ -22,6 +22,7 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import zipkin.TestObjects;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,12 +60,90 @@ public class HttpClientTest {
 
     RecordedRequest request = es.takeRequest();
     assertThat(request.getPath())
-        .isEqualTo("/zipkin-2016-10-01,zipkin-2016-10-02/dependencylink/_search?allow_no_indices=true&expand_wildcards=open&ignore_unavailable=true");
+        .isEqualTo(
+            "/zipkin-2016-10-01,zipkin-2016-10-02/dependencylink/_search?allow_no_indices=true&expand_wildcards=open&ignore_unavailable=true");
     assertThat(request.getBody().buffer().readUtf8())
         .isEqualTo("{\n"
             + "  \"query\" : {\n"
             + "    \"match_all\" : { }\n"
             + "  }\n"
             + "}");
+  }
+
+  /** Unsupported, but we should test that parsing works */
+  @Test
+  public void getVersion_1() throws Exception {
+    es.enqueue(new MockResponse().setBody("{\n"
+        + "  \"status\" : 200,\n"
+        + "  \"name\" : \"Shen Kuei\",\n"
+        + "  \"cluster_name\" : \"elasticsearch\",\n"
+        + "  \"version\" : {\n"
+        + "    \"number\" : \"1.7.3\",\n"
+        + "    \"build_hash\" : \"05d4530971ef0ea46d0f4fa6ee64dbc8df659682\",\n"
+        + "    \"build_timestamp\" : \"2015-10-15T09:14:17Z\",\n"
+        + "    \"build_snapshot\" : false,\n"
+        + "    \"lucene_version\" : \"4.10.4\"\n"
+        + "  },\n"
+        + "  \"tagline\" : \"You Know, for Search\"\n"
+        + "}"));
+
+    assertThat(client.getVersion()).isEqualTo("1.7.3");
+  }
+
+  @Test
+  public void getVersion_2() throws Exception {
+    es.enqueue(new MockResponse().setBody("{\n"
+        + "  \"name\" : \"Kamal\",\n"
+        + "  \"cluster_name\" : \"elasticsearch\",\n"
+        + "  \"version\" : {\n"
+        + "    \"number\" : \"2.4.0\",\n"
+        + "    \"build_hash\" : \"ce9f0c7394dee074091dd1bc4e9469251181fc55\",\n"
+        + "    \"build_timestamp\" : \"2016-08-29T09:14:17Z\",\n"
+        + "    \"build_snapshot\" : false,\n"
+        + "    \"lucene_version\" : \"5.5.2\"\n"
+        + "  },\n"
+        + "  \"tagline\" : \"You Know, for Search\"\n"
+        + "}"));
+
+    assertThat(client.getVersion()).isEqualTo("2.4.0");
+  }
+
+  @Test
+  public void getVersion_5() throws Exception {
+    es.enqueue(new MockResponse().setBody("{\n"
+        + "  \"name\" : \"vU0g1--\",\n"
+        + "  \"cluster_name\" : \"elasticsearch\",\n"
+        + "  \"cluster_uuid\" : \"Fnm277ITSNyzsy0UCVFN7g\",\n"
+        + "  \"version\" : {\n"
+        + "    \"number\" : \"5.0.0\",\n"
+        + "    \"build_hash\" : \"253032b\",\n"
+        + "    \"build_date\" : \"2016-10-26T04:37:51.531Z\",\n"
+        + "    \"build_snapshot\" : false,\n"
+        + "    \"lucene_version\" : \"6.2.0\"\n"
+        + "  },\n"
+        + "  \"tagline\" : \"You Know, for Search\"\n"
+        + "}"));
+
+    assertThat(client.getVersion()).isEqualTo("5.0.0");
+  }
+
+  @Test
+  public void addsPipelineId() throws Exception {
+    client.close();
+    client = (HttpClient) new HttpClientBuilder(new OkHttpClient())
+        .pipeline("zipkin")
+        .hosts(asList(es.url("").toString()))
+        .buildFactory().create("zipkin-*");
+
+    es.enqueue(new MockResponse());
+
+    client.bulkSpanIndexer()
+        .add("zipkin-2016-10-01", TestObjects.TRACE.get(0), null)
+        .execute()
+        .get();
+
+    RecordedRequest request = es.takeRequest();
+    assertThat(request.getPath())
+        .isEqualTo("/_bulk?pipeline=zipkin");
   }
 }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpElasticsearchTestGraph.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpElasticsearchTestGraph.java
@@ -25,7 +25,7 @@ public enum HttpElasticsearchTestGraph {
 
   public final LazyCloseable<ElasticsearchStorage> storage =
       new LazyCloseable<ElasticsearchStorage>() {
-        public AssumptionViolatedException ex;
+        AssumptionViolatedException ex;
 
         @Override protected ElasticsearchStorage compute() {
           if (ex != null) throw ex;

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
@@ -84,6 +84,9 @@ public abstract class InternalElasticsearchClient implements Closeable {
     public abstract Factory buildFactory();
   }
 
+  /** Returns the Elasticsearch version of the transport. */
+  protected abstract String getVersion() throws IOException;
+
   /** Ensures the existence of a template, creating it if it does not exist. */
   protected abstract void ensureTemplate(String name, String indexTemplate) throws IOException;
 
@@ -133,15 +136,16 @@ public abstract class InternalElasticsearchClient implements Closeable {
      *
      * <p>For example. {"traceId":".. becomes {"timestamp_millis":12345,"traceId":"...
      */
-    void add(String index, Span span, Long timestampMillis) throws IOException;
+    BulkSpanIndexer add(String index, Span span, Long timestampMillis) throws IOException;
 
     ListenableFuture<Void> execute() throws IOException;
   }
 
   protected static abstract class SpanBytesBulkSpanIndexer implements BulkSpanIndexer {
 
-    @Override public final void add(String index, Span span, Long timestampMillis) {
+    @Override public final BulkSpanIndexer add(String index, Span span, Long timestampMillis) {
       add(index, toSpanBytes(span, timestampMillis));
+      return this;
     }
 
     abstract protected void add(String index, byte[] spanBytes);

--- a/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
+++ b/zipkin-storage/elasticsearch/src/main/resources/zipkin/storage/elasticsearch/zipkin_template.json
@@ -27,8 +27,7 @@
         {
           "strings": {
             "mapping": {
-              "type": "string",
-              "index": "not_analyzed",
+              KEYWORD,
               "ignore_above": 256
             },
             "match_mapping_type": "string",
@@ -39,9 +38,8 @@
           "value": {
             "match": "value",
             "mapping": {
-              "type": "string",
               "match_mapping_type": "string",
-              "index": "not_analyzed",
+              KEYWORD,
               "ignore_above": 256,
               "ignore_malformed": true
             }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumerTest.java
@@ -14,27 +14,13 @@
 package zipkin.storage.elasticsearch;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ObjectArrays;
-import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import zipkin.Annotation;
 import zipkin.Codec;
 import zipkin.Span;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -59,8 +45,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Test
-  public void spanGoesIntoADailyIndex_whenTimestampIsDerived()
-      throws ExecutionException, InterruptedException {
+  public void spanGoesIntoADailyIndex_whenTimestampIsDerived() throws Exception {
     long twoDaysAgo = (TODAY - 2 * DAY);
 
     Span span = Span.builder().traceId(20L).id(20L).name("get")
@@ -81,8 +66,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Test
-  public void spanGoesIntoADailyIndex_whenTimestampIsExplicit()
-      throws ExecutionException, InterruptedException {
+  public void spanGoesIntoADailyIndex_whenTimestampIsExplicit() throws Exception {
     long twoDaysAgo = (TODAY - 2 * DAY);
 
     Span span = Span.builder().traceId(20L).id(20L).name("get")
@@ -101,8 +85,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Test
-  public void spanGoesIntoADailyIndex_fallsBackToTodayWhenNoTimestamps()
-      throws ExecutionException, InterruptedException {
+  public void spanGoesIntoADailyIndex_fallsBackToTodayWhenNoTimestamps() throws Exception {
     Span span = Span.builder().traceId(20L).id(20L).name("get").build();
 
     accept(span);
@@ -118,7 +101,7 @@ public class ElasticsearchSpanConsumerTest {
   }
 
   @Test
-  public void searchByTimestampMillis() throws ExecutionException, InterruptedException {
+  public void searchByTimestampMillis() throws Exception {
     Span span = Span.builder().timestamp(TODAY * 1000).traceId(20L).id(20L).name("get").build();
 
     accept(span);
@@ -148,7 +131,7 @@ public class ElasticsearchSpanConsumerTest {
         .isEqualTo(span); // ignores timestamp_millis field
   }
 
-  void accept(Span span) {
-    Futures.getUnchecked(storage.computeGuavaSpanConsumer().accept(ImmutableList.of(span)));
+  void accept(Span span) throws Exception {
+    storage.guavaSpanConsumer().accept(ImmutableList.of(span)).get();
   }
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
@@ -21,7 +21,7 @@ enum ElasticsearchTestGraph {
   INSTANCE;
 
   final LazyCloseable<ElasticsearchStorage> storage = new LazyCloseable<ElasticsearchStorage>() {
-    public AssumptionViolatedException ex;
+    AssumptionViolatedException ex;
 
     @Override protected ElasticsearchStorage compute() {
       if (ex != null) throw ex;

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/NativeClientTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/NativeClientTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NativeClientTest {
+
+  /**
+   * The native client can only support the version matching the cluster. Since 2.x and 5.x classes
+   * are incompatible, NativeClient is limited to the version it is built against: 2.x
+   */
+  @Test
+  public void builderGetsVersionFromProperties() {
+    NativeClient.Builder builder = new NativeClient.Builder();
+
+    assertThat(builder.clientVersion).isNull(); // lazy init
+
+    builder.buildFactory();
+    assertThat(builder.clientVersion)
+        .startsWith("2.4");
+  }
+}


### PR DESCRIPTION
This allows use of Elasticsearch 5.x and its notable ingest pipeline
feature when using `zipkin-storage-elasticsearch-http`.

It is important to note that `zipkin-storage-elasticsearch` remains
pinned to ES 2.x libraries as they are compile incompatible with 5.x.
In other words, you must use http if you want to use ES 5 (for now).

Version detection is implemented in order to choose the correct index
template format for the major version number. The implementation of
such is string manip, as it was less work than making a new type.

This adds a new parameter `ES_PIPELINE` which allows you to manipulate
the json sent by Zipkin collector before it is indexed. This could be
used for many things including cleaning service names or adding ingest
timestamps.

Integration tests run version 2.x on CircleCI and 5.x on Travis

Fixes #1312
Fixes #1318