### PR TITLE
be more forgiving of IPv4-mapped addresses in json

### DIFF
--- a/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
@@ -293,6 +293,32 @@ public final class JsonCodecTest extends CodecTest {
   }
 
   @Test
+  public void mappedIPv6toIPv4() {
+    String json = "{\n"
+        + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+        + "  \"name\": \"get-traces\",\n"
+        + "  \"id\": \"6b221d5bc9e6496c\",\n"
+        + "  \"binaryAnnotations\": [\n"
+        + "    {\n"
+        + "      \"key\": \"foo\",\n"
+        + "      \"value\": \"bar\",\n"
+        + "      \"endpoint\": {\n"
+        + "        \"serviceName\": \"service\",\n"
+        + "        \"port\": 65535,\n"
+        + "        \"ipv6\": \"::ffff:192.0.2.128\"\n"
+        + "      }\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    Span span = Codec.JSON.readSpan(json.getBytes(UTF_8));
+    assertThat(span.binaryAnnotations.get(0).endpoint.ipv6)
+        .isNull();
+    assertThat(span.binaryAnnotations.get(0).endpoint.ipv4)
+        .isEqualTo((192 << 24) | (0 << 16) | (2 << 8) | 128); // 192.0.2.128
+  }
+
+  @Test
   public void sizeInBytes_span() throws IOException {
     Span span = TestObjects.LOTS_OF_SPANS[0];
     assertThat(JsonCodec.SPAN_ADAPTER.sizeInBytes(span))


### PR DESCRIPTION
Currently Zipkin checks that all IPv6 addresses are 16 bytes long.
However, if an IPv4-mapped addresses such as `::ffff:192.168.1.128` is
given then InetAddress.getByName will return an Inet4Address and the
assertion will fail.

Instead accept the address, but store it as ipv4 to maintain all
existing assertions.  This absolves clients of reconciling the nuances
of IPv4-mapped addresses in their environments (for example, in node
`net.isIPv6('::ffff:192.168.1.128')` is true) with Java's.