### PR TITLE
Fixes regression in ZipkinRule when returning all traces

### DIFF
--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinRule.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinRule.java
@@ -30,7 +30,6 @@ import org.junit.runners.model.Statement;
 import zipkin.Span;
 import zipkin.collector.InMemoryCollectorMetrics;
 import zipkin.storage.InMemoryStorage;
-import zipkin.storage.QueryRequest;
 
 import static okhttp3.mockwebserver.SocketPolicy.KEEP_OPEN;
 
@@ -132,7 +131,7 @@ public final class ZipkinRule implements TestRule {
 
   /** Retrieves all traces this zipkin server has received. */
   public List<List<Span>> getTraces() {
-    return storage.spanStore().getTraces(QueryRequest.builder().limit(Integer.MAX_VALUE).build());
+    return storage.spanStore().getRawTraces();
   }
 
   /**

--- a/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
@@ -56,6 +56,18 @@ public class ZipkinRuleTest {
         .containsOnly(TRACE);
   }
 
+  /** The rule is here to help debugging. Even partial spans should be returned */
+  @Test
+  public void getTraces_whenMissingTimestamps() throws IOException {
+    Span span = Span.builder().traceId(traceId).id(traceId).name("foo").build();
+    // write the span to the zipkin using http
+    assertThat(postSpans(asList(span)).code()).isEqualTo(202);
+
+    // read the traces directly
+    assertThat(zipkin.getTraces())
+        .containsOnly(asList(span));
+  }
+
   @Test
   public void healthIsOK() throws IOException {
     Response getResponse = client.newCall(new Request.Builder()

--- a/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
@@ -83,6 +83,10 @@ public final class InMemorySpanStore implements SpanStore {
     }
   };
 
+  /**
+   * @deprecated use {@link #getRawTraces()}
+   */
+  @Deprecated
   public synchronized List<Long> traceIds() {
     return sortedList(traceIdToSpans.keySet());
   }
@@ -91,6 +95,21 @@ public final class InMemorySpanStore implements SpanStore {
     acceptedSpanCount = 0;
     traceIdToSpans.clear();
     serviceToTraceIdTimeStamp.clear();
+  }
+
+  /**
+   * Used for testing. Returns all traces unconditionally.
+   */
+  public synchronized List<List<Span>> getRawTraces() {
+    List<List<Span>> result = new ArrayList<List<Span>>();
+    for (long traceId : traceIdToSpans.keySet()) {
+      Collection<Span> sameTraceId = traceIdToSpans.get(traceId);
+      for (List<Span> next : GroupByTraceId.apply(sameTraceId, strictTraceId, false)) {
+        result.add(next);
+      }
+    }
+    Collections.sort(result, TRACE_DESCENDING);
+    return result;
   }
 
   @Override


### PR DESCRIPTION
When we switched to 128-bit trace ids, we accidentally broke our junit
rule. Basically, we were only returning traces who reported timestamps.
This fixes the problem (noticed in Brave).