### PR TITLE
Add logs button on the trace page.

### DIFF
--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
@@ -15,6 +15,7 @@ package zipkin.autoconfigure.ui;
 
 import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 @ConfigurationProperties("zipkin.ui")
 public class ZipkinUiProperties {
@@ -22,6 +23,7 @@ public class ZipkinUiProperties {
   private int queryLimit = 10;
   private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);
   private String instrumented = ".*";
+  private String logsUrl = null;
 
   public int getDefaultLookback() {
     return defaultLookback;
@@ -53,5 +55,15 @@ public class ZipkinUiProperties {
 
   public void setInstrumented(String instrumented) {
     this.instrumented = instrumented;
+  }
+
+  public String getLogsUrl() {
+    return logsUrl;
+  }
+
+  public void setLogsUrl(String logsUrl) {
+    if (!StringUtils.isEmpty(logsUrl)) {
+      this.logsUrl = logsUrl;
+    }
   }
 }

--- a/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
@@ -34,22 +34,56 @@ public class ZipkinUiAutoConfigurationTest {
 
   @Test
   public void indexHtmlFromClasspath() {
-    context = new AnnotationConfigApplicationContext();
-    context.register(PropertyPlaceholderAutoConfiguration.class, ZipkinUiAutoConfiguration.class);
-    context.refresh();
+    context = createContext();
 
     assertThat(context.getBean(ZipkinUiAutoConfiguration.class).indexHtml)
         .isNotNull();
   }
 
+
   @Test
   public void canOverridesProperty_defaultLookback() {
-    context = new AnnotationConfigApplicationContext();
-    addEnvironment(context, "zipkin.ui.defaultLookback:100");
-    context.register(PropertyPlaceholderAutoConfiguration.class, ZipkinUiAutoConfiguration.class);
-    context.refresh();
+    context = createContextWithOverridenProperty("zipkin.ui.defaultLookback:100");
 
     assertThat(context.getBean(ZipkinUiProperties.class).getDefaultLookback())
         .isEqualTo(100);
+  }
+
+
+  @Test
+  public void canOverrideProperty_logsUrl() {
+    final String url = "http://mycompany.com/kibana";
+    context = createContextWithOverridenProperty("zipkin.ui.logs-url:"+ url);
+
+    assertThat(context.getBean(ZipkinUiProperties.class).getLogsUrl()).isEqualTo(url);
+  }
+
+  @Test
+  public void logsUrlIsNullIfOverridenByEmpty() {
+    context = createContextWithOverridenProperty("zipkin.ui.logs-url:");
+
+    assertThat(context.getBean(ZipkinUiProperties.class).getLogsUrl()).isNull();
+  }
+
+  @Test
+  public void logsUrlIsNullByDefault() {
+    context = createContext();
+
+    assertThat(context.getBean(ZipkinUiProperties.class).getLogsUrl()).isNull();
+  }
+
+  private static AnnotationConfigApplicationContext createContext() {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.register(PropertyPlaceholderAutoConfiguration.class, ZipkinUiAutoConfiguration.class);
+    context.refresh();
+    return context;
+  }
+
+  private static AnnotationConfigApplicationContext createContextWithOverridenProperty(String pair) {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, pair);
+    context.register(PropertyPlaceholderAutoConfiguration.class, ZipkinUiAutoConfiguration.class);
+    context.refresh();
+    return context;
   }
 }

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -111,7 +111,9 @@ zipkin:
     # - .*example2.com
     # Default is "match all websites"
     instrumented: .*
-
+    # Url of the logs associated with a given request.
+    # It will be formatted with the trace id if your url contains {traceId} (e.g. http://kibana/trace{traceId})
+    logs-url: ${LOGS_URL:}
 server:
   port: ${QUERY_PORT:9411}
   compression:

--- a/zipkin-ui/js/component_data/trace.js
+++ b/zipkin-ui/js/component_data/trace.js
@@ -3,13 +3,22 @@ import $ from 'jquery';
 import {getError} from '../../js/component_ui/error';
 import traceToMustache from '../../js/component_ui/traceToMustache';
 
+export function toContextualLogsUrl(logsUrl, traceId) {
+  if (logsUrl) {
+    return logsUrl.replace('{traceId}', traceId);
+  }
+  return logsUrl;
+}
+
 export default component(function TraceData() {
   this.after('initialize', function() {
-    $.ajax(`/api/v1/trace/${this.attr.traceId}`, {
+    const traceId = this.attr.traceId;
+    const logsUrl = toContextualLogsUrl(this.attr.logsUrl, traceId);
+    $.ajax(`/api/v1/trace/${traceId}`, {
       type: 'GET',
       dataType: 'json'
     }).done(trace => {
-      const modelview = traceToMustache(trace);
+      const modelview = traceToMustache(trace, logsUrl);
       this.trigger('tracePageModelView', {modelview, trace});
     }).fail(e => {
       this.trigger('uiServerError',

--- a/zipkin-ui/js/component_ui/traceToMustache.js
+++ b/zipkin-ui/js/component_ui/traceToMustache.js
@@ -92,7 +92,7 @@ export function formatEndpoint({ipv4, ipv6, port = 0, serviceName = ''}) {
   return `${ipv4}:${port}`;
 }
 
-export default function traceToMustache(trace) {
+export default function traceToMustache(trace, logsUrl = undefined) {
   const summary = traceSummary(trace);
   const traceId = summary.traceId;
   const duration = mkDurationStr(summary.duration);
@@ -194,6 +194,7 @@ export default function traceToMustache(trace) {
     timeMarkers,
     timeMarkersBackup,
     spans,
-    spansBackup
+    spansBackup,
+    logsUrl
   };
 }

--- a/zipkin-ui/js/page/trace.js
+++ b/zipkin-ui/js/page/trace.js
@@ -16,7 +16,8 @@ const TracePageComponent = component(function TracePage() {
     window.document.title = 'Zipkin - Traces';
 
     TraceData.attachTo(document, {
-      traceId: this.attr.traceId
+      traceId: this.attr.traceId,
+      logsUrl: this.attr.config('logsUrl')
     });
     this.on(document, 'tracePageModelView', function(ev, data) {
       this.$node.html(traceTemplate(data.modelview));

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -4,6 +4,9 @@
     <li class=''><a href='#'><strong>Services:</strong> <span class='badge'>{{services}}</span></a></li>
     <li class=''><a href='#'><strong>Depth:</strong> <span class='badge'>{{depth}}</span></a></li>
     <li class=''><a href='#'><strong>Total Spans:</strong> <span class='badge'>{{totalSpans}}</span></a></li>
+    {{#logsUrl}}
+    <li class='navbar-right'><a href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-primary btn-xs badge'>Logs</span></a></li>
+    {{/logsUrl}}
     <li class='navbar-right'><a href='/api/v1/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
   </ul>
 

--- a/zipkin-ui/test/component_data/trace.test.js
+++ b/zipkin-ui/test/component_data/trace.test.js
@@ -1,0 +1,22 @@
+import {toContextualLogsUrl} from '../../js/component_data/trace';
+
+describe('toContextualLogsUrl', () => {
+  it('replaces token in logsUrl when set', () => {
+    const kibanaLogsUrl = 'http://company.com/kibana/#/discover?_a=(query:(query_string:(query:\'{traceId}\')))';
+    const traceId = '86bad84b319c8379';
+    toContextualLogsUrl(kibanaLogsUrl, traceId)
+      .should.equal(kibanaLogsUrl.replace('{traceId}', traceId));
+  });
+
+  it('returns logsUrl when not set', () => {
+    const kibanaLogsUrl = undefined;
+    const traceId = '86bad84b319c8379';
+    (typeof toContextualLogsUrl(kibanaLogsUrl, traceId)).should.equal('undefined');
+  });
+
+  it('returns the same url when token not present', () => {
+    const kibanaLogsUrl = 'http://mylogqueryservice.com/';
+    const traceId = '86bad84b319c8379';
+    toContextualLogsUrl(kibanaLogsUrl, traceId).should.equal(kibanaLogsUrl);
+  });
+});

--- a/zipkin-ui/test/component_ui/traceToMustache.test.js
+++ b/zipkin-ui/test/component_ui/traceToMustache.test.js
@@ -52,6 +52,12 @@ describe('traceToMustache', () => {
     modelview.services.should.equal(3);
   });
 
+  it('should show logsUrl', () => {
+    const logsUrl = 'http/url.com';
+    const modelview = traceToMustache(trace, logsUrl);
+    modelview.logsUrl.should.equal(logsUrl);
+  });
+
   it('should show service counts', () => {
     const modelview = traceToMustache(trace);
     modelview.serviceCounts.should.eql([{


### PR DESCRIPTION
When troubleshooting our system, we often need to check
if there were logs. Since a good pratice is to add the
trace id to your logs, it seems really natural to have
a button to open a link to query your logs with this id.
Also, people generally have kibana to search for specific
logs (or at least have a query-able log service).

The button is deactivated by default (if you don't have a log
query service or the trace id in the logs) and it's simply
activated by adding LOGS_URL="http://company.com/logs?query={traceId}".
The traceId will be contextually replaced.

Here's a preview:
<img width="1280" alt="logs button" src="https://cloud.githubusercontent.com/assets/9842366/20482538/6e35ca66-afed-11e6-90e9-1e28f66d985e.png">