### PR TITLE
Adds better error message when a binary annotation key or value is unset

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -191,15 +191,19 @@ public final class JsonCodec implements Codec {
     @Override
     public BinaryAnnotation fromJson(JsonReader reader) throws IOException {
       BinaryAnnotation.Builder result = BinaryAnnotation.builder();
+      String key = null;
+      Type type = Type.STRING;
+      boolean valueSet = false;
       String number = null;
       String string = null;
-      Type type = Type.STRING;
+
       reader.beginObject();
       while (reader.hasNext()) {
         String nextName = reader.nextName();
         if (nextName.equals("key")) {
-          result.key(reader.nextString());
+          result.key(key = reader.nextString());
         } else if (nextName.equals("value")) {
+          valueSet = true;
           switch (reader.peek()) {
             case BOOLEAN:
               type = Type.BOOL;
@@ -223,6 +227,11 @@ public final class JsonCodec implements Codec {
         } else {
           reader.skipValue();
         }
+      }
+      if (key == null) {
+        throw new MalformedJsonException("No key at " + reader.getPath());
+      } else if (!valueSet) {
+        throw new MalformedJsonException("No value for key " + key + " at " + reader.getPath());
       }
       reader.endObject();
       result.type(type);

--- a/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
@@ -371,6 +371,44 @@ public final class JsonCodecTest extends CodecTest {
   }
 
   @Test
+  public void missingKey() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("No key at $.binaryAnnotations[0]");
+
+    String json = "{\n"
+        + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+        + "  \"name\": \"get-traces\",\n"
+        + "  \"id\": \"6b221d5bc9e6496c\",\n"
+        + "  \"binaryAnnotations\": [\n"
+        + "    {\n"
+        + "      \"value\": \"bar\"\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
+  }
+
+  @Test
+  public void missingValue() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("No value for key foo at $.binaryAnnotations[0]");
+
+    String json = "{\n"
+        + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+        + "  \"name\": \"get-traces\",\n"
+        + "  \"id\": \"6b221d5bc9e6496c\",\n"
+        + "  \"binaryAnnotations\": [\n"
+        + "    {\n"
+        + "      \"key\": \"foo\"\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    Codec.JSON.readSpan(json.getBytes(UTF_8));
+  }
+
+  @Test
   public void sizeInBytes_span() throws IOException {
     Span span = TestObjects.LOTS_OF_SPANS[0];
     assertThat(JsonCodec.SPAN_ADAPTER.sizeInBytes(span))


### PR DESCRIPTION
When people are making instrumentation, they could accidentally leave
data missing. This gives a contextual error message of which binary
annotation was malformed.