### PR TITLE
Allows elasticsearch-http to accept multiple hosts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <mockito.version>1.10.19</mockito.version>
     <assertj.version>3.5.1</assertj.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <okhttp.version>3.4.1</okhttp.version>
+    <okhttp.version>3.4.2</okhttp.version>
     <testcontainers.version>1.1.7</testcontainers.version>
 
     <animal-sniffer-maven-plugin.version>1.15</animal-sniffer-maven-plugin.version>

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -155,6 +155,13 @@ $ STORAGE_TYPE=mysql MYSQL_USER=root java -jar zipkin.jar
 ```
 
 ### Elasticsearch Storage
+Zipkin's [Elasticsearch storage component](../zipkin-storage/elasticsearch)
+supports version 2.x and applies when `STORAGE_TYPE` is set to `elasticsearch`
+
+When the value of `ES_HOSTS` includes an Http URL (ex http://elasticsearch:9200),
+Zipkin's [Elasticsearch Http storage component](../zipkin-storage/elasticsearch-http)
+is used, which supports versions 2.x and 5.x.
+
 The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
 
     * `ES_CLUSTER`: The name of the elasticsearch cluster to connect to. Defaults to "elasticsearch".

--- a/zipkin-storage/elasticsearch-http/README.md
+++ b/zipkin-storage/elasticsearch-http/README.md
@@ -7,6 +7,22 @@ HTTP by way of [OkHttp 3](https://github.com/square/okttp) and
 
 See [storage-elasticsearch](../elasticsearch) for more details.
 
+## Multiple hosts
+Most users will supply a DNS name that's mapped to multiple A or AAAA
+records. For example, `http://elasticsearch:9200` will use normal host
+lookups to get the list of IP addresses.
+
+You can alternatively supply a list of http base urls. This list is used
+to recover from failures. Note that all ports must be the same, and the
+scheme must be http, not https.
+
+Here are some examples:
+
+* http://1.1.1.1:9200,http://2.2.2.2:9200
+* http://1.1.1.1:9200,http://[2001:db8::c001]:9200
+* http://elasticsearch:9200,http://1.2.3.4:9200
+* http://elasticsearch-1:9200,http://elasticsearch-2:9200
+
 ## Customizing the ingest pipeline
 
 When using Elasticsearch 5.x, you can setup an [ingest pipeline](https://www.elastic.co/guide/en/elasticsearch/reference/master/pipeline.html)

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClient.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClient.java
@@ -87,11 +87,11 @@ final class HttpClient extends InternalElasticsearchClient {
 
   HttpClient(Factory f, String allIndices) {
     List<String> hosts = f.hosts.get();
-    checkArgument(hosts.size() == 1, "Only a single hostname is supported %s", hosts);
-    // TODO: provided the hosts all have the same port, and they are all http (not https), we could
-    // implement okhttp3.Dns to collect all the supplied hosts' IP addresses.
+    checkArgument(!hosts.isEmpty(), "no hosts configured");
+    this.http = hosts.size() == 1
+        ? f.client
+        : f.client.newBuilder().dns(PseudoAddressRecordSet.create(hosts, f.client.dns())).build();
     this.baseUrl = HttpUrl.parse(hosts.get(0));
-    this.http = f.client;
     this.flushOnWrites = f.flushOnWrites;
     this.pipeline = f.pipeline;
     this.allIndices = new String[] {allIndices};

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/PseudoAddressRecordSet.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/PseudoAddressRecordSet.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch.http;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import com.google.common.net.InetAddresses;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Set;
+import okhttp3.Dns;
+import okhttp3.HttpUrl;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * This returns a Dns provider that combines the IPv4 or IPv6 addresses from a supplied list of
+ * urls, provided they are all http and share the same port.
+ */
+final class PseudoAddressRecordSet {
+
+  static Dns create(List<String> urls, Dns actualDns) {
+    Set<String> schemes = Sets.newLinkedHashSet();
+    Set<String> hosts = Sets.newLinkedHashSet();
+    Set<InetAddress> ipAddresses = Sets.newLinkedHashSet();
+    Set<Integer> ports = Sets.newLinkedHashSet();
+
+    for (String url : urls) {
+      HttpUrl httpUrl = HttpUrl.parse(url);
+      schemes.add(httpUrl.scheme());
+      if (InetAddresses.isInetAddress(httpUrl.host())) {
+        ipAddresses.add(InetAddresses.forString(httpUrl.host()));
+      } else {
+        hosts.add(httpUrl.host());
+      }
+      ports.add(httpUrl.port());
+    }
+
+    checkArgument(ports.size() == 1, "Only one port supported with multiple hosts %s", urls);
+    checkArgument(schemes.size() == 1 && schemes.iterator().next().equals("http"),
+        "Only http supported with multiple hosts %s", urls);
+
+    if (hosts.isEmpty()) return new StaticDns(ipAddresses);
+    return new ConcatenatingDns(ipAddresses, hosts, actualDns);
+  }
+
+  static final class StaticDns implements Dns {
+    private final List<InetAddress> ipAddresses;
+
+    StaticDns(Set<InetAddress> ipAddresses) {
+      this.ipAddresses = ImmutableList.copyOf(ipAddresses);
+    }
+
+    @Override public List<InetAddress> lookup(String hostname) {
+      return ipAddresses;
+    }
+
+    @Override public String toString() {
+      return "StaticDns(" + ipAddresses + ")";
+    }
+  }
+
+  static final class ConcatenatingDns implements Dns {
+    final Set<InetAddress> ipAddresses;
+    final Set<String> hosts;
+    final Dns actualDns;
+
+    ConcatenatingDns(Set<InetAddress> ipAddresses, Set<String> hosts, Dns actualDns) {
+      this.ipAddresses = ipAddresses;
+      this.hosts = hosts;
+      this.actualDns = actualDns;
+    }
+
+    @Override public List<InetAddress> lookup(String hostname) throws UnknownHostException {
+      ImmutableList.Builder<InetAddress> result = ImmutableList.builder();
+      result.addAll(ipAddresses);
+      for (String host : hosts) {
+        result.addAll(actualDns.lookup(host));
+      }
+      return result.build();
+    }
+
+    @Override public String toString() {
+      return "ConcatenatingDns(" + ipAddresses + "," + hosts + ")";
+    }
+  }
+}

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/PseudoAddressRecordSetTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/PseudoAddressRecordSetTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch.http;
+
+import com.google.common.net.InetAddresses;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import okhttp3.Dns;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PseudoAddressRecordSetTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  Dns underlying = new Dns() {
+    @Override public List<InetAddress> lookup(String hostname) throws UnknownHostException {
+      throw new UnsupportedOperationException();
+    }
+  };
+
+  @Test
+  public void mixedPortsNotSupported() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "Only one port supported with multiple hosts [http://1.1.1.1:9200, http://2.2.2.2:9201]");
+
+    PseudoAddressRecordSet.create(asList("http://1.1.1.1:9200", "http://2.2.2.2:9201"), underlying);
+  }
+
+  @Test
+  public void httpsNotSupported() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "Only http supported with multiple hosts [https://1.1.1.1:9200, https://2.2.2.2:9200]");
+
+    PseudoAddressRecordSet.create(asList("https://1.1.1.1:9200", "https://2.2.2.2:9200"),
+        underlying);
+  }
+
+  @Test
+  public void concatenatesIPv4List() throws UnknownHostException {
+    Dns result = PseudoAddressRecordSet.create(asList("http://1.1.1.1:9200", "http://2.2.2.2:9200"),
+        underlying);
+
+    assertThat(result).isInstanceOf(PseudoAddressRecordSet.StaticDns.class);
+    assertThat(result.lookup("foo"))
+        .containsExactly(InetAddresses.forString("1.1.1.1"), InetAddresses.forString("2.2.2.2"));
+  }
+
+  @Test
+  public void onlyLooksUpHostnames() throws UnknownHostException {
+    underlying = new Dns() {
+      @Override public List<InetAddress> lookup(String hostname) throws UnknownHostException {
+        assertThat(hostname).isEqualTo("myhost");
+        return asList(InetAddresses.forString("2.2.2.2"));
+      }
+    };
+
+    Dns result = PseudoAddressRecordSet.create(asList("http://1.1.1.1:9200", "http://myhost:9200"),
+        underlying);
+
+    assertThat(result.lookup("foo"))
+        .containsExactly(InetAddresses.forString("1.1.1.1"), InetAddresses.forString("2.2.2.2"));
+  }
+
+  @Test
+  public void concatenatesMixedIpLengths() throws UnknownHostException {
+    Dns result =
+        PseudoAddressRecordSet.create(asList("http://1.1.1.1:9200", "http://[2001:db8::c001]:9200"),
+            underlying);
+
+    assertThat(result).isInstanceOf(PseudoAddressRecordSet.StaticDns.class);
+    assertThat(result.lookup("foo"))
+        .containsExactly(InetAddresses.forString("1.1.1.1"),
+            InetAddresses.forString("2001:db8::c001"));
+  }
+}


### PR DESCRIPTION
Our first version of elasticsearch-http had a TODO to support multiple
base urls. This implements that feature using round-robin DNS.

Fixes #1420 

## Multiple hosts

Most users will supply a DNS name that's mapped to multiple A or AAAA
records. For example, `http://elasticsearch:9200` will use normal host
lookups to get the list of IP addresses.

You can alternatively supply a list of http base urls. This list is used
to recover from failures. Note that all ports must be the same, and the
scheme must be http, not https.

Here are some examples:

* http://1.1.1.1:9200,http://2.2.2.2:9200
* http://1.1.1.1:9200,http://[2001:db8::c001]:9200
* http://elasticsearch:9200,http://1.2.3.4:9200
* http://elasticsearch-1:9200,http://elasticsearch-2:9200