### PR TITLE
Add documentation on the logsUrl feature.

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -100,6 +100,7 @@ environment | zipkin.ui.environment | The value here becomes a label in the top-
 defaultLookback | zipkin.ui.default-lookback | Default duration in millis to look back when finding traces. Affects the "Start time" element in the UI. Defaults to 3600000 (1 hour in millis).
 queryLimit | zipkin.ui.query-limit | Default limit for Find Traces. Defaults to 10.
 instrumented | zipkin.ui.instrumented | Which sites this Zipkin UI covers. Regex syntax. e.g. `http:\/\/example.com\/.*` Defaults to match all websites (`.*`).
+logsUrl | zipkin.ui.logs-url | Logs query service url pattern. If specified, a button will appear on the trace page and will replace {traceId} in the url by the traceId. Not required.
 
 For example, if using docker you can set `ZIPKIN_UI_QUERY_LIMIT=100` to affect `$.queryLimit` in `/config.json`.
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -111,9 +111,6 @@ zipkin:
     # - .*example2.com
     # Default is "match all websites"
     instrumented: .*
-    # Url of the logs associated with a given request.
-    # It will be formatted with the trace id if your url contains {traceId} (e.g. http://kibana/trace{traceId})
-    logs-url: ${LOGS_URL:}
 
 server:
   port: ${QUERY_PORT:9411}

--- a/zipkin-ui/README.md
+++ b/zipkin-ui/README.md
@@ -70,3 +70,21 @@ and then you can submit the span(s) via curl:
 ```bash
 $ curl -H "Content-Type: application/json" --data @span.json http://localhost:9411/api/v1/spans 
 ```
+
+#### How do I find logs associated with a particular trace
+
+Since zipkin provides a correlation id (the trace id), it's a good pattern to add it in your logs.
+If you use zipkin, it's very likely that you have distributed logging sytem also and a way to query your logs (e.g. ELK stack).
+
+One convenient way to switch from a trace to its logs is to get a button which directly links a trace to its logs.
+
+This feature can be activated by setting the property zipkin.ui.logs-url or its corresponding environment variable:
+
+`ZIPKIN_UI_LOGS_URL=http://kibana.company.com/query={traceId}`
+
+where `{traceId}` will be contextually replaced by the trace id.
+
+If this feature is activated, you'll see on the trace detail page an additional button named `logs`.
+
+![Logs Button]
+(https://cloud.githubusercontent.com/assets/9842366/20482538/6e35ca66-afed-11e6-90e9-1e28f66d985e.png)


### PR DESCRIPTION
With https://github.com/openzipkin/zipkin/pull/1414, we can add a button
to link directly the trace and its logs. This review adds the documentation
of this feature.