### PR TITLE
Uses RetroLambda to get rid of IDE setup and cruft

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -29,6 +29,8 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
     <jmh.version>1.14</jmh.version>
     <libthrift.version>0.9.3</libthrift.version>
   </properties>
@@ -71,6 +73,16 @@
 
   <build>
     <plugins>
+      <!-- disable retrolambda as we allow language level 1.8 benchmark classes -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,6 @@
     <main.java.version>1.7</main.java.version>
     <main.signature.artifact>java17</main.signature.artifact>
 
-    <!-- default bytecode version for src/test -->
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-
     <main.basedir>${project.basedir}</main.basedir>
 
     <brave.version>3.13.0</brave.version>
@@ -433,33 +429,51 @@
           <artifactId>maven-shade-plugin</artifactId>
           <version>${maven-shade-plugin.version}</version>
         </plugin>
+
         <plugin>
-                <groupId>org.eclipse.m2e</groupId>
-                <artifactId>lifecycle-mapping</artifactId>
-                <version>1.0.0</version>
-                <configuration>
-                    <lifecycleMappingMetadata>
-                        <pluginExecutions>
-                            <pluginExecution>
-                                <pluginExecutionFilter>
-                                    <groupId>org.apache.maven.plugins</groupId>
-                                    <artifactId>maven-compiler-plugin</artifactId>
-                                    <versionRange>[3.3,)</versionRange>
-                                    <goals>
-                                        <goal>compile</goal>
-                                        <goal>testCompile</goal>
-                                    </goals>
-                                </pluginExecutionFilter>
-                                <action>
-                                    <configurator>
-                                        <id>org.eclipse.m2e.jdt.javaConfigurator</id>
-                                    </configurator>
-                                </action>
-                            </pluginExecution>
-                        </pluginExecutions>
-                    </lifecycleMappingMetadata>
-                </configuration>
-            </plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <versionRange>[3.3,)</versionRange>
+                    <goals>
+                      <goal>compile</goal>
+                      <goal>testCompile</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <configurator>
+                      <id>org.eclipse.m2e.jdt.javaConfigurator</id>
+                    </configurator>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>net.orfjackal.retrolambda</groupId>
+          <artifactId>retrolambda-maven-plugin</artifactId>
+          <version>2.3.0</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>process-main</goal>
+              </goals>
+              <configuration>
+                <target>${main.java.version}</target>
+                <fork>false</fork>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -467,21 +481,10 @@
       <plugin>
         <inherited>true</inherited>
         <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <!-- Ensure main source tree compiles to Java ${main.java.version} bytecode. -->
-          <execution>
-            <id>default-compile</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <source>${main.java.version}</source>
-              <target>${main.java.version}</target>
-            </configuration>
-          </execution>
-        </executions>
         <configuration>
+          <!-- Retrolambda will rewrite lambdas as ${main.java.version} bytecode -->
+          <source>1.8</source>
+          <target>1.8</target>
           <compilerId>javac-with-errorprone</compilerId>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <showWarnings>true</showWarnings>
@@ -498,6 +501,12 @@
             <version>${errorprone.version}</version>
           </dependency>
         </dependencies>
+      </plugin>
+
+      <!-- Explicitly disable when using java version 1.8+ or not using java -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
       </plugin>
 
       <plugin>

--- a/zipkin-autoconfigure/storage-cassandra/pom.xml
+++ b/zipkin-autoconfigure/storage-cassandra/pom.xml
@@ -28,8 +28,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>

--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/brave/TraceZipkinCassandraStorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/brave/TraceZipkinCassandraStorageAutoConfiguration.java
@@ -13,7 +13,6 @@
  */
 package zipkin.autoconfigure.storage.cassandra.brave;
 
-import com.datastax.driver.core.Session;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.SpanCollector;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,10 +36,6 @@ public class TraceZipkinCassandraStorageAutoConfiguration {
   @Autowired @Lazy SpanCollector collector;
 
   @Bean SessionFactory tracingSessionFactory() {
-    return new SessionFactory() {
-      @Override public Session create(CassandraStorage storage) {
-        return TracedSession.create(delegate.create(storage), brave, collector);
-      }
-    };
+    return storage -> TracedSession.create(delegate.create(storage), brave, collector);
   }
 }

--- a/zipkin-autoconfigure/storage-cassandra3/pom.xml
+++ b/zipkin-autoconfigure/storage-cassandra3/pom.xml
@@ -28,8 +28,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>

--- a/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/brave/TraceZipkinCassandra3StorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/brave/TraceZipkinCassandra3StorageAutoConfiguration.java
@@ -13,7 +13,6 @@
  */
 package zipkin.autoconfigure.storage.cassandra3.brave;
 
-import com.datastax.driver.core.Session;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.SpanCollector;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,10 +38,6 @@ public class TraceZipkinCassandra3StorageAutoConfiguration {
   @Autowired @Lazy SpanCollector collector;
 
   @Bean SessionFactory tracingSessionFactory() {
-    return new SessionFactory() {
-      @Override public Session create(Cassandra3Storage storage) {
-        return TracedSession.create(delegate.create(storage), brave, collector);
-      }
-    };
+    return storage -> TracedSession.create(delegate.create(storage), brave, collector);
   }
 }

--- a/zipkin-autoconfigure/storage-mysql/pom.xml
+++ b/zipkin-autoconfigure/storage-mysql/pom.xml
@@ -55,4 +55,19 @@
       <optional>true</optional>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- disable retrolambda as jooq itself is language level is 1.8 -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/zipkin-collector/kafka/src/main/java/zipkin/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin/collector/kafka/KafkaCollector.java
@@ -200,13 +200,11 @@ public final class KafkaCollector implements CollectorComponent {
     }
 
     Runnable guardFailures(final Runnable delegate) {
-      return new Runnable() {
-        @Override public void run() {
-          try {
-            delegate.run();
-          } catch (RuntimeException e) {
-            failure.set(CheckResult.failed(e));
-          }
+      return () -> {
+        try {
+          delegate.run();
+        } catch (RuntimeException e) {
+          failure.set(CheckResult.failed(e));
         }
       };
     }

--- a/zipkin-junit/src/test/java/zipkin/junit/HttpStorage.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/HttpStorage.java
@@ -13,7 +13,6 @@
  */
 package zipkin.junit;
 
-import java.util.concurrent.Executor;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import zipkin.storage.AsyncSpanConsumer;
@@ -43,11 +42,8 @@ final class HttpStorage implements StorageComponent {
     this.client = new OkHttpClient();
     this.baseUrl = HttpUrl.parse(baseUrl);
     this.spanStore = new HttpSpanStore(this.client, this.baseUrl);
-    this.asyncSpanStore = blockingToAsync(spanStore, new Executor() {
-      @Override public void execute(Runnable command) {
-        command.run();
-      }
-    }); // TODO: rewrite http span store to default to async
+    // TODO: rewrite http span store to default to async
+    this.asyncSpanStore = blockingToAsync(spanStore, Runnable::run);
     this.consumer = new HttpSpanConsumer(this.client, this.baseUrl);
   }
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -235,6 +235,16 @@
           <classifier>exec</classifier>
         </configuration>
       </plugin>
+      <!-- disable retrolambda since this module uses java 8 types -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
@@ -74,12 +74,7 @@ final class CassandraSpanStore implements GuavaSpanStore {
 
   static final ListenableFuture<List<String>> EMPTY_LIST =
       immediateFuture(Collections.<String>emptyList());
-  static final Function<List<Span>, List<Span>> OR_NULL =
-      new Function<List<Span>, List<Span>>() {
-        @Override public List<Span> apply(List<Span> input) {
-          return input.isEmpty() ? null : input;
-        }
-      };
+  static final Function<List<Span>, List<Span>> OR_NULL = input -> input.isEmpty() ? null : input;
 
   private final int maxTraceCols;
   private final int indexFetchMultiplier;
@@ -158,27 +153,20 @@ final class CassandraSpanStore implements GuavaSpanStore {
             .limit(QueryBuilder.bindMarker("limit_"))
             .allowFiltering());
 
-    traceIdToTimestamp = new Function<ResultSet, Map<TraceIdUDT, Long>>() {
-      @Override public Map<TraceIdUDT, Long> apply(ResultSet input) {
-        Map<TraceIdUDT, Long> traceIdsToTimestamps = new LinkedHashMap<>();
-        for (Row row : input) {
-          traceIdsToTimestamps.put(
-              row.get("trace_id", TraceIdUDT.class),
-              UUIDs.unixTimestamp(row.getUUID("ts")));
-        }
-        return traceIdsToTimestamps;
+    traceIdToTimestamp = input -> {
+      Map<TraceIdUDT, Long> result = new LinkedHashMap<>();
+      for (Row row : input) {
+        result.put(row.get("trace_id", TraceIdUDT.class), UUIDs.unixTimestamp(row.getUUID("ts")));
       }
+      return result;
     };
 
-    collapseTraceIdMaps = new Function<List<Map<TraceIdUDT, Long>>, Map<TraceIdUDT, Long>>() {
-      @Override
-      public Map<TraceIdUDT, Long> apply(List<Map<TraceIdUDT, Long>> input) {
-        Map<TraceIdUDT, Long> result = new LinkedHashMap<>();
-        for (Map<TraceIdUDT, Long> m : input) {
-          result.putAll(m);
-        }
-        return result;
+    collapseTraceIdMaps = input -> {
+      Map<TraceIdUDT, Long> result = new LinkedHashMap<>();
+      for (Map<TraceIdUDT, Long> m : input) {
+        result.putAll(m);
       }
+      return result;
     };
 
     KeyspaceMetadata md = Schema.getKeyspaceMetadata(session);
@@ -360,7 +348,7 @@ final class CassandraSpanStore implements GuavaSpanStore {
       return transform(session.executeAsync(bound),
           new Function<ResultSet, List<Span>>() {
             @Override public List<Span> apply(ResultSet input) {
-              List<Span> result = new ArrayList<Span>(input.getAvailableWithoutFetching());
+              List<Span> result = new ArrayList<>(input.getAvailableWithoutFetching());
               for (Row row : input) {
                 TraceIdUDT traceId = row.get("trace_id", TraceIdUDT.class);
                 Span.Builder builder = Span.builder()

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/PseudoAddressRecordSetTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/PseudoAddressRecordSetTest.java
@@ -14,9 +14,7 @@
 package zipkin.storage.elasticsearch.http;
 
 import com.google.common.net.InetAddresses;
-import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 import okhttp3.Dns;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,10 +27,8 @@ public class PseudoAddressRecordSetTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  Dns underlying = new Dns() {
-    @Override public List<InetAddress> lookup(String hostname) throws UnknownHostException {
-      throw new UnsupportedOperationException();
-    }
+  Dns underlying = hostname -> {
+    throw new UnsupportedOperationException();
   };
 
   @Test
@@ -66,11 +62,9 @@ public class PseudoAddressRecordSetTest {
 
   @Test
   public void onlyLooksUpHostnames() throws UnknownHostException {
-    underlying = new Dns() {
-      @Override public List<InetAddress> lookup(String hostname) throws UnknownHostException {
-        assertThat(hostname).isEqualTo("myhost");
-        return asList(InetAddresses.forString("2.2.2.2"));
-      }
+    underlying = hostname -> {
+      assertThat(hostname).isEqualTo("myhost");
+      return asList(InetAddresses.forString("2.2.2.2"));
     };
 
     Dns result = PseudoAddressRecordSet.create(asList("http://1.1.1.1:9200", "http://myhost:9200"),

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
@@ -14,7 +14,6 @@
 package zipkin.storage.elasticsearch;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
@@ -182,11 +181,7 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
             if (input == null) return Collections.emptyList();
             // Due to tokenization of the trace ID, our matches are imprecise on Span.traceIdHigh
             return FluentIterable.from(GroupByTraceId.apply(input, strictTraceId, true))
-                .filter(new Predicate<List<Span>>() {
-                  @Override public boolean apply(List<Span> input) {
-                    return input.get(0).traceIdHigh == 0 || request.test(input);
-                  }
-                }).toList();
+                .filter(trace -> trace.get(0).traceIdHigh == 0 || request.test(trace)).toList();
           }
         });
   }

--- a/zipkin-storage/mysql/pom.xml
+++ b/zipkin-storage/mysql/pom.xml
@@ -126,5 +126,18 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <!-- disable retrolambda as jooq itself is language level is 1.8 -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/Schema.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/Schema.java
@@ -80,7 +80,7 @@ final class Schema {
 
   /** Returns a mutable list */
   static <T> List<T> list(T... elements) {
-    return new ArrayList<T>(Arrays.asList(elements));
+    return new ArrayList<>(Arrays.asList(elements));
   }
 
   Condition spanTraceIdCondition(SelectOffsetStep<? extends Record> traceIdQuery) {

--- a/zipkin-ui/pom.xml
+++ b/zipkin-ui/pom.xml
@@ -105,6 +105,16 @@
           </execution>
         </executions>
       </plugin>
+      <!-- disable retrolambda as this module doesn't include Java -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/zipkin-zookeeper/pom.xml
+++ b/zipkin-zookeeper/pom.xml
@@ -72,4 +72,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- disable retrolambda since this module uses java 8 types -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/zipkin/src/main/java/zipkin/InMemoryCollectorMetrics.java
+++ b/zipkin/src/main/java/zipkin/InMemoryCollectorMetrics.java
@@ -34,7 +34,7 @@ public final class InMemoryCollectorMetrics implements CollectorMetrics {
   private final String spansDropped;
 
   public InMemoryCollectorMetrics() {
-    this(new ConcurrentHashMap<String, AtomicInteger>(), null);
+    this(new ConcurrentHashMap<>(), null);
   }
 
   InMemoryCollectorMetrics(ConcurrentHashMap<String, AtomicInteger> metrics, String transport) {

--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -307,14 +307,14 @@ public final class Span implements Comparable<Span>, Serializable {
      * @see Span#annotations
      */
     public Builder annotations(Collection<Annotation> annotations) {
-      this.annotations = new HashSet<Annotation>(annotations);
+      this.annotations = new HashSet<>(annotations);
       return this;
     }
 
     /** @see Span#annotations */
     public Builder addAnnotation(Annotation annotation) {
       if (annotations == null) {
-        annotations = new HashSet<Annotation>();
+        annotations = new HashSet<>();
       }
       annotations.add(annotation);
       return this;
@@ -326,14 +326,14 @@ public final class Span implements Comparable<Span>, Serializable {
      * @see Span#binaryAnnotations
      */
     public Builder binaryAnnotations(Collection<BinaryAnnotation> binaryAnnotations) {
-      this.binaryAnnotations = new HashSet<BinaryAnnotation>(binaryAnnotations);
+      this.binaryAnnotations = new HashSet<>(binaryAnnotations);
       return this;
     }
 
     /** @see Span#binaryAnnotations */
     public Builder addBinaryAnnotation(BinaryAnnotation binaryAnnotation) {
       if (binaryAnnotations == null) {
-        binaryAnnotations = new HashSet<BinaryAnnotation>();
+        binaryAnnotations = new HashSet<>();
       }
       binaryAnnotations.add(binaryAnnotation);
       return this;
@@ -436,7 +436,7 @@ public final class Span implements Comparable<Span>, Serializable {
 
   /** Returns the distinct {@link Endpoint#serviceName service names} that logged to this span. */
   public Set<String> serviceNames() {
-    Set<String> result = new HashSet<String>();
+    Set<String> result = new HashSet<>();
     for (Annotation a : annotations) {
       if (a.endpoint == null) continue;
       if (a.endpoint.serviceName.isEmpty()) continue;

--- a/zipkin/src/main/java/zipkin/collector/Collector.java
+++ b/zipkin/src/main/java/zipkin/collector/Collector.java
@@ -99,7 +99,7 @@ public final class Collector {
   }
 
   public void acceptSpans(List<byte[]> serializedSpans, Codec codec, Callback<Void> callback) {
-    List<Span> spans = new ArrayList<Span>(serializedSpans.size());
+    List<Span> spans = new ArrayList<>(serializedSpans.size());
     try {
       int bytesRead = 0;
       for (byte[] serializedSpan : serializedSpans) {
@@ -137,7 +137,7 @@ public final class Collector {
   }
 
   List<Span> sample(List<Span> input) {
-    List<Span> sampled = new ArrayList<Span>(input.size());
+    List<Span> sampled = new ArrayList<>(input.size());
     for (Span s : input) {
       if (sampler.isSampled(s)) sampled.add(s);
     }

--- a/zipkin/src/main/java/zipkin/collector/InMemoryCollectorMetrics.java
+++ b/zipkin/src/main/java/zipkin/collector/InMemoryCollectorMetrics.java
@@ -28,7 +28,7 @@ public final class InMemoryCollectorMetrics implements CollectorMetrics {
   private final String spansDropped;
 
   public InMemoryCollectorMetrics() {
-    this(new ConcurrentHashMap<String, AtomicInteger>(), null);
+    this(new ConcurrentHashMap<>(), null);
   }
 
   InMemoryCollectorMetrics(ConcurrentHashMap<String, AtomicInteger> metrics, String transport) {

--- a/zipkin/src/main/java/zipkin/internal/CallbackCaptor.java
+++ b/zipkin/src/main/java/zipkin/internal/CallbackCaptor.java
@@ -20,7 +20,7 @@ import zipkin.storage.Callback;
 public final class CallbackCaptor<V> implements Callback<V> {
   // countDown + ref as BlockingQueue forbids null
   final CountDownLatch countDown = new CountDownLatch(1);
-  final AtomicReference<Object> ref = new AtomicReference<Object>();
+  final AtomicReference<Object> ref = new AtomicReference<>();
 
   /**
    * Blocks until {@link Callback#onSuccess(Object)} or {@link Callback#onError(Throwable)}.

--- a/zipkin/src/main/java/zipkin/internal/CorrectForClockSkew.java
+++ b/zipkin/src/main/java/zipkin/internal/CorrectForClockSkew.java
@@ -45,7 +45,7 @@ public final class CorrectForClockSkew {
       if (s.parentId == null) {
         Node<Span> tree = Node.constructTree(spans);
         adjust(tree, null);
-        List<Span> result = new ArrayList<Span>(spans.size());
+        List<Span> result = new ArrayList<>(spans.size());
         for (Iterator<Node<Span>> i = tree.traverse(); i.hasNext();) {
           result.add(i.next().value());
         }
@@ -85,7 +85,7 @@ public final class CorrectForClockSkew {
       Annotation a = span.annotations.get(i);
       if (a.endpoint == null) continue;
       if (ipsMatch(skew.endpoint, a.endpoint)) {
-        if (annotations == null) annotations = new ArrayList<Annotation>(span.annotations);
+        if (annotations == null) annotations = new ArrayList<>(span.annotations);
         annotations.set(i, a.toBuilder().timestamp(a.timestamp - skew.skew).build());
       }
     }
@@ -145,7 +145,7 @@ public final class CorrectForClockSkew {
 
   /** Get the annotations as a map with value to annotation bindings. */
   static Map<String, Annotation> asMap(List<Annotation> annotations) {
-    Map<String, Annotation> result = new LinkedHashMap<String, Annotation>(annotations.size());
+    Map<String, Annotation> result = new LinkedHashMap<>(annotations.size());
     for (Annotation a : annotations) {
       result.put(a.value, a);
     }

--- a/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
@@ -37,7 +37,7 @@ import static java.util.logging.Level.FINE;
 public final class DependencyLinker {
   private static final Logger logger = Logger.getLogger(DependencyLinker.class.getName());
 
-  private final Map<Pair<String>, Long> linkMap = new LinkedHashMap<Pair<String>, Long>();
+  private final Map<Pair<String>, Long> linkMap = new LinkedHashMap<>();
 
   /**
    * @param spans spans where all spans have the same trace id
@@ -45,7 +45,7 @@ public final class DependencyLinker {
   public DependencyLinker putTrace(Collection<Span> spans) {
     if (spans.isEmpty()) return this;
 
-    List<DependencyLinkSpan> linkSpans = new LinkedList<DependencyLinkSpan>();
+    List<DependencyLinkSpan> linkSpans = new LinkedList<>();
     for (Span s : MergeById.apply(spans)) {
       linkSpans.add(DependencyLinkSpan.from(s));
     }
@@ -58,7 +58,7 @@ public final class DependencyLinker {
   public DependencyLinker putTrace(Iterator<DependencyLinkSpan> spans) {
     if (!spans.hasNext()) return this;
 
-    Node.TreeBuilder<DependencyLinkSpan> builder = new Node.TreeBuilder<DependencyLinkSpan>();
+    Node.TreeBuilder<DependencyLinkSpan> builder = new Node.TreeBuilder<>();
     while (spans.hasNext()) {
       DependencyLinkSpan next = spans.next();
       builder.addNode(next.parentId, next.id, next);
@@ -129,7 +129,7 @@ public final class DependencyLinker {
 
   public List<DependencyLink> link() {
     // links are merged by mapping to parent/child and summing corresponding links
-    List<DependencyLink> result = new ArrayList<DependencyLink>(linkMap.size());
+    List<DependencyLink> result = new ArrayList<>(linkMap.size());
     for (Map.Entry<Pair<String>, Long> entry : linkMap.entrySet()) {
       result.add(DependencyLink.create(entry.getKey()._1, entry.getKey()._2, entry.getValue()));
     }
@@ -138,7 +138,7 @@ public final class DependencyLinker {
 
   /** links are merged by mapping to parent/child and summing corresponding links */
   public static List<DependencyLink> merge(Iterable<DependencyLink> in) {
-    Map<Pair<String>, Long> links = new LinkedHashMap<Pair<String>, Long>();
+    Map<Pair<String>, Long> links = new LinkedHashMap<>();
 
     for (DependencyLink link : in) {
       Pair<String> parentChild = Pair.create(link.parent, link.child);
@@ -147,7 +147,7 @@ public final class DependencyLinker {
       links.put(parentChild, callCount);
     }
 
-    List<DependencyLink> result = new ArrayList<DependencyLink>(links.size());
+    List<DependencyLink> result = new ArrayList<>(links.size());
     for (Map.Entry<Pair<String>, Long> link : links.entrySet()) {
       result.add(DependencyLink.create(link.getKey()._1, link.getKey()._2, link.getValue()));
     }

--- a/zipkin/src/main/java/zipkin/internal/GroupByTraceId.java
+++ b/zipkin/src/main/java/zipkin/internal/GroupByTraceId.java
@@ -25,27 +25,23 @@ import zipkin.Span;
 
 public final class GroupByTraceId {
 
-  public static final Comparator<List<Span>> TRACE_DESCENDING = new Comparator<List<Span>>() {
-    @Override
-    public int compare(List<Span> left, List<Span> right) {
-      return right.get(0).compareTo(left.get(0));
-    }
-  };
+  public static final Comparator<List<Span>> TRACE_DESCENDING =
+      (left, right) -> right.get(0).compareTo(left.get(0));
 
   public static List<List<Span>> apply(Collection<Span> input, boolean strictTraceId,
       boolean adjust) {
     if (input == null || input.isEmpty()) return Collections.emptyList();
 
-    Map<Pair<Long>, List<Span>> groupedByTraceId = new LinkedHashMap<Pair<Long>, List<Span>>();
+    Map<Pair<Long>, List<Span>> groupedByTraceId = new LinkedHashMap<>();
     for (Span span : input) {
       Pair<Long> traceId = Pair.create(strictTraceId ? span.traceIdHigh : 0L, span.traceId);
       if (!groupedByTraceId.containsKey(traceId)) {
-        groupedByTraceId.put(traceId, new LinkedList<Span>());
+        groupedByTraceId.put(traceId, new LinkedList<>());
       }
       groupedByTraceId.get(traceId).add(span);
     }
 
-    List<List<Span>> result = new ArrayList<List<Span>>(groupedByTraceId.size());
+    List<List<Span>> result = new ArrayList<>(groupedByTraceId.size());
     for (List<Span> sameTraceId : groupedByTraceId.values()) {
       result.add(adjust ? CorrectForClockSkew.apply(MergeById.apply(sameTraceId)) : sameTraceId);
     }

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -518,12 +518,12 @@ public final class JsonCodec implements Codec {
 
   public List<List<Span>> readTraces(byte[] bytes) {
     JsonReader reader = jsonReader(bytes);
-    List<List<Span>> result = new LinkedList<List<Span>>(); // cause we don't know how long it will be
+    List<List<Span>> result = new LinkedList<>(); // cause we don't know how long it will be
     try {
       reader.beginArray();
       while (reader.hasNext()) {
         reader.beginArray();
-        List<Span> trace = new LinkedList<Span>(); // cause we don't know how long it will be
+        List<Span> trace = new LinkedList<>(); // cause we don't know how long it will be
         while (reader.hasNext()) {
           trace.add(SPAN_ADAPTER.fromJson(reader));
         }
@@ -638,7 +638,7 @@ public final class JsonCodec implements Codec {
     try {
       reader.beginArray();
       if (reader.hasNext()) {
-        result = new LinkedList<T>(); // cause we don't know how long it will be
+        result = new LinkedList<>(); // cause we don't know how long it will be
       } else {
         result = Collections.emptyList();
       }

--- a/zipkin/src/main/java/zipkin/internal/MergeById.java
+++ b/zipkin/src/main/java/zipkin/internal/MergeById.java
@@ -28,11 +28,11 @@ public final class MergeById {
 
   public static List<Span> apply(Collection<Span> spans) {
     if (spans == null || spans.isEmpty()) return Collections.emptyList();
-    List<Span> result = new ArrayList<Span>(spans.size());
-    Map<Long, List<Span>> spanIdToSpans = new LinkedHashMap<Long, List<Span>>();
+    List<Span> result = new ArrayList<>(spans.size());
+    Map<Long, List<Span>> spanIdToSpans = new LinkedHashMap<>();
     for (Span span : spans) {
       if (!spanIdToSpans.containsKey(span.id)) {
-        spanIdToSpans.put(span.id, new LinkedList<Span>());
+        spanIdToSpans.put(span.id, new LinkedList<>());
       }
       spanIdToSpans.get(span.id).add(span);
     }

--- a/zipkin/src/main/java/zipkin/internal/Node.java
+++ b/zipkin/src/main/java/zipkin/internal/Node.java
@@ -57,7 +57,7 @@ public final class Node<V> {
 
   public Node<V> addChild(Node<V> child) {
     child.parent = this;
-    if (children.equals(Collections.emptyList())) children = new LinkedList<Node<V>>();
+    if (children.equals(Collections.emptyList())) children = new LinkedList<>();
     children.add(child);
     return this;
   }
@@ -69,11 +69,11 @@ public final class Node<V> {
 
   /** Traverses the tree, breadth-first. */
   public Iterator<Node<V>> traverse() {
-    return new BreadthFirstIterator<V>(this);
+    return new BreadthFirstIterator<>(this);
   }
 
   static final class BreadthFirstIterator<V> implements Iterator<Node<V>> {
-    private final Queue<Node<V>> queue = new ArrayDeque<Node<V>>();
+    private final Queue<Node<V>> queue = new ArrayDeque<>();
 
     BreadthFirstIterator(Node<V> root) {
       queue.add(root);
@@ -101,7 +101,7 @@ public final class Node<V> {
    * @param trace spans that belong to the same {@link Span#traceId trace}, in any order.
    */
   static Node<Span> constructTree(List<Span> trace) {
-    TreeBuilder<Span> treeBuilder = new TreeBuilder<Span>();
+    TreeBuilder<Span> treeBuilder = new TreeBuilder<>();
     for (Span s : trace) {
       treeBuilder.addNode(s.parentId, s.id, s);
     }
@@ -118,9 +118,9 @@ public final class Node<V> {
     Node<V> rootNode = null;
 
     // Nodes representing the trace tree
-    Map<Long, Node<V>> idToNode = new LinkedHashMap<Long, Node<V>>();
+    Map<Long, Node<V>> idToNode = new LinkedHashMap<>();
     // Collect the parent-child relationships between all spans.
-    Map<Long, Long> idToParent = new LinkedHashMap<Long, Long>(idToNode.size());
+    Map<Long, Long> idToParent = new LinkedHashMap<>(idToNode.size());
 
     public void addNode(Long parentId, long id, @Nullable V value) {
       Node<V> node = new Node<V>().value(value);
@@ -146,7 +146,7 @@ public final class Node<V> {
           parent.addChild(node);
         }
       }
-      return rootNode != null ? rootNode : new Node<V>();
+      return rootNode != null ? rootNode : new Node<>();
     }
   }
 }

--- a/zipkin/src/main/java/zipkin/internal/Pair.java
+++ b/zipkin/src/main/java/zipkin/internal/Pair.java
@@ -19,7 +19,7 @@ import static zipkin.internal.Util.checkNotNull;
 public final class Pair<T> {
 
   public static <T> Pair<T> create(T _1, T _2) {
-    return new Pair<T>(_1, _2);
+    return new Pair<>(_1, _2);
   }
 
   public final T _1;

--- a/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
@@ -282,8 +282,10 @@ public final class ThriftCodec implements Codec {
     }
   };
 
-  static final ThriftAdapter<List<Annotation>> ANNOTATIONS_ADAPTER = new ListAdapter<Annotation>(ANNOTATION_ADAPTER);
-  static final ThriftAdapter<List<BinaryAnnotation>> BINARY_ANNOTATIONS_ADAPTER = new ListAdapter<BinaryAnnotation>(BINARY_ANNOTATION_ADAPTER);
+  static final ThriftAdapter<List<Annotation>> ANNOTATIONS_ADAPTER =
+      new ListAdapter<>(ANNOTATION_ADAPTER);
+  static final ThriftAdapter<List<BinaryAnnotation>> BINARY_ANNOTATIONS_ADAPTER =
+      new ListAdapter<>(BINARY_ANNOTATION_ADAPTER);
 
   static final ThriftAdapter<Span> SPAN_ADAPTER = new ThriftAdapter<Span>() {
 
@@ -404,8 +406,8 @@ public final class ThriftCodec implements Codec {
     }
   };
 
-  static final ThriftAdapter<List<Span>> SPANS_ADAPTER = new ListAdapter<Span>(SPAN_ADAPTER);
-  static final ThriftAdapter<List<List<Span>>> TRACES_ADAPTER = new ListAdapter<List<Span>>(SPANS_ADAPTER);
+  static final ThriftAdapter<List<Span>> SPANS_ADAPTER = new ListAdapter<>(SPAN_ADAPTER);
+  static final ThriftAdapter<List<List<Span>>> TRACES_ADAPTER = new ListAdapter<>(SPANS_ADAPTER);
 
   static final ThriftAdapter<DependencyLink> DEPENDENCY_LINK_ADAPTER = new ThriftAdapter<DependencyLink>() {
 
@@ -465,7 +467,8 @@ public final class ThriftCodec implements Codec {
     }
   };
 
-  static final ThriftAdapter<List<DependencyLink>> DEPENDENCY_LINKS_ADAPTER = new ListAdapter<DependencyLink>(DEPENDENCY_LINK_ADAPTER);
+  static final ThriftAdapter<List<DependencyLink>> DEPENDENCY_LINKS_ADAPTER =
+      new ListAdapter<>(DEPENDENCY_LINK_ADAPTER);
 
   @Override
   public DependencyLink readDependencyLink(byte[] bytes) {
@@ -522,7 +525,7 @@ public final class ThriftCodec implements Codec {
     int length = guardLength(bytes, CONTAINER_LENGTH_LIMIT);
     if (length == 0) return Collections.emptyList();
     if (length == 1) return Collections.singletonList(reader.read(bytes));
-    List<T> result = new ArrayList<T>(length);
+    List<T> result = new ArrayList<>(length);
     for (int i = 0; i < length; i++) {
       result.add(reader.read(bytes));
     }

--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -86,7 +86,7 @@ public final class Util {
     long to = midnightUTC(endTs);
     long from = midnightUTC(endTs - (lookback != null ? lookback : endTs));
 
-    List<Date> days = new ArrayList<Date>();
+    List<Date> days = new ArrayList<>();
     for (long time = from; time <= to; time += TimeUnit.DAYS.toMillis(1)) {
       days.add(new Date(time));
     }

--- a/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
@@ -40,12 +40,12 @@ import static zipkin.internal.Util.sortedList;
 
 /** Internally, spans are indexed on 64-bit trace ID */
 public final class InMemorySpanStore implements SpanStore {
-  private final Multimap<Long, Span> traceIdToSpans = new LinkedListMultimap<Long, Span>();
-  private final Set<Pair<Long>> traceIdTimeStamps = new TreeSet<Pair<Long>>(VALUE_2_DESCENDING);
+  private final Multimap<Long, Span> traceIdToSpans = new LinkedListMultimap<>();
+  private final Set<Pair<Long>> traceIdTimeStamps = new TreeSet<>(VALUE_2_DESCENDING);
   private final Multimap<String, Pair<Long>> serviceToTraceIdTimeStamp =
-      new SortedByValue2Descending<String>();
+      new SortedByValue2Descending<>();
   private final Multimap<String, String> serviceToSpanNames =
-      new LinkedHashSetMultimap<String, String>();
+      new LinkedHashSetMultimap<>();
   private final boolean strictTraceId;
   volatile int acceptedSpanCount;
 
@@ -101,7 +101,7 @@ public final class InMemorySpanStore implements SpanStore {
    * Used for testing. Returns all traces unconditionally.
    */
   public synchronized List<List<Span>> getRawTraces() {
-    List<List<Span>> result = new ArrayList<List<Span>>();
+    List<List<Span>> result = new ArrayList<>();
     for (long traceId : traceIdToSpans.keySet()) {
       Collection<Span> sameTraceId = traceIdToSpans.get(traceId);
       for (List<Span> next : GroupByTraceId.apply(sameTraceId, strictTraceId, false)) {
@@ -117,7 +117,7 @@ public final class InMemorySpanStore implements SpanStore {
     Set<Long> traceIdsInTimerange = traceIdsDescendingByTimestamp(request);
     if (traceIdsInTimerange.isEmpty()) return Collections.emptyList();
 
-    List<List<Span>> result = new ArrayList<List<Span>>();
+    List<List<Span>> result = new ArrayList<>();
     for (Iterator<Long> traceId = traceIdsInTimerange.iterator();
         traceId.hasNext() && result.size() < request.limit; ) {
       Collection<Span> sameTraceId = traceIdToSpans.get(traceId.next());
@@ -139,7 +139,7 @@ public final class InMemorySpanStore implements SpanStore {
     long startTs = endTs - request.lookback * 1000;
 
     if (traceIdTimestamps == null || traceIdTimestamps.isEmpty()) return Collections.emptySet();
-    Set<Long> result = new LinkedHashSet<Long>();
+    Set<Long> result = new LinkedHashSet<>();
     for (Pair<Long> traceIdTimestamp : traceIdTimestamps) {
       if (traceIdTimestamp._2 >= startTs || traceIdTimestamp._2 <= endTs) {
         result.add(traceIdTimestamp._1);
@@ -167,7 +167,7 @@ public final class InMemorySpanStore implements SpanStore {
     if (spans == null || spans.isEmpty()) return null;
     if (!strictTraceId) return sortedList(spans);
 
-    List<Span> filtered = new ArrayList<Span>(spans);
+    List<Span> filtered = new ArrayList<>(spans);
     Iterator<Span> iterator = filtered.iterator();
     while (iterator.hasNext()) {
       if (iterator.next().traceIdHigh != traceIdHigh) {
@@ -205,34 +205,31 @@ public final class InMemorySpanStore implements SpanStore {
 
   static final class LinkedListMultimap<K, V> extends Multimap<K, V> {
     @Override Collection<V> valueContainer() {
-      return new LinkedList<V>();
+      return new LinkedList<>();
     }
   }
 
-  static final Comparator<Pair<Long>> VALUE_2_DESCENDING = new Comparator<Pair<Long>>() {
-    @Override
-    public int compare(Pair<Long> left, Pair<Long> right) {
-      int result = right._2.compareTo(left._2);
-      if (result != 0) return result;
-      return right._1.compareTo(left._1);
-    }
+  static final Comparator<Pair<Long>> VALUE_2_DESCENDING = (left, right) -> {
+    int result = right._2.compareTo(left._2);
+    if (result != 0) return result;
+    return right._1.compareTo(left._1);
   };
 
   /** QueryRequest.limit needs trace ids are returned in timestamp descending order. */
   static final class SortedByValue2Descending<K> extends Multimap<K, Pair<Long>> {
     @Override Set<Pair<Long>> valueContainer() {
-      return new TreeSet<Pair<Long>>(VALUE_2_DESCENDING);
+      return new TreeSet<>(VALUE_2_DESCENDING);
     }
   }
 
   static final class LinkedHashSetMultimap<K, V> extends Multimap<K, V> {
     @Override Collection<V> valueContainer() {
-      return new LinkedHashSet<V>();
+      return new LinkedHashSet<>();
     }
   }
 
   static abstract class Multimap<K, V> {
-    private final Map<K, Collection<V>> delegate = new LinkedHashMap<K, Collection<V>>();
+    private final Map<K, Collection<V>> delegate = new LinkedHashMap<>();
 
     abstract Collection<V> valueContainer();
 

--- a/zipkin/src/main/java/zipkin/storage/InMemoryStorage.java
+++ b/zipkin/src/main/java/zipkin/storage/InMemoryStorage.java
@@ -13,8 +13,6 @@
  */
 package zipkin.storage;
 
-import java.util.concurrent.Executor;
-
 import static zipkin.storage.StorageAdapters.blockingToAsync;
 
 /**
@@ -52,13 +50,8 @@ public final class InMemoryStorage implements StorageComponent {
 
   InMemoryStorage(Builder builder) {
     spanStore = new InMemorySpanStore(builder);
-    final Executor callingThread = new Executor() {
-      @Override public void execute(Runnable command) {
-        command.run();
-      }
-    };
-    asyncSpanStore = blockingToAsync(spanStore, callingThread);
-    asyncConsumer = blockingToAsync(spanStore.spanConsumer, callingThread);
+    asyncSpanStore = blockingToAsync(spanStore, Runnable::run);
+    asyncConsumer = blockingToAsync(spanStore.spanConsumer, Runnable::run);
   }
 
   @Override public InMemorySpanStore spanStore() {

--- a/zipkin/src/main/java/zipkin/storage/InternalAsyncToBlockingSpanStoreAdapter.java
+++ b/zipkin/src/main/java/zipkin/storage/InternalAsyncToBlockingSpanStoreAdapter.java
@@ -27,7 +27,7 @@ final class InternalAsyncToBlockingSpanStoreAdapter implements SpanStore {
   }
 
   @Override public List<List<Span>> getTraces(QueryRequest request) {
-    CallbackCaptor<List<List<Span>>> captor = new CallbackCaptor<List<List<Span>>>();
+    CallbackCaptor<List<List<Span>>> captor = new CallbackCaptor<>();
     delegate.getTraces(request, captor);
     return captor.get();
   }
@@ -37,7 +37,7 @@ final class InternalAsyncToBlockingSpanStoreAdapter implements SpanStore {
   }
 
   @Override public List<Span> getTrace(long traceIdHigh, long traceIdLow) {
-    CallbackCaptor<List<Span>> captor = new CallbackCaptor<List<Span>>();
+    CallbackCaptor<List<Span>> captor = new CallbackCaptor<>();
     delegate.getTrace(traceIdHigh, traceIdLow, captor);
     return captor.get();
   }
@@ -47,25 +47,25 @@ final class InternalAsyncToBlockingSpanStoreAdapter implements SpanStore {
   }
 
   @Override public List<Span> getRawTrace(long traceIdHigh, long traceIdLow) {
-    CallbackCaptor<List<Span>> captor = new CallbackCaptor<List<Span>>();
+    CallbackCaptor<List<Span>> captor = new CallbackCaptor<>();
     delegate.getRawTrace(traceIdHigh, traceIdLow, captor);
     return captor.get();
   }
 
   @Override public List<String> getServiceNames() {
-    CallbackCaptor<List<String>> captor = new CallbackCaptor<List<String>>();
+    CallbackCaptor<List<String>> captor = new CallbackCaptor<>();
     delegate.getServiceNames(captor);
     return captor.get();
   }
 
   @Override public List<String> getSpanNames(String serviceName) {
-    CallbackCaptor<List<String>> captor = new CallbackCaptor<List<String>>();
+    CallbackCaptor<List<String>> captor = new CallbackCaptor<>();
     delegate.getSpanNames(serviceName, captor);
     return captor.get();
   }
 
   @Override public List<DependencyLink> getDependencies(long endTs, @Nullable Long lookback) {
-    CallbackCaptor<List<DependencyLink>> captor = new CallbackCaptor<List<DependencyLink>>();
+    CallbackCaptor<List<DependencyLink>> captor = new CallbackCaptor<>();
     delegate.getDependencies(endTs, lookback, captor);
     return captor.get();
   }

--- a/zipkin/src/main/java/zipkin/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin/storage/QueryRequest.java
@@ -179,8 +179,8 @@ public final class QueryRequest {
   public static final class Builder {
     private String serviceName;
     private String spanName;
-    private List<String> annotations = new LinkedList<String>();
-    private Map<String, String> binaryAnnotations = new LinkedHashMap<String, String>();
+    private List<String> annotations = new LinkedList<>();
+    private Map<String, String> binaryAnnotations = new LinkedHashMap<>();
     private Long minDuration;
     private Long maxDuration;
     private Long endTs;
@@ -362,14 +362,14 @@ public final class QueryRequest {
         timestamp > endTs * 1000) {
       return false;
     }
-    Set<String> serviceNames = new LinkedHashSet<String>();
+    Set<String> serviceNames = new LinkedHashSet<>();
     boolean testedDuration = minDuration == null && maxDuration == null;
 
     String spanNameToMatch = spanName;
-    Set<String> annotationsToMatch = new LinkedHashSet<String>(annotations);
-    Map<String, String> binaryAnnotationsToMatch = new LinkedHashMap<String, String>(binaryAnnotations);
+    Set<String> annotationsToMatch = new LinkedHashSet<>(annotations);
+    Map<String, String> binaryAnnotationsToMatch = new LinkedHashMap<>(binaryAnnotations);
 
-    Set<String> currentServiceNames = new LinkedHashSet<String>();
+    Set<String> currentServiceNames = new LinkedHashSet<>();
     for (Span span : spans) {
       currentServiceNames.clear();
 

--- a/zipkin/src/test/java/zipkin/internal/LazyCloseableTest.java
+++ b/zipkin/src/test/java/zipkin/internal/LazyCloseableTest.java
@@ -115,7 +115,7 @@ public class LazyCloseableTest {
 
   static class TestLazyCloseable<T> extends LazyCloseable<T> {
     static <T> TestLazyCloseable<T> create(Supplier<T> delegate) {
-      return new TestLazyCloseable<T>(delegate);
+      return new TestLazyCloseable<>(delegate);
     }
 
     final Supplier<T> delegate;


### PR DESCRIPTION
This uses RetroLambda which allows you to use Java 8 source level even
if your bytecode level is Java 6. This makes coding more fun and also
obviates IDE setup needed to manage different source levels between main
and test code trees.

This also moves modules who don't use Java 8 types back to language
level 7.

The same has been in use by zipkin-reporter-java for some time.

See https://github.com/orfjackal/retrolambda
Closes #1256