### PR TITLE
Allows arbitrary overriding of Kafka consumer properties

### DIFF
--- a/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka/ZipkinKafkaCollectorProperties.java
+++ b/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka/ZipkinKafkaCollectorProperties.java
@@ -13,6 +13,9 @@
  */
 package zipkin.autoconfigure.collector.kafka;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.collector.kafka.KafkaCollector;
 
@@ -23,6 +26,7 @@ public class ZipkinKafkaCollectorProperties {
   private String groupId = "zipkin";
   private int streams = 1;
   private int maxMessageSize = 1024 * 1024;
+  private Map<String, String> overrides = new LinkedHashMap<>();
 
   public String getTopic() {
     return topic;
@@ -64,12 +68,21 @@ public class ZipkinKafkaCollectorProperties {
     this.maxMessageSize = maxMessageSize;
   }
 
+  public Map<String, String> getOverrides() {
+    return overrides;
+  }
+
+  public void setOverrides(Map<String, String> overrides) {
+    this.overrides = overrides;
+  }
+
   public KafkaCollector.Builder toBuilder() {
     return KafkaCollector.builder()
         .topic(topic)
         .zookeeper(zookeeper)
         .groupId(groupId)
         .streams(streams)
-        .maxMessageSize(maxMessageSize);
+        .maxMessageSize(maxMessageSize)
+        .overrides(overrides);
   }
 }

--- a/zipkin-autoconfigure/collector-kafka/src/test/java/zipkin/collector/kafka/ZipkinKafkaCollectorAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/collector-kafka/src/test/java/zipkin/collector/kafka/ZipkinKafkaCollectorAutoConfigurationTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.autoconfigure.collector.kafka;
+package zipkin.collector.kafka;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -22,9 +22,10 @@ import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfigurati
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import zipkin.autoconfigure.collector.kafka.ZipkinKafkaCollectorAutoConfiguration;
+import zipkin.autoconfigure.collector.kafka.ZipkinKafkaCollectorProperties;
 import zipkin.collector.CollectorMetrics;
 import zipkin.collector.CollectorSampler;
-import zipkin.collector.kafka.KafkaCollector;
 import zipkin.storage.InMemoryStorage;
 import zipkin.storage.StorageComponent;
 
@@ -68,7 +69,7 @@ public class ZipkinKafkaCollectorAutoConfigurationTest {
   }
 
   @Test
-  public void canOverridesProperty_port() {
+  public void canOverrideProperty_topic() {
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context,
         "zipkin.collector.kafka.zookeeper:localhost",
@@ -80,6 +81,21 @@ public class ZipkinKafkaCollectorAutoConfigurationTest {
 
     assertThat(context.getBean(ZipkinKafkaCollectorProperties.class).getTopic())
         .isEqualTo("zapkin");
+  }
+
+  @Test
+  public void overrideWithNestedProperties() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.collector.kafka.zookeeper:localhost",
+        "zipkin.collector.kafka.overrides.auto.offset.reset:largest"
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinKafkaCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(KafkaCollector.class).connector.config.autoOffsetReset())
+        .isEqualTo("largest");
   }
 
   @Configuration

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -259,6 +259,19 @@ $ docker run -d -p 2181:2181 -p 9092:9092 \
 $ java -jar zipkin.jar
 ```
 
+#### Overriding other properties
+You may need to override other consumer properties than what zipkin
+explicitly defines. In such case, you need to prefix that property name
+with "zipkin.collector.kafka.overrides" and pass it as a CLI argument or
+system property.
+
+For example, to override "overrides.auto.offset.reset", you can set a
+prefixed system property:
+
+```bash
+$ KAFKA_ZOOKEEPER=127.0.0.1:2181 java -Dzipkin.collector.kafka.overrides.auto.offset.reset=largest -jar zipkin.jar
+```
+
 ### 128-bit trace IDs
 
 Zipkin supports 64 and 128-bit trace identifiers, typically serialized


### PR DESCRIPTION
You may need to override other consumer properties than what zipkin
explicitly defines. In such case, you need to prefix that property name
with "zipkin.collector.kafka.overrides" and pass it as a CLI argument or
system property.

For example, to override "overrides.auto.offset.reset", you can set a
prefixed system property:

```bash
$ KAFKA_ZOOKEEPER=127.0.0.1:2181 java -Dzipkin.collector.kafka.overrides.auto.offset.reset=largest -jar zipkin.jar
```

Fixes #1427