### PR TITLE
really make "Expand All" the default view for a trace

### DIFF
--- a/zipkin-ui/js/component_ui/trace.js
+++ b/zipkin-ui/js/component_ui/trace.js
@@ -454,7 +454,7 @@ export default component(function trace() {
     if (serviceName !== undefined) {
       this.trigger(document, 'uiAddServiceNameFilter', {value: serviceName});
     } else {
-      this.expandSpans([this.spans[this.$node.find('.span:nth(1)').data('id')]]);
+      this.trigger(document, 'uiExpandAllSpans');
     }
   });
 });

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -25,7 +25,7 @@
 
   <div class='trace-details services'>
   {{#serviceCounts}}
-    <span class='label label-default service-filter-label' data-service-name='{{name}}'>{{name}} x{{count}}</span>
+    <span class='label label-default service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
   {{/serviceCounts}}
   </div>
 </div>


### PR DESCRIPTION
Previously the default expansion was either:
 * The `serviceName` query parameter, or
 * A heuristic roughly along the lines of "the immediate children of
   the root"

PR #1326 set the active button to "Expand All".  However, to mimic the
behavior of actually pressing "Expand All" we also need to:
 * Fire the UI event
 * Set the filters to active.

The interaction with `serviceName` and filters (should a filter be
toggled by the query parameter?) is not improved.

ref #1046 #1326