### PR TITLE
show {trace,span}-id in span details pane

### DIFF
--- a/zipkin-ui/css/trace.css
+++ b/zipkin-ui/css/trace.css
@@ -194,6 +194,11 @@
   max-width: 75%;
 }
 
+#spanPanel #debugInfo td.value {
+  word-break: break-all;
+  max-width: 75%;
+}
+
 .modal-header .save {
   float: right;
   margin-right: 5px;

--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -5,6 +5,7 @@ import {Constants} from './traceConstants';
 export default component(function spanPanel() {
   this.$annotationTemplate = null;
   this.$binaryAnnotationTemplate = null;
+  this.$moreInfoTemplate = null;
 
   this.show = function(e, span) {
     const self = this;
@@ -57,6 +58,16 @@ export default component(function spanPanel() {
       $binAnnoBody.append($row);
     });
 
+    const $moreInfoBody = this.$node.find('#moreInfo tbody').text('');
+    const moreInfo = [['traceId', span.traceId],
+                       ['spanId', span.id]];
+    $.each(moreInfo, (i, pair) => {
+      const $row = self.$moreInfoTemplate.clone();
+      $row.find('.key').text(pair[0]);
+      $row.find('.value').text(pair[1]);
+      $moreInfoBody.append($row);
+    });
+
     this.$node.modal('show');
   };
 
@@ -64,6 +75,7 @@ export default component(function spanPanel() {
     this.$node.modal('hide');
     this.$annotationTemplate = this.$node.find('#annotations tbody tr').remove();
     this.$binaryAnnotationTemplate = this.$node.find('#binaryAnnotations tbody tr').remove();
+    this.$moreInfoTemplate = this.$node.find('#moreInfo tbody tr').remove();
     this.on(document, 'uiRequestSpanPanel', this.show);
   });
 });

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -44,8 +44,9 @@
   <div
     id='{{spanId}}'
     class='span service-span depth-{{depthClass}}'
-    data-keys='id,spanName,serviceNames,serviceName,durationStr,duration'
+    data-keys='id,traceId,spanName,serviceNames,serviceName,durationStr,duration'
     data-id='{{spanId}}'
+    data-trace-id='{{traceId}}'
     data-parent-id='{{parentId}}'
     data-span-name='{{spanName}}'
     data-service-name='{{serviceName}}'
@@ -134,6 +135,18 @@
             </tr>
           </tbody>
         </table>
+
+        <button class="btn btn-info btn-xs pull-right" type="button" data-toggle="collapse"
+                data-target="#moreInfo" aria-expanded="false" aria-controls="moreInfo">More Info</button>
+        <hr/>
+        <table id='moreInfo' class='table table-striped collapse'>
+          <tbody>
+            <tr>
+              <td class='key' data-key='key'></td>
+              <td class='value' data-key='value'></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>
@@ -153,8 +166,9 @@
   <div
     id='{{spanId}}'
     class='span service-span depth-{{depthClass}}'
-    data-keys='id,spanName,serviceNames,serviceName,durationStr,duration'
+    data-keys='id,traceId,spanName,serviceNames,serviceName,durationStr,duration'
     data-id='{{spanId}}'
+    data-trace-id='{{traceId}}'
     data-parent-id='{{parentId}}'
     data-span-name='{{spanName}}'
     data-service-name='{{serviceName}}'


### PR DESCRIPTION
Placed at the bottom since it is primarily intended as a debugging
convenience.

ref #1300

 * I'm not attached to the placement at the bottom, but it was convenient and I think it looks okay.
 * Passing traceId through the html to get it hack to the js feels a bit wonky, but I couldn't find a cleaner approach and it does happen to mirror the current json data format.