### PR TITLE
apply basic size optimizations to js output

### DIFF
--- a/zipkin-ui/package.json
+++ b/zipkin-ui/package.json
@@ -8,7 +8,7 @@
     "test": "node node_modules/karma/bin/karma start --single-run",
     "test-watch": "node node_modules/karma/bin/karma start",
     "lint": "node node_modules/eslint/bin/eslint js test",
-    "build": "node node_modules/webpack/bin/webpack.js --bail"
+    "build": "node node_modules/webpack/bin/webpack.js --bail --optimize-minimize --optimize-occurrence-order --optimize-dedupe"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/zipkin-ui/webpack.config.js
+++ b/zipkin-ui/webpack.config.js
@@ -6,7 +6,7 @@ var CopyWebpackPlugin = require('copy-webpack-plugin');
 var proxyURL = process.env.proxy || "http://localhost:8080/";
 console.log("API requests are forwarded to " + proxyURL);
 
-module.exports = {
+var webpackConfig = {
     entry: [
         __dirname + '/js/main.js',
         __dirname + '/css/style-loader.js'
@@ -56,3 +56,5 @@ module.exports = {
         }
     }
 };
+
+module.exports = webpackConfig;


### PR DESCRIPTION
See:
 * https://github.com/webpack/docs/wiki/optimization
 * http://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin

for background.  All default settings should be safe and
license headers preserved.  Only applied if `NODE_ENV=production` is
set (an apparently common webpack idiom) so the dev server workflow is
unaffected.

This reduces the size of the `min.js` file from about 2.2 MiB to 821
KiB.

ref #1170