### PR TITLE
do not use serviceName when linking to trace results

### DIFF
--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -87,7 +87,7 @@
   <ul id="traces">
   {{#traces}}
     <li class="trace {{infoClass}}" data-traceId="{{traceId}}" data-duration="{{duration}}" data-timestamp="{{timestamp}}" data-service-percentage="{{servicePercentage}}">
-      <a href="/traces/{{traceId}}?serviceName={{serviceName}}">
+      <a href="/traces/{{traceId}}">
         <div class="bar-block">
           <span class="bar-graphic" style="width:{{width}}%;"></span>
           <span class="bar-label">{{durationStr}}</span>


### PR DESCRIPTION
38275c75229bf1941af09d5afacda8fe9ef72073 "really" made "Expand All"
the default way to view a span.  However, in practice search results
are a popular way to view a span, and they used the `serviceName`
query parameter to confusingly show only a single service.

ref #1046