### PR TITLE
allow escape key to close modal dialogs

### DIFF
--- a/zipkin-ui/templates/dependency.mustache
+++ b/zipkin-ui/templates/dependency.mustache
@@ -19,10 +19,11 @@
 </div>
 
 <div id="service-data-modal-container">
-  <div class="modal" id="serviceModal">
+  <div class="modal" id="serviceModal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
           <h3 class="modal-title">
             <span id="serviceModalTitle">[title]</span>
           </h3>
@@ -46,10 +47,11 @@
     </div>
   </div>
 
-  <div class="modal" id="dependencyModal">
+  <div class="modal" id="dependencyModal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
           <h3 class="modal-title text-center">
             <div id="dependencyModalParent">[parent]</div>
             <div class=""><span class="glyphicon glyphicon-arrow-down"></span></div>

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -113,7 +113,7 @@
 </div>
 
 <!-- help panel for different lookup options -->
-<div class="modal fade" id="infoPanel">
+<div class="modal fade" id="infoPanel" tabindex="-1">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -96,7 +96,7 @@
   {{/spans}}
 </div>
 
-<div class='modal fade' id='spanPanel'>
+<div class='modal fade' id='spanPanel' tabindex='-1'>
   <div class='modal-dialog modal-lg'>
     <div class='modal-content'>
       <div class='modal-header'>
@@ -204,7 +204,7 @@
   {{/spansBackup}}
 </div>
 
-<div class='modal fade' id='jsonPanel'>
+<div class='modal fade' id='jsonPanel' tabindex='-1'>
   <div class='modal-dialog modal-lg'>
     <div class='modal-content'>
       <div class='modal-header'>


### PR DESCRIPTION
An "x" button is also added to the dependency modals which
inconsistently lacked one.

On this "tabindex" thing: http://stackoverflow.com/a/32912224

ref #1277