### PR TITLE
cleanup first load events for service/span names

### DIFF
--- a/zipkin-ui/js/component_data/spanNames.js
+++ b/zipkin-ui/js/component_data/spanNames.js
@@ -4,6 +4,10 @@ import $ from 'jquery';
 
 export default component(function spanNames() {
   this.updateSpanNames = function(ev, serviceName) {
+    if (!serviceName) {
+      this.trigger('dataSpanNames', {spans: []});
+      return;
+    }
     $.ajax(`/api/v1/spans?serviceName=${serviceName}`, {
       type: 'GET',
       dataType: 'json'
@@ -16,5 +20,6 @@ export default component(function spanNames() {
 
   this.after('initialize', function() {
     this.on('uiChangeServiceName', this.updateSpanNames);
+    this.on('uiFirstLoadSpanNames', this.updateSpanNames);
   });
 });

--- a/zipkin-ui/js/component_ui/serviceName.js
+++ b/zipkin-ui/js/component_ui/serviceName.js
@@ -23,6 +23,13 @@ export default component(function serviceName() {
     this.$node.find(`[value="${data.lastServiceName}"]`).attr('selected', 'selected');
 
     this.trigger('chosen:updated');
+
+    // On the first view there won't be a selected or "last" service
+    // name.  Instead the first service at the top of the list will be
+    // displayed, so load the span names for the top service too.
+    if (!data.lastServiceName && data.names && data.names.length > 1) {
+      this.$node.trigger('uiFirstLoadSpanNames', data.names[0]);
+    }
   };
 
   this.after('initialize', function() {


### PR DESCRIPTION
During initialization an unconditional `uiChangeServiceName` is fired
to populate the lists of service and corresponding span names.  This
had two problematic consequence:
 * Since there was no service name yet, an http request for spans in
   the `undefined` service was made (looking "bad" in dev tools).
 * On first load we never went back and loaded the span names if no
   service was selected (via query parameters or cookies).  This meant
   the list of span names would just be "all".

These can both be resolved by:
 * Guarding against span search queries when no service name is set.
 * Loading the spans names for the first service in the list when no
   service name is set.

ref #1440 #1072