### PR TITLE
Adds Span.Builder.clear()

### DIFF
--- a/benchmarks/src/main/java/zipkin/benchmarks/SpanBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/SpanBenchmarks.java
@@ -49,6 +49,8 @@ public class SpanBenchmarks {
   static final Endpoint db =
       Endpoint.builder().serviceName("db").ipv4(172 << 24 | 17 << 16 | 2).port(3306).build();
 
+  final Span.Builder sharedBuilder = Span.builder();
+
   @Benchmark
   public Span buildLocalSpan() {
     return Span.builder()
@@ -64,6 +66,20 @@ public class SpanBenchmarks {
   @Benchmark
   public Span buildClientOnlySpan() {
     return Span.builder()
+        .traceId(1L)
+        .id(1L)
+        .name("")
+        .timestamp(1444438900948000L)
+        .duration(31000L)
+        .addAnnotation(Annotation.create(1444438900948000L, Constants.CLIENT_SEND, app))
+        .addAnnotation(Annotation.create(1444438900979000L, Constants.CLIENT_RECV, app))
+        .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, db))
+        .build();
+  }
+
+  @Benchmark
+  public Span buildClientOnlySpan_clear() {
+    return sharedBuilder.clear()
         .traceId(1L)
         .id(1L)
         .name("")

--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -197,6 +197,19 @@ public final class Span implements Comparable<Span>, Serializable {
     Builder() {
     }
 
+    public Builder clear() {
+      traceId = null;
+      traceIdHigh = null;
+      name = null;
+      id = null;
+      parentId = null;
+      timestamp = null;
+      if (annotations != null) annotations.clear();
+      if (binaryAnnotations != null) binaryAnnotations.clear();
+      debug = null;
+      return this;
+    }
+
     Builder(Span source) {
       this.traceId = source.traceId;
       this.traceIdHigh = source.traceIdHigh;


### PR DESCRIPTION
Unlike Endpoint, Annotation, etc Span cannot be composed without a
builder. This makes it possible to reuse the builder which improves
straight-line performance quite a bit.

```
Benchmark                                  Mode  Cnt  Score   Error   Units
SpanBenchmarks.buildClientOnlySpan        thrpt   15  6.088 ± 0.161  ops/us
SpanBenchmarks.buildClientOnlySpan_clear  thrpt   15  8.080 ± 0.227  ops/us
```