### PR TITLE
Update Span merge

### DIFF
--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -254,8 +254,8 @@ public final class Span implements Comparable<Span>, Serializable {
           this.duration = Math.max(this.duration, that.duration);
         }
       } else {
-        // We have 2 different timestamps and we don't know which one is authoritative as there
-        // can be a clock skew. Setting it to null here so that it can be applied later.
+        // We have 2 different timestamps and we don't know which one is authoritative.
+        // Setting it to null here so that it can be applied later.
         this.timestamp = null;
         this.duration = null;
       }

--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -253,11 +253,11 @@ public final class Span implements Comparable<Span>, Serializable {
         } else if (that.duration != null) {
           this.duration = Math.max(this.duration, that.duration);
         }
-      } else { // duration might need to be recalculated, since we have 2 different timestamps
-        long thisEndTs = this.duration != null ? this.timestamp + this.duration : this.timestamp;
-        long thatEndTs = that.duration != null ? that.timestamp + that.duration : that.timestamp;
-        this.timestamp = Math.min(this.timestamp, that.timestamp);
-        this.duration = Math.max(thisEndTs, thatEndTs) - this.timestamp;
+      } else {
+        // We have 2 different timestamps and we don't know which one is authoritative as there
+        // can be a clock skew. Setting it to null here so that it can be applied later.
+        this.timestamp = null;
+        this.duration = null;
       }
 
       for (Annotation a : that.annotations) {

--- a/zipkin/src/test/java/zipkin/SpanTest.java
+++ b/zipkin/src/test/java/zipkin/SpanTest.java
@@ -22,6 +22,10 @@ import org.junit.Test;
 import zipkin.internal.Util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.Constants.CLIENT_RECV;
+import static zipkin.Constants.CLIENT_SEND;
+import static zipkin.Constants.SERVER_RECV;
+import static zipkin.Constants.SERVER_SEND;
 import static zipkin.TestObjects.APP_ENDPOINT;
 
 public class SpanTest {
@@ -85,6 +89,48 @@ public class SpanTest {
 
     assertThat(part1.toBuilder().merge(part2).build()).isEqualTo(expected);
     assertThat(part2.toBuilder().merge(part1).build()).isEqualTo(expected);
+  }
+
+  /**
+   * Test merging of client and server spans into a single span, with a clock skew. Final timestamp
+   * and duration for the span should be same as client.
+   */
+  @Test
+  public void timeStampAndDurationMergeWithClockSkew() {
+
+    long today = Util.midnightUTC(System.currentTimeMillis());
+
+    long clientTimestamp = (today + 100) * 1000;
+    long clientDuration = 35 * 1000;
+
+    long serverTimestamp = (today + 200) * 1000;
+    long serverDuration = 30 * 1000;
+
+    Span clientPart = Span.builder()
+        .traceId(1L)
+        .name("test")
+        .id(1L)
+        .timestamp(clientTimestamp).duration(clientDuration)
+        .addAnnotation(Annotation.create(clientTimestamp, CLIENT_SEND, APP_ENDPOINT))
+        .addAnnotation(Annotation.create(clientTimestamp + clientDuration, CLIENT_RECV, APP_ENDPOINT))
+        .build();
+
+
+    Span serverPart = Span.builder()
+        .traceId(1L)
+        .name("test")
+        .id(1L)
+        .timestamp(serverTimestamp).duration(serverDuration)
+        .addAnnotation(Annotation.create(serverTimestamp, SERVER_RECV, APP_ENDPOINT))
+        .addAnnotation(Annotation.create(serverTimestamp + serverDuration, SERVER_SEND, APP_ENDPOINT))
+        .build();
+
+    Span completeSpan = clientPart.toBuilder()
+        .merge(serverPart)
+        .build();
+
+    assertThat(completeSpan.timestamp).isEqualTo(clientTimestamp);
+    assertThat(completeSpan.duration).isEqualTo(clientDuration);
   }
 
   /**

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -807,8 +807,8 @@ public abstract class SpanStoreTest {
   }
 
   /**
-   * This test shows this even if there is clock skew between client and server, span.timestamp and
-   * duration is computed properly when we merge client and server part of a span.
+   * Test merging of client and server spans into a single span, with a clock skew. Final timestamp
+   * and duration for the span should be computed from the CLIENT_SEND and CLIENT_RECV.
    */
   @Test
   public void timeStampAndDurationWithClockSkew() {


### PR DESCRIPTION
In the current implementation, when we merge spans from client and server, we compute timestamp and duration for the Span by looking at the min and max timestamps. This breaks if we have a clock skew. Once timestamp and duration is set here, we don't recompute it in [ApplyTimestampAndDuration](https://github.com/openzipkin/zipkin/blob/1d0e657e6f89b929a0be27db843a848611242b92/zipkin/src/main/java/zipkin/internal/ApplyTimestampAndDuration.java#L34). 

In this change all we are doing is set timestamp and duration to null, when we merge two spans and and both have direct timestamp set.
