### PR TITLE
add a button to view the raw json of a search query

### DIFF
--- a/zipkin-ui/js/component_data/default.js
+++ b/zipkin-ui/js/component_data/default.js
@@ -21,12 +21,15 @@ export default component(function DefaultData() {
     const query = convertToApiQuery(window.location.search);
     const serviceName = query.serviceName;
     if (serviceName) {
-      $.ajax(`/api/v1/traces?${queryString.stringify(query)}`, {
+      const apiURL = `/api/v1/traces?${queryString.stringify(query)}`;
+      $.ajax(apiURL, {
         type: 'GET',
         dataType: 'json'
       }).done(traces => {
         const modelview = {
-          traces: traceSummariesToMustache(serviceName, traces.map(traceSummary))
+          traces: traceSummariesToMustache(serviceName, traces.map(traceSummary)),
+          apiURL,
+          rawResponse: traces
         };
         this.trigger('defaultPageModelView', modelview);
       }).fail(e => {

--- a/zipkin-ui/js/page/default.js
+++ b/zipkin-ui/js/page/default.js
@@ -9,6 +9,7 @@ import ServiceNameUI from '../component_ui/serviceName';
 import SpanNameUI from '../component_ui/spanName';
 import InfoPanelUI from '../component_ui/infoPanel';
 import InfoButtonUI from '../component_ui/infoButton';
+import JsonPanelUI from '../component_ui/jsonPanel';
 import TraceFiltersUI from '../component_ui/traceFilters';
 import TracesUI from '../component_ui/traces';
 import TimeStampUI from '../component_ui/timeStamp';
@@ -39,6 +40,7 @@ const DefaultPageComponent = component(function DefaultPage() {
         annotationQuery,
         queryWasPerformed,
         count: modelView.traces.length,
+        apiURL: modelView.apiURL,
         ...modelView
       }));
 
@@ -48,6 +50,7 @@ const DefaultPageComponent = component(function DefaultPage() {
       SpanNameUI.attachTo('#spanName');
       InfoPanelUI.attachTo('#infoPanel');
       InfoButtonUI.attachTo('button.info-request');
+      JsonPanelUI.attachTo('#jsonPanel');
       TraceFiltersUI.attachTo('#trace-filters');
       TracesUI.attachTo('#traces');
       TimeStampUI.attachTo('#end-ts');
@@ -55,6 +58,13 @@ const DefaultPageComponent = component(function DefaultPage() {
       BackToTop.attachTo('#backToTop');
 
       $('.timeago').timeago();
+
+      this.$node.find('#rawResultsJsonLink').click(e => {
+        e.preventDefault();
+        this.trigger('uiRequestJsonPanel', {title: 'Search Results',
+                                            obj: modelView.rawResponse,
+                                            link: modelView.apiURL});
+      });
     });
 
     DefaultData.attachTo(document);

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -68,6 +68,9 @@
       Services:
       <span class='label service-tag-filtered' data-service-name="{{serviceName}}">{{serviceName}}</span>
     </div>
+    <div class="pull-right">
+        <a href='{{apiURL}}' id='rawResultsJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a>
+    </div>
   </div>
 {{/queryWasPerformed}}
 </div>
@@ -160,4 +163,19 @@
       </div>
     </div>
   </div>
+</div>
+
+<div class='modal fade' id='jsonPanel' tabindex='-1'>
+    <div class='modal-dialog modal-lg'>
+        <div class='modal-content'>
+            <div class='modal-header'>
+                <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&times;</button>
+                <a href='#' class='save'><span class='glyphicon glyphicon-save' aria-hidden='true' aria-label='save'></span></a>
+                <h4 class='modal-title'></h4>
+            </div>
+            <div class='modal-body'>
+                <pre></pre>
+            </div>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
Easy access to the raw json can aid in debugging.  Uses the same panel
as the per trace json display.

ref #1143