### PR TITLE
Adds ES_MAX_REQUESTS to control maximum in-flight Elasticsearch requests

### DIFF
--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
@@ -36,8 +36,11 @@ public class ZipkinElasticsearchHttpStorageAutoConfiguration {
   @ConditionalOnMissingBean
   InternalElasticsearchClient.Builder clientBuilder(
       @Qualifier("zipkinElasticsearchHttp") OkHttpClient client,
-      @Value("${zipkin.storage.elasticsearch.pipeline:}") String pipeline) {
-    return HttpClientBuilder.create(client).pipeline(pipeline.isEmpty() ? null : pipeline);
+      @Value("${zipkin.storage.elasticsearch.pipeline:}") String pipeline,
+      @Value("${zipkin.storage.elasticsearch.max-requests:64}") int maxRequests) {
+    return HttpClientBuilder.create(client)
+        .pipeline(pipeline.isEmpty() ? null : pipeline)
+        .maxRequests(maxRequests);
   }
 
   /** cheap check to see if we are likely to include urls */

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfigurationTest.java
@@ -90,6 +90,23 @@ public class ZipkinElasticsearchHttpStorageAutoConfigurationTest {
   }
 
   @Test
+  public void configuresMaxRequests() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.storage.type:elasticsearch",
+        "zipkin.storage.elasticsearch.hosts:http://host1:9200",
+        "zipkin.storage.elasticsearch.max-requests:200"
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinElasticsearchOkHttpAutoConfiguration.class,
+        ZipkinElasticsearchHttpStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(HttpClientBuilder.class).maxRequests)
+        .isEqualTo(200);
+  }
+
+  @Test
   public void doesntProvideClientBuilder_whenStorageTypeElasticsearchAndHostsNotUrls() {
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context, "zipkin.storage.type:elasticsearch");

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -178,7 +178,9 @@ The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
                   files, or ec2 profiles) to sign outbound requests to the cluster.
     * `ES_PIPELINE`: Only valid when the destination is Elasticsearch 5.x. Indicates the ingest
                      pipeline used before spans are indexed. No default.
-    * `ES_AWS_DOMAIN`: The name of the AWS-hosted elasticsearch domain to use. Supercedes any set 
+    * `ES_MAX_REQUESTS`: Only valid when the transport is http. Sets maximum in-flight requests from
+                         this process to any Elasticsearch host. Defaults to 64.
+    * `ES_AWS_DOMAIN`: The name of the AWS-hosted elasticsearch domain to use. Supercedes any set
                        `ES_HOSTS`. Triggers the same request signing behavior as with `ES_HOSTS`, but
                        requires the additional IAM permission to describe the given domain.
     * `ES_AWS_REGION`: An optional override to the default region lookup to search for the domain

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -82,6 +82,7 @@ zipkin:
       # host is left unset intentionally, to defer the decision
       hosts: ${ES_HOSTS:}
       pipeline: ${ES_PIPELINE:}
+      max-requests: ${ES_MAX_REQUESTS:64}
       aws:
         domain: ${ES_AWS_DOMAIN:}
         region: ${ES_AWS_REGION:}

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClient.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClient.java
@@ -60,12 +60,15 @@ final class HttpClient extends InternalElasticsearchClient {
     final OkHttpClient client;
     final boolean flushOnWrites;
     final String pipeline;
+    final int maxRequests;
+
 
     Factory(HttpClientBuilder builder) {
       this.hosts = builder.hosts;
       this.client = builder.client;
       this.flushOnWrites = builder.flushOnWrites;
       this.pipeline = builder.pipeline;
+      this.maxRequests = builder.maxRequests;
     }
 
     @Override public InternalElasticsearchClient create(String allIndices) {
@@ -91,6 +94,8 @@ final class HttpClient extends InternalElasticsearchClient {
     this.http = hosts.size() == 1
         ? f.client
         : f.client.newBuilder().dns(PseudoAddressRecordSet.create(hosts, f.client.dns())).build();
+    this.http.dispatcher().setMaxRequests(f.maxRequests);
+    this.http.dispatcher().setMaxRequestsPerHost(f.maxRequests);
     this.baseUrl = HttpUrl.parse(hosts.get(0));
     this.flushOnWrites = f.flushOnWrites;
     this.pipeline = f.pipeline;

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClientBuilder.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClientBuilder.java
@@ -26,6 +26,7 @@ public final class HttpClientBuilder extends InternalElasticsearchClient.Builder
   Lazy<List<String>> hosts;
   String pipeline;
   boolean flushOnWrites;
+  int maxRequests = 64;
 
   public static HttpClientBuilder create(OkHttpClient client) {
     return new HttpClientBuilder(client);
@@ -50,6 +51,12 @@ public final class HttpClientBuilder extends InternalElasticsearchClient.Builder
    */
   @Override public HttpClientBuilder hosts(Lazy<List<String>> hosts) {
     this.hosts = checkNotNull(hosts, "hosts");
+    return this;
+  }
+
+  /** Sets maximum in-flight requests from this process to any Elasticsearch host. Defaults to 64 */
+  public HttpClientBuilder maxRequests(int maxRequests) {
+    this.maxRequests = maxRequests;
     return this;
   }
 


### PR DESCRIPTION
The http client used for Elasticsearch is exclusively for Elasticsearch.
However, it was using defaults for web sites, which constrained it to 5
in-flight requests per host. This raises the default to the same as max
requests, which is 64. It also opens `ES_MAX_REQUESTS` to adjust that
count.

The intended behavior is that there will be less contension in a server
that is both storing spans and serving api requests. It should also
allow higher throughput to the Elasticsearch cluster.

Fixes #1449