### PR TITLE
Small fix for ArrayIndexOutOfBoundsException in Buffer class

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/Buffer.java
+++ b/zipkin/src/main/java/zipkin/internal/Buffer.java
@@ -103,7 +103,7 @@ final class Buffer {
 
   Buffer writeAscii(String v) {
     int length = v.length();
-    for (char i = 0; i < length; i++) {
+    for (int i = 0; i < length; i++) {
       buf[pos++] = (byte) v.charAt(i);
     }
     return this;

--- a/zipkin/src/test/java/zipkin/internal/BufferTest.java
+++ b/zipkin/src/test/java/zipkin/internal/BufferTest.java
@@ -14,6 +14,7 @@
 package zipkin.internal;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import org.junit.Test;
 import sun.net.util.IPAddressUtil;
 
@@ -170,5 +171,17 @@ public class BufferTest {
   static String writeJsonEscaped(byte[] v) {
     byte[] buffered = new Buffer(jsonEscapedSizeInBytes(v)).writeJsonEscaped(v).toByteArray();
     return new String(buffered, UTF_8);
+  }
+
+  // Test creating Buffer for a long string
+  @Test
+  public void writeString() throws UnsupportedEncodingException {
+    StringBuffer stringBuffer = new StringBuffer();
+    for (int i = 0 ; i < 100000 ; i ++) {
+      stringBuffer.append("a");
+    }
+    String string = stringBuffer.toString();
+    byte[] buffered = new Buffer(Buffer.asciiSizeInBytes(string)).writeAscii(string).toByteArray();
+    assertThat(new String(buffered, "US-ASCII")).isEqualTo(string);
   }
 }


### PR DESCRIPTION
Looks like there is typo, and a char is used instead of an int. This throws ArrayIndexOutOfBoundsException if binary annotation length is greater than 65,535 (range to char)