### PR TITLE
Beautify JSON in case of binary annotation value

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -47,7 +47,12 @@ export default component(function spanPanel() {
         const maybeObject = anno[$this.data('key')];
         // In case someone is storing escaped json as binary annotation values
         // TODO: this class is not testable at the moment
-        $this.text($.type(maybeObject) === 'object' ? JSON.stringify(maybeObject) : maybeObject);
+        const type = $.type(maybeObject);
+        if (type === 'object' || type === 'array') {
+          $this.append(`<pre>${JSON.stringify(maybeObject, null, 2)}</pre>`);
+        } else {
+          $this.text(maybeObject);
+        }
       });
       $binAnnoBody.append($row);
     });


### PR DESCRIPTION
 In case JSON is passed as value of binary annotation, the JSON is displayed as one liner. This small fix will ensure that JSON is displayed with correct spacing and indentation level of 4 spaces.

The use-case for this is for example passing current thread's stack trace as JSON value in binary annotation where each stack trace element is element of JSON array.

btw: Thanks guys for great work!