### PR TITLE
Annotation query can be error prone.

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanStore.java
@@ -219,7 +219,9 @@ public final class CassandraSpanStore implements GuavaSpanStore {
       // While a valid port of the scala cassandra span store (from zipkin 1.35), there is a fault.
       // each annotation key is an intersection, meaning we likely return < traceIndexFetchSize.
       List<ListenableFuture<Map<Long, Long>>> futureKeySetsToIntersect = new ArrayList<>();
-      futureKeySetsToIntersect.add(traceIdToTimestamp);
+      if (request.spanName != null) {
+        futureKeySetsToIntersect.add(traceIdToTimestamp);
+      }
       for (String annotationKey : annotationKeys) {
         futureKeySetsToIntersect.add(getTraceIdsByAnnotation(annotationKey,
             request.endTs * 1000, request.lookback * 1000, traceIndexFetchSize));

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
@@ -203,7 +203,9 @@ final class CassandraSpanStore implements GuavaSpanStore {
       // While a valid port of the scala cassandra span store (from zipkin 1.35), there is a fault.
       // each annotation key is an intersection, meaning we likely return < traceIndexFetchSize.
       List<ListenableFuture<Map<TraceIdUDT, Long>>> futureKeySetsToIntersect = new ArrayList<>();
-      futureKeySetsToIntersect.add(traceIdToTimestamp);
+      if (request.spanName != null) {
+        futureKeySetsToIntersect.add(traceIdToTimestamp);
+      }
       for (String annotationKey : annotationKeys) {
         futureKeySetsToIntersect
             .add(getTraceIdsByAnnotation(annotationKey, request.endTs, request.lookback, traceIndexFetchSize));

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraSpanStoreTest.java
@@ -15,13 +15,18 @@ package zipkin.storage.cassandra3;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Endpoint;
 import zipkin.Span;
 import zipkin.TestObjects;
 import zipkin.internal.ApplyTimestampAndDuration;
+import zipkin.internal.Util;
 import zipkin.storage.QueryRequest;
 import zipkin.storage.SpanStoreTest;
 
@@ -91,6 +96,33 @@ public class CassandraSpanStoreTest extends SpanStoreTest {
     assertThat(
         store().getTraces(QueryRequest.builder().lookback(86400000L).limit(traceCount).build()))
         .hasSize(traceCount);
+  }
+
+  @Test
+  public void searchingByAnnotationShouldFilterBeforeLimiting() {
+    long now = System.currentTimeMillis();
+
+    int queryLimit = 2;
+    Endpoint endpoint = TestObjects.LOTS_OF_SPANS[0].annotations.get(0).endpoint;
+    BinaryAnnotation ba = BinaryAnnotation.create("host.name", "host1", endpoint);
+
+    int nbTraceFetched = queryLimit * storage.indexFetchMultiplier;
+    IntStream.range(0, nbTraceFetched).forEach(i ->
+            accept(TestObjects.LOTS_OF_SPANS[i++].toBuilder().timestamp(now - (i * 1000)).build())
+    );
+    // Add two traces with the binary annotation we're looking for
+    IntStream.range(nbTraceFetched, nbTraceFetched + 2).forEach(i ->
+            accept(TestObjects.LOTS_OF_SPANS[i++].toBuilder().timestamp(now - (i * 1000))
+                    .addBinaryAnnotation(ba)
+                    .build())
+    );
+    QueryRequest queryRequest =
+            QueryRequest.builder()
+                    .addBinaryAnnotation(ba.key, new String(ba.value, Util.UTF_8))
+                    .serviceName(endpoint.serviceName)
+                    .limit(queryLimit)
+                    .build();
+    assertThat(store().getTraces(queryRequest)).hasSize(queryLimit);
   }
 
   long rowCount(String table) {


### PR DESCRIPTION
With cassandra storage, results from cassandra are intersected with unfiltered traces. The result is that the number of result may vary depending on the limit but would likely to answer no result by default.