### PR TITLE
Don't sort span names in elasticsearch

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java
@@ -214,10 +214,7 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
 
     return client.collectBucketKeys(catchAll,
         boolQuery().must(matchAllQuery()).filter(filter),
-        AggregationBuilders.terms("name_agg")
-            .order(Order.term(true))
-            .field("name")
-            .size(Integer.MAX_VALUE));
+        AggregationBuilders.terms("name_agg").field("name").size(Integer.MAX_VALUE));
   }
 
   @Override public ListenableFuture<List<DependencyLink>> getDependencies(long endMillis,


### PR DESCRIPTION
While probably not a big contributor to performance, we don't need to
sort span names in elasticsearch as we already copy out into a sorted
list.

See #1462