### PR TITLE
Created index for zipkin_annotations, so DEPENDENCIES can run faster

### DIFF
--- a/zipkin-storage/mysql/src/main/resources/mysql.sql
+++ b/zipkin-storage/mysql/src/main/resources/mysql.sql
@@ -35,6 +35,7 @@ ALTER TABLE zipkin_annotations ADD INDEX(`trace_id_high`, `trace_id`) COMMENT 'f
 ALTER TABLE zipkin_annotations ADD INDEX(`endpoint_service_name`) COMMENT 'for getTraces and getServiceNames';
 ALTER TABLE zipkin_annotations ADD INDEX(`a_type`) COMMENT 'for getTraces';
 ALTER TABLE zipkin_annotations ADD INDEX(`a_key`) COMMENT 'for getTraces';
+ALTER TABLE zipkin_annotations ADD INDEX(`trace_id`, `span_id`, `a_key`) COMMENT 'for dependencies job';
 
 CREATE TABLE IF NOT EXISTS zipkin_dependencies (
   `day` DATE NOT NULL,


### PR DESCRIPTION
Having 238460 rows inside zipkin_annotations, show this benefit :

BEFORE
---
`
mysql> explain  SELECT `trace_id_high`,`trace_id`,`parent_id`,`id`,`a_key`,`endpoint_service_name` FROM (select distinct s.trace_id_high, s.trace_id, s.parent_id, s.id, a.a_key, a.endpoint_service_name from zipkin_spans s left outer join zipkin_annotations a on   (s.trace_id = a.trace_id and s.id = a.span_id and a.a_key in ('ca', 'cs', 'sr', 'sa')) where s.start_ts between 1483401600000000 and 1483487999999999 group by s.trace_id_high, s.trace_id, s.id, a.a_key, a.endpoint_service_name)  as link_spans;

| id   | select_type | table      | type | possible_keys | key  | key_len | ref  | rows       | Extra           |
|    1 | PRIMARY     | <derived2> | ALL  | NULL   | NULL | NULL    | NULL | 2529761520|                                                 |
|    2 | DERIVED     | s          | ALL  | start_ts      | NULL | NULL    | NULL |      94380 | Using where; Using temporary                    |
|    2 | DERIVED     | a          | ALL  | a_key         | NULL | NULL    | NULL |     236871 | Using where; Using join buffer (flat, BNL join) |
`

AFTER
---
`
mysql> explain  SELECT `trace_id_high`,`trace_id`,`parent_id`,`id`,`a_key`,`endpoint_service_name` FROM (select distinct s.trace_id_high, s.trace_id, s.parent_id, s.id, a.a_key, a.endpoint_service_name from zipkin_spans s left outer join zipkin_annotations a on   (s.trace_id = a.trace_id and s.id = a.span_id and a.a_key in ('ca', 'cs', 'sr', 'sa')) where s.start_ts between 1483401600000000 and 1483487999999999 group by s.trace_id_high, s.trace_id, s.id, a.a_key, a.endpoint_service_name)  as link_spans;

| id   | select_type | table      | type | possible_keys | key  | key_len | ref        | rows  | Extra      |
|    1 | PRIMARY     | <derived2> | ALL  | NULL          | NULL | NULL    | NULL                          | 47190 |                              |
|    2 | DERIVED     | s          | ALL  | start_ts      | NULL | NULL    | NULL                          | 94380 | Using where; Using temporary |
|    2 | DERIVED     | a          | ref  | a_key,akey    | akey | 16      | zipkin.s.trace_id,zipkin.s.id |     1 | Using where                  |
`

As you can see, rows seeked went from 2529761520 to a mere 47190.
