### PR TITLE
Backfills tests for async spans in the dependencies graph

### DIFF
--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraDependenciesTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraDependenciesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,6 +34,7 @@ import zipkin.storage.InMemoryStorage;
 
 import static zipkin.TestObjects.DAY;
 import static zipkin.TestObjects.TODAY;
+import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
 import static zipkin.internal.Util.midnightUTC;
 
 public class CassandraDependenciesTest extends DependenciesTest {
@@ -68,7 +69,7 @@ public class CassandraDependenciesTest extends DependenciesTest {
     List<DependencyLink> links = mem.spanStore().getDependencies(TODAY + DAY, null);
 
     // This gets or derives a timestamp from the spans
-    long midnight = midnightUTC(MergeById.apply(spans).get(0).timestamp / 1000);
+    long midnight = midnightUTC(guessTimestamp(MergeById.apply(spans).get(0)) / 1000);
     new CassandraDependenciesWriter(storage.session.get()).write(links, midnight);
   }
 

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import zipkin.storage.elasticsearch.http.HttpElasticsearchDependencyWriter;
 
 import static zipkin.TestObjects.DAY;
 import static zipkin.TestObjects.TODAY;
+import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
 import static zipkin.internal.Util.midnightUTC;
 
 public abstract class ElasticsearchDependenciesTest extends DependenciesTest {
@@ -50,7 +51,7 @@ public abstract class ElasticsearchDependenciesTest extends DependenciesTest {
     List<DependencyLink> links = mem.spanStore().getDependencies(TODAY + DAY, null);
 
     // This gets or derives a timestamp from the spans
-    long midnight = midnightUTC(MergeById.apply(spans).get(0).timestamp / 1000);
+    long midnight = midnightUTC(guessTimestamp(MergeById.apply(spans).get(0)) / 1000);
     writeDependencyLinks(links, midnight);
   }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,6 +28,7 @@ import zipkin.storage.InMemoryStorage;
 
 import static zipkin.TestObjects.DAY;
 import static zipkin.TestObjects.TODAY;
+import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
 import static zipkin.internal.Util.midnightUTC;
 
 public abstract class ElasticsearchDependenciesTest extends DependenciesTest {
@@ -51,7 +52,7 @@ public abstract class ElasticsearchDependenciesTest extends DependenciesTest {
     List<DependencyLink> links = mem.spanStore().getDependencies(TODAY + DAY, null);
 
     // This gets or derives a timestamp from the spans
-    long midnight = midnightUTC(MergeById.apply(spans).get(0).timestamp / 1000);
+    long midnight = midnightUTC(guessTimestamp(MergeById.apply(spans).get(0)) / 1000);
     writeDependencyLinks(links, midnight);
   }
 

--- a/zipkin/src/main/java/zipkin/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin/storage/QueryRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import zipkin.Annotation;
 import zipkin.BinaryAnnotation;
 import zipkin.Endpoint;
 import zipkin.Span;
+import zipkin.internal.ApplyTimestampAndDuration;
 import zipkin.internal.Nullable;
 
 import static zipkin.Constants.CORE_ANNOTATIONS;
@@ -356,7 +357,7 @@ public final class QueryRequest {
 
   /** Tests the supplied trace against the current request */
   public boolean test(List<Span> spans) {
-    Long timestamp = spans.get(0).timestamp;
+    Long timestamp = ApplyTimestampAndDuration.guessTimestamp(spans.get(0));
     if (timestamp == null ||
         timestamp < (endTs - lookback) * 1000 ||
         timestamp > endTs * 1000) {

--- a/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,9 +16,15 @@ package zipkin.storage;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import zipkin.Annotation;
 import zipkin.Constants;
+import zipkin.Span;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.Constants.SERVER_RECV;
+import static zipkin.TestObjects.APP_ENDPOINT;
+import static zipkin.TestObjects.TODAY;
 import static zipkin.TraceKeys.HTTP_METHOD;
 
 public class QueryRequestTest {
@@ -177,5 +183,18 @@ public class QueryRequestTest {
     thrown.expectMessage("maxDuration should be >= minDuration");
 
     QueryRequest.builder().serviceName("foo").minDuration(1L).maxDuration(0L).build();
+  }
+
+  /** When a span comes in without a timestamp, use the implicit one based on annotations. */
+  @Test
+  public void matchesImplicitTimestamp() {
+    Span asyncReceive = Span.builder().traceId(10L).id(10L).name("receive")
+        .addAnnotation(Annotation.create((TODAY) * 1000, SERVER_RECV, APP_ENDPOINT))
+        .build();
+
+    QueryRequest request = QueryRequest.builder().endTs(TODAY).build();
+
+    assertThat(request.test(asList(asyncReceive)))
+        .isTrue();
   }
 }


### PR DESCRIPTION
This unveiled a small bug left unnoticed.