### PR TITLE
do not silently drop subsequent spans missing a parent

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -91,7 +91,8 @@ export default component(function spanPanel() {
 
     const $moreInfoBody = this.$node.find('#moreInfo tbody').text('');
     const moreInfo = [['traceId', span.traceId],
-                       ['spanId', span.id]];
+                      ['spanId', span.id],
+                      ['parentId', span.parentId]];
     $.each(moreInfo, (i, pair) => {
       const $row = self.$moreInfoTemplate.clone();
       $row.find('.key').text(pair[0]);

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -44,7 +44,7 @@
   <div
     id='{{spanId}}'
     class='span service-span depth-{{depthClass}}'
-    data-keys='id,traceId,spanName,serviceNames,serviceName,durationStr,duration'
+    data-keys='id,traceId,parentId,spanName,serviceNames,serviceName,durationStr,duration'
     data-id='{{spanId}}'
     data-trace-id='{{traceId}}'
     data-parent-id='{{parentId}}'
@@ -166,7 +166,7 @@
   <div
     id='{{spanId}}'
     class='span service-span depth-{{depthClass}}'
-    data-keys='id,traceId,spanName,serviceNames,serviceName,durationStr,duration'
+    data-keys='id,traceId,parentId,spanName,serviceNames,serviceName,durationStr,duration'
     data-id='{{spanId}}'
     data-trace-id='{{traceId}}'
     data-parent-id='{{parentId}}'

--- a/zipkin/src/main/java/zipkin/internal/Node.java
+++ b/zipkin/src/main/java/zipkin/internal/Node.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -124,8 +124,15 @@ public final class Node<V> {
 
     public void addNode(Long parentId, long id, @Nullable V value) {
       Node<V> node = new Node<V>().value(value);
-      if (parentId == null) { // special-case root
-        rootNode = node;
+      if (parentId == null) {
+        // special-case root, and attribute missing parents to it. In
+        // other words, assume that the first root is the "real" root.
+        if (rootNode == null) {
+          rootNode = node;
+        } else {
+          idToNode.put(id, node);
+          idToParent.put(id, null);
+        }
       } else {
         idToNode.put(id, node);
         idToParent.put(id, parentId);


### PR DESCRIPTION
Currently zipkin models traces as a tree of spans.  During the
conversation from a list (or whatever the underlying storage engine
uses) to a tree, spans are dropped if more than one of them is missing
a parentId (it is a "root" node).  This appears to be an unintentional
regression (possibly around 9d8261a33c3adaad9aecd290744b651290c72e24),
since the comment still indicate a workaround for this problem:
attribute missing parents to root.

This is still imperfect, but exposes it to the the user so they can
debug the instrumentation problem instead of silently dropping data.
Note that the workaround only applies when constructing a tree
internally the actual spans returned by the API still have no
parentID, and this is what is displayed in the web ui.

This problem is alluded to in #324, but the thrust of that ticket is
modeling asynchronous actions.

Highlighting suspect traces is discussed in #1484 and this condition
would be a prime candidate.