### PR TITLE
Consistently handles fatal errors in catch Throwable blocks

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
@@ -48,6 +48,8 @@ import zipkin.reporter.Sender;
 import zipkin.server.ConditionalOnSelfTracing;
 import zipkin.storage.StorageComponent;
 
+import static zipkin.internal.Util.propagateIfFatal;
+
 @Configuration
 @ConditionalOnSelfTracing
 @Import(ApiTracerConfiguration.class)
@@ -140,9 +142,9 @@ public class BraveConfiguration {
           spans.add(Codec.THRIFT.readSpan(encodedSpan));
         }
         delegate.asyncSpanConsumer().accept(spans, new CallbackAdapter(callback));
-      } catch (Throwable e) {
-        callback.onError(e);
-        if (e instanceof Error) throw (Error) e;
+      } catch (Throwable t) {
+        propagateIfFatal(t);
+        callback.onError(t);
       }
     }
 

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/CallbackListenableFuture.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/CallbackListenableFuture.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,8 @@ import java.io.IOException;
 import okhttp3.Call;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+
+import static zipkin.internal.Util.propagateIfFatal;
 
 class CallbackListenableFuture<V> extends AbstractFuture<V> implements okhttp3.Callback {
   final Call call;
@@ -51,17 +53,6 @@ class CallbackListenableFuture<V> extends AbstractFuture<V> implements okhttp3.C
     } catch (Throwable t) {
       propagateIfFatal(t);
       setException(t);
-    }
-  }
-
-  // Taken from RxJava, which was taken from scala
-  static void propagateIfFatal(Throwable t) {
-    if (t instanceof VirtualMachineError) {
-      throw (VirtualMachineError) t;
-    } else if (t instanceof ThreadDeath) {
-      throw (ThreadDeath) t;
-    } else if (t instanceof LinkageError) {
-      throw (LinkageError) t;
     }
   }
 

--- a/zipkin-zookeeper/src/test/java/zipkin/collector/zookeeper/ZooKeeperRule.java
+++ b/zipkin-zookeeper/src/test/java/zipkin/collector/zookeeper/ZooKeeperRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import zipkin.internal.Util;
 
 import static com.google.common.base.Preconditions.checkState;
 import static org.apache.curator.framework.CuratorFrameworkFactory.newClient;
+import static zipkin.internal.Util.propagateIfFatal;
 
 final class ZooKeeperRule implements TestRule {
   TestingCluster cluster;
@@ -48,9 +49,10 @@ final class ZooKeeperRule implements TestRule {
           try {
             doEvaluate(base);
             break;
-          } catch (Throwable e) {
+          } catch (Throwable t) {
+            propagateIfFatal(t);
             if (i == 3) {
-              throw e;
+              throw t;
             }
             Thread.sleep(1000);
           }

--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -161,6 +161,17 @@ public final class Util {
     writeHexByte(data, pos + 10, (byte) ((v >>> 16L) & 0xff));
     writeHexByte(data, pos + 12, (byte) ((v >>> 8L) & 0xff));
     writeHexByte(data, pos + 14, (byte)  (v & 0xff));
+  }
+
+  // Taken from RxJava throwIfFatal, which was taken from scala
+  public static void propagateIfFatal(Throwable t) {
+    if (t instanceof VirtualMachineError) {
+      throw (VirtualMachineError) t;
+    } else if (t instanceof ThreadDeath) {
+      throw (ThreadDeath) t;
+    } else if (t instanceof LinkageError) {
+      throw (LinkageError) t;
+    }
   }
 
   static final char[] HEX_DIGITS =

--- a/zipkin/src/main/java/zipkin/storage/InternalCallbackRunnable.java
+++ b/zipkin/src/main/java/zipkin/storage/InternalCallbackRunnable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,7 @@
 package zipkin.storage;
 
 import static zipkin.internal.Util.checkNotNull;
+import static zipkin.internal.Util.propagateIfFatal;
 
 abstract class InternalCallbackRunnable<V> implements Runnable {
   final Callback<V> callback;
@@ -27,9 +28,9 @@ abstract class InternalCallbackRunnable<V> implements Runnable {
   @Override public void run() {
     try {
       callback.onSuccess(complete());
-    } catch (Throwable e) {
-      callback.onError(e);
-      if (e instanceof Error) throw (Error) e;
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      callback.onError(t);
     }
   }
 }


### PR DESCRIPTION
I noticed we weren't consistent when catching Throwable.