### PR TITLE
Begins migration off Elasticsearch 2.x library (and Guava)

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/CallbackAdapter.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/CallbackAdapter.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch.http;
+
+import java.io.IOException;
+import okhttp3.Call;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import zipkin.storage.Callback;
+
+import static zipkin.internal.Util.propagateIfFatal;
+
+class CallbackAdapter<V> implements okhttp3.Callback {
+  final Call call;
+  final Callback<V> delegate;
+
+  CallbackAdapter(Call call, zipkin.storage.Callback<V> delegate) {
+    this.call = call;
+    this.delegate = delegate;
+  }
+
+  @Override public void onFailure(Call call, IOException e) {
+    delegate.onError(e);
+  }
+
+  void enqueue() {
+    call.enqueue(this);
+  }
+
+  /** Note: this runs on the {@link okhttp3.OkHttpClient#dispatcher() dispatcher} thread! */
+  @Override public void onResponse(Call call, Response response) {
+    try (ResponseBody responseBody = response.body()) {
+      if (response.isSuccessful()) {
+        delegate.onSuccess(convert(responseBody));
+      } else {
+        delegate.onError(new IllegalStateException("response failed: " + response));
+      }
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      delegate.onError(t);
+    }
+  }
+
+  V convert(ResponseBody responseBody) throws IOException {
+    return null;
+  }
+}

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkSpanIndexer.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkSpanIndexer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,7 +28,7 @@ final class HttpBulkSpanIndexer extends HttpBulkIndexer<Span> implements
   }
 
   @Override
-  public HttpBulkSpanIndexer add(String index, Span span, Long timestampMillis) throws IOException {
+  public HttpBulkSpanIndexer add(String index, Span span, Long timestampMillis) {
     String id = null; // Allow ES to choose an ID
     if (timestampMillis == null) {
       super.add(index, span, id);

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/CallbackAdapterTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/CallbackAdapterTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch.http;
+
+import com.google.common.util.concurrent.SimpleTimeLimiter;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import zipkin.internal.CallbackCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class CallbackAdapterTest {
+  @Rule
+  public MockWebServer mws = new MockWebServer();
+
+  OkHttpClient client = new OkHttpClient();
+  CallbackCaptor<Void> callback = new CallbackCaptor<>();
+  Call call = client.newCall(new Request.Builder().url(mws.url("")).build());
+
+  @After
+  public void close() throws IOException {
+    client.dispatcher().executorService().shutdownNow();
+  }
+
+  @Test
+  public void propagatesOnDispatcherThreadWhenFatal() throws Exception {
+    mws.enqueue(new MockResponse());
+
+    new CallbackAdapter<Void>(call, callback) {
+      @Override Void convert(ResponseBody responseBody) throws IOException {
+        throw new LinkageError();
+      }
+    }.enqueue();
+
+    SimpleTimeLimiter timeLimiter = new SimpleTimeLimiter();
+    try {
+      timeLimiter.callWithTimeout(callback::get, 100, TimeUnit.MILLISECONDS, true);
+      failBecauseExceptionWasNotThrown(UncheckedTimeoutException.class);
+    } catch (UncheckedTimeoutException expected) {
+    }
+  }
+
+  @Test
+  public void executionException_conversionException() throws Exception {
+    mws.enqueue(new MockResponse());
+
+    new CallbackAdapter<Void>(call, callback) {
+      @Override Void convert(ResponseBody responseBody) throws IOException {
+        throw new IllegalArgumentException("eeek");
+      }
+    }.enqueue();
+
+    try {
+      callback.get();
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  public void executionException_httpFailure() throws Exception {
+    mws.enqueue(new MockResponse().setResponseCode(500));
+
+    new CallbackAdapter<Void>(call, callback).enqueue();
+
+    try {
+      callback.get();
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException expected) {
+      assertThat(expected).isInstanceOf(IllegalStateException.class);
+    }
+  }
+}

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpBulkSpanIndexerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpBulkSpanIndexerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import zipkin.Codec;
 import zipkin.TestObjects;
+import zipkin.internal.CallbackCaptor;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +35,8 @@ public class HttpBulkSpanIndexerTest {
   public ExpectedException thrown = ExpectedException.none();
   @Rule
   public MockWebServer es = new MockWebServer();
+
+  CallbackCaptor<Void> callback = new CallbackCaptor<>();
 
   HttpBulkSpanIndexer indexer =
       new HttpBulkSpanIndexer((HttpClient) new HttpClientBuilder(new OkHttpClient())
@@ -50,7 +53,8 @@ public class HttpBulkSpanIndexerTest {
     es.enqueue(new MockResponse());
 
     indexer.add("test_zipkin_http-2016-10-01", TestObjects.LOTS_OF_SPANS[0], (Long) null);
-    indexer.execute().get();
+    indexer.execute(callback);
+    callback.get();
 
     RecordedRequest request = es.takeRequest();
     assertThat(request.getBody().readByteString().utf8())
@@ -62,7 +66,8 @@ public class HttpBulkSpanIndexerTest {
     es.enqueue(new MockResponse());
 
     indexer.add("test_zipkin_http-2016-10-01", TestObjects.LOTS_OF_SPANS[0], (Long) null);
-    indexer.execute().get();
+    indexer.execute(callback);
+    callback.get();
 
     RecordedRequest request = es.takeRequest();
     assertThat(request.getBody().readByteString().utf8())

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpClientTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import zipkin.TestObjects;
+import zipkin.internal.CallbackCaptor;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -137,10 +138,11 @@ public class HttpClientTest {
 
     es.enqueue(new MockResponse());
 
+    CallbackCaptor<Void> callback = new CallbackCaptor<>();
     client.bulkSpanIndexer()
         .add("zipkin-2016-10-01", TestObjects.TRACE.get(0), null)
-        .execute()
-        .get();
+        .execute(callback);
+    callback.get();
 
     RecordedRequest request = es.takeRequest();
     assertThat(request.getPath())

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumer.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanConsumer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,23 +13,20 @@
  */
 package zipkin.storage.elasticsearch;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import zipkin.Span;
+import zipkin.storage.AsyncSpanConsumer;
+import zipkin.storage.Callback;
 import zipkin.storage.elasticsearch.InternalElasticsearchClient.BulkSpanIndexer;
-import zipkin.storage.guava.GuavaSpanConsumer;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
 import static zipkin.internal.Util.UTF_8;
+import static zipkin.internal.Util.propagateIfFatal;
 
-final class ElasticsearchSpanConsumer implements GuavaSpanConsumer {
+final class ElasticsearchSpanConsumer implements AsyncSpanConsumer {
   private static final byte[] TIMESTAMP_MILLIS_PREFIX = "{\"timestamp_millis\":".getBytes(UTF_8);
-  private static final ListenableFuture<Void> VOID = immediateFuture(null);
 
   private final InternalElasticsearchClient client;
   private final IndexNameFormatter indexNameFormatter;
@@ -40,12 +37,16 @@ final class ElasticsearchSpanConsumer implements GuavaSpanConsumer {
     this.indexNameFormatter = indexNameFormatter;
   }
 
-  @Override public ListenableFuture<Void> accept(List<Span> spans) {
-    if (spans.isEmpty()) return VOID;
+  @Override public void accept(List<Span> spans, Callback<Void> callback) {
+    if (spans.isEmpty()) {
+      callback.onSuccess(null);
+      return;
+    }
     try {
-      return indexSpans(client.bulkSpanIndexer(), spans).execute();
-    } catch (Exception e) {
-      return Futures.immediateFailedFuture(e);
+      indexSpans(client.bulkSpanIndexer(), spans).execute(callback);
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      callback.onError(t);
     }
   }
 
@@ -71,7 +72,6 @@ final class ElasticsearchSpanConsumer implements GuavaSpanConsumer {
    * when storing. The cheapest way to do this without changing the codec is prefixing it to the
    * json. For example. {"traceId":"... becomes {"timestamp_millis":12345,"traceId":"...
    */
-  @VisibleForTesting
   static byte[] prefixWithTimestampMillis(byte[] input, long timestampMillis) {
     String dateAsString = Long.toString(timestampMillis);
     byte[] newSpanBytes =

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import zipkin.Codec;
 import zipkin.DependencyLink;
 import zipkin.Span;
 import zipkin.internal.Lazy;
+import zipkin.storage.Callback;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static zipkin.storage.elasticsearch.ElasticsearchSpanConsumer.prefixWithTimestampMillis;
@@ -85,10 +86,10 @@ public abstract class InternalElasticsearchClient implements Closeable {
   }
 
   /** Returns the Elasticsearch version of the transport. */
-  protected abstract String getVersion() throws IOException;
+  protected abstract String getVersion();
 
   /** Ensures the existence of a template, creating it if it does not exist. */
-  protected abstract void ensureTemplate(String name, String indexTemplate) throws IOException;
+  protected abstract void ensureTemplate(String name, String indexTemplate);
 
   /** Deletes the specified index pattern is supplied */
   protected abstract void clear(String index) throws IOException;
@@ -136,9 +137,9 @@ public abstract class InternalElasticsearchClient implements Closeable {
      *
      * <p>For example. {"traceId":".. becomes {"timestamp_millis":12345,"traceId":"...
      */
-    BulkSpanIndexer add(String index, Span span, Long timestampMillis) throws IOException;
+    BulkSpanIndexer add(String index, Span span, Long timestampMillis);
 
-    ListenableFuture<Void> execute() throws IOException;
+    void execute(Callback<Void> callback);
   }
 
   protected static abstract class SpanBytesBulkSpanIndexer implements BulkSpanIndexer {
@@ -162,7 +163,7 @@ public abstract class InternalElasticsearchClient implements Closeable {
    *
    * @param catchAll See {@link IndexNameFormatter#catchAll()}
    */
-  protected abstract void ensureClusterReady(String catchAll) throws IOException;
+  protected abstract void ensureClusterReady(String catchAll);
 
   /** Overridden to remove checked exceptions. */
   @Override

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/LazyClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package zipkin.storage.elasticsearch;
 
 import com.google.common.io.Resources;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import zipkin.internal.LazyCloseable;
@@ -49,9 +48,9 @@ final class LazyClient extends LazyCloseable<InternalElasticsearchClient> {
       String version = client.getVersion();
       String versionSpecificTemplate = versionSpecificTemplate(version);
       client.ensureTemplate(indexTemplateName, versionSpecificTemplate);
-    } catch (IOException e) {
+    } catch (RuntimeException e) {
       client.close();
-      throw new UncheckedExecutionException(e);
+      throw e;
     }
     return client;
   }
@@ -72,4 +71,5 @@ final class LazyClient extends LazyCloseable<InternalElasticsearchClient> {
   @Override public String toString() {
     return clientFactory.toString();
   }
+
 }


### PR DESCRIPTION
Currently, our Elasticsearch 2.x dependency makes it impossible to load
recent versions of Elasticsearch or Guava.

This begins work to migrate off by porting write and health code to not
use guava types.

See #1431