### PR TITLE
Fixes bug where UI swallowed the tag value 'false'

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -22,7 +22,7 @@ export function formatAnnotationValue(value) {
   if (type === 'object' || type === 'array') {
     return JSON.stringify(value);
   } else {
-    return value;
+    return value.toString(); // prevents false from coercing to empty!
   }
 }
 
@@ -34,7 +34,7 @@ export function formatBinaryAnnotationValue(value) {
   if (type === 'object' || type === 'array') {
     return `<pre>${JSON.stringify(value, null, 2)}</pre>`;
   } else {
-    return value;
+    return value.toString(); // prevents false from coercing to empty!
   }
 }
 

--- a/zipkin-ui/test/component_ui/spanPanel.test.js
+++ b/zipkin-ui/test/component_ui/spanPanel.test.js
@@ -48,6 +48,14 @@ describe('formatAnnotationValue', () => {
     formatAnnotationValue('foo').should.equal('foo');
   });
 
+  it('should return string when false', () => {
+    formatAnnotationValue(false).should.equal('false');
+  });
+
+  it('should return string when true', () => {
+    formatAnnotationValue(true).should.equal('true');
+  });
+
   it('should format object as one-line json', () => {
     formatAnnotationValue({foo: 'bar'}).should.equal(
       '{"foo":"bar"}'
@@ -64,6 +72,14 @@ describe('formatAnnotationValue', () => {
 describe('formatBinaryAnnotationValue', () => {
   it('should return same value when string', () => {
     formatBinaryAnnotationValue('foo').should.equal('foo');
+  });
+
+  it('should return string when false', () => {
+    formatBinaryAnnotationValue(false).should.equal('false');
+  });
+
+  it('should return string when true', () => {
+    formatBinaryAnnotationValue(true).should.equal('true');
   });
 
   it('should format object as pre-formatted multi-line json', () => {

--- a/zipkin-ui/test/component_ui/traceToMustache.test.js
+++ b/zipkin-ui/test/component_ui/traceToMustache.test.js
@@ -95,12 +95,17 @@ describe('traceToMustache', () => {
         key: 'sa',
         value: true,
         endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
+      }, {
+        key: 'literally-false',
+        value: 'false',
+        endpoint: {serviceName: 'zipkin-query', ipv4: '127.0.0.1', port: 9411}
       }]
     }];
     const {spans: [testSpan]} = traceToMustache(testTrace);
     testSpan.annotations[0].value.should.equal('Server Receive');
     testSpan.annotations[1].value.should.equal('Server Send');
     testSpan.binaryAnnotations[0].key.should.equal('Server Address');
+    testSpan.binaryAnnotations[1].value.should.equal('false');
   });
 
   it('should tolerate spans without annotations', () => {


### PR DESCRIPTION
Our span panel code had to special case formerly escaped json, as that would become an object at render time. This guards against the same where 'false' becomes false.

ex with this json, the value of  "x-ricebook-normal-request" was "false", but would render as blank in the UI. It is now fixed.
```
curl -s localhost:9411/api/v1/spans -H'Content-type: application/json' -d '[
  {
    "traceId": "ddd2fe61b649ff21",
    "id": "c0582f5176c78f23",
    "name": "servlet",
    "parentId": "1def4bb81e274350",
    "timestamp": 1484924830273035,
    "duration": 17920,
    "annotations": [
      {
        "timestamp": 1484924830272977,
        "value": "sr",
        "endpoint": {
          "serviceName": "contract",
          "ipv4": "10.227.145.181",
          "port": 8091
        }
      },
      {
        "timestamp": 1484924830290955,
        "value": "ss",
        "endpoint": {
          "serviceName": "contract",
          "ipv4": "10.227.145.181",
          "port": 8091
        }
      }
    ],
    "binaryAnnotations": [
      {
        "key": "Method",
        "value": "GET",
        "endpoint": {
          "serviceName": "contract",
          "ipv4": "10.227.145.181",
          "port": 8091
        }
      },
      {
        "key": "Path",
        "value": "/contract/list.json",
        "endpoint": {
          "serviceName": "contract",
          "ipv4": "10.227.145.181",
          "port": 8091
        }
      },
      {
        "key": "x-ricebook-trace",
        "value": "43905eb3-3591-4fd3-9e73-270a889a2666-emd11sbm94-427mahv82yk",
        "endpoint": {
          "serviceName": "contract",
          "ipv4": "10.227.145.181",
          "port": 8091
        }
      }
    ]
  },
  {
    "traceId": "ddd2fe61b649ff21",
    "id": "1def4bb81e274350",
    "name": "gateway",
    "timestamp": 1484924830273391,
    "duration": 26009,
    "annotations": [
      {
        "timestamp": 1484924830273371,
        "value": "cs",
        "endpoint": {
          "serviceName": "rhllor-gateway",
          "ipv4": "10.10.23.134",
          "port": 8080
        }
      },
      {
        "timestamp": 1484924830273409,
        "value": "ws",
        "endpoint": {
          "serviceName": "rhllor-gateway",
          "ipv4": "10.10.23.134",
          "port": 8080
        }
      },
      {
        "timestamp": 1484924830299385,
        "value": "wr",
        "endpoint": {
          "serviceName": "rhllor-gateway",
          "ipv4": "10.10.23.134",
          "port": 8080
        }
      },
      {
        "timestamp": 1484924830299400,
        "value": "cr",
        "endpoint": {
          "serviceName": "rhllor-gateway",
          "ipv4": "10.10.23.134",
          "port": 8080
        }
      }
    ],
    "binaryAnnotations": [
      {
        "key": "x-ricebook-normal-request",
        "value": "false",
        "endpoint": {
          "serviceName": "rhllor-gateway",
          "ipv4": "10.10.23.134",
          "port": 8080
        }
      }
    ]
  }
]'
```