### PR TITLE
Set result size when fetching dependency links from ElasticSearch

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClient.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClient.java
@@ -198,7 +198,7 @@ final class HttpClient extends InternalElasticsearchClient {
   }
 
   @Override protected ListenableFuture<List<Span>> findSpans(String[] indices, QueryBuilder query) {
-    String body = new SearchSourceBuilder().query(query).size(MAX_RAW_SPANS).toString();
+    String body = new SearchSourceBuilder().query(query).size(MAX_RAW_ITEMS).toString();
     Call searchRequest = http.newCall(new Request.Builder().url(lenientSearch(indices, SPAN))
         .post(RequestBody.create(APPLICATION_JSON, body))
         .tag("search-spans").build());
@@ -209,7 +209,7 @@ final class HttpClient extends InternalElasticsearchClient {
   @Override
   protected ListenableFuture<List<DependencyLink>> findDependencies(String[] indices) {
     QueryBuilder query = QueryBuilders.matchAllQuery();
-    String body = new SearchSourceBuilder().query(query).toString();
+    String body = new SearchSourceBuilder().query(query).size(MAX_RAW_ITEMS).toString();
     Call searchRequest =
         http.newCall(new Request.Builder().url(lenientSearch(indices, DEPENDENCY_LINK))
             .post(RequestBody.create(APPLICATION_JSON, body))

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
@@ -49,7 +49,7 @@ public abstract class InternalElasticsearchClient implements Closeable {
    *
    * <p> See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html
    */
-  protected static final int MAX_RAW_SPANS = 10000; // the default elasticsearch allowed limit
+  protected static final int MAX_RAW_ITEMS = 10000; // the default elasticsearch allowed limit
   protected static final String SPAN = "span";
   protected static final String DEPENDENCY_LINK = "dependencylink";
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/NativeClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/NativeClient.java
@@ -251,7 +251,7 @@ final class NativeClient extends InternalElasticsearchClient {
     SearchRequestBuilder elasticRequest = client.prepareSearch(indices)
         .setIndicesOptions(IndicesOptions.lenientExpandOpen())
         .setTypes(SPAN)
-        .setSize(MAX_RAW_SPANS)
+        .setSize(MAX_RAW_ITEMS)
         .setQuery(query);
 
     return transform(toGuava(elasticRequest.execute()),
@@ -276,6 +276,7 @@ final class NativeClient extends InternalElasticsearchClient {
         indices)
         .setIndicesOptions(IndicesOptions.lenientExpandOpen())
         .setTypes(DEPENDENCY_LINK)
+        .setSize(MAX_RAW_ITEMS)
         .setQuery(matchAllQuery());
 
     return transform(toGuava(elasticRequest.execute()), ConvertDependenciesResponse.INSTANCE);


### PR DESCRIPTION
Otherwise it only returns 10.