### PR TITLE
Set result size when fetching dependency links from ElasticSearch

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClient.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpClient.java
@@ -198,7 +198,7 @@ final class HttpClient extends InternalElasticsearchClient {
   }
 
   @Override protected ListenableFuture<List<Span>> findSpans(String[] indices, QueryBuilder query) {
-    String body = new SearchSourceBuilder().query(query).size(MAX_RAW_SPANS).toString();
+    String body = new SearchSourceBuilder().query(query).size(MAX_RESULT_WINDOW).toString();
     Call searchRequest = http.newCall(new Request.Builder().url(lenientSearch(indices, SPAN))
         .post(RequestBody.create(APPLICATION_JSON, body))
         .tag("search-spans").build());
@@ -209,7 +209,7 @@ final class HttpClient extends InternalElasticsearchClient {
   @Override
   protected ListenableFuture<List<DependencyLink>> findDependencies(String[] indices) {
     QueryBuilder query = QueryBuilders.matchAllQuery();
-    String body = new SearchSourceBuilder().query(query).toString();
+    String body = new SearchSourceBuilder().query(query).size(MAX_RESULT_WINDOW).toString();
     Call searchRequest =
         http.newCall(new Request.Builder().url(lenientSearch(indices, DEPENDENCY_LINK))
             .post(RequestBody.create(APPLICATION_JSON, body))

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpClientTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/HttpClientTest.java
@@ -65,6 +65,7 @@ public class HttpClientTest {
             "/zipkin-2016-10-01,zipkin-2016-10-02/dependencylink/_search?allow_no_indices=true&expand_wildcards=open&ignore_unavailable=true");
     assertThat(request.getBody().buffer().readUtf8())
         .isEqualTo("{\n"
+            + "  \"size\" : 10000,\n"
             + "  \"query\" : {\n"
             + "    \"match_all\" : { }\n"
             + "  }\n"

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/InternalElasticsearchClient.java
@@ -49,7 +49,7 @@ public abstract class InternalElasticsearchClient implements Closeable {
    *
    * <p> See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html
    */
-  protected static final int MAX_RAW_SPANS = 10000; // the default elasticsearch allowed limit
+  protected static final int MAX_RESULT_WINDOW = 10000; // the default elasticsearch allowed limit
   protected static final String SPAN = "span";
   protected static final String DEPENDENCY_LINK = "dependencylink";
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/NativeClient.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/NativeClient.java
@@ -251,7 +251,7 @@ final class NativeClient extends InternalElasticsearchClient {
     SearchRequestBuilder elasticRequest = client.prepareSearch(indices)
         .setIndicesOptions(IndicesOptions.lenientExpandOpen())
         .setTypes(SPAN)
-        .setSize(MAX_RAW_SPANS)
+        .setSize(MAX_RESULT_WINDOW)
         .setQuery(query);
 
     return transform(toGuava(elasticRequest.execute()),
@@ -276,6 +276,7 @@ final class NativeClient extends InternalElasticsearchClient {
         indices)
         .setIndicesOptions(IndicesOptions.lenientExpandOpen())
         .setTypes(DEPENDENCY_LINK)
+        .setSize(MAX_RESULT_WINDOW)
         .setQuery(matchAllQuery());
 
     return transform(toGuava(elasticRequest.execute()), ConvertDependenciesResponse.INSTANCE);


### PR DESCRIPTION
Otherwise it only returns 10.

Fixes #1503