### PR TITLE
Quiets zipkin-server integration test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ before_install:
   - nohup bash -c "cd kafka_* && bin/zookeeper-server-start.sh config/zookeeper.properties >/dev/null 2>&1 &"
   - nohup bash -c "cd kafka_* && bin/kafka-server-start.sh config/server.properties >/dev/null 2>&1 &"
 
+  # Quiet Maven invoker logs (Downloading... when running zipkin-server/src/it)
+  - echo "MAVEN_OPTS='-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'" > ~/.mavenrc
+
 install:
   # Override default travis to use the maven wrapper
   # skip license on travis due to #1512

--- a/circle.yml
+++ b/circle.yml
@@ -44,6 +44,8 @@ machine:
   environment:
     MYSQL_USER: ubuntu
     MYSQL_DB: circle_test
+    # Quiet Maven invoker logs (Downloading... when running zipkin-server/src/it)
+    MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 dependencies:
   override:


### PR DESCRIPTION
Our CI builds are full of log output that isn't helpful, ex.

```
[INFO] [INFO] Downloading: file:///Users/acole/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.pom
[INFO] [INFO] Downloaded: file:///Users/acole/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.pom (2 KB at 501.3 KB/sec)
```

See http://stackoverflow.com/questions/35119522/disable-downloaded-logs-in-maven-invoker-tests