### PR TITLE
Do not add incorrect dependencies when processing partial/broken traces

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
@@ -68,20 +68,20 @@ public final class DependencyLinker {
     if (logger.isLoggable(FINE)) logger.fine("traversing trace tree, breadth-first");
     for (Iterator<Node<DependencyLinkSpan>> i = tree.traverse(); i.hasNext(); ) {
       Node<DependencyLinkSpan> current = i.next();
-      DependencyLinkSpan value = current.value();
+      DependencyLinkSpan currentSpan = current.value();
       if (logger.isLoggable(FINE)) {
-        logger.fine("processing " + value);
+        logger.fine("processing " + currentSpan);
       }
-      if (value == null) {
+      if (currentSpan == null) {
         logger.fine("skipping synthetic node for broken span tree");
         continue;
       }
       String child;
       String parent;
-      switch (value.kind) {
+      switch (currentSpan.kind) {
         case SERVER:
-          child = current.value().service;
-          parent = current.value().peerService;
+          child = currentSpan.service;
+          parent = currentSpan.peerService;
           if (current == tree) { // we are the root-most span.
             if (parent == null) {
               logger.fine("root's peer is unknown; skipping");
@@ -90,8 +90,8 @@ public final class DependencyLinker {
           }
           break;
         case CLIENT:
-          child = current.value().peerService;
-          parent = current.value().service;
+          child = currentSpan.peerService;
+          parent = currentSpan.service;
           break;
         default:
           logger.fine("non-rpc span; skipping");

--- a/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
@@ -72,7 +72,7 @@ public final class DependencyLinker {
       if (logger.isLoggable(FINE)) {
         logger.fine("processing " + currentSpan);
       }
-      if (currentSpan == null) {
+      if (current.isSyntheticRootForPartialTree()) {
         logger.fine("skipping synthetic node for broken span tree");
         continue;
       }
@@ -110,7 +110,7 @@ public final class DependencyLinker {
           logger.fine("processing ancestor " + ancestor.value());
         }
         DependencyLinkSpan ancestorLink = ancestor.value();
-        if (ancestorLink != null &&
+        if (!ancestor.isSyntheticRootForPartialTree() &&
               ancestorLink.kind == DependencyLinkSpan.Kind.SERVER) {
           parent = ancestorLink.service;
           break;

--- a/zipkin/src/main/java/zipkin/internal/Node.java
+++ b/zipkin/src/main/java/zipkin/internal/Node.java
@@ -39,6 +39,7 @@ public final class Node<V> {
   private V value;
   /** mutable to avoid allocating lists for childless nodes */
   private List<Node<V>> children = Collections.emptyList();
+  private boolean missingRootDummyNode;
 
   /** Returns the parent, or null if root */
   @Nullable
@@ -70,6 +71,10 @@ public final class Node<V> {
   /** Traverses the tree, breadth-first. */
   public Iterator<Node<V>> traverse() {
     return new BreadthFirstIterator<>(this);
+  }
+
+  public boolean isSyntheticRootForPartialTree() {
+    return missingRootDummyNode;
   }
 
   static final class BreadthFirstIterator<V> implements Iterator<Node<V>> {
@@ -146,8 +151,10 @@ public final class Node<V> {
         Node<V> node = idToNode.get(entry.getKey());
         Node<V> parent = idToNode.get(entry.getValue());
         if (parent == null) { // handle headless trace
-          if (rootNode == null)
+          if (rootNode == null) {
             rootNode = new Node<>();
+            rootNode.missingRootDummyNode = true;
+          }
           rootNode.addChild(node);
         } else {
           parent.addChild(node);

--- a/zipkin/src/main/java/zipkin/internal/Node.java
+++ b/zipkin/src/main/java/zipkin/internal/Node.java
@@ -145,9 +145,9 @@ public final class Node<V> {
       for (Map.Entry<Long, Long> entry : idToParent.entrySet()) {
         Node<V> node = idToNode.get(entry.getKey());
         Node<V> parent = idToNode.get(entry.getValue());
-        if (parent == null && rootNode == null) { // handle headless trace
-          rootNode = node;
-        } else if (parent == null) { // attribute missing parents to root
+        if (parent == null) { // handle headless trace
+          if (rootNode == null)
+            rootNode = new Node<>();
           rootNode.addChild(node);
         } else {
           parent.addChild(node);

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
@@ -195,6 +195,19 @@ public class DependencyLinkerTest {
   }
 
   @Test
+  public void linksRelatedSpansWhenMissingRootSpan() {
+    long missingParentId = 1;
+    List<DependencyLinkSpan> trace = asList(
+        new DependencyLinkSpan(new TraceId(0L, 1L), missingParentId, 2L, Kind.SERVER, "service1", null),
+        new DependencyLinkSpan(new TraceId(0L, 1L), 2L, 3L, Kind.SERVER, "service2", null)
+    );
+
+    assertThat(new DependencyLinker()
+        .putTrace(trace.iterator()).link())
+        .containsOnly(DependencyLink.create("service1", "service2", 1L));
+  }
+
+  @Test
   public void merge() {
     List<DependencyLink> links = asList(
         DependencyLink.create("client", "server", 2L),

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
@@ -183,9 +183,10 @@ public class DependencyLinkerTest {
 
   @Test
   public void doesntLinkUnrelatedSpansWhenMissingRootSpan() {
+    long missingParentId = 1;
     List<DependencyLinkSpan> trace = asList(
-        new DependencyLinkSpan(new TraceId(0L, 1L), 3L, 1L, Kind.SERVER, "service1", null),
-        new DependencyLinkSpan(new TraceId(0L, 1L), 3L, 2L, Kind.SERVER, "service2", null)
+        new DependencyLinkSpan(new TraceId(0L, 1L), missingParentId, 2L, Kind.SERVER, "service1", null),
+        new DependencyLinkSpan(new TraceId(0L, 1L), missingParentId, 3L, Kind.SERVER, "service2", null)
     );
 
     assertThat(new DependencyLinker()

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -179,6 +179,18 @@ public class DependencyLinkerTest {
           .putTrace(asList(span).iterator()).link())
           .isEmpty();
     }
+  }
+
+  @Test
+  public void doesntLinkUnrelatedSpansWhenMissingRootSpan() {
+    List<DependencyLinkSpan> trace = asList(
+        new DependencyLinkSpan(new TraceId(0L, 1L), 3L, 1L, Kind.SERVER, "service1", null),
+        new DependencyLinkSpan(new TraceId(0L, 1L), 3L, 2L, Kind.SERVER, "service2", null)
+    );
+
+    assertThat(new DependencyLinker()
+        .putTrace(trace.iterator()).link())
+        .isEmpty();
   }
 
   @Test


### PR DESCRIPTION
The current dependency building logic uses the first spen as root for span
trees that are missing a span with null parentId.

So for example given this span tree (where all spans are server spans):

    1: {traceId: 1, spanId: 1, serviceName: A}
    2: {traceId: 1, spanId: 2, serviceName: B, parentId: 1}
    3: {traceId: 1, spanId: 3, serviceName: C, parentId: 1}

if the first span is not received, the dependency graph will contain a B -> C
dependency, which is obviously wrong.

This commit uses an empty node as the tree root for this case instead of using
the first server span as the parent.