### PR TITLE
Lets MergeById.apply accept an Iterable

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/MergeById.java
+++ b/zipkin/src/main/java/zipkin/internal/MergeById.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package zipkin.internal;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -26,9 +25,9 @@ import static zipkin.internal.Util.sortedList;
 
 public final class MergeById {
 
-  public static List<Span> apply(Collection<Span> spans) {
-    if (spans == null || spans.isEmpty()) return Collections.emptyList();
-    List<Span> result = new ArrayList<>(spans.size());
+  public static List<Span> apply(Iterable<Span> spans) {
+    if (spans == null || !spans.iterator().hasNext()) return Collections.emptyList();
+    List<Span> result = new ArrayList<>();
     Map<Long, List<Span>> spanIdToSpans = new LinkedHashMap<>();
     for (Span span : spans) {
       if (!spanIdToSpans.containsKey(span.id)) {


### PR DESCRIPTION
Spark jobs result in iterables. This change allows MergeById to be more
conveniently reused.