### PR TITLE
Makes storage auto-configuration properties serializable for Spark

### DIFF
--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,12 +13,15 @@
  */
 package zipkin.autoconfigure.storage.cassandra;
 
+import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.storage.cassandra.CassandraStorage;
 
 @ConfigurationProperties("zipkin.storage.cassandra")
-public class ZipkinCassandraStorageProperties {
+public class ZipkinCassandraStorageProperties implements Serializable { // for Spark jobs
+  private static final long serialVersionUID = 0L;
+
   private String keyspace = "zipkin";
   private String contactPoints = "localhost";
   private String localDc;

--- a/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra3/src/main/java/zipkin/autoconfigure/storage/cassandra3/ZipkinCassandra3StorageProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
  */
 package zipkin.autoconfigure.storage.cassandra3;
 
+import java.io.Serializable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.storage.cassandra3.Cassandra3Storage;
 
@@ -20,7 +21,9 @@ import static zipkin.storage.cassandra3.Cassandra3Storage.Builder;
 import static zipkin.storage.cassandra3.Cassandra3Storage.builder;
 
 @ConfigurationProperties("zipkin.storage.cassandra3")
-public class ZipkinCassandra3StorageProperties {
+public class ZipkinCassandra3StorageProperties implements Serializable { // for Spark jobs
+  private static final long serialVersionUID = 0L;
+
   private String keyspace = "zipkin3";
   private String contactPoints = "localhost";
   private String localDc;

--- a/zipkin-autoconfigure/storage-elasticsearch-aws/src/main/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/src/main/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,10 +13,13 @@
  */
 package zipkin.autoconfigure.storage.elasticsearch.aws;
 
+import java.io.Serializable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("zipkin.storage.elasticsearch.aws")
-public class ZipkinElasticsearchAwsStorageProperties {
+public class ZipkinElasticsearchAwsStorageProperties implements Serializable { // for Spark jobs
+  private static final long serialVersionUID = 0L;
+
   /** The name of a domain to look up by endpoint. Exclusive with hosts list. */
   private String domain;
 

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageProperties.java
@@ -13,13 +13,16 @@
  */
 package zipkin.autoconfigure.storage.elasticsearch.http;
 
+import java.io.Serializable;
 import java.util.List;
 import okhttp3.OkHttpClient;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.storage.elasticsearch.http.ElasticsearchHttpStorage;
 
 @ConfigurationProperties("zipkin.storage.elasticsearch")
-public class ZipkinElasticsearchHttpStorageProperties {
+public class ZipkinElasticsearchHttpStorageProperties implements Serializable { // for Spark jobs
+  private static final long serialVersionUID = 0L;
+
   /** Indicates the ingest pipeline used before spans are indexed. no default */
   private String pipeline;
   /** A List of transport-specific hosts to connect to, e.g. "localhost:9300" */

--- a/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -13,6 +13,7 @@
  */
 package zipkin.autoconfigure.storage.elasticsearch;
 
+import java.io.Serializable;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.internal.Nullable;
@@ -20,7 +21,9 @@ import zipkin.storage.elasticsearch.ElasticsearchStorage;
 import zipkin.storage.elasticsearch.InternalElasticsearchClient;
 
 @ConfigurationProperties("zipkin.storage.elasticsearch")
-public class ZipkinElasticsearchStorageProperties {
+public class ZipkinElasticsearchStorageProperties implements Serializable { // for Spark jobs
+  private static final long serialVersionUID = 0L;
+
   /** The elasticsearch cluster to connect to, defaults to "elasticsearch". */
   private String cluster = "elasticsearch";
   /** A List of transport-specific hosts to connect to, e.g. "localhost:9300" */

--- a/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageProperties.java
+++ b/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,10 +13,13 @@
  */
 package zipkin.autoconfigure.storage.mysql;
 
+import java.io.Serializable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("zipkin.storage.mysql")
-public class ZipkinMySQLStorageProperties {
+public class ZipkinMySQLStorageProperties implements Serializable { // for Spark jobs
+  private static final long serialVersionUID = 0L;
+
   private String host = "localhost";
   private int port = 3306;
   private String username;

--- a/zipkin/src/main/java/zipkin/DependencyLink.java
+++ b/zipkin/src/main/java/zipkin/DependencyLink.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@ import java.io.StreamCorruptedException;
 import static zipkin.internal.Util.UTF_8;
 import static zipkin.internal.Util.checkNotNull;
 
-public final class DependencyLink implements Serializable {
+public final class DependencyLink implements Serializable { // for Spark jobs
   private static final long serialVersionUID = 0L;
 
   public static DependencyLink create(String parent, String child, long callCount) {

--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -44,7 +44,7 @@ import static zipkin.internal.Util.writeHexLong;
  * <p>Span identifiers are packed into longs, but should be treated opaquely. ID encoding is
  * 16 or 32 character lower-hex, to avoid signed interpretation.
  */
-public final class Span implements Comparable<Span>, Serializable {
+public final class Span implements Comparable<Span>, Serializable { // for Spark jobs
   private static final long serialVersionUID = 0L;
 
   /**


### PR DESCRIPTION
zipkin-sparkstreaming is best being able to re-use properties here.
As jobs have to be serialized across a cluster, the easiest way is
to make storage properties objects serializable.