### PR TITLE
Exposes property derived MySQL datasource so sparkstreaming can use it

### DIFF
--- a/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
  */
 package zipkin.autoconfigure.storage.mysql;
 
-import com.zaxxer.hikari.HikariDataSource;
 import java.util.concurrent.Executor;
 import javax.sql.DataSource;
 import org.jooq.ExecuteListenerProvider;
@@ -49,19 +48,7 @@ public class ZipkinMySQLStorageAutoConfiguration {
   }
 
   @Bean @ConditionalOnMissingBean(DataSource.class) DataSource mysqlDataSource() {
-    StringBuilder url = new StringBuilder("jdbc:mysql://");
-    url.append(mysql.getHost()).append(":").append(mysql.getPort());
-    url.append("/").append(mysql.getDb());
-    url.append("?autoReconnect=true");
-    url.append("&useSSL=").append(mysql.isUseSsl());
-    url.append("&useUnicode=yes&characterEncoding=UTF-8");
-    HikariDataSource result = new HikariDataSource();
-    result.setDriverClassName("org.mariadb.jdbc.Driver");
-    result.setJdbcUrl(url.toString());
-    result.setMaximumPoolSize(mysql.getMaxActive());
-    result.setUsername(mysql.getUsername());
-    result.setPassword(mysql.getPassword());
-    return result;
+    return mysql.toDataSource();
   }
 
   @Bean StorageComponent storage(Executor executor, DataSource dataSource,

--- a/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageProperties.java
+++ b/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageProperties.java
@@ -13,7 +13,9 @@
  */
 package zipkin.autoconfigure.storage.mysql;
 
+import com.zaxxer.hikari.HikariDataSource;
 import java.io.Serializable;
+import javax.sql.DataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("zipkin.storage.mysql")
@@ -82,5 +84,21 @@ public class ZipkinMySQLStorageProperties implements Serializable { // for Spark
 
   public void setUseSsl(boolean useSsl) {
     this.useSsl = useSsl;
+  }
+
+  public DataSource toDataSource() {
+    StringBuilder url = new StringBuilder("jdbc:mysql://");
+    url.append(getHost()).append(":").append(getPort());
+    url.append("/").append(getDb());
+    url.append("?autoReconnect=true");
+    url.append("&useSSL=").append(isUseSsl());
+    url.append("&useUnicode=yes&characterEncoding=UTF-8");
+    HikariDataSource result = new HikariDataSource();
+    result.setDriverClassName("org.mariadb.jdbc.Driver");
+    result.setJdbcUrl(url.toString());
+    result.setMaximumPoolSize(getMaxActive());
+    result.setUsername(getUsername());
+    result.setPassword(getPassword());
+    return result;
   }
 }


### PR DESCRIPTION
The only thing ZipkinMySQLStorageProperties is used for is creating a
datasource. This exposes that so that the logic doesn't have to be copy
pasted into zipkin-sparkstreaming.