### PR TITLE
Handle null values in annotation value formatting

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -19,7 +19,7 @@ export function maybeMarkTransientError(row, anno) {
 // aren't disrupted.
 export function formatAnnotationValue(value) {
   const type = $.type(value);
-  if (type === 'object' || type === 'array') {
+  if (type === 'object' || type === 'array' || value == null) {
     return JSON.stringify(value);
   } else {
     return value.toString(); // prevents false from coercing to empty!
@@ -31,7 +31,7 @@ export function formatAnnotationValue(value) {
 // scroll off the side of the screen.
 export function formatBinaryAnnotationValue(value) {
   const type = $.type(value);
-  if (type === 'object' || type === 'array') {
+  if (type === 'object' || type === 'array' || value == null) {
     return `<pre>${JSON.stringify(value, null, 2)}</pre>`;
   } else {
     return value.toString(); // prevents false from coercing to empty!

--- a/zipkin-ui/test/component_ui/spanPanel.test.js
+++ b/zipkin-ui/test/component_ui/spanPanel.test.js
@@ -67,6 +67,10 @@ describe('formatAnnotationValue', () => {
       '[{"foo":"bar"},{"baz":"qux"}]'
     );
   });
+
+  it('should format null as json', () => {
+    formatAnnotationValue(null).should.equal('null');
+  });
 });
 
 describe('formatBinaryAnnotationValue', () => {
@@ -92,5 +96,9 @@ describe('formatBinaryAnnotationValue', () => {
     formatBinaryAnnotationValue([{foo: 'bar'}, {baz: 'qux'}]).should.equal(
       '<pre>[\n  {\n    "foo": "bar"\n  },\n  {\n    "baz": "qux"\n  }\n]</pre>'
     );
+  });
+
+  it('should format null as pre-formatted json', () => {
+    formatBinaryAnnotationValue(null).should.equal('<pre>null</pre>');
   });
 });


### PR DESCRIPTION
This happens due to the string "null" being converted to an actual null

We are adding binaryAnnotations with a potential value of the string "null" - somewhere in the UI processing this gets converted to the value null and blows up during span binary annotation formatting.

I am fairly confident that this is a UI bug - as I can retrieve the raw json of the trace and still see the quoted null string value in the annotations listing.  I debugged the javascript code and I believe it is happening during the mustache templating -> spanPanel.component.show function.

I wasn't too familiar with how to write a unit test for this.  Test span below.

`
[
  {
    "traceId": "c60aebe24bf0e16b",
    "id": "c60aebe24bf0e16b",
    "name": "/foo/bar",
    "timestamp": 1488880527927637,
    "duration": 9860466,
    "annotations": [
      {
        "timestamp": 1488880527927637,
        "value": "sr",
        "endpoint": {
          "serviceName": "foo",
          "ipv4": "10.200.96.137"
        }
      },
      {
        "timestamp": 1488880537788103,
        "value": "ss",
        "endpoint": {
          "serviceName": "foo",
          "ipv4": "10.200.96.137"
        }
      }
    ],
    "binaryAnnotations": [
      {
        "key": "customAnnotation",
        "value": "null",
        "endpoint": {
          "serviceName": "foo",
          "ipv4": "10.200.96.137"
        }
      },
      {
        "key": "http.status_code",
        "value": "200",
        "endpoint": {
          "serviceName": "foo",
          "ipv4": "10.200.96.137"
        }
      },
      {
        "key": "http.url",
        "value": "http://localhost:8084/foo/bar",
        "endpoint": {
          "serviceName": "foo",
          "ipv4": "10.200.96.137"
        }
      }
    ],
    "serviceName": "foo"
  }
]
`
