### PR TITLE
Explicitly sets line endings to LF for source, doc and configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+*.java text=auto eol=lf
+*.bnd text=auto eol=lf
+
+*.sh text=auto eol=lf
+
+*.md text=auto eol=lf
+*.txt text=auto eol=lf
+
+*.yml text=auto eol=lf
+*.yaml text=auto eol=lf
+*.xml text=auto eol=lf
+*.properties text=auto eol=lf
+
+*.js text=auto eol=lf
+*.mustache text=auto eol=lf
+*.css text=auto eol=lf


### PR DESCRIPTION
Per https://help.github.com/articles/dealing-with-line-endings/ in
efforts to help avoid mixed line endings with unix and windows.

See #1535