### PR TITLE
Add basic auth security configuration

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -52,6 +52,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
 
     <!-- zipkin requires exporting /health endpoint -->
     <dependency>

--- a/zipkin-server/src/main/resources/zipkin-server-security.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-security.yml
@@ -1,0 +1,14 @@
+security:
+  basic:
+    enabled: true
+  user:
+    name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
+    password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}
+
+management:
+  security:
+    basic:
+      enabled: true
+    user:
+      name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
+      password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -136,17 +136,17 @@ spring:
 security:
   basic:
     enabled: ${ZIPKIN_BASIC_SECURITY:false}
-    user:
-      name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
-      password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}
+  user:
+    name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
+    password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}
 
 management:
   security:
     basic:
       enabled: ${ZIPKIN_BASIC_SECURITY:false}
-      user:
-        name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
-        password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}
+    user:
+      name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
+      password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}
 
 info:
   zipkin:

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -133,6 +133,21 @@ spring:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
       - org.springframework.boot.autoconfigure.elasticsearch.jest.JestAutoConfiguration
 
+security:
+  basic:
+    enabled: ${ZIPKIN_BASIC_SECURITY:false}
+    user:
+      name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
+      password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}
+
+management:
+  security:
+    basic:
+      enabled: ${ZIPKIN_BASIC_SECURITY:false}
+      user:
+        name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
+        password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}
+
 info:
   zipkin:
     version: "@project.version@"

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -135,18 +135,12 @@ spring:
 
 security:
   basic:
-    enabled: ${ZIPKIN_BASIC_SECURITY:false}
-  user:
-    name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
-    password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}
+    enabled: false
 
 management:
   security:
     basic:
-      enabled: ${ZIPKIN_BASIC_SECURITY:false}
-    user:
-      name: ${ZIPKIN_BASIC_SECURITY_USERNAME:}
-      password: ${ZIPKIN_BASIC_SECURITY_PASSWORD:}
+      enabled: false
 
 info:
   zipkin:


### PR DESCRIPTION
I would like to add security onto our zipkin server so we can do away with our IP whitelists that we currently use. This is a small first step toward that. (Ideally I will have an OAuth type solution at some point)

This leverages only existing code that was already in the project so it should only grow the artifact by a few properties files and a pom.

Running the docker images with these changes:

```
$ docker run -it -p 9411:9411 -e ZIPKIN_BASIC_SECURITY_USERNAME=zipkin \
    -e ZIPKIN_BASIC_SECURITY_PASSWORD=password \
    -e JAVA_OPTS='-Dspring.profiles.active=security' zipkin:local
```