### PR TITLE
Limits names lookback in Elasticsearch

### DIFF
--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfiguration.java
@@ -45,8 +45,11 @@ public class ZipkinElasticsearchHttpStorageAutoConfiguration {
   ElasticsearchHttpStorage.Builder esHttpBuilder(
       ZipkinElasticsearchHttpStorageProperties elasticsearch,
       @Qualifier("zipkinElasticsearchHttp") OkHttpClient client,
-      @Value("${zipkin.storage.strict-trace-id:true}") boolean strictTraceId) {
-    return elasticsearch.toBuilder(client).strictTraceId(strictTraceId);
+      @Value("${zipkin.storage.strict-trace-id:true}") boolean strictTraceId,
+      @Value("${zipkin.query.lookback:86400000}") int namesLookback) {
+    return elasticsearch.toBuilder(client)
+        .strictTraceId(strictTraceId)
+        .namesLookback(namesLookback);
   }
 
   /** cheap check to see if we are likely to include urls */

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfigurationTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin.storage.elasticsearch.http;
 
+import java.util.concurrent.TimeUnit;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import org.junit.After;
@@ -241,6 +242,22 @@ public class ZipkinElasticsearchHttpStorageAutoConfigurationTest {
 
     assertThat(es().indexNameFormatter().indexNameForTimestamp(0))
         .isEqualTo("zipkin-1970.01.01");
+  }
+
+  @Test
+  public void namesLookbackAssignedFromQueryLookback() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.storage.type:elasticsearch",
+        "zipkin.storage.elasticsearch.hosts:http://host1:9200",
+        "zipkin.query.lookback:" + TimeUnit.DAYS.toMillis(2));
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinElasticsearchOkHttpAutoConfiguration.class,
+        ZipkinElasticsearchHttpStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(es().namesLookback())
+        .isEqualTo((int) TimeUnit.DAYS.toMillis(2));
   }
 
   ElasticsearchHttpStorage es() {

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -221,6 +221,13 @@ $ STORAGE_TYPE=elasticsearch ES_HOSTS=https://search-mydomain-2rlih66ibw43ftlk43
 $ STORAGE_TYPE=elasticsearch ES_AWS_DOMAIN=mydomain ES_AWS_REGION=ap-southeast-1 java -jar zipkin.jar
 ```
 
+#### Service and Span names query
+The [Zipkin query api v1](http://zipkin.io/zipkin-api/#/paths/%252Fservices) does not include
+a parameter for how far back to look for service or span names. In order
+to prevent excessive load, service and span name queries are limited by
+`QUERY_LOOKBACK`, which defaults to 24hrs (two daily buckets: one for
+today and one for yesterday)
+
 ### Scribe Collector
 The Scribe collector is enabled by default, configured by the following:
 

--- a/zipkin-server/src/it/elasticsearch-http/src/test/java/zipkin/elasticsearch/http/ZipkinServerTest.java
+++ b/zipkin-server/src/it/elasticsearch-http/src/test/java/zipkin/elasticsearch/http/ZipkinServerTest.java
@@ -33,6 +33,7 @@ import org.springframework.util.SocketUtils;
 import zipkin.server.ZipkinServer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
@@ -71,7 +72,7 @@ public class ZipkinServerTest {
 
       assertEquals("/", es.takeRequest().getPath()); // version
       assertEquals("/_template/zipkin_template", es.takeRequest().getPath());
-      assertEquals("/zipkin-*/span/_search", es.takeRequest().getPath().replaceAll("\\?.*", ""));
+      assertTrue(es.takeRequest().getPath().replaceAll("\\?.*", "").endsWith("/span/_search"));
     }
   }
 

--- a/zipkin-storage/elasticsearch-http/README.md
+++ b/zipkin-storage/elasticsearch-http/README.md
@@ -97,6 +97,9 @@ collector in a different language, make sure you write span and service
 names in lowercase. Also, if there are any custom query tools, ensure
 inputs are downcased.
 
+Span and service name queries default to look back 24hrs (2 index days).
+This can be controlled by `ElasticsearchHttpStorage.Builder.namesLookback`
+
 ## Customizing the ingest pipeline
 
 When using Elasticsearch 5.x, you can setup an [ingest pipeline](https://www.elastic.co/guide/en/elasticsearch/reference/master/pipeline.html)

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
@@ -59,6 +59,7 @@ public abstract class ElasticsearchHttpStorage implements StorageComponent {
         .dateSeparator('-')
         .indexShards(5)
         .indexReplicas(1)
+        .namesLookback(86400000)
         .shutdownClientOnClose(false)
         .flushOnWrites(false);
   }
@@ -110,6 +111,12 @@ public abstract class ElasticsearchHttpStorage implements StorageComponent {
      * <p>See https://www.elastic.co/guide/en/elasticsearch/reference/master/pipeline.html
      */
     public abstract Builder pipeline(String pipeline);
+
+    /**
+     * Only return span and service names where all {@link zipkin.Span#timestamp} are at or after
+     * (now - lookback) in milliseconds. Defaults to 1 day (86400000).
+     */
+    public abstract Builder namesLookback(int namesLookback);
 
     /** Visible for testing */
     abstract Builder flushOnWrites(boolean flushOnWrites);
@@ -183,6 +190,8 @@ public abstract class ElasticsearchHttpStorage implements StorageComponent {
   abstract int indexReplicas();
 
   abstract IndexNameFormatter indexNameFormatter();
+
+  abstract int namesLookback();
 
   @Override public SpanStore spanStore() {
     return StorageAdapters.asyncToBlocking(asyncSpanStore());

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/internal/client/SearchRequest.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/internal/client/SearchRequest.java
@@ -88,10 +88,6 @@ public final class SearchRequest {
     return new SearchRequest(indices, type);
   }
 
-  public SearchRequest nestedTermsEqual(Collection<String> nestedFields, String value) {
-    return query(_nestedTermsEqual(nestedFields, value));
-  }
-
   public SearchRequest term(String field, String value) {
     return query(new Term(field, value));
   }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/moshi/JsonReadersTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/moshi/JsonReadersTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,6 +20,8 @@ import okio.Buffer;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.storage.elasticsearch.TestResponses.SERVICE_NAMES;
+import static zipkin.storage.elasticsearch.TestResponses.SPAN_NAMES;
 
 public class JsonReadersTest {
 
@@ -57,84 +59,16 @@ public class JsonReadersTest {
 
   @Test
   public void collectValuesNamed_mergesArrays() throws IOException {
-    Set<String> result = JsonReaders.collectValuesNamed(JsonReader.of(new Buffer().writeUtf8("{\n"
-        + "  \"took\": 1,\n"
-        + "  \"timed_out\": false,\n"
-        + "  \"_shards\": {\n"
-        + "    \"total\": 5,\n"
-        + "    \"successful\": 5,\n"
-        + "    \"failed\": 0\n"
-        + "  },\n"
-        + "  \"hits\": {\n"
-        + "    \"total\": 2,\n"
-        + "    \"max_score\": 0,\n"
-        + "    \"hits\": []\n"
-        + "  },\n"
-        + "  \"aggregations\": {\n"
-        + "    \"name_agg\": {\n"
-        + "      \"doc_count_error_upper_bound\": 0,\n"
-        + "      \"sum_other_doc_count\": 0,\n"
-        + "      \"buckets\": [\n"
-        + "        {\n"
-        + "          \"key\": \"methodcall\",\n"
-        + "          \"doc_count\": 1\n"
-        + "        },\n"
-        + "        {\n"
-        + "          \"key\": \"yak\",\n"
-        + "          \"doc_count\": 1\n"
-        + "        }\n"
-        + "      ]\n"
-        + "    }\n"
-        + "  }\n"
-        + "}")), "key");
+    Set<String> result =
+        JsonReaders.collectValuesNamed(JsonReader.of(new Buffer().writeUtf8(SPAN_NAMES)), "key");
 
     assertThat(result).containsExactly("methodcall", "yak");
   }
 
   @Test
   public void collectValuesNamed_mergesChildren() throws IOException {
-    Set<String> result = JsonReaders.collectValuesNamed(JsonReader.of(new Buffer().writeUtf8("{\n"
-        + "  \"took\": 4,\n"
-        + "  \"timed_out\": false,\n"
-        + "  \"_shards\": {\n"
-        + "    \"total\": 5,\n"
-        + "    \"successful\": 5,\n"
-        + "    \"failed\": 0\n"
-        + "  },\n"
-        + "  \"hits\": {\n"
-        + "    \"total\": 1,\n"
-        + "    \"max_score\": 0,\n"
-        + "    \"hits\": []\n"
-        + "  },\n"
-        + "  \"aggregations\": {\n"
-        + "    \"binaryAnnotations_agg\": {\n"
-        + "      \"doc_count\": 1,\n"
-        + "      \"binaryAnnotationsServiceName_agg\": {\n"
-        + "        \"doc_count_error_upper_bound\": 0,\n"
-        + "        \"sum_other_doc_count\": 0,\n"
-        + "        \"buckets\": [\n"
-        + "          {\n"
-        + "            \"key\": \"yak\",\n"
-        + "            \"doc_count\": 1\n"
-        + "          }\n"
-        + "        ]\n"
-        + "      }\n"
-        + "    },\n"
-        + "    \"annotations_agg\": {\n"
-        + "      \"doc_count\": 2,\n"
-        + "      \"annotationsServiceName_agg\": {\n"
-        + "        \"doc_count_error_upper_bound\": 0,\n"
-        + "        \"sum_other_doc_count\": 0,\n"
-        + "        \"buckets\": [\n"
-        + "          {\n"
-        + "            \"key\": \"service\",\n"
-        + "            \"doc_count\": 2\n"
-        + "          }\n"
-        + "        ]\n"
-        + "      }\n"
-        + "    }\n"
-        + "  }\n"
-        + "}")), "key");
+    Set<String> result =
+        JsonReaders.collectValuesNamed(JsonReader.of(new Buffer().writeUtf8(SERVICE_NAMES)), "key");
 
     assertThat(result).containsExactly("yak", "service");
   }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/TestResponses.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/TestResponses.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch;
+
+public final class TestResponses {
+  public static final String SERVICE_NAMES = "{\n"
+      + "  \"took\": 4,\n"
+      + "  \"timed_out\": false,\n"
+      + "  \"_shards\": {\n"
+      + "    \"total\": 5,\n"
+      + "    \"successful\": 5,\n"
+      + "    \"failed\": 0\n"
+      + "  },\n"
+      + "  \"hits\": {\n"
+      + "    \"total\": 1,\n"
+      + "    \"max_score\": 0,\n"
+      + "    \"hits\": []\n"
+      + "  },\n"
+      + "  \"aggregations\": {\n"
+      + "    \"binaryAnnotations_agg\": {\n"
+      + "      \"doc_count\": 1,\n"
+      + "      \"binaryAnnotationsServiceName_agg\": {\n"
+      + "        \"doc_count_error_upper_bound\": 0,\n"
+      + "        \"sum_other_doc_count\": 0,\n"
+      + "        \"buckets\": [\n"
+      + "          {\n"
+      + "            \"key\": \"yak\",\n"
+      + "            \"doc_count\": 1\n"
+      + "          }\n"
+      + "        ]\n"
+      + "      }\n"
+      + "    },\n"
+      + "    \"annotations_agg\": {\n"
+      + "      \"doc_count\": 2,\n"
+      + "      \"annotationsServiceName_agg\": {\n"
+      + "        \"doc_count_error_upper_bound\": 0,\n"
+      + "        \"sum_other_doc_count\": 0,\n"
+      + "        \"buckets\": [\n"
+      + "          {\n"
+      + "            \"key\": \"service\",\n"
+      + "            \"doc_count\": 2\n"
+      + "          }\n"
+      + "        ]\n"
+      + "      }\n"
+      + "    }\n"
+      + "  }\n"
+      + "}";
+
+  public static final String SPAN_NAMES = "{\n"
+      + "  \"took\": 1,\n"
+      + "  \"timed_out\": false,\n"
+      + "  \"_shards\": {\n"
+      + "    \"total\": 5,\n"
+      + "    \"successful\": 5,\n"
+      + "    \"failed\": 0\n"
+      + "  },\n"
+      + "  \"hits\": {\n"
+      + "    \"total\": 2,\n"
+      + "    \"max_score\": 0,\n"
+      + "    \"hits\": []\n"
+      + "  },\n"
+      + "  \"aggregations\": {\n"
+      + "    \"name_agg\": {\n"
+      + "      \"doc_count_error_upper_bound\": 0,\n"
+      + "      \"sum_other_doc_count\": 0,\n"
+      + "      \"buckets\": [\n"
+      + "        {\n"
+      + "          \"key\": \"methodcall\",\n"
+      + "          \"doc_count\": 1\n"
+      + "        },\n"
+      + "        {\n"
+      + "          \"key\": \"yak\",\n"
+      + "          \"doc_count\": 1\n"
+      + "        }\n"
+      + "      ]\n"
+      + "    }\n"
+      + "  }\n"
+      + "}";
+}

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStoreTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStoreTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.elasticsearch.http;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.internal.Util;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.storage.elasticsearch.TestResponses.SERVICE_NAMES;
+import static zipkin.storage.elasticsearch.TestResponses.SPAN_NAMES;
+
+public class ElasticsearchHttpSpanStoreTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  @Rule
+  public MockWebServer es = new MockWebServer();
+
+  ElasticsearchHttpStorage storage = ElasticsearchHttpStorage.builder()
+      .hosts(asList(es.url("").toString()))
+      .build();
+
+  /** gets the index template so that each test doesn't have to */
+  @Before
+  public void getIndexTemplate() throws IOException, InterruptedException {
+    es.enqueue(new MockResponse().setBody("{\"version\":{\"number\":\"2.4.0\"}}"));
+    es.enqueue(new MockResponse()); // get template
+    storage.ensureIndexTemplate();
+    es.takeRequest(); // get version
+    es.takeRequest(); // get template
+  }
+
+  @After
+  public void close() throws IOException {
+    storage.close();
+  }
+
+  @Test
+  public void serviceNames_defaultsTo24HrsAgo() throws Exception {
+    es.enqueue(new MockResponse().setBody(SERVICE_NAMES));
+    storage.spanStore().getServiceNames();
+
+    requestLimitedTo2DaysOfIndices();
+  }
+
+  @Test
+  public void spanNames_defaultsTo24HrsAgo() throws Exception {
+    es.enqueue(new MockResponse().setBody(SPAN_NAMES));
+    storage.spanStore().getSpanNames("foo");
+
+    requestLimitedTo2DaysOfIndices();
+  }
+
+  private void requestLimitedTo2DaysOfIndices() throws InterruptedException {
+    long today = Util.midnightUTC(System.currentTimeMillis());
+    long yesterday = today - TimeUnit.DAYS.toMillis(1);
+
+    // 24 hrs ago always will fall into 2 days (ex. if it is 4:00pm, 24hrs ago is a different day)
+    String indexesToSearch = ""
+        + storage.indexNameFormatter().indexNameForTimestamp(yesterday)
+        + ","
+        + storage.indexNameFormatter().indexNameForTimestamp(today);
+
+    RecordedRequest request = es.takeRequest();
+    assertThat(request.getPath())
+        .startsWith("/" + indexesToSearch + "/span/_search");
+    assertThat(request.getBody().readUtf8())
+        .contains("{\"range\":{\"timestamp_millis\"");
+  }
+}


### PR DESCRIPTION
This reuses `QUERY_LOOKBACK` to limit names queries (service and span
names) from searching all indexes. This is particularly important for
high-volume sites (ex 100% sampling or high traffic), and those who do
not use curator or otherwise to prune data.

Fixes #1462 (at least helps a lot with no schema change)