### PR TITLE
Disables scribe by default

### DIFF
--- a/zipkin-autoconfigure/collector-scribe/src/main/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorAutoConfiguration.java
+++ b/zipkin-autoconfigure/collector-scribe/src/main/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -29,7 +29,7 @@ import zipkin.storage.StorageComponent;
  */
 @Configuration
 @EnableConfigurationProperties(ZipkinScribeCollectorProperties.class)
-@ConditionalOnProperty(value = "zipkin.collector.scribe.enabled", matchIfMissing = true)
+@ConditionalOnProperty(value = "zipkin.collector.scribe.enabled", havingValue = "true")
 public class ZipkinScribeCollectorAutoConfiguration {
   /** The init method will block until the scribe port is listening, or crash on port conflict */
   @Bean(initMethod = "start") ScribeCollector scribe(ZipkinScribeCollectorProperties scribe,

--- a/zipkin-autoconfigure/collector-scribe/src/test/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/collector-scribe/src/test/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -46,9 +46,8 @@ public class ZipkinScribeCollectorAutoConfigurationTest {
   }
 
   @Test
-  public void doesntProvidesCollectorComponent_whenDisabled() {
+  public void doesntProvidesCollectorComponent_byDefault() {
     context = new AnnotationConfigApplicationContext();
-    addEnvironment(context, "zipkin.collector.scribe.enabled:false");
     context.register(PropertyPlaceholderAutoConfiguration.class,
         ZipkinScribeCollectorAutoConfiguration.class, InMemoryConfiguration.class);
     context.refresh();
@@ -59,8 +58,9 @@ public class ZipkinScribeCollectorAutoConfigurationTest {
 
   /** Note: this will flake if you happen to be running a server on port 9410! */
   @Test
-  public void providesCollectorComponent() {
+  public void providesCollectorComponent_whenEnabled() {
     context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.collector.scribe.enabled:true");
     context.register(PropertyPlaceholderAutoConfiguration.class,
         ZipkinScribeCollectorAutoConfiguration.class, InMemoryConfiguration.class);
     context.refresh();
@@ -69,9 +69,12 @@ public class ZipkinScribeCollectorAutoConfigurationTest {
   }
 
   @Test
-  public void canOverridesProperty_port() {
+  public void canOverrideProperty_port() {
     context = new AnnotationConfigApplicationContext();
-    addEnvironment(context, "zipkin.collector.scribe.port:9999");
+    addEnvironment(context,
+        "zipkin.collector.scribe.enabled:true",
+        "zipkin.collector.scribe.port:9999"
+    );
     context.register(PropertyPlaceholderAutoConfiguration.class,
         ZipkinScribeCollectorAutoConfiguration.class, InMemoryConfiguration.class);
     context.refresh();

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -113,7 +113,6 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
     * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 7 days
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`
-    * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 
 ### Cassandra Storage
@@ -229,9 +228,9 @@ to prevent excessive load, service and span name queries are limited by
 today and one for yesterday)
 
 ### Scribe Collector
-The Scribe collector is enabled by default, configured by the following:
+The Scribe collector is disabled by default, configured by the following:
 
-    * `SCRIBE_ENABLED`: Set to false to prevent scribe from starting; Defaults to true
+    * `SCRIBE_ENABLED`: Set to true to listen for scribe (thrift RPC); Defaults to false
     * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410
 
 ### Kafka Collector

--- a/zipkin-server/src/it/elasticsearch-http/src/test/java/zipkin/elasticsearch/http/ZipkinServerTest.java
+++ b/zipkin-server/src/it/elasticsearch-http/src/test/java/zipkin/elasticsearch/http/ZipkinServerTest.java
@@ -42,7 +42,6 @@ import static org.junit.Assert.assertTrue;
     properties = {
         "zipkin.storage.type=elasticsearch",
         "zipkin.storage.elasticsearch.hosts=http://localhost:${mock.elasticsearch.port}",
-        "zipkin.collector.scribe.enabled=false",
         "spring.config.name=zipkin-server"
     })
 @ContextConfiguration(initializers = ZipkinServerTest.RandomPortInitializer.class)

--- a/zipkin/src/main/java/zipkin/collector/CollectorMetrics.java
+++ b/zipkin/src/main/java/zipkin/collector/CollectorMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -61,7 +61,7 @@ public interface CollectorMetrics {
    *
    * <p>For example, an implementation may by default report {@link #incrementSpans(int) incremented
    * spans} to the key "zipkin.collector.span.accepted". When {@code metrics.forTransport("kafka"}
-   * is called, the counter would report to "zipkin.collector.scribe.span.accepted"
+   * is called, the counter would report to "zipkin.collector.kafka.span.accepted"
    *
    * @param transportType ex "http", "scribe", "kafka"
    */


### PR DESCRIPTION
Scribe has been listening on the legacy port 9410 to help with migration
off the old zipkin codebase. A year and a half has passed, and all major
instrumentation packages support HTTP. By disabling scribe by default,
we only listen on one port, which helps in configuration management and
also eliminate the common confusion where people accidentally send http
traffic to the scribe port.

Fixes #1192