### PR TITLE
Preformats multi-line tag/binary annotations in the UI

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -33,9 +33,10 @@ export function formatBinaryAnnotationValue(value) {
   const type = $.type(value);
   if (type === 'object' || type === 'array' || value == null) {
     return `<pre>${JSON.stringify(value, null, 2)}</pre>`;
-  } else {
-    return value.toString(); // prevents false from coercing to empty!
   }
+  const result = value.toString();
+  // Preformat if the text includes newlines
+  return result.indexOf('\n') === -1 ? result : `<pre>${result}</pre>`;
 }
 
 export default component(function spanPanel() {

--- a/zipkin-ui/test/component_ui/spanPanel.test.js
+++ b/zipkin-ui/test/component_ui/spanPanel.test.js
@@ -101,4 +101,10 @@ describe('formatBinaryAnnotationValue', () => {
   it('should format null as pre-formatted json', () => {
     formatBinaryAnnotationValue(null).should.equal('<pre>null</pre>');
   });
+
+  it('should format multi-line string as pre-formatted', () => {
+    formatBinaryAnnotationValue('foo\nbar\n').should.equal(
+      '<pre>foo\nbar\n</pre>'
+    );
+  });
 });


### PR DESCRIPTION
Before, we didn't preformat text that included newlines. This made them
run off the screen. Now we do.

Before:
<img width="820" alt="screen shot 2017-04-04 at 1 14 16 pm" src="https://cloud.githubusercontent.com/assets/64215/24643157/a2f40dc0-193e-11e7-8221-a1efb4a86387.png">

After:
<img width="884" alt="screen shot 2017-04-04 at 1 54 20 pm" src="https://cloud.githubusercontent.com/assets/64215/24643161/a7470ed6-193e-11e7-8a27-505efdd2c9b5.png">
