### PR TITLE
Corrects search results to display total spans as "NN Spans"

### DIFF
--- a/zipkin-ui/js/component_ui/traceSummary.js
+++ b/zipkin-ui/js/component_ui/traceSummary.js
@@ -157,13 +157,15 @@ export function traceSummary(spans = []) {
     const timestamp = spans[0].timestamp;
     const spanTimestamps = getSpanTimestamps(spans);
     const errorType = getTraceErrorType(spans);
+    const totalSpans = spans.length;
     return {
       traceId,
       timestamp,
       duration,
       spanTimestamps,
       endpoints,
-      errorType
+      errorType,
+      totalSpans
     };
   }
 }
@@ -241,7 +243,6 @@ export function traceSummariesToMustache(serviceName = null, traceSummaries, utc
       const servicePercentage = parseInt(
           parseFloat(serviceTime) / parseFloat(t.duration) * 100,
         10);
-      const spanCount = _(groupedTimestamps).values().sumBy((sts) => sts.length);
       const width = parseInt(parseFloat(duration) / parseFloat(maxDuration) * 100, 10);
       const infoClass = t.errorType === 'none' ? '' : `trace-error-${t.errorType}`;
 
@@ -252,7 +253,7 @@ export function traceSummariesToMustache(serviceName = null, traceSummaries, utc
         duration,
         durationStr,
         servicePercentage,
-        spanCount,
+        totalSpans: t.totalSpans,
         serviceDurations,
         width,
         infoClass

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -87,7 +87,7 @@
         <div class="bar-block">
           <span class="bar-graphic" style="width:{{width}}%;"></span>
           <span class="bar-label">{{durationStr}}</span>
-          <span class="bar-label">{{spanCount}} spans</span>
+          <span class="bar-label">{{totalSpans}} spans</span>
         </div>
         <div class="bar-block">
           <span class="bar-graphic" style="width:{{servicePercentage}}%;"></span>

--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -68,6 +68,11 @@ describe('traceSummary', () => {
     summary.timestamp.should.equal(100);
     summary.duration.should.equal(400);
   });
+
+  it('should get total spans count', () => {
+    const summary = traceSummary(trace);
+    summary.totalSpans.should.equal(trace.length);
+  });
 });
 
 describe('get service name of a span', () => {
@@ -301,11 +306,6 @@ describe('traceSummariesToMustache', () => {
     model[0].servicePercentage.should.equal(50);
   });
 
-  it('should get span count', () => {
-    const model = traceSummariesToMustache(null, [summary]);
-    model[0].spanCount.should.equal(3);
-  });
-
   it('should format start time', () => {
     const model = traceSummariesToMustache(null, [summary], true);
     model[0].startTs.should.equal('02-26-2016T00:51:51.000+0000');
@@ -326,7 +326,7 @@ describe('traceSummariesToMustache', () => {
     model[0].timestamp.should.equal(summary.timestamp);
   });
 
-  it('should get correct spanCount', () => {
+  it('should get correct totalSpans', () => {
     const spans = [{
       traceId: 'd397ce70f5192a8b',
       name: 'get',
@@ -362,7 +362,7 @@ describe('traceSummariesToMustache', () => {
     }];
     const testSummary = traceSummary(spans);
     const model = traceSummariesToMustache(null, [testSummary])[0];
-    model.spanCount.should.equal(1);
+    model.totalSpans.should.equal(1);
   });
 
   it('should order traces by duration and tie-break using trace id', () => {


### PR DESCRIPTION
Before, the search results view showed the total service/span pairs as
opposed to the total spans. This made things confusing as when people
clicked into the trace detail view the total spans would be a different
sometimes smaller count.