### PR TITLE
Fixes Elasticsearch AWS integration (broken dependency)

### DIFF
--- a/zipkin-autoconfigure/storage-elasticsearch-aws/pom.xml
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <aws.sdk.version>1.11.69</aws.sdk.version>
+    <aws.sdk.version>1.11.117</aws.sdk.version>
   </properties>
 
   <dependencies>
@@ -41,13 +41,6 @@
       <artifactId>aws-java-sdk-core</artifactId>
       <groupId>com.amazonaws</groupId>
       <version>${aws.sdk.version}</version>
-      <exclusions>
-        <!-- provided by way of org.elasticsearch -->
-        <exclusion>
-          <groupId>joda-time</groupId>
-          <artifactId>joda-time</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- Used indirectly by ProfileCredentialsProvider -->
     <dependency>


### PR DESCRIPTION
We used to transiently include elasticsearch, which had joda dependency.
In order to not conflict with AWS, we excluded joda from AWS. Now, we
don't depend on Elasticsearch anymore so need joda again!

Reported by @mclarke47 as an exception like:

```
Exception in thread "OkHttp Dispatcher" java.lang.NoClassDefFoundError: org/joda/time/ReadableInstant
        at com.amazonaws.auth.EC2CredentialsFetcher.fetchCredentials(EC2CredentialsFetcher.java:151)
```