### PR TITLE
add internal cache for /api/v1/services with scheduled update

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinSchedulerConfig.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinSchedulerConfig.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.TaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class ZipkinSchedulerConfig {
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(1);
+        return taskScheduler;
+    }
+}

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -31,6 +31,10 @@ zipkin:
     names-max-age: 300
     # CORS allowed-origins.
     allowed-origins: "*"
+    # Internal cache for service names, updated by scheduler with fixed interval
+    # Prevents timeouts in UI
+    internal-service-names-cache-enabled: ${INTERNAL_SERVICE_NAMES_CACHE_ENABLED:false}
+    internal-service-names-cache-update-interval: ${INTERNAL_SERVICE_NAMES_CACHE_UPDATE_INTERVAL:300000} 
 
   storage:
     strict-trace-id: ${STRICT_TRACE_ID:true}


### PR DESCRIPTION
We use Zipkin with ElasticSearch in AWS and have the following problem: on a big amount of data request to /api/v1/services takes too long time and often we have timeouts in UI.
There is a try to implement opt-in internal caching of getServiceNames() result with scheduled updates. Now we are using this patch in our external environment, it improves a bit our users' experience. Hope it can help for upstream (maybe in another way of implementation).
