### PR TITLE
remove traces with null timestamps on rendering

### DIFF
--- a/zipkin-ui/js/component_ui/traceSummary.js
+++ b/zipkin-ui/js/component_ui/traceSummary.js
@@ -220,13 +220,24 @@ export function mkDurationStr(duration) {
   }
 }
 
+function removeEmptyFromArray(array) {
+  const newArray = [];
+  for (let i = 0; i < array.length; i++) {
+    if (array[i]) {
+      newArray.push(array[i]);
+    }
+  }
+  return newArray;
+}
+
 export function traceSummariesToMustache(serviceName = null, traceSummaries, utc = false) {
   if (traceSummaries.length === 0) {
     return [];
   } else {
-    const maxDuration = Math.max(...traceSummaries.map((s) => s.duration)) / 1000;
+    const traceSummariesCleaned = removeEmptyFromArray(traceSummaries);
+    const maxDuration = Math.max(...traceSummariesCleaned.map((s) => s.duration)) / 1000;
 
-    return traceSummaries.map((t) => {
+    return traceSummariesCleaned.map((t) => {
       const duration = t.duration / 1000;
       const groupedTimestamps = getGroupedTimestamps(t);
       const serviceDurations = getServiceDurations(groupedTimestamps);


### PR DESCRIPTION
I began receiving "blank pages" (with header) when enabled self-tracing and tried to search for them with following JS error:

Uncaught TypeError: Cannot read property 'duration' of null (traceSummary.js)

Then figured out that there are some traces with absent timestamp field in root spans (actually, there are cases with some contiguous spans with null timestamps, starting from root spans).
As far as I remember, there are some existing valid cases (aren't they?) when timestamps may be null.
So, there is a straightforward (maybe not very elegant) solution with removing useless null-timestamped traces. Actually, I'm not sure that it's the right way to solve the problem, but it allows to see at least valid traces and not blank pages.
