### PR TITLE
Fix comments in docs about QUERY_LOOKBACK

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -111,7 +111,7 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
 
     * `QUERY_PORT`: Listen port for the http api and web ui; Defaults to 9411
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
-    * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 7 days
+    * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 24 hours (two daily buckets: one for today and one for yesterday)
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -25,7 +25,7 @@ zipkin:
       category: zipkin
       port: ${COLLECTOR_PORT:9410}
   query:
-    # 7 days in millis
+    # 1 day in millis
     lookback: ${QUERY_LOOKBACK:86400000}
     # The Cache-Control max-age (seconds) for /api/v1/services and /api/v1/spans
     names-max-age: 300


### PR DESCRIPTION
```
3600*24*1000 = 86400000 (1day)
3600*24*1000*7 = 604800000 (7 days)
```

Just to not confuse users (: (It's correct in some places and wrong in another)