### PR TITLE
Add cache for servicespans, reduce unnecessary writes

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumer.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumer.java
@@ -41,7 +41,7 @@ class ElasticsearchHttpSpanConsumer implements AsyncSpanConsumer { // not final 
   private final static int MAX_CACHE_DAYS = 2;
   private final static int MAX_CACHE_ENTRIES = 1000;
 
-  private final static Map<String, Set<Pair<String>>> indexToServiceSpansCache = new LinkedHashMap<String, Set<Pair<String>>>() {
+  final static Map<String, Set<Pair<String>>> indexToServiceSpansCache = new LinkedHashMap<String, Set<Pair<String>>>() {
     @Override
     protected boolean removeEldestEntry(Map.Entry<String, Set<Pair<String>>> eldest) {
       return size() > MAX_CACHE_DAYS;

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumer.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumer.java
@@ -75,7 +75,7 @@ class ElasticsearchHttpSpanConsumer implements AsyncSpanConsumer { // not final 
     try {
       HttpBulkIndexer indexer = new HttpBulkIndexer("index-span", es);
       indexToServiceSpans = indexSpans(indexer, spans);
-      
+
       // remove already cached items from indexToServiceSpans, add new items to cache
       for (Map.Entry<String, Set<Pair<String>>> entry : indexToServiceSpans.entrySet()) {
         Set<Pair<String>> serviceSpansEntryCached = null;
@@ -108,7 +108,7 @@ class ElasticsearchHttpSpanConsumer implements AsyncSpanConsumer { // not final 
       callbackWrapper.onError(t);
     }
   }
-  /** Remove recently added items from cache */
+  /** Remove recently added items from servicespan cache */
   void clearIndexToServiceSpansCache(Map<String, Set<Pair<String>>> index, Map<String, Set<Pair<String>>> cache) {
     for (Map.Entry<String, Set<Pair<String>>> entry : index.entrySet()) {
       Set<Pair<String>> serviceSpansEntryCached = null;
@@ -121,6 +121,11 @@ class ElasticsearchHttpSpanConsumer implements AsyncSpanConsumer { // not final 
         serviceSpansEntryCached.removeAll(entry.getValue());
       }
     }
+  }
+
+  /** Clear servicespan cache (for testing purposes) */
+  void resetIndexToServiceSpansCache() {
+    indexToServiceSpansCache.clear();
   }
 
   /** Indexes spans and returns a mapping of indexes that may need a names update */

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
@@ -110,15 +110,111 @@ public class ElasticsearchHttpSpanConsumerTest {
   }
 
   @Test
+  public void addsPipelineId() throws Exception {
+    close();
+
+    storage = ElasticsearchHttpStorage.builder()
+      .hosts(asList(es.url("").toString()))
+      .pipeline("zipkin")
+      .build();
+    ensureIndexTemplate();
+
+    es.enqueue(new MockResponse());
+
+    accept(TestObjects.TRACE.get(0));
+
+    RecordedRequest request = es.takeRequest();
+    assertThat(request.getPath())
+      .isEqualTo("/_bulk?pipeline=zipkin");
+  }
+
+  @Test
+  public void indexesServiceSpan_basedOnAnnotationTimestamp() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Annotation foo = Annotation.create(
+      TimeUnit.DAYS.toMicros(365), // 1971-01-01
+      "foo",
+      TestObjects.APP_ENDPOINT
+    );
+
+    Span span = Span.builder().traceId(1L).id(2L).parentId(1L).name("s").addAnnotation(foo).build();
+
+    // sanity check data
+    assertThat(span.timestamp).isNull();
+    assertThat(guessTimestamp(span)).isNull();
+
+    accept(span);
+
+    // index timestamp is the server timestamp, not current time!
+    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
+      "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"span\"}}\n",
+      "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
+    );
+  }
+
+  @Test
+  public void indexesServiceSpan_basedOnGuessTimestamp() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Annotation cs = Annotation.create(
+      TimeUnit.DAYS.toMicros(365), // 1971-01-01
+      CLIENT_SEND,
+      TestObjects.APP_ENDPOINT
+    );
+
+    Span span = Span.builder().traceId(1L).id(1L).name("t").addAnnotation(cs).build();
+
+    // sanity check data
+    assertThat(span.timestamp).isNull();
+    assertThat(guessTimestamp(span)).isNotNull();
+
+    accept(span);
+
+    // index timestamp is the server timestamp, not current time!
+    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
+      "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"span\"}}\n",
+      "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"servicespan\",\"_id\":\"app|t\"}}\n"
+    );
+  }
+
+  @Test
+  public void indexesServiceSpan_currentTimestamp() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Span span = Span.builder().traceId(1L).id(2L).parentId(1L).name("s")
+      .addBinaryAnnotation(BinaryAnnotation.create("f", "", TestObjects.APP_ENDPOINT))
+      .build();
+
+    // sanity check data
+    assertThat(span.timestamp).isNull();
+    assertThat(guessTimestamp(span)).isNull();
+
+    accept(span);
+
+    String today = storage.indexNameFormatter().indexNameForTimestamp(TODAY);
+    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
+      "{\"index\":{\"_index\":\"" + today + "\",\"_type\":\"span\"}}\n",
+      "{\"index\":{\"_index\":\"" + today + "\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
+    );
+  }
+
+  @Test
   public void indexesServiceSpan_explicitTimestamp() throws Exception {
     es.enqueue(new MockResponse());
 
-    Span span = TestObjects.TRACE.get(0);
+    Annotation sr = Annotation.create(
+      (TODAY + 550) * 1000,
+      SERVER_RECV,
+      TestObjects.WEB_ENDPOINT
+    );
+
+    Span span = Span.builder().traceId(10L).id(10L).name("post").addAnnotation(sr).build();
     accept(span);
 
     assertThat(es.takeRequest().getBody().readByteString().utf8()).endsWith(
-        "\"_type\":\"servicespan\",\"_id\":\"web|get\"}}\n"
-            + "{\"serviceName\":\"web\",\"spanName\":\"get\"}\n"
+        "\"_type\":\"servicespan\",\"_id\":\"web|post\"}}\n"
+            + "{\"serviceName\":\"web\",\"spanName\":\"post\"}\n"
     );
   }
 
@@ -135,6 +231,47 @@ public class ElasticsearchHttpSpanConsumerTest {
     assertThat(es.takeRequest().getBody().readByteString().utf8()).endsWith(
       "\"_type\":\"servicespan\",\"_id\":\"web|" + nameEscaped + "\"}}\n"
         + "{\"serviceName\":\"web\",\"spanName\":\"" + nameEscaped + "\"}\n"
+    );
+  }
+
+  @Test
+  public void indexesServiceSpan_multipleServices() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Span span = TestObjects.TRACE.get(1);
+    accept(span);
+
+    assertThat(es.takeRequest().getBody().readByteString().utf8())
+      .contains(
+        "\"_type\":\"servicespan\",\"_id\":\"app|get\"}}\n"
+          + "{\"serviceName\":\"app\",\"spanName\":\"get\"}\n"
+      )
+      .contains(
+        "\"_type\":\"servicespan\",\"_id\":\"db|get\"}}\n"
+          + "{\"serviceName\":\"db\",\"spanName\":\"get\"}\n"
+      )
+      .doesNotContain( // must be already in cache
+        "\"_type\":\"servicespan\",\"_id\":\"web|get\"}}\n"
+          + "{\"serviceName\":\"web\",\"spanName\":\"get\"}\n"
+    );
+  }
+
+  @Test
+  public void indexesServiceSpan_serviceSpanCache() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Annotation sr = Annotation.create(
+      (TODAY + 650) * 1000,
+      SERVER_RECV,
+      TestObjects.WEB_ENDPOINT
+    );
+
+    Span span = Span.builder().traceId(20L).id(20L).name("post").addAnnotation(sr).build();
+    accept(span);
+
+    assertThat(es.takeRequest().getBody().readByteString().utf8()).doesNotContain( // must be already in cache
+      "\"_type\":\"servicespan\",\"_id\":\"web|post\"}}\n"
+        + "{\"serviceName\":\"web\",\"spanName\":\"post\"}\n"
     );
   }
 
@@ -156,114 +293,6 @@ public class ElasticsearchHttpSpanConsumerTest {
     assertThat(es.takeRequest().getBody().readByteString().utf8())
         .contains("{\"timestamp_millis\":1")
         .contains("{\"timestamp_millis\":0");
-  }
-
-  @Test
-  public void indexesServiceSpan_multipleServices() throws Exception {
-    es.enqueue(new MockResponse());
-
-    Span span = TestObjects.TRACE.get(1);
-    accept(span);
-
-    assertThat(es.takeRequest().getBody().readByteString().utf8())
-        .contains(
-            "\"_type\":\"servicespan\",\"_id\":\"app|get\"}}\n"
-                + "{\"serviceName\":\"app\",\"spanName\":\"get\"}\n"
-        )
-        .contains(
-            "\"_type\":\"servicespan\",\"_id\":\"web|get\"}}\n"
-                + "{\"serviceName\":\"web\",\"spanName\":\"get\"}\n"
-        );
-  }
-
-  @Test
-  public void indexesServiceSpan_basedOnGuessTimestamp() throws Exception {
-    es.enqueue(new MockResponse());
-
-    Annotation cs = Annotation.create(
-        TimeUnit.DAYS.toMicros(365), // 1971-01-01
-        CLIENT_SEND,
-        TestObjects.APP_ENDPOINT
-    );
-
-    Span span = Span.builder().traceId(1L).id(1L).name("s").addAnnotation(cs).build();
-
-    // sanity check data
-    assertThat(span.timestamp).isNull();
-    assertThat(guessTimestamp(span)).isNotNull();
-
-    accept(span);
-
-    // index timestamp is the server timestamp, not current time!
-    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
-        "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"span\"}}\n",
-        "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
-    );
-  }
-
-  @Test
-  public void indexesServiceSpan_basedOnAnnotationTimestamp() throws Exception {
-    es.enqueue(new MockResponse());
-
-    Annotation foo = Annotation.create(
-        TimeUnit.DAYS.toMicros(365), // 1971-01-01
-        "foo",
-        TestObjects.APP_ENDPOINT
-    );
-
-    Span span = Span.builder().traceId(1L).id(2L).parentId(1L).name("s").addAnnotation(foo).build();
-
-    // sanity check data
-    assertThat(span.timestamp).isNull();
-    assertThat(guessTimestamp(span)).isNull();
-
-    accept(span);
-
-    // index timestamp is the server timestamp, not current time!
-    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
-        "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"span\"}}\n",
-        "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
-    );
-  }
-
-  @Test
-  public void indexesServiceSpan_currentTimestamp() throws Exception {
-    es.enqueue(new MockResponse());
-
-    Span span = Span.builder().traceId(1L).id(2L).parentId(1L).name("s")
-        .addBinaryAnnotation(BinaryAnnotation.create("f", "", TestObjects.APP_ENDPOINT))
-        .build();
-
-    // sanity check data
-    assertThat(span.timestamp).isNull();
-    assertThat(guessTimestamp(span)).isNull();
-
-    accept(span);
-
-    String today = storage.indexNameFormatter().indexNameForTimestamp(TODAY);
-    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
-        "{\"index\":{\"_index\":\"" + today + "\",\"_type\":\"span\"}}\n",
-        "{\"index\":{\"_index\":\"" + today + "\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
-    );
-  }
-
-  @Test
-  public void addsPipelineId() throws Exception {
-    close();
-
-    storage = ElasticsearchHttpStorage.builder()
-        .hosts(asList(es.url("").toString()))
-        .pipeline("zipkin")
-        .build();
-    ensureIndexTemplate();
-
-    es.enqueue(new MockResponse());
-
-    accept(TestObjects.TRACE.get(0));
-
-    RecordedRequest request = es.takeRequest();
-    assertThat(request.getPath())
-        .isEqualTo("/_bulk?pipeline=zipkin");
   }
 
   void accept(Span ... spans) throws Exception {

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
@@ -57,6 +57,8 @@ public class ElasticsearchHttpSpanConsumerTest {
     storage.ensureIndexTemplate();
     es.takeRequest(); // get version
     es.takeRequest(); // get template
+    // clear servicespan cache in order to prevent tests breaking
+    ((ElasticsearchHttpSpanConsumer)storage.asyncSpanConsumer()).resetIndexToServiceSpansCache();
   }
 
   @After
@@ -110,111 +112,15 @@ public class ElasticsearchHttpSpanConsumerTest {
   }
 
   @Test
-  public void addsPipelineId() throws Exception {
-    close();
-
-    storage = ElasticsearchHttpStorage.builder()
-      .hosts(asList(es.url("").toString()))
-      .pipeline("zipkin")
-      .build();
-    ensureIndexTemplate();
-
-    es.enqueue(new MockResponse());
-
-    accept(TestObjects.TRACE.get(0));
-
-    RecordedRequest request = es.takeRequest();
-    assertThat(request.getPath())
-      .isEqualTo("/_bulk?pipeline=zipkin");
-  }
-
-  @Test
-  public void indexesServiceSpan_basedOnAnnotationTimestamp() throws Exception {
-    es.enqueue(new MockResponse());
-
-    Annotation foo = Annotation.create(
-      TimeUnit.DAYS.toMicros(365), // 1971-01-01
-      "foo",
-      TestObjects.APP_ENDPOINT
-    );
-
-    Span span = Span.builder().traceId(1L).id(2L).parentId(1L).name("s").addAnnotation(foo).build();
-
-    // sanity check data
-    assertThat(span.timestamp).isNull();
-    assertThat(guessTimestamp(span)).isNull();
-
-    accept(span);
-
-    // index timestamp is the server timestamp, not current time!
-    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
-      "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"span\"}}\n",
-      "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
-    );
-  }
-
-  @Test
-  public void indexesServiceSpan_basedOnGuessTimestamp() throws Exception {
-    es.enqueue(new MockResponse());
-
-    Annotation cs = Annotation.create(
-      TimeUnit.DAYS.toMicros(365), // 1971-01-01
-      CLIENT_SEND,
-      TestObjects.APP_ENDPOINT
-    );
-
-    Span span = Span.builder().traceId(1L).id(1L).name("t").addAnnotation(cs).build();
-
-    // sanity check data
-    assertThat(span.timestamp).isNull();
-    assertThat(guessTimestamp(span)).isNotNull();
-
-    accept(span);
-
-    // index timestamp is the server timestamp, not current time!
-    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
-      "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"span\"}}\n",
-      "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"servicespan\",\"_id\":\"app|t\"}}\n"
-    );
-  }
-
-  @Test
-  public void indexesServiceSpan_currentTimestamp() throws Exception {
-    es.enqueue(new MockResponse());
-
-    Span span = Span.builder().traceId(1L).id(2L).parentId(1L).name("s")
-      .addBinaryAnnotation(BinaryAnnotation.create("f", "", TestObjects.APP_ENDPOINT))
-      .build();
-
-    // sanity check data
-    assertThat(span.timestamp).isNull();
-    assertThat(guessTimestamp(span)).isNull();
-
-    accept(span);
-
-    String today = storage.indexNameFormatter().indexNameForTimestamp(TODAY);
-    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
-      "{\"index\":{\"_index\":\"" + today + "\",\"_type\":\"span\"}}\n",
-      "{\"index\":{\"_index\":\"" + today + "\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
-    );
-  }
-
-  @Test
   public void indexesServiceSpan_explicitTimestamp() throws Exception {
     es.enqueue(new MockResponse());
 
-    Annotation sr = Annotation.create(
-      (TODAY + 550) * 1000,
-      SERVER_RECV,
-      TestObjects.WEB_ENDPOINT
-    );
-
-    Span span = Span.builder().traceId(10L).id(10L).name("post").addAnnotation(sr).build();
+    Span span = TestObjects.TRACE.get(0);
     accept(span);
 
     assertThat(es.takeRequest().getBody().readByteString().utf8()).endsWith(
-        "\"_type\":\"servicespan\",\"_id\":\"web|post\"}}\n"
-            + "{\"serviceName\":\"web\",\"spanName\":\"post\"}\n"
+        "\"_type\":\"servicespan\",\"_id\":\"web|get\"}}\n"
+            + "{\"serviceName\":\"web\",\"spanName\":\"get\"}\n"
     );
   }
 
@@ -231,47 +137,6 @@ public class ElasticsearchHttpSpanConsumerTest {
     assertThat(es.takeRequest().getBody().readByteString().utf8()).endsWith(
       "\"_type\":\"servicespan\",\"_id\":\"web|" + nameEscaped + "\"}}\n"
         + "{\"serviceName\":\"web\",\"spanName\":\"" + nameEscaped + "\"}\n"
-    );
-  }
-
-  @Test
-  public void indexesServiceSpan_multipleServices() throws Exception {
-    es.enqueue(new MockResponse());
-
-    Span span = TestObjects.TRACE.get(1);
-    accept(span);
-
-    assertThat(es.takeRequest().getBody().readByteString().utf8())
-      .contains(
-        "\"_type\":\"servicespan\",\"_id\":\"app|get\"}}\n"
-          + "{\"serviceName\":\"app\",\"spanName\":\"get\"}\n"
-      )
-      .contains(
-        "\"_type\":\"servicespan\",\"_id\":\"db|get\"}}\n"
-          + "{\"serviceName\":\"db\",\"spanName\":\"get\"}\n"
-      )
-      .doesNotContain( // must be already in cache
-        "\"_type\":\"servicespan\",\"_id\":\"web|get\"}}\n"
-          + "{\"serviceName\":\"web\",\"spanName\":\"get\"}\n"
-    );
-  }
-
-  @Test
-  public void indexesServiceSpan_serviceSpanCache() throws Exception {
-    es.enqueue(new MockResponse());
-
-    Annotation sr = Annotation.create(
-      (TODAY + 650) * 1000,
-      SERVER_RECV,
-      TestObjects.WEB_ENDPOINT
-    );
-
-    Span span = Span.builder().traceId(20L).id(20L).name("post").addAnnotation(sr).build();
-    accept(span);
-
-    assertThat(es.takeRequest().getBody().readByteString().utf8()).doesNotContain( // must be already in cache
-      "\"_type\":\"servicespan\",\"_id\":\"web|post\"}}\n"
-        + "{\"serviceName\":\"web\",\"spanName\":\"post\"}\n"
     );
   }
 
@@ -293,6 +158,143 @@ public class ElasticsearchHttpSpanConsumerTest {
     assertThat(es.takeRequest().getBody().readByteString().utf8())
         .contains("{\"timestamp_millis\":1")
         .contains("{\"timestamp_millis\":0");
+  }
+
+  @Test
+  public void indexesServiceSpan_multipleServices() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Span span = TestObjects.TRACE.get(1);
+    accept(span);
+
+    assertThat(es.takeRequest().getBody().readByteString().utf8())
+        .contains(
+            "\"_type\":\"servicespan\",\"_id\":\"app|get\"}}\n"
+                + "{\"serviceName\":\"app\",\"spanName\":\"get\"}\n"
+        )
+        .contains(
+            "\"_type\":\"servicespan\",\"_id\":\"web|get\"}}\n"
+                + "{\"serviceName\":\"web\",\"spanName\":\"get\"}\n"
+        );
+  }
+
+  @Test
+  public void indexesServiceSpan_basedOnGuessTimestamp() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Annotation cs = Annotation.create(
+        TimeUnit.DAYS.toMicros(365), // 1971-01-01
+        CLIENT_SEND,
+        TestObjects.APP_ENDPOINT
+    );
+
+    Span span = Span.builder().traceId(1L).id(1L).name("s").addAnnotation(cs).build();
+
+    // sanity check data
+    assertThat(span.timestamp).isNull();
+    assertThat(guessTimestamp(span)).isNotNull();
+
+    accept(span);
+
+    // index timestamp is the server timestamp, not current time!
+    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
+        "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"span\"}}\n",
+        "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
+    );
+  }
+
+  @Test
+  public void indexesServiceSpan_basedOnAnnotationTimestamp() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Annotation foo = Annotation.create(
+        TimeUnit.DAYS.toMicros(365), // 1971-01-01
+        "foo",
+        TestObjects.APP_ENDPOINT
+    );
+
+    Span span = Span.builder().traceId(1L).id(2L).parentId(1L).name("s").addAnnotation(foo).build();
+
+    // sanity check data
+    assertThat(span.timestamp).isNull();
+    assertThat(guessTimestamp(span)).isNull();
+
+    accept(span);
+
+    // index timestamp is the server timestamp, not current time!
+    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
+        "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"span\"}}\n",
+        "{\"index\":{\"_index\":\"zipkin-1971-01-01\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
+    );
+  }
+
+  @Test
+  public void indexesServiceSpan_currentTimestamp() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Span span = Span.builder().traceId(1L).id(2L).parentId(1L).name("s")
+        .addBinaryAnnotation(BinaryAnnotation.create("f", "", TestObjects.APP_ENDPOINT))
+        .build();
+
+    // sanity check data
+    assertThat(span.timestamp).isNull();
+    assertThat(guessTimestamp(span)).isNull();
+
+    accept(span);
+
+    String today = storage.indexNameFormatter().indexNameForTimestamp(TODAY);
+    assertThat(es.takeRequest().getBody().readByteString().utf8()).contains(
+        "{\"index\":{\"_index\":\"" + today + "\",\"_type\":\"span\"}}\n",
+        "{\"index\":{\"_index\":\"" + today + "\",\"_type\":\"servicespan\",\"_id\":\"app|s\"}}\n"
+    );
+  }
+
+  @Test
+  public void addsPipelineId() throws Exception {
+    close();
+
+    storage = ElasticsearchHttpStorage.builder()
+        .hosts(asList(es.url("").toString()))
+        .pipeline("zipkin")
+        .build();
+    ensureIndexTemplate();
+
+    es.enqueue(new MockResponse());
+
+    accept(TestObjects.TRACE.get(0));
+
+    RecordedRequest request = es.takeRequest();
+    assertThat(request.getPath())
+        .isEqualTo("/_bulk?pipeline=zipkin");
+  }
+
+  @Test
+  public void indexesServiceSpanCache() throws Exception {
+    es.enqueue(new MockResponse());
+
+    Span span1 = TestObjects.TRACE.get(0).toBuilder().traceId(10L).build();
+    accept(span1);
+
+    assertThat(es.takeRequest().getBody().readByteString().utf8())
+      .contains(
+        "\"_type\":\"servicespan\",\"_id\":\"web|get\"}}\n"
+          + "{\"serviceName\":\"web\",\"spanName\":\"get\"}\n"
+      );
+
+    es.enqueue(new MockResponse());
+
+    Span span2 = TestObjects.TRACE.get(1).toBuilder().traceId(11L).build();
+    accept(span2);
+
+    assertThat(es.takeRequest().getBody().readByteString().utf8())
+      .contains(
+        "\"_type\":\"servicespan\",\"_id\":\"app|get\"}}\n"
+          + "{\"serviceName\":\"app\",\"spanName\":\"get\"}\n"
+      )
+      .doesNotContain(
+        "\"_type\":\"servicespan\",\"_id\":\"web|get\"}}\n"
+          + "{\"serviceName\":\"web\",\"spanName\":\"get\"}\n"
+      );
   }
 
   void accept(Span ... spans) throws Exception {

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
@@ -14,6 +14,7 @@
 package zipkin.storage.elasticsearch.http;
 
 import java.io.IOException;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -29,6 +30,7 @@ import zipkin.Codec;
 import zipkin.Span;
 import zipkin.TestObjects;
 import zipkin.internal.CallbackCaptor;
+import zipkin.internal.Pair;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -295,6 +297,92 @@ public class ElasticsearchHttpSpanConsumerTest {
         "\"_type\":\"servicespan\",\"_id\":\"web|get\"}}\n"
           + "{\"serviceName\":\"web\",\"spanName\":\"get\"}\n"
       );
+  }
+
+  @Test
+  public void indexesServiceSpanCache_failedConcurrency() throws Exception {
+    final Integer threadCount = 10;
+    List<String> testElemsForCache = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "k", "l");
+    Boolean broken = false;
+    for (int j = 0; j < 10; j++) {
+      List<Thread> getOrSet = new ArrayList<>(threadCount * 2);
+      for (int i = 0; i < threadCount; i++) {
+        getOrSet.add(new Thread(
+          () -> testElemsForCache.forEach(elem ->
+            ElasticsearchHttpSpanConsumer.indexToServiceSpansCache.put(elem,
+              new HashSet<Pair<String>>())
+          )
+        ));
+      }
+      for (int i = 0; i < threadCount; i++) {
+        getOrSet.add(new Thread(
+          () -> testElemsForCache.forEach(elem ->
+            ElasticsearchHttpSpanConsumer.indexToServiceSpansCache.remove(elem)
+          )
+        ));
+      }
+
+      Collections.shuffle(getOrSet);
+      getOrSet.forEach(Thread::start);
+      for (Thread thread : getOrSet) {
+        thread.join();
+      }
+
+      if (ElasticsearchHttpSpanConsumer.indexToServiceSpansCache.keySet().size() != testElemsForCache.size()
+        && ElasticsearchHttpSpanConsumer.indexToServiceSpansCache.keySet().size() != 0) {
+        broken = true;
+      }
+
+      ((ElasticsearchHttpSpanConsumer)storage.asyncSpanConsumer()).resetIndexToServiceSpansCache();
+    }
+    assert(broken);
+  }
+
+  @Test
+  public void indexesServiceSpanCache_failedConcurrencyOnSet() throws Exception {
+    final Integer threadCount = 10;
+    List<String> testElemsForCache = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "k", "l");
+    String key = "A";
+    Boolean broken = false;
+
+    ElasticsearchHttpSpanConsumer.indexToServiceSpansCache.put(key, Collections.newSetFromMap(new LinkedHashMap<Pair<String>, Boolean>() {
+      @Override
+      protected boolean removeEldestEntry(Map.Entry<Pair<String>, Boolean> eldest) {
+        return size() > 5;
+      }
+    }));
+
+    for (int j = 0; j < 10; j++) {
+      List<Thread> getOrSet = new ArrayList<>(threadCount * 2);
+      for (int i = 0; i < threadCount; i++) {
+        getOrSet.add(new Thread(
+          () -> {
+            Set<Pair<String>> serviceSpansEntryCached = ElasticsearchHttpSpanConsumer.indexToServiceSpansCache.get(key);
+            testElemsForCache.forEach(elem -> serviceSpansEntryCached.add(Pair.create(elem, elem)));
+          }
+        ));
+      }
+      for (int i = 0; i < threadCount; i++) {
+        getOrSet.add(new Thread(
+          () -> {
+            Set<Pair<String>> serviceSpansEntryCached = ElasticsearchHttpSpanConsumer.indexToServiceSpansCache.get(key);
+            testElemsForCache.forEach(elem -> serviceSpansEntryCached.remove(Pair.create(elem, elem)));
+          }
+        ));
+      }
+
+      Collections.shuffle(getOrSet);
+      getOrSet.forEach(Thread::start);
+      for (Thread thread : getOrSet) {
+        thread.join();
+      }
+
+      if (ElasticsearchHttpSpanConsumer.indexToServiceSpansCache.get(key).size() != testElemsForCache.size()
+        && ElasticsearchHttpSpanConsumer.indexToServiceSpansCache.get(key).size() != 0) {
+        broken = true;
+      }
+    }
+    assert(broken);
   }
 
   void accept(Span ... spans) throws Exception {

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/InternalForTests.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/InternalForTests.java
@@ -43,6 +43,8 @@ public class InternalForTests {
 
   public static void clear(ElasticsearchHttpStorage es) throws IOException {
     es.clear();
+    // clear servicespan cache in order to prevent tests breaking
+    ((ElasticsearchHttpSpanConsumer)es.asyncSpanConsumer()).resetIndexToServiceSpansCache();
   }
 
   public static void flushOnWrites(ElasticsearchHttpStorage.Builder builder) {

--- a/zipkin/src/test/java/zipkin/TestObjects.java
+++ b/zipkin/src/test/java/zipkin/TestObjects.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -65,6 +65,8 @@ public final class TestObjects {
           .addAnnotation(Annotation.create((TODAY + 100) * 1000, SERVER_RECV, APP_ENDPOINT))
           .addAnnotation(Annotation.create((TODAY + 250) * 1000, SERVER_SEND, APP_ENDPOINT))
           .addAnnotation(Annotation.create((TODAY + 300) * 1000, CLIENT_RECV, WEB_ENDPOINT))
+          .addAnnotation(Annotation.create((TODAY + 350) * 1000, SERVER_SEND, DB_ENDPOINT))
+          .addAnnotation(Annotation.create((TODAY + 400) * 1000, CLIENT_RECV, DB_ENDPOINT))
           .addBinaryAnnotation(BinaryAnnotation.address(CLIENT_ADDR, WEB_ENDPOINT))
           .addBinaryAnnotation(BinaryAnnotation.address(SERVER_ADDR, APP_ENDPOINT))
           .build(),

--- a/zipkin/src/test/java/zipkin/TestObjects.java
+++ b/zipkin/src/test/java/zipkin/TestObjects.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -65,8 +65,6 @@ public final class TestObjects {
           .addAnnotation(Annotation.create((TODAY + 100) * 1000, SERVER_RECV, APP_ENDPOINT))
           .addAnnotation(Annotation.create((TODAY + 250) * 1000, SERVER_SEND, APP_ENDPOINT))
           .addAnnotation(Annotation.create((TODAY + 300) * 1000, CLIENT_RECV, WEB_ENDPOINT))
-          .addAnnotation(Annotation.create((TODAY + 350) * 1000, SERVER_SEND, DB_ENDPOINT))
-          .addAnnotation(Annotation.create((TODAY + 400) * 1000, CLIENT_RECV, DB_ENDPOINT))
           .addBinaryAnnotation(BinaryAnnotation.address(CLIENT_ADDR, WEB_ENDPOINT))
           .addBinaryAnnotation(BinaryAnnotation.address(SERVER_ADDR, APP_ENDPOINT))
           .build(),


### PR DESCRIPTION
Trying to implement cache for servicespans to reduce excessive writes ( https://github.com/openzipkin/zipkin/issues/1570 ).
Cache limited with 2 days and 1000 entries for each day (non-configurable for now).