### PR TITLE
Helps tracers be more safe about IP Addresses

### DIFF
--- a/benchmarks/src/test/java/zipkin/internal/ThriftCodecInteropTest.java
+++ b/benchmarks/src/test/java/zipkin/internal/ThriftCodecInteropTest.java
@@ -37,11 +37,10 @@ public class ThriftCodecInteropTest {
   @Test
   public void spanSerializationIsCompatible() throws UnknownHostException, TException {
 
-    zipkin.Endpoint zipkinEndpoint = zipkin.Endpoint.builder()
-        .serviceName("web")
-        .ipv4(124 << 24 | 13 << 16 | 90 << 8 | 3)
-        .ipv6(Inet6Address.getByName("2001:db8::c001").getAddress())
-        .port((short) 80).build();
+    zipkin.Endpoint.Builder builder = zipkin.Endpoint.builder().serviceName("web").port(80);
+    builder.parseIp("124.13.90.3");
+    builder.parseIp("2001:db8::c001");
+    zipkin.Endpoint zipkinEndpoint = builder.build();
 
     zipkin.Span zipkinSpan = zipkin.Span.builder().traceId(1L).traceIdHigh(2L).id(1L).name("get")
         .addAnnotation(zipkin.Annotation.create(1000, SERVER_RECV, zipkinEndpoint))

--- a/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
@@ -21,8 +21,8 @@ import com.github.kristofa.brave.InheritableServerClientAndLocalSpanState;
 import com.github.kristofa.brave.ServerClientAndLocalSpanState;
 import com.github.kristofa.brave.TracerAdapter;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -63,17 +63,12 @@ public class BraveConfiguration {
         .serviceName("zipkin-server")
         .port(port == -1 ? 0 : port);
     try {
-      byte[] address = Collections.list(NetworkInterface.getNetworkInterfaces()).stream()
+      InetAddress address = Collections.list(NetworkInterface.getNetworkInterfaces()).stream()
           .flatMap(i -> Collections.list(i.getInetAddresses()).stream())
           .filter(ip -> ip.isSiteLocalAddress())
-          .findAny().get().getAddress();
-      if (address.length == 4) {
-        builder.ipv4(ByteBuffer.wrap(address).getInt());
-      } else if (address.length == 16) {
-        builder.ipv6(address);
-      }
+          .findAny().get();
+      builder.parseIp(address);
     } catch (Exception ignored) {
-      builder.ipv4(127 << 24 | 1);
     }
     return builder.build();
   }

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Schema.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Schema.java
@@ -231,14 +231,9 @@ final class Schema {
     }
 
     private Endpoint toEndpoint() {
-      Endpoint.Builder builder = Endpoint.builder()
-          .serviceName(service_name)
-          .ipv4(ipv4 == null ? 0 : ByteBuffer.wrap(ipv4.getAddress()).getInt())
-          .port(port);
-
-      if (null != ipv6) {
-        builder = builder.ipv6(ipv6.getAddress());
-      }
+      Endpoint.Builder builder = Endpoint.builder().serviceName(service_name).port(port);
+      builder.parseIp(ipv4);
+      builder.parseIp(ipv6);
       return builder.build();
     }
   }

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/JsonAdapters.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/JsonAdapters.java
@@ -18,7 +18,6 @@ import com.squareup.moshi.JsonDataException;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
-import java.net.InetAddress;
 import okio.Buffer;
 import okio.ByteString;
 import zipkin.Annotation;
@@ -142,18 +141,8 @@ final class JsonAdapters {
             result.serviceName(reader.nextString());
             break;
           case "ipv4":
-            String[] ipv4String = reader.nextString().split("\\.", 5);
-            int ipv4 = 0;
-            for (String b : ipv4String) {
-              ipv4 = ipv4 << 8 | (Integer.parseInt(b) & 0xff);
-            }
-            result.ipv4(ipv4);
-            break;
           case "ipv6":
-            String input = reader.nextString();
-            // Shouldn't hit DNS, because it's an IP string literal.
-            byte[] ipv6 = InetAddress.getByName(input).getAddress();
-            result.ipv6(ipv6);
+            result.parseIp(reader.nextString());
             break;
           case "port":
             result.port(reader.nextInt());

--- a/zipkin/src/main/java/zipkin/internal/InetAddresses.java
+++ b/zipkin/src/main/java/zipkin/internal/InetAddresses.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+
+/** Utilities for working with IP Addresses. */
+public final class InetAddresses {
+
+  //** Start code from Guava v20 **//
+  private static final int IPV4_PART_COUNT = 4;
+  private static final int IPV6_PART_COUNT = 8;
+
+  /**
+   * Returns the {@link InetAddress#getAddress()} having the given string representation or null if
+   * unable to parse.
+   *
+   * <p>This deliberately avoids all nameservice lookups (e.g. no DNS).
+   *
+   * <p>This is the same as com.google.common.net.InetAddresses.ipStringToBytes(), except internally
+   * Splitter isn't used (as that would introduce more dependencies).
+   *
+   * @param ipString {@code String} containing an IPv4 or IPv6 string literal, e.g. {@code
+   * "192.168.0.1"} or {@code "2001:db8::1"}
+   */
+  @Nullable
+  public static byte[] ipStringToBytes(String ipString) {
+    // PATCHED! adding null/empty escape
+    if (ipString == null || ipString.isEmpty()) return null;
+    // Make a first pass to categorize the characters in this string.
+    boolean hasColon = false;
+    boolean hasDot = false;
+    for (int i = 0; i < ipString.length(); i++) {
+      char c = ipString.charAt(i);
+      if (c == '.') {
+        hasDot = true;
+      } else if (c == ':') {
+        if (hasDot) {
+          return null; // Colons must not appear after dots.
+        }
+        hasColon = true;
+      } else if (Character.digit(c, 16) == -1) {
+        return null; // Everything else must be a decimal or hex digit.
+      }
+    }
+
+    // Now decide which address family to parse.
+    if (hasColon) {
+      if (hasDot) {
+        ipString = convertDottedQuadToHex(ipString);
+        if (ipString == null) {
+          return null;
+        }
+      }
+      return textToNumericFormatV6(ipString);
+    } else if (hasDot) {
+      return textToNumericFormatV4(ipString);
+    }
+    return null;
+  }
+
+  @Nullable
+  private static byte[] textToNumericFormatV4(String ipString) {
+    byte[] bytes = new byte[IPV4_PART_COUNT];
+    int i = 0;
+    try {
+      // PATCHED! for (String octet : IPV4_SPLITTER.split(ipString)) {
+      for (String octet : ipString.split("\\.", 5)) {
+        bytes[i++] = parseOctet(octet);
+      }
+    } catch (NumberFormatException ex) {
+      return null;
+    }
+
+    return i == IPV4_PART_COUNT ? bytes : null;
+  }
+
+  @Nullable
+  private static byte[] textToNumericFormatV6(String ipString) {
+    // An address can have [2..8] colons, and N colons make N+1 parts.
+    String[] parts = ipString.split(":", IPV6_PART_COUNT + 2);
+    if (parts.length < 3 || parts.length > IPV6_PART_COUNT + 1) {
+      return null;
+    }
+
+    // Disregarding the endpoints, find "::" with nothing in between.
+    // This indicates that a run of zeroes has been skipped.
+    int skipIndex = -1;
+    for (int i = 1; i < parts.length - 1; i++) {
+      if (parts[i].length() == 0) {
+        if (skipIndex >= 0) {
+          return null; // Can't have more than one ::
+        }
+        skipIndex = i;
+      }
+    }
+
+    int partsHi; // Number of parts to copy from above/before the "::"
+    int partsLo; // Number of parts to copy from below/after the "::"
+    if (skipIndex >= 0) {
+      // If we found a "::", then check if it also covers the endpoints.
+      partsHi = skipIndex;
+      partsLo = parts.length - skipIndex - 1;
+      if (parts[0].length() == 0 && --partsHi != 0) {
+        return null; // ^: requires ^::
+      }
+      if (parts[parts.length - 1].length() == 0 && --partsLo != 0) {
+        return null; // :$ requires ::$
+      }
+    } else {
+      // Otherwise, allocate the entire address to partsHi. The endpoints
+      // could still be empty, but parseHextet() will check for that.
+      partsHi = parts.length;
+      partsLo = 0;
+    }
+
+    // If we found a ::, then we must have skipped at least one part.
+    // Otherwise, we must have exactly the right number of parts.
+    int partsSkipped = IPV6_PART_COUNT - (partsHi + partsLo);
+    if (!(skipIndex >= 0 ? partsSkipped >= 1 : partsSkipped == 0)) {
+      return null;
+    }
+
+    // Now parse the hextets into a byte array.
+    ByteBuffer rawBytes = ByteBuffer.allocate(2 * IPV6_PART_COUNT);
+    try {
+      for (int i = 0; i < partsHi; i++) {
+        rawBytes.putShort(parseHextet(parts[i]));
+      }
+      for (int i = 0; i < partsSkipped; i++) {
+        rawBytes.putShort((short) 0);
+      }
+      for (int i = partsLo; i > 0; i--) {
+        rawBytes.putShort(parseHextet(parts[parts.length - i]));
+      }
+    } catch (NumberFormatException ex) {
+      return null;
+    }
+    return rawBytes.array();
+  }
+
+  @Nullable
+  private static String convertDottedQuadToHex(String ipString) {
+    int lastColon = ipString.lastIndexOf(':');
+    String initialPart = ipString.substring(0, lastColon + 1);
+    String dottedQuad = ipString.substring(lastColon + 1);
+    byte[] quad = textToNumericFormatV4(dottedQuad);
+    if (quad == null) {
+      return null;
+    }
+    String penultimate = Integer.toHexString(((quad[0] & 0xff) << 8) | (quad[1] & 0xff));
+    String ultimate = Integer.toHexString(((quad[2] & 0xff) << 8) | (quad[3] & 0xff));
+    return initialPart + penultimate + ":" + ultimate;
+  }
+
+  private static byte parseOctet(String ipPart) {
+    // Note: we already verified that this string contains only hex digits.
+    int octet = Integer.parseInt(ipPart);
+    // Disallow leading zeroes, because no clear standard exists on
+    // whether these should be interpreted as decimal or octal.
+    if (octet > 255 || (ipPart.startsWith("0") && ipPart.length() > 1)) {
+      throw new NumberFormatException();
+    }
+    return (byte) octet;
+  }
+
+  private static short parseHextet(String ipPart) {
+    // Note: we already verified that this string contains only hex digits.
+    int hextet = Integer.parseInt(ipPart, 16);
+    if (hextet > 0xffff) {
+      throw new NumberFormatException();
+    }
+    return (short) hextet;
+  }
+  //** End code from Guava v20 **//
+
+  InetAddresses() {
+  }
+}


### PR DESCRIPTION
Before, tracers including Brave and Finagle blindly assumed addresses
and strings were IPv4. While that's usually the case, it can lead to
very late problems, such as runtime exceptions.

This adds a utility to encourage safe parsing practice of potentially
null inputs. By re-using code from guava, we can safely parse IP
literals as well, avoiding troublesome IP from name service lookups.

Ex. if your input is an `HttpServletRequest`, the following is safe:
```java
if (!builder.parseIp(input.getHeader("X-Forwarded-For"))) {
  builder.parseIp(input.getRemoteAddr());
}
```