### PR TITLE
Breaking test for trace search in ES.

### DIFF
--- a/benchmarks/src/test/java/zipkin/internal/ThriftCodecInteropTest.java
+++ b/benchmarks/src/test/java/zipkin/internal/ThriftCodecInteropTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -389,7 +389,7 @@ final class CassandraSpanStore implements GuavaSpanStore {
   }
 
   ListenableFuture<Map<TraceIdUDT, Long>> getTraceIdsByServiceNames(QueryRequest request) {
-    long oldestData = indexTtl == 0 ? 0 : (System.currentTimeMillis() - indexTtl * 1000);
+    long oldestData = Math.max(System.currentTimeMillis() - indexTtl * 1000, 0); // >= 1970
     long startTsMillis = Math.max((request.endTs - request.lookback), oldestData);
     long endTsMillis = Math.max(request.endTs, oldestData);
 
@@ -456,7 +456,7 @@ final class CassandraSpanStore implements GuavaSpanStore {
       long endTsMillis,
       long lookbackMillis,
       int limit) {
-    long oldestData = traceTtl == 0 ? 0 : (System.currentTimeMillis() - traceTtl * 1000);
+    long oldestData = Math.max(System.currentTimeMillis() - indexTtl * 1000, 0); // >= 1970
     long startTsMillis = Math.max((endTsMillis - lookbackMillis), oldestData);
     endTsMillis = Math.max(endTsMillis, oldestData);
 

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Schema.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/Schema.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/integration/ElasticsearchHttpSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/integration/ElasticsearchHttpSpanConsumerTest.java
@@ -16,7 +16,6 @@ package zipkin.storage.elasticsearch.http.integration;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 import java.util.TimeZone;
 import okhttp3.Call;
 import okhttp3.HttpUrl;
@@ -25,17 +24,16 @@ import okhttp3.Request;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin.Annotation;
-import zipkin.Endpoint;
 import zipkin.Span;
 import zipkin.internal.CallbackCaptor;
 import zipkin.internal.Util;
-import zipkin.storage.QueryRequest;
 import zipkin.storage.elasticsearch.http.ElasticsearchHttpStorage;
 import zipkin.storage.elasticsearch.http.InternalForTests;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static zipkin.Constants.*;
+import static zipkin.Constants.SERVER_RECV;
+import static zipkin.Constants.SERVER_SEND;
 import static zipkin.TestObjects.DAY;
 import static zipkin.TestObjects.TODAY;
 import static zipkin.TestObjects.WEB_ENDPOINT;
@@ -151,28 +149,6 @@ abstract class ElasticsearchHttpSpanConsumerTest {
 
     assertThat(searchRequest.execute().body().string())
         .contains("\"hits\":{\"total\":1");
-  }
-  
-  @Test
-  public void traceIsSearchableBySRServiceName() throws Exception {
-    String clientServiceName = "public-webserver";
-    Span clientSpan = Span.builder().traceId(20L).id(22L).name("get").parentId(21L).timestamp(TODAY * 1000)
-            .addAnnotation(Annotation.create(TODAY * 1000, CLIENT_SEND, Endpoint.create(clientServiceName, 123456)))
-            .addAnnotation(Annotation.create((TODAY + 3) * 1000, CLIENT_RECV, Endpoint.create(clientServiceName, 123456)))
-            .build();
-
-    String serverServiceName = "petshop-service";
-    Span serverSpan = Span.builder().traceId(20L).id(22L).name("get").parentId(21L)
-            .addAnnotation(Annotation.create((TODAY + 1) * 1000, SERVER_RECV, Endpoint.create(serverServiceName, 654321)))
-            .addAnnotation(Annotation.create((TODAY + 2) * 1000, SERVER_RECV, Endpoint.create(serverServiceName, 654321)))
-            .build();
-
-    accept(serverSpan);
-    accept(clientSpan);
-
-    List<List<Span>> traces = storage().spanStore().getTraces(QueryRequest.builder().serviceName(serverServiceName).build());
-
-    assertThat(traces.size()).isEqualTo(1);
   }
 
   abstract String baseUrl();

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/integration/ElasticsearchHttpSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/integration/ElasticsearchHttpSpanConsumerTest.java
@@ -16,6 +16,7 @@ package zipkin.storage.elasticsearch.http.integration;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.TimeZone;
 import okhttp3.Call;
 import okhttp3.HttpUrl;
@@ -24,16 +25,17 @@ import okhttp3.Request;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin.Annotation;
+import zipkin.Endpoint;
 import zipkin.Span;
 import zipkin.internal.CallbackCaptor;
 import zipkin.internal.Util;
+import zipkin.storage.QueryRequest;
 import zipkin.storage.elasticsearch.http.ElasticsearchHttpStorage;
 import zipkin.storage.elasticsearch.http.InternalForTests;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static zipkin.Constants.SERVER_RECV;
-import static zipkin.Constants.SERVER_SEND;
+import static zipkin.Constants.*;
 import static zipkin.TestObjects.DAY;
 import static zipkin.TestObjects.TODAY;
 import static zipkin.TestObjects.WEB_ENDPOINT;
@@ -149,6 +151,28 @@ abstract class ElasticsearchHttpSpanConsumerTest {
 
     assertThat(searchRequest.execute().body().string())
         .contains("\"hits\":{\"total\":1");
+  }
+  
+  @Test
+  public void traceIsSearchableBySRServiceName() throws Exception {
+    String clientServiceName = "public-webserver";
+    Span clientSpan = Span.builder().traceId(20L).id(22L).name("get").parentId(21L).timestamp(TODAY * 1000)
+            .addAnnotation(Annotation.create(TODAY * 1000, CLIENT_SEND, Endpoint.create(clientServiceName, 123456)))
+            .addAnnotation(Annotation.create((TODAY + 3) * 1000, CLIENT_RECV, Endpoint.create(clientServiceName, 123456)))
+            .build();
+
+    String serverServiceName = "petshop-service";
+    Span serverSpan = Span.builder().traceId(20L).id(22L).name("get").parentId(21L)
+            .addAnnotation(Annotation.create((TODAY + 1) * 1000, SERVER_RECV, Endpoint.create(serverServiceName, 654321)))
+            .addAnnotation(Annotation.create((TODAY + 2) * 1000, SERVER_RECV, Endpoint.create(serverServiceName, 654321)))
+            .build();
+
+    accept(serverSpan);
+    accept(clientSpan);
+
+    List<List<Span>> traces = storage().spanStore().getTraces(QueryRequest.builder().serviceName(serverServiceName).build());
+
+    assertThat(traces.size()).isEqualTo(1);
   }
 
   abstract String baseUrl();

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanConsumer.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanConsumer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,12 +27,11 @@ import org.jooq.Record;
 import org.jooq.TableField;
 import zipkin.Annotation;
 import zipkin.BinaryAnnotation;
-import zipkin.Constants;
 import zipkin.Span;
-import zipkin.internal.Lazy;
 import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.StorageAdapters;
 
+import static zipkin.internal.ApplyTimestampAndDuration.authoritativeTimestamp;
 import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
 import static zipkin.storage.mysql.internal.generated.tables.ZipkinAnnotations.ZIPKIN_ANNOTATIONS;
 import static zipkin.storage.mysql.internal.generated.tables.ZipkinSpans.ZIPKIN_SPANS;
@@ -136,17 +135,5 @@ final class MySQLSpanConsumer implements StorageAdapters.SpanConsumer {
     } catch (SQLException e) {
       throw new RuntimeException(e); // TODO
     }
-  }
-
-  /** When performing updates, don't overwrite an authoritative timestamp with a guess! */
-  static Long authoritativeTimestamp(Span span) {
-    if (span.timestamp != null) return span.timestamp;
-    for (int i = 0, length = span.annotations.size(); i < length; i++) {
-      Annotation a = span.annotations.get(i);
-      if (a.value.equals(Constants.CLIENT_SEND)) {
-        return a.timestamp;
-      }
-    }
-    return null;
   }
 }

--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -84,7 +84,8 @@ public final class Util {
 
   public static List<Date> getDays(long endTs, @Nullable Long lookback) {
     long to = midnightUTC(endTs);
-    long from = midnightUTC(endTs - (lookback != null ? lookback : endTs));
+    long startMillis = endTs - (lookback != null ? lookback : endTs);
+    long from = startMillis <= 0 ? 0 : midnightUTC(startMillis); // >= 1970
 
     List<Date> days = new ArrayList<>();
     for (long time = from; time <= to; time += TimeUnit.DAYS.toMillis(1)) {

--- a/zipkin/src/test/java/zipkin/internal/UtilTest.java
+++ b/zipkin/src/test/java/zipkin/internal/UtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.TimeZone;
 import org.junit.Test;
 
+import static java.util.concurrent.TimeUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.junit.Assert.assertFalse;
@@ -51,6 +52,19 @@ public class UtilTest {
 
     assertThat(iso8601.format(new Date(midnight)))
         .isEqualTo("2011-04-15T00:00:00Z");
+  }
+
+  @Test
+  public void getDays() throws ParseException {
+    assertThat(Util.getDays(DAYS.toMillis(2), DAYS.toMillis(1)))
+        .containsExactly(new Date(DAYS.toMillis(1)), new Date(DAYS.toMillis(2)));
+  }
+
+  /** Looking back earlier than 1970 is likely a bug */
+  @Test
+  public void getDays_doesntLookEarlierThan1970() throws ParseException {
+    assertThat(Util.getDays(DAYS.toMillis(2), DAYS.toMillis(3)))
+        .containsExactly(new Date(0), new Date(DAYS.toMillis(1)), new Date(DAYS.toMillis(2)));
   }
 
   @Test


### PR DESCRIPTION
The Elastic Search implementation should be able to search traces
by serviceName of the server, when the server is not also a client
of another service.

For @adriancole