### PR TITLE
Enables search by binary annotation aka tag key

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package zipkin.storage.cassandra;
 
 import com.datastax.driver.core.BoundStatement;
@@ -86,6 +85,7 @@ final class CassandraUtil {
         String value = new String(b.value, UTF_8);
         if (value.length() > LONGEST_VALUE_TO_INDEX) continue;
 
+        annotationKeys.add(b.endpoint.serviceName + ":" + b.key);
         annotationKeys.add(b.endpoint.serviceName + ":" + b.key + ":" + new String(b.value, UTF_8));
       }
     }

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -92,6 +92,6 @@ public class CassandraUtilTest {
     )).build();
 
     assertThat(CassandraUtil.annotationKeys(span))
-        .containsOnly("web:aws.arn:" + arn);
+        .containsOnly("web:aws.arn", "web:aws.arn:" + arn);
   }
 }

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraUtil.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package zipkin.storage.cassandra3;
 
 import com.datastax.driver.core.BoundStatement;
@@ -94,6 +93,8 @@ final class CassandraUtil {
       String value = new String(b.value, UTF_8);
       if (value.length() > LONGEST_VALUE_TO_INDEX) continue;
 
+      // Using colon to allow allow annotation query search to work on key
+      annotationKeys.add(b.endpoint.serviceName + ":" + b.key);
       annotationKeys.add(b.endpoint.serviceName + ";" + b.key + ";" + new String(b.value, UTF_8));
     }
     return annotationKeys;

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
@@ -95,6 +95,6 @@ public class CassandraUtilTest {
     )).build();
 
     assertThat(CassandraUtil.annotationKeys(span))
-        .containsOnly("web;aws.arn;" + arn);
+        .containsOnly("web:aws.arn", "web;aws.arn;" + arn);
   }
 }

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStore.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStore.java
@@ -74,13 +74,17 @@ final class ElasticsearchHttpSpanStore implements AsyncSpanStore {
     }
 
     for (String annotation : request.annotations) {
-      Map<String, String> nestedTerms = new LinkedHashMap<>();
-      nestedTerms.put("annotations.value", annotation);
+      Map<String, String> annotationValues = new LinkedHashMap<>();
+      annotationValues.put("annotations.value", annotation);
+      Map<String, String> binaryAnnotationKeys = new LinkedHashMap<>();
+      binaryAnnotationKeys.put("binaryAnnotations.key", annotation);
       if (request.serviceName != null) {
-        nestedTerms.put("annotations.endpoint.serviceName", request.serviceName);
+        annotationValues.put("annotations.endpoint.serviceName", request.serviceName);
+        binaryAnnotationKeys.put("binaryAnnotations.endpoint.serviceName", request.serviceName);
       }
-      filters.addNestedTerms(nestedTerms);
+      filters.addNestedTerms(annotationValues, binaryAnnotationKeys);
     }
+
     for (Map.Entry<String, String> kv : request.binaryAnnotations.entrySet()) {
       // In our index template, we make sure the binaryAnnotation value is indexed as string,
       // meaning non-string values won't even be indexed at all. This means that we can only

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanStore.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -99,7 +99,6 @@ final class MySQLSpanStore implements SpanStore {
       ZipkinAnnotations aTable = ZIPKIN_ANNOTATIONS.as("a" + i++);
       table = maybeOnService(table.join(aTable)
           .on(schema.joinCondition(aTable))
-          .and(aTable.A_TYPE.eq(-1))
           .and(aTable.A_KEY.eq(key)), aTable, request.serviceName);
     }
 

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -40,7 +40,7 @@
     </button>
 
     <div class="clearfix"></div>
-    <input type="text" class="form-control input-sm" id="annotationQuery" name="annotationQuery" value="{{annotationQuery}}" style="width: 100%" placeholder='Annotations Query (e.g. "finagle.timeout", "http.path=/foo/bar/ and cluster=foo and cache.miss")'>
+    <input type="text" class="form-control input-sm" id="annotationQuery" name="annotationQuery" value="{{annotationQuery}}" style="width: 100%" placeholder='Annotations Query (e.g. "finagle.timeout", "error", "http.path=/foo/bar/ and cluster=foo and cache.miss")'>
   </form>
   <div id="trace-filters">
     <div class="pull-left">

--- a/zipkin/src/main/java/zipkin/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin/storage/QueryRequest.java
@@ -56,7 +56,8 @@ public final class QueryRequest {
   public final String spanName;
 
   /**
-   * Include traces whose {@link zipkin.Span#annotations} include a value in this set.
+   * Include traces whose {@link zipkin.Span#annotations} include a value in this set, or where
+   * {@link zipkin.Span#binaryAnnotations} include a String whose key is in this set.
    *
    * <p> This is an AND condition against the set, as well against {@link #binaryAnnotations}
    */
@@ -232,7 +233,8 @@ public final class QueryRequest {
             addAnnotation(ann);
           } else {
             String[] keyValue = ann.split("=");
-            addBinaryAnnotation(ann.substring(0, idx), keyValue.length < 2 ? "" : ann.substring(idx+1));
+            addBinaryAnnotation(ann.substring(0, idx),
+                keyValue.length < 2 ? "" : ann.substring(idx + 1));
           }
         }
       }
@@ -389,6 +391,9 @@ public final class QueryRequest {
             b.type == BinaryAnnotation.Type.STRING &&
             new String(b.value, UTF_8).equals(binaryAnnotationsToMatch.get(b.key))) {
           binaryAnnotationsToMatch.remove(b.key);
+        }
+        if (appliesToServiceName(b.endpoint, serviceName)) {
+          annotationsToMatch.remove(b.key);
         }
         if (b.endpoint != null) {
           serviceNames.add(b.endpoint.serviceName);

--- a/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin/storage/QueryRequestTest.java
@@ -126,8 +126,8 @@ public class QueryRequestTest {
   public void annotationQuery_complexValue() {
     String annotationQuery = "http.method=GET=1 and error";
 
-    QueryRequest request =
-        QueryRequest.builder().serviceName("security-service").parseAnnotationQuery(annotationQuery).build();
+    QueryRequest request = QueryRequest.builder().serviceName("security-service")
+        .parseAnnotationQuery(annotationQuery).build();
     
     assertThat(request.binaryAnnotations)
         .containsEntry(HTTP_METHOD, "GET=1")

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -495,6 +495,10 @@ public abstract class SpanStoreTest {
 
     assertThat(store().getTraces(QueryRequest.builder().serviceName("service").addAnnotation("foo").addAnnotation("bar").addBinaryAnnotation("baz", "qux").build()))
         .containsExactly(asList(barAndFooAndBazAndQux));
+
+    // ensure we can search only by tag/binaryAnnotation key
+    assertThat(store().getTraces(QueryRequest.builder().serviceName("service").addAnnotation("baz").build()))
+        .containsExactly(asList(barAndFooAndBazAndQux), asList(fooAndBazAndQux));
   }
 
   /**
@@ -539,13 +543,13 @@ public abstract class SpanStoreTest {
     assertThat(store().getTraces(QueryRequest.builder().serviceName("web").addAnnotation("app").build()))
         .isEmpty();
 
-    // Binary annotations are not returned for annotation queries
+    // Binary annotations are returned for annotation queries
     assertThat(store().getTraces(QueryRequest.builder().serviceName("web").addAnnotation("web-b").build()))
-        .isEmpty();
+        .containsExactly(asList(trace1));
     assertThat(store().getTraces(QueryRequest.builder().serviceName("app").addAnnotation("web-b").build()))
         .isEmpty();
     assertThat(store().getTraces(QueryRequest.builder().serviceName("app").addAnnotation("app-b").build()))
-        .isEmpty();
+        .containsExactly(asList(trace2));
     assertThat(store().getTraces(QueryRequest.builder().serviceName("web").addAnnotation("app-b").build()))
         .isEmpty();
 


### PR DESCRIPTION
I believe we once were able to search by presence of a tag key. Ex
"http.method" would return any traces that included any http request.
Somewhere along the way this stopped working. This resurrects the
feature along with tests. Here's the impact:

* Cassandra will index a bit more: once per unique service/tag key
* Elasticsearch now does two nested queries when looking for a key
* MySQL now considers all annotation rows when looking for a key

I think the value is greater than the impact as this is intuitive and
answers a functionality many expect to "just work".