### PR TITLE
bootstrap styles for 'pre' doesn't break long lines with many words

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -32,7 +32,7 @@ export function formatAnnotationValue(value) {
 export function formatBinaryAnnotationValue(value) {
   const type = $.type(value);
   if (type === 'object' || type === 'array' || value == null) {
-    return `<pre>${JSON.stringify(value, null, 2)}</pre>`;
+    return `<pre><code>${JSON.stringify(value, null, 2)}</code></pre>`;
   }
   const result = value.toString();
   // Preformat if the text includes newlines


### PR DESCRIPTION
Zipkin wraps text in 'pre' tag if it has new line symbols (zipkin-ui/js/component_ui/spanPanel.js:39), but bootstrap styles for 'pre' are not correct (please see http://code.rohitink.com/2015/05/17/solution-tag-bootstrap-breaking-every-word/).

It can be fixed by 1) overriding bootstrap styles for 'pre' or 2) creating additional css class or 3) wrapping a text in <pre><code>text</code></pre> (Bootstrap styles for 'pre code' are correct). 

I prefer the third way.