### PR TITLE
Allows collector-only servers to disable the UI and query apis

### DIFF
--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnResource;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -59,6 +60,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
  */
 @Configuration
 @EnableConfigurationProperties(ZipkinUiProperties.class)
+@ConditionalOnProperty(value = "zipkin.ui.enabled", havingValue = "true", matchIfMissing = true)
 @RestController
 public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
 

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -60,7 +60,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
  */
 @Configuration
 @EnableConfigurationProperties(ZipkinUiProperties.class)
-@ConditionalOnProperty(value = "zipkin.ui.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = "zipkin.ui.enabled", matchIfMissing = true)
 @RestController
 public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
 

--- a/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,8 @@ package zipkin.autoconfigure.ui;
 
 import org.junit.After;
 import org.junit.Test;
-import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,6 +71,13 @@ public class ZipkinUiAutoConfigurationTest {
     context = createContext();
 
     assertThat(context.getBean(ZipkinUiProperties.class).getLogsUrl()).isNull();
+  }
+
+  @Test(expected = NoSuchBeanDefinitionException.class)
+  public void canOverridesProperty_disable() {
+    context = createContextWithOverridenProperty("zipkin.ui.enabled:false");
+
+    context.getBean(ZipkinUiProperties.class);
   }
 
   private static AnnotationConfigApplicationContext createContext() {

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -110,6 +110,7 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
 [yaml configuration](src/main/resources/zipkin-server-shared.yml) binds the following environment variables from zipkin-scala:
 
     * `QUERY_PORT`: Listen port for the http api and web ui; Defaults to 9411
+    * `QUERY_ENABLED`: False disables the query api and UI assets; Defaults to true
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
     * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 24 hours (two daily buckets: one for today and one for yesterday)
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -110,7 +110,7 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
 [yaml configuration](src/main/resources/zipkin-server-shared.yml) binds the following environment variables from zipkin-scala:
 
     * `QUERY_PORT`: Listen port for the http api and web ui; Defaults to 9411
-    * `QUERY_ENABLED`: False disables the query api and UI assets; Defaults to true
+    * `QUERY_ENABLED`: `false` disables the query api and UI assets; Defaults to true
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
     * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 24 hours (two daily buckets: one for today and one for yesterday)
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -46,6 +47,7 @@ import static zipkin.internal.Util.lowerHexToUnsignedLong;
 @RestController
 @RequestMapping("/api/v1")
 @CrossOrigin("${zipkin.query.allowed-origins:*}")
+@ConditionalOnProperty(value = "zipkin.query.enabled", havingValue = "true", matchIfMissing = true)
 public class ZipkinQueryApiV1 {
 
   @Autowired

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
@@ -47,7 +47,7 @@ import static zipkin.internal.Util.lowerHexToUnsignedLong;
 @RestController
 @RequestMapping("/api/v1")
 @CrossOrigin("${zipkin.query.allowed-origins:*}")
-@ConditionalOnProperty(value = "zipkin.query.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = "zipkin.query.enabled", matchIfMissing = true)
 public class ZipkinQueryApiV1 {
 
   @Autowired

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -25,6 +25,7 @@ zipkin:
       category: zipkin
       port: ${COLLECTOR_PORT:9410}
   query:
+    enabled: ${QUERY_ENABLED:true}
     # 1 day in millis
     lookback: ${QUERY_LOOKBACK:86400000}
     # The Cache-Control max-age (seconds) for /api/v1/services and /api/v1/spans
@@ -100,6 +101,7 @@ zipkin:
       max-active: ${MYSQL_MAX_CONNECTIONS:10}
       use-ssl: ${MYSQL_USE_SSL:false}
   ui:
+    enabled: ${QUERY_ENABLED:true}
     ## Values below here are mapped to ZipkinUiProperties, served as /config.json
     # Default limit for Find Traces
     query-limit: 10

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerCORSTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerCORSTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = ZipkinServer.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@TestPropertySource(properties = {"zipkin.storage.type=mem", "spring.config.name=zipkin-server", "zipkin.collector.scribe.enabled=false", "zipkin.query.allowed-origins=foo.example.com"})
+@TestPropertySource(properties = {"zipkin.storage.type=mem", "spring.config.name=zipkin-server", "zipkin.query.allowed-origins=foo.example.com"})
 public class ZipkinServerCORSTest {
 
   @Autowired

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerConfigurationTest.java
@@ -22,7 +22,7 @@ import org.springframework.boot.actuate.health.OrderedHealthAggregator;
 import org.springframework.boot.actuate.metrics.Metric;
 import org.springframework.boot.actuate.metrics.buffer.CounterBuffers;
 import org.springframework.boot.actuate.metrics.buffer.GaugeBuffers;
-import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerQueryDisabledTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerQueryDisabledTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.ConfigurableWebApplicationContext;
+import zipkin.autoconfigure.ui.ZipkinUiAutoConfiguration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Collector-only builds should be able to disable the query (and indirectly the UI), so that
+ * associated assets 404 vs throw exceptions.
+ */
+@SpringBootTest(classes = ZipkinServer.class, properties = {
+    "zipkin.storage.type=mem",
+    "spring.config.name=zipkin-server",
+    "zipkin.query.enabled=false",
+    "zipkin.ui.enabled=false"
+})
+@RunWith(SpringRunner.class)
+public class ZipkinServerQueryDisabledTest {
+
+  @Autowired ConfigurableWebApplicationContext context;
+
+  @Test(expected = NoSuchBeanDefinitionException.class)
+  public void disabledQueryBean() throws Exception {
+    context.getBean(ZipkinQueryApiV1.class);
+  }
+
+  @Test(expected = NoSuchBeanDefinitionException.class)
+  public void disabledUiBean() throws Exception {
+    context.getBean(ZipkinUiAutoConfiguration.class);
+  }
+
+  @Test public void queryRelatedEndpoints404() throws Exception {
+    MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build();
+    mockMvc.perform(get("/api/v1/traces"))
+        .andExpect(status().isNotFound());
+    mockMvc.perform(get("/index.html"))
+        .andExpect(status().isNotFound());
+
+    // but other endpoints are ok
+    mockMvc.perform(get("/health"))
+        .andExpect(status().isOk());
+  }
+}

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerSelfTracingTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerSelfTracingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,8 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = ZipkinServer.class, properties = {
     "zipkin.storage.type=mem",
     "spring.config.name=zipkin-server",
-    "zipkin.self-tracing.enabled=true",
-    "zipkin.collector.scribe.enabled=false"
+    "zipkin.self-tracing.enabled=true"
 })
 @RunWith(SpringRunner.class)
 public class ZipkinServerSelfTracingTest {

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/CassandraUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
This adds the ability to set `QUERY_ENABLED=false` for reasons including
security policy.

Fixes #1591