### PR TITLE
Adds the ability to log http requests sent to Elasticsearch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <brave.version>4.1.1</brave.version>
     <cassandra-driver-core.version>3.2.0</cassandra-driver-core.version>
-    <okio.version>1.12.0</okio.version>
+    <okio.version>1.13.0</okio.version>
     <!-- important to keep this with spring-boot -->
     <jooq.version>3.9.1</jooq.version>
     <spring-boot.version>1.5.3.RELEASE</spring-boot.version>
@@ -69,7 +69,7 @@
     <mockito.version>2.6.3</mockito.version>
     <assertj.version>3.6.1</assertj.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <okhttp.version>3.6.0</okhttp.version>
+    <okhttp.version>3.8.0</okhttp.version>
     <testcontainers.version>1.2.1</testcontainers.version>
 
     <animal-sniffer-maven-plugin.version>1.15</animal-sniffer-maven-plugin.version>

--- a/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/src/test/java/zipkin/autoconfigure/storage/elasticsearch/aws/ZipkinElasticsearchAwsStorageAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import zipkin.autoconfigure.storage.elasticsearch.http.ZipkinElasticsearchOkHttpAutoConfiguration;
 

--- a/zipkin-autoconfigure/storage-elasticsearch-http/pom.xml
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/pom.xml
@@ -35,6 +35,15 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-storage-elasticsearch-http</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>logging-interceptor</artifactId>
+      <version>${okhttp.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>io.zipkin.brave</groupId>

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageProperties.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.storage.elasticsearch.http.ElasticsearchHttpStorage;
 
@@ -47,6 +48,8 @@ public class ZipkinElasticsearchHttpStorageProperties implements Serializable { 
   private String username;
   /** password used for basic auth. Needed when Shield or X-Pack security is enabled */
   private String password;
+  /** When set, controls the volume of HTTP logging of the Elasticsearch Api. Options are BASIC, HEADERS, BODY */
+  private HttpLoggingInterceptor.Level httpLogging;
 
   public String getPipeline() {
     return pipeline;
@@ -138,6 +141,14 @@ public class ZipkinElasticsearchHttpStorageProperties implements Serializable { 
 
   public void setPassword(String password) {
     this.password = password;
+  }
+
+  public HttpLoggingInterceptor.Level getHttpLogging() {
+    return httpLogging;
+  }
+
+  public void setHttpLogging(HttpLoggingInterceptor.Level httpLogging) {
+    this.httpLogging = httpLogging;
   }
 
   public ElasticsearchHttpStorage.Builder toBuilder(OkHttpClient client) {

--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageAutoConfigurationTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -192,12 +192,18 @@ The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
                            to 0 as it would mean a machine failure results in data loss.
     * `ES_USERNAME` and `ES_PASSWORD`: Elasticsearch basic authentication, which defaults to empty string.
                                        Use when X-Pack security (formerly Shield) is in place.
-
+    * `ES_HTTP_LOGGING`: When set, controls the volume of HTTP logging of the Elasticsearch Api.
+                         Options are BASIC, HEADERS, BODY
 Example usage:
 
-To connect with http:
+To connect normally:
 ```bash
-$ STORAGE_TYPE=elasticsearch ES_HOSTS=http://localhost:9200 java -jar zipkin.jar
+$ STORAGE_TYPE=elasticsearch ES_HOSTS=http://myhost:9200 java -jar zipkin.jar
+```
+
+To log Elasticsearch api requests:
+```bash
+$ STORAGE_TYPE=elasticsearch ES_HTTP_LOGGING=BASIC java -jar zipkin.jar
 ```
 
 Or to use the Amazon Elasticsearch Service.

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -92,6 +92,7 @@ zipkin:
       index-replicas: ${ES_INDEX_REPLICAS:1}
       username: ${ES_USERNAME:}
       password: ${ES_PASSWORD:}
+      http-logging: ${ES_HTTP_LOGGING:}
     mysql:
       host: ${MYSQL_HOST:localhost}
       port: ${MYSQL_TCP_PORT:3306}

--- a/zipkin-storage/elasticsearch-http/pom.xml
+++ b/zipkin-storage/elasticsearch-http/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This is helpful when troubleshooting.

Ex.
```bash
STORAGE_TYPE=elasticsearch ES_HTTP_LOGGING=BASIC  java -jar ./zipkin-server/target/zipkin-server-*exec.jar
```

```
2017-05-15 23:05:10.600  INFO 78150 --- [alhost:9200/...] z.s.e.http.ElasticsearchHttpStorage      : --> GET http://localhost:9200/ http/1.1
2017-05-15 23:05:10.617  INFO 78150 --- [alhost:9200/...] z.s.e.http.ElasticsearchHttpStorage      : <-- 200 OK http://localhost:9200/ (16ms, unknown-length body)
2017-05-15 23:05:10.624  INFO 78150 --- [alhost:9200/...] z.s.e.http.ElasticsearchHttpStorage      : --> GET http://localhost:9200/_template/zipkin_template http/1.1
2017-05-15 23:05:10.626  INFO 78150 --- [alhost:9200/...] z.s.e.http.ElasticsearchHttpStorage      : <-- 200 OK http://localhost:9200/_template/zipkin_template (1ms, unknown-length body)
2017-05-15 23:05:10.635  INFO 78150 --- [alhost:9200/...] z.s.e.http.ElasticsearchHttpStorage      : --> POST http://localhost:9200/_bulk http/1.1 (1756-byte body)
2017-05-15 23:05:10.640  INFO 78150 --- [alhost:9200/...] z.s.e.http.ElasticsearchHttpStorage      : <-- 200 OK http://localhost:9200/_bulk (4ms, unknown-length body)
```