### PR TITLE
Makes the simple type name of kafka10's autoconfiguration unique

### DIFF
--- a/zipkin-autoconfigure/collector-kafka10/src/main/java/zipkin/autoconfigure/collector/kafka10/ZipkinKafka10CollectorAutoConfiguration.java
+++ b/zipkin-autoconfigure/collector-kafka10/src/main/java/zipkin/autoconfigure/collector/kafka10/ZipkinKafka10CollectorAutoConfiguration.java
@@ -31,8 +31,8 @@ import zipkin.storage.StorageComponent;
  */
 @Configuration
 @EnableConfigurationProperties(ZipkinKafkaCollectorProperties.class)
-@Conditional(ZipkinKafkaCollectorAutoConfiguration.KafkaBootstrapServersSet.class)
-public class ZipkinKafkaCollectorAutoConfiguration {
+@Conditional(ZipkinKafka10CollectorAutoConfiguration.KafkaBootstrapServersSet.class)
+public class ZipkinKafka10CollectorAutoConfiguration { // makes simple type name unique for /autoconfig
 
   @Bean(initMethod = "start") KafkaCollector kafka(ZipkinKafkaCollectorProperties properties,
       CollectorSampler sampler, CollectorMetrics metrics, StorageComponent storage) {

--- a/zipkin-autoconfigure/collector-kafka10/src/main/resources/META-INF/spring.factories
+++ b/zipkin-autoconfigure/collector-kafka10/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-zipkin.autoconfigure.collector.kafka10.ZipkinKafkaCollectorAutoConfiguration
+zipkin.autoconfigure.collector.kafka10.ZipkinKafka10CollectorAutoConfiguration

--- a/zipkin-autoconfigure/collector-kafka10/src/test/java/zipkin/collector/kafka10/ZipkinKafka10CollectorAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/collector-kafka10/src/test/java/zipkin/collector/kafka10/ZipkinKafka10CollectorAutoConfigurationTest.java
@@ -22,7 +22,7 @@ import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfigurati
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import zipkin.autoconfigure.collector.kafka10.ZipkinKafkaCollectorAutoConfiguration;
+import zipkin.autoconfigure.collector.kafka10.ZipkinKafka10CollectorAutoConfiguration;
 import zipkin.collector.CollectorMetrics;
 import zipkin.collector.CollectorSampler;
 import zipkin.storage.InMemoryStorage;
@@ -31,7 +31,7 @@ import zipkin.storage.StorageComponent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
 
-public class ZipkinKafkaCollectorAutoConfigurationTest {
+public class ZipkinKafka10CollectorAutoConfigurationTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -49,7 +49,7 @@ public class ZipkinKafkaCollectorAutoConfigurationTest {
   public void doesNotProvideCollectorComponent_whenBootstrapServersUnset() {
     context = new AnnotationConfigApplicationContext();
     context.register(PropertyPlaceholderAutoConfiguration.class,
-        ZipkinKafkaCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+        ZipkinKafka10CollectorAutoConfiguration.class, InMemoryConfiguration.class);
     context.refresh();
 
     thrown.expect(NoSuchBeanDefinitionException.class);
@@ -61,7 +61,7 @@ public class ZipkinKafkaCollectorAutoConfigurationTest {
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context, "zipkin.collector.kafka.bootstrap-servers:");
     context.register(PropertyPlaceholderAutoConfiguration.class,
-        ZipkinKafkaCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+        ZipkinKafka10CollectorAutoConfiguration.class, InMemoryConfiguration.class);
     context.refresh();
 
     thrown.expect(NoSuchBeanDefinitionException.class);
@@ -73,7 +73,7 @@ public class ZipkinKafkaCollectorAutoConfigurationTest {
     context = new AnnotationConfigApplicationContext();
     addEnvironment(context, "zipkin.collector.kafka.bootstrap-servers:localhost:9091");
     context.register(PropertyPlaceholderAutoConfiguration.class,
-        ZipkinKafkaCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+        ZipkinKafka10CollectorAutoConfiguration.class, InMemoryConfiguration.class);
     context.refresh();
 
     assertThat(context.getBean(KafkaCollector.class)).isNotNull();


### PR DESCRIPTION
The /autoconfig endpoint expects the simple type names of autoconfiguration
to be different.