### PR TITLE
Gracefully handle recursive spans in Zipkin Dependency Job 

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
@@ -111,7 +111,7 @@ public final class DependencyLinker {
         }
         DependencyLinkSpan ancestorLink = ancestor.value();
         if (!ancestor.isSyntheticRootForPartialTree() &&
-              ancestorLink.kind == DependencyLinkSpan.Kind.SERVER) {
+          ancestorLink.kind == DependencyLinkSpan.Kind.SERVER) {
           parent = ancestorLink.service;
           break;
         }

--- a/zipkin/src/test/java/zipkin/TestObjects.java
+++ b/zipkin/src/test/java/zipkin/TestObjects.java
@@ -78,6 +78,32 @@ public final class TestObjects {
           .build()
   ).stream().map(ApplyTimestampAndDuration::apply).collect(toList());
 
+
+  // this object simulates
+  public static final List<Span> TRACEWITHSAMEIDANDSAMEPARENTID = asList(
+    Span.builder().traceId(WEB_SPAN_ID+1).id(WEB_SPAN_ID).name("get")
+      .addAnnotation(Annotation.create(TODAY * 1000, SERVER_RECV, WEB_ENDPOINT))
+      .addAnnotation(Annotation.create((TODAY + 350) * 1000, SERVER_SEND, WEB_ENDPOINT))
+      .build(),
+    Span.builder().traceId(WEB_SPAN_ID+1).parentId(WEB_SPAN_ID).id(WEB_SPAN_ID).name("get")
+      .addAnnotation(Annotation.create((TODAY + 50) * 1000, CLIENT_SEND, WEB_ENDPOINT))
+      .addAnnotation(Annotation.create((TODAY + 100) * 1000, SERVER_RECV, APP_ENDPOINT))
+      .addAnnotation(Annotation.create((TODAY + 250) * 1000, SERVER_SEND, APP_ENDPOINT))
+      .addAnnotation(Annotation.create((TODAY + 300) * 1000, CLIENT_RECV, WEB_ENDPOINT))
+      .addBinaryAnnotation(BinaryAnnotation.address(CLIENT_ADDR, WEB_ENDPOINT))
+      .addBinaryAnnotation(BinaryAnnotation.address(SERVER_ADDR, APP_ENDPOINT))
+      .build(),
+    Span.builder().traceId(WEB_SPAN_ID+1).parentId(WEB_SPAN_ID).id(WEB_SPAN_ID).name("query")
+      .addAnnotation(Annotation.create((TODAY + 150) * 1000, CLIENT_SEND, APP_ENDPOINT))
+      .addAnnotation(Annotation.create((TODAY + 200) * 1000, CLIENT_RECV, APP_ENDPOINT))
+      .addAnnotation(Annotation.create((TODAY + 190) * 1000, "⻩", NO_IP_ENDPOINT))
+      .addBinaryAnnotation(BinaryAnnotation.address(CLIENT_ADDR, APP_ENDPOINT))
+      .addBinaryAnnotation(BinaryAnnotation.address(SERVER_ADDR, DB_ENDPOINT))
+      .addBinaryAnnotation(BinaryAnnotation.create(ERROR, "\uD83D\uDCA9", NO_IP_ENDPOINT))
+      .build()
+  ).stream().map(ApplyTimestampAndDuration::apply).collect(toList());
+
+
   public static final List<DependencyLink> LINKS = asList(
       DependencyLink.builder().parent("web").child("app").callCount(1).build(),
       DependencyLink.builder().parent("app").child("db").callCount(1).build()

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
@@ -39,6 +39,12 @@ public class DependencyLinkerTest {
     );
   }
 
+  /***
+   * This is the test to show null pointer exception occuring
+   * when we encounter a span which has itself as a parent
+   * TestObjects.TRACEWITHSAMEIDANDSAMEPARENTID is a test object to simulate.
+   */
+
   @Test(expected = NullPointerException.class)
   public void linksSpansShouldHandleNullSpans() {
 


### PR DESCRIPTION
We encountered null pointer exception on Zipkin dependency job when a span has itself as a parent. We know this is bad behavior by the instrumented application; we want to protect the dependencies job from such bad behavior.

We plan to prevent this bad data from getting into Zipkin at all, but we think this fix is still useful.

Opening the PR now with the failing test so we can begin the discussion. We'll be back with a fix (and updated tests).
```
17/06/01 23:18:00 ERROR Executor: Exception in task 361.0 in stage 0.0 (TID 361)
java.lang.NullPointerException
	at zipkin.internal.DependencyLinker.putTrace(DependencyLinker.java:81)
	at zipkin.internal.DependencyLinker.putTrace(DependencyLinker.java:52)
	at zipkin.dependencies.cassandra.CassandraRowsToDependencyLinks.call(CassandraRowsToDependencyLinks.java:68)
	at zipkin.dependencies.cassandra.CassandraRowsToDependencyLinks.call(CassandraRowsToDependencyLinks.java:32)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$fn$1$1.apply(JavaPairRDD.scala:655)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$fn$1$1.apply(JavaPairRDD.scala:655)
	at org.apache.spark.rdd.PairRDDFunctions$$anonfun$flatMapValues$1$$anonfun$apply$45$$anonfun$apply$46.apply(PairRDDFunctions.scala:767)
	at org.apache.spark.rdd.PairRDDFunctions$$anonfun$flatMapValues$1$$anonfun$apply$45$$anonfun$apply$46.apply(PairRDDFunctions.scala:766)
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:371)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327)
	at org.apache.spark.util.collection.ExternalSorter.insertAll(ExternalSorter.scala:189)
	at org.apache.spark.shuffle.sort.SortShuffleWriter.write(SortShuffleWriter.scala:64)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:73)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:41)
	at org.apache.spark.scheduler.Task.run(Task.scala:89)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:227)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
17/06/01 23:18:00 WARN TaskSetManager: Lost task 361.0 in stage 0.0 (TID 361, localhost): java.lang.NullPointerException
	at zipkin.internal.DependencyLinker.putTrace(DependencyLinker.java:81)
	at zipkin.internal.DependencyLinker.putTrace(DependencyLinker.java:52)
	at zipkin.dependencies.cassandra.CassandraRowsToDependencyLinks.call(CassandraRowsToDependencyLinks.java:68)
	at zipkin.dependencies.cassandra.CassandraRowsToDependencyLinks.call(CassandraRowsToDependencyLinks.java:32)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$fn$1$1.apply(JavaPairRDD.scala:655)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$fn$1$1.apply(JavaPairRDD.scala:655)
	at org.apache.spark.rdd.PairRDDFunctions$$anonfun$flatMapValues$1$$anonfun$apply$45$$anonfun$apply$46.apply(PairRDDFunctions.scala:767)
	at org.apache.spark.rdd.PairRDDFunctions$$anonfun$flatMapValues$1$$anonfun$apply$45$$anonfun$apply$46.apply(PairRDDFunctions.scala:766)
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:371)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327)
	at org.apache.spark.util.collection.ExternalSorter.insertAll(ExternalSorter.scala:189)
	at org.apache.spark.shuffle.sort.SortShuffleWriter.write(SortShuffleWriter.scala:64)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:73)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:41)
	at org.apache.spark.scheduler.Task.run(Task.scala:89)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:227)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

17/06/01 23:18:00 ERROR TaskSetManager: Task 361 in stage 0.0 failed 1 times; aborting job
[GC (Metadata GC Threshold)  344080K->281376K(1037312K), 0.0134731 secs]
[Full GC (Metadata GC Threshold)  281376K->47252K(1037312K), 0.2627739 secs]
Exception in thread "main" org.apache.spark.SparkException: Job aborted due to stage failure: Task 361 in stage 0.0 failed 1 times, most recent failure: Lost task 361.0 in stage 0.0 (TID 361, localhost): java.lang.NullPointerException
	at zipkin.internal.DependencyLinker.putTrace(DependencyLinker.java:81)
	at zipkin.internal.DependencyLinker.putTrace(DependencyLinker.java:52)
	at zipkin.dependencies.cassandra.CassandraRowsToDependencyLinks.call(CassandraRowsToDependencyLinks.java:68)
	at zipkin.dependencies.cassandra.CassandraRowsToDependencyLinks.call(CassandraRowsToDependencyLinks.java:32)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$fn$1$1.apply(JavaPairRDD.scala:655)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$fn$1$1.apply(JavaPairRDD.scala:655)
	at org.apache.spark.rdd.PairRDDFunctions$$anonfun$flatMapValues$1$$anonfun$apply$45$$anonfun$apply$46.apply(PairRDDFunctions.scala:767)
	at org.apache.spark.rdd.PairRDDFunctions$$anonfun$flatMapValues$1$$anonfun$apply$45$$anonfun$apply$46.apply(PairRDDFunctions.scala:766)
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:371)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327)
	at org.apache.spark.util.collection.ExternalSorter.insertAll(ExternalSorter.scala:189)
	at org.apache.spark.shuffle.sort.SortShuffleWriter.write(SortShuffleWriter.scala:64)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:73)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:41)
	at org.apache.spark.scheduler.Task.run(Task.scala:89)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:227)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

Driver stacktrace:
	at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$failJobAndIndependentStages(DAGScheduler.scala:1431)
	at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1419)
	at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1418)
	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:47)
	at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:1418)
	at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:799)
	at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:799)
	at scala.Option.foreach(Option.scala:236)
	at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:799)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:1640)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1599)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1588)
	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:48)
	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:620)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:1832)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:1845)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:1858)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:1929)
	at org.apache.spark.rdd.RDD$$anonfun$collect$1.apply(RDD.scala:927)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:150)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:111)
	at org.apache.spark.rdd.RDD.withScope(RDD.scala:316)
	at org.apache.spark.rdd.RDD.collect(RDD.scala:926)
	at org.apache.spark.api.java.JavaRDDLike$class.collect(JavaRDDLike.scala:339)
	at org.apache.spark.api.java.AbstractJavaRDDLike.collect(JavaRDDLike.scala:46)
	at zipkin.dependencies.cassandra.CassandraDependenciesJob.run(CassandraDependenciesJob.java:150)
	at zipkin.dependencies.ZipkinDependenciesJob.main(ZipkinDependenciesJob.java:48)
Caused by: java.lang.NullPointerException
	at zipkin.internal.DependencyLinker.putTrace(DependencyLinker.java:81)
	at zipkin.internal.DependencyLinker.putTrace(DependencyLinker.java:52)
	at zipkin.dependencies.cassandra.CassandraRowsToDependencyLinks.call(CassandraRowsToDependencyLinks.java:68)
	at zipkin.dependencies.cassandra.CassandraRowsToDependencyLinks.call(CassandraRowsToDependencyLinks.java:32)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$fn$1$1.apply(JavaPairRDD.scala:655)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$fn$1$1.apply(JavaPairRDD.scala:655)
	at org.apache.spark.rdd.PairRDDFunctions$$anonfun$flatMapValues$1$$anonfun$apply$45$$anonfun$apply$46.apply(PairRDDFunctions.scala:767)
	at org.apache.spark.rdd.PairRDDFunctions$$anonfun$flatMapValues$1$$anonfun$apply$45$$anonfun$apply$46.apply(PairRDDFunctions.scala:766)
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:371)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327)
	at org.apache.spark.util.collection.ExternalSorter.insertAll(ExternalSorter.scala:189)
	at org.apache.spark.shuffle.sort.SortShuffleWriter.write(SortShuffleWriter.scala:64)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:73)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:41)
	at org.apache.spark.scheduler.Task.run(Task.scala:89)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:227)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

```


