### PR TITLE
Fix broken image markup in UI README

### DIFF
--- a/zipkin-ui/README.md
+++ b/zipkin-ui/README.md
@@ -86,5 +86,4 @@ where `{traceId}` will be contextually replaced by the trace id.
 
 If this feature is activated, you'll see on the trace detail page an additional button named `logs`.
 
-![Logs Button]
-(https://cloud.githubusercontent.com/assets/9842366/20482538/6e35ca66-afed-11e6-90e9-1e28f66d985e.png)
+![Logs Button](https://cloud.githubusercontent.com/assets/9842366/20482538/6e35ca66-afed-11e6-90e9-1e28f66d985e.png)


### PR DESCRIPTION
The image does not show up on [this page](https://github.com/openzipkin/zipkin/tree/master/zipkin-ui#how-do-i-find-logs-associated-with-a-particular-trace) because of the line break in the markup.