### PR TITLE
Allow query-only servers to disable the HTTP collector

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -115,6 +115,7 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
     * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 24 hours (two daily buckets: one for today and one for yesterday)
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
+    * `HTTP_COLLECTOR_ENABLED`: `false` disables the http collector; Defaults to true
 
 ### Cassandra Storage
 Zipkin's [Cassandra storage component](../zipkin-storage/cassandra)

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -115,7 +115,6 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
     * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 24 hours (two daily buckets: one for today and one for yesterday)
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
-    * `HTTP_COLLECTOR_ENABLED`: `false` disables the http collector; Defaults to true
 
 ### Cassandra Storage
 Zipkin's [Cassandra storage component](../zipkin-storage/cassandra)
@@ -224,6 +223,14 @@ a parameter for how far back to look for service or span names. In order
 to prevent excessive load, service and span name queries are limited by
 `QUERY_LOOKBACK`, which defaults to 24hrs (two daily buckets: one for
 today and one for yesterday)
+
+### HTTP Collector
+The HTTP collector is enabled by default. It accepts spans via `POST /api/v1/spans`. The HTTP 
+collector supports the following configuration:
+
+Property | Environment Variable | Description
+--- | --- | ---
+`zipkin.collector.http.enabled` | `HTTP_COLLECTOR_ENABLED` | `false` disables the HTTP collector. Defaults to `true`.
 
 ### Scribe Collector
 The Scribe collector is disabled by default, configured by the following:

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.zip.GZIPInputStream;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.concurrent.ListenableFuture;
@@ -44,6 +45,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
  */
 @RestController
 @CrossOrigin("${zipkin.query.allowed-origins:*}")
+@ConditionalOnProperty(name = "zipkin.collector.http.enabled", matchIfMissing = true)
 public class ZipkinHttpCollector {
   static final ResponseEntity<?> SUCCESS = ResponseEntity.accepted().build();
   static final String APPLICATION_THRIFT = "application/x-thrift";

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -9,6 +9,9 @@ zipkin:
   collector:
     # percentage to traces to retain
     sample-rate: ${COLLECTOR_SAMPLE_RATE:1.0}
+    http:
+      # Set to false to disable creation of spans via HTTP collector API
+      enabled: ${HTTP_COLLECTOR_ENABLED:true}
     kafka:
       # ZooKeeper host string, comma-separated host:port value.
       zookeeper: ${KAFKA_ZOOKEEPER:}

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerHttpCollectorDisabledTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerHttpCollectorDisabledTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.ConfigurableWebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Query-only builds should be able to disable the HTTP collector, so that
+ * associated assets 404 instead of allowing creation of spans.
+ */
+@SpringBootTest(classes = ZipkinServer.class, properties = {
+  "zipkin.storage.type=mem",
+  "spring.config.name=zipkin-server",
+  "zipkin.collector.http.enabled=false"
+})
+@RunWith(SpringRunner.class)
+public class ZipkinServerHttpCollectorDisabledTest {
+
+  @Autowired ConfigurableWebApplicationContext context;
+
+  @Test(expected = NoSuchBeanDefinitionException.class)
+  public void disabledHttpCollectorBean() throws Exception {
+    context.getBean(ZipkinHttpCollector.class);
+  }
+
+  @Test public void httpCollectorEndpointReturns405() throws Exception {
+    MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build();
+    mockMvc.perform(post("/api/v1/spans"))
+      .andExpect(status().isMethodNotAllowed());
+  }
+
+  @Test public void getOnSpansEndpointReturnsOK() throws Exception {
+    MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build();
+    mockMvc.perform(get("/api/v1/spans?serviceName=unknown"))
+      .andExpect(status().isOk());
+  }
+}


### PR DESCRIPTION
We have a Zipkin deployment where there is one instance of zipkin-server providing the query API and a second instance running the (kafka in our case) collector. The zipkin-server instance providing the query API will be exposed to HTTP traffic from our internal network and it is preferable if the exposed HTTP API is read-only to prevent users from creating span data. Disabling the HTTP collector accomplishes this.

The motivation for this change is similar to the rationale described on #1591, and the approach taken to implement this is very similar to the one from the PR for that issue (#1593).

These changes add a configuration point for enabling or disabling the HTTP collector in zipkin-server. This can be controlled through the property zipkin.collector.http.enabled or the corresponding environment variable HTTP_COLLECTOR_ENABLED. The collector is enabled by default.