### PR TITLE
Accepts json span names (previously broke ElasticSearch)

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkIndexer.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkIndexer.java
@@ -21,6 +21,7 @@ import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import zipkin.internal.JsonCodec;
 import zipkin.internal.Nullable;
 import zipkin.storage.Callback;
 import zipkin.storage.elasticsearch.http.internal.client.HttpCall;
@@ -56,7 +57,7 @@ final class HttpBulkIndexer {
     body.writeUtf8("{\"index\":{\"_index\":\"").writeUtf8(index).writeByte('"');
     body.writeUtf8(",\"_type\":\"").writeUtf8(typeName).writeByte('"');
     if (id != null) {
-      body.writeUtf8(",\"_id\":\"").writeUtf8(id).writeByte('"');
+      body.writeUtf8(",\"_id\":\"").writeUtf8(JsonCodec.escape(id)).writeByte('"');
     }
     body.writeUtf8("}}\n");
   }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
@@ -122,6 +122,22 @@ public class ElasticsearchHttpSpanConsumerTest {
     );
   }
 
+  /** Not a good span name, but better to test it than break mysteriously */
+  @Test
+  public void indexesServiceSpan_jsonInSpanName() throws Exception {
+    es.enqueue(new MockResponse());
+
+    String name = "{\"foo\":\"bar\"}";
+    String nameEscaped = "{\\\"foo\\\":\\\"bar\\\"}";
+
+    accept(TestObjects.TRACE.get(0).toBuilder().name(name).build());
+
+    assertThat(es.takeRequest().getBody().readByteString().utf8()).endsWith(
+      "\"_type\":\"servicespan\",\"_id\":\"web|" + nameEscaped + "\"}}\n"
+        + "{\"serviceName\":\"web\",\"spanName\":\"" + nameEscaped + "\"}\n"
+    );
+  }
+
   @Test
   public void traceIsSearchableBySRServiceName() throws Exception {
     es.enqueue(new MockResponse());

--- a/zipkin/src/main/java/zipkin/internal/Buffer.java
+++ b/zipkin/src/main/java/zipkin/internal/Buffer.java
@@ -200,6 +200,10 @@ final class Buffer {
   }
 
   Buffer writeJsonEscaped(String v) {
+    return writeUtf8(jsonEscape(v));
+  }
+
+  static String jsonEscape(String v) {
     int afterReplacement = 0;
     int length = v.length();
     StringBuilder builder = null;
@@ -224,13 +228,16 @@ final class Buffer {
       builder.append(replacement);
       afterReplacement = i + 1;
     }
+    String escaped;
     if (builder == null) { // then we didn't escape anything
-      return writeUtf8(v);
+      escaped = v;
+    } else {
+      if (afterReplacement < length) {
+        builder.append(v, afterReplacement, length);
+      }
+      escaped = builder.toString();
     }
-    if (afterReplacement < length) {
-      builder.append(v, afterReplacement, length);
-    }
-    return writeUtf8(builder.toString());
+    return escaped;
   }
 
   Buffer writeUtf8(String v) {

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -458,6 +458,11 @@ public final class JsonCodec implements Codec {
     return write(ENDPOINT_ADAPTER, value);
   }
 
+  /** Exposed for ElasticSearch HttpBulkIndexer */
+  public static String escape(String value) {
+    return Buffer.jsonEscape(value);
+  }
+
   @Override
   public List<Span> readSpans(byte[] bytes) {
     checkArgument(bytes.length > 0, "Empty input reading List<Span>");

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -967,6 +967,19 @@ public abstract class SpanStoreTest {
         .contains(Tuple.tuple((TODAY - 4) * 1000L, 4000L)); // but the client's timestamp wins
   }
 
+  /** Not a good span name, but better to test it than break mysteriously */
+  @Test
+  public void spanNameIsJson() {
+    String json = "{\"foo\":\"bar\"}";
+    Span withJsonSpanName = span1.toBuilder().name(json).build();
+
+    accept(withJsonSpanName);
+
+    assertThat(store().getTraces(QueryRequest.builder().spanName(json).build()))
+      .flatExtracting(t -> t)
+      .contains(withJsonSpanName);
+  }
+
   static long clientDuration(Span span) {
     long[] timestamps = span.annotations.stream()
         .filter(a -> a.value.startsWith("c"))


### PR DESCRIPTION
While not good practice, if we break on json span names, users can't
easily troubleshoot. This works around the problem by escaping json.

Fixes #1613