### PR TITLE
Adding ability to listen to multiple kafka10 topics via comma separated list

### DIFF
--- a/zipkin-autoconfigure/collector-kafka10/README.md
+++ b/zipkin-autoconfigure/collector-kafka10/README.md
@@ -71,7 +71,7 @@ Environment Variable | Property | New Consumer Config | Description
 --- | --- | --- | ---
 `KAFKA_BOOTSTRAP_SERVERS` | `zipkin.collector.kafka.bootstrap-servers` | bootstrap.servers | Comma-separated list of brokers, ex. 127.0.0.1:9092. No default
 `KAFKA_GROUP_ID` | `zipkin.collector.kafka.group-id` | group.id | The consumer group this process is consuming on behalf of. Defaults to `zipkin`
-`KAFKA_TOPIC` | `zipkin.collector.kafka.topic` | N/A | Topic zipkin spans will be consumed from. Defaults to `zipkin`
+`KAFKA_TOPIC` | `zipkin.collector.kafka.topic` | N/A | Comma-separated list of topics that zipkin spans will be consumed from. Defaults to `zipkin`
 `KAFKA_STREAMS` | `zipkin.collector.kafka.streams` | N/A | Count of threads consuming the topic. Defaults to `1`
 
 ### Other Kafka consumer properties
@@ -107,14 +107,14 @@ $ KAFKA_BOOTSTRAP_SERVERS=broker1:9092.local,broker2.local:9092 \
     org.springframework.boot.loader.PropertiesLauncher
 ```
 
-Alternate topic name:
+Alternate topic name(s):
 
 ```bash
 $ KAFKA_BOOTSTRAP_SERVERS=127.0.0.1:9092 \
     java \
     -Dloader.path='zipkin-autoconfigure-collector-kafka10-module.jar,zipkin-autoconfigure-collector-kafka10-module.jar!/lib' \
     -Dspring.profiles.active=kafka \
-    -Dzipkin.collector.kafka.topic=zapkin \
+    -Dzipkin.collector.kafka.topic=zapkin,zipken \
     -cp zipkin-server-exec.jar \
     org.springframework.boot.loader.PropertiesLauncher
 ```

--- a/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollector.java
+++ b/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollector.java
@@ -76,7 +76,8 @@ public final class KafkaCollector implements CollectorComponent {
       return this;
     }
 
-    /** Topic zipkin spans will be consumed from. Defaults to "zipkin" */
+    /** Topic zipkin spans will be consumed from. Defaults to "zipkin".
+     * Multiple topics may be specified if comma delimited.*/
     public Builder topic(String topic) {
       this.topic = checkNotNull(topic, "topic");
       return this;

--- a/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollectorWorker.java
+++ b/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollectorWorker.java
@@ -14,6 +14,7 @@
 package zipkin.collector.kafka10;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +46,8 @@ final class KafkaCollectorWorker implements Runnable {
 
   KafkaCollectorWorker(KafkaCollector.Builder builder) {
     kafkaConsumer = new KafkaConsumer<>(builder.properties);
-    kafkaConsumer.subscribe(Collections.singleton(builder.topic), new ConsumerRebalanceListener() {
+    List<String> topics = Arrays.asList(builder.topic.split(","));
+    kafkaConsumer.subscribe(topics, new ConsumerRebalanceListener() {
       @Override public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
         assignedPartitions.set(Collections.emptyList());
       }

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -246,7 +246,7 @@ A collector supporting Kafka versions 0.10 and later is available as an external
 
 The following apply when `KAFKA_ZOOKEEPER` is set:
 
-    * `KAFKA_TOPIC`: Topic zipkin spans will be consumed from. Defaults to "zipkin"
+    * `KAFKA_TOPIC`: Topic zipkin spans will be consumed from. Defaults to "zipkin". When Kafka 0.10 is in use, multiple topics may be specified if comma delimited.
     * `KAFKA_STREAMS`: Count of threads/streams consuming the topic. Defaults to 1
 
 Settings below correspond to "Old Consumer Configs" in [Kafka documentation](http://kafka.apache.org/documentation.html)


### PR DESCRIPTION
Useful for cases like span info from different environments coming from different topics, etc.