### PR TITLE
InMemorySpanStore.clear() should clear all its data

### DIFF
--- a/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -93,8 +93,10 @@ public final class InMemorySpanStore implements SpanStore {
 
   synchronized void clear() {
     acceptedSpanCount = 0;
+    traceIdTimeStamps.clear();
     traceIdToSpans.clear();
     serviceToTraceIdTimeStamp.clear();
+    serviceToSpanNames.clear();
   }
 
   /**


### PR DESCRIPTION
This is a minor change, but it seems like InMemorySpanStore.clear() should clear all the data it has accumulated.

This affects no tests because all tests get a new instantiation of InMemorySpanStore.  I'd be happy to add a test for the clear if it seems worthwhile.

All tests passed as reported by:  ./mvnw --also-make -pl zipkin-server clean install