### PR TITLE
Add migration documentation from kafka 0.8 to 0.10

### DIFF
--- a/zipkin-autoconfigure/collector-kafka10/README.md
+++ b/zipkin-autoconfigure/collector-kafka10/README.md
@@ -129,3 +129,8 @@ $ java \
     -cp zipkin-server-exec.jar \
     org.springframework.boot.loader.PropertiesLauncher
 ```
+
+### Migration from Kafka < 0.8.1
+
+As explained [on kafka wiki](https://cwiki.apache.org/co\
+nfluence/display/KAFKA/Committing+and+fetching+consumer+offsets+in+Kafka), offsets were stored in ZooKeeper. This has changed and offsets are now stored directly in Kafka. You need to update offsets in Kafka 0.10 by following the instructions.


### PR DESCRIPTION
When migrating Kafka from 0.8.1 to 0.10, users should pay attention to the change in offset management.