### PR TITLE
Moves the zipkin UI under the path /zipkin

### DIFF
--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
@@ -212,11 +212,11 @@ public class ZipkinServerIntegrationTest {
   /** The zipkin-ui is a single-page app. This prevents reloading all resources on each click. */
   @Test
   public void setsMaxAgeOnUiResources() throws Exception {
-    mockMvc.perform(get("/favicon.ico"))
+    mockMvc.perform(get("/zipkin/favicon.ico"))
         .andExpect(header().string("Cache-Control", "max-age=31536000"));
-    mockMvc.perform(get("/config.json"))
+    mockMvc.perform(get("/zipkin/config.json"))
         .andExpect(header().string("Cache-Control", "max-age=600"));
-    mockMvc.perform(get("/index.html"))
+    mockMvc.perform(get("/zipkin/index.html"))
         .andExpect(header().string("Cache-Control", "max-age=60"));
   }
 
@@ -253,6 +253,18 @@ public class ZipkinServerIntegrationTest {
     mockMvc.perform(get("/api/v1/traces")
         .header(HttpHeaders.ORIGIN, "foo.example.com"))
            .andExpect(status().isOk());
+  }
+
+  @Test
+  public void forwardsApiForUi() throws Exception {
+    mockMvc.perform(get("/zipkin/api/v1/traces"))
+      .andExpect(status().isOk());
+  }
+
+  @Test
+  public void redirectsRootToZipkin() throws Exception {
+    mockMvc.perform(get("/"))
+      .andExpect(status().is(302));
   }
 
   ResultActions performAsync(MockHttpServletRequestBuilder request) throws Exception {

--- a/zipkin-ui/README.md
+++ b/zipkin-ui/README.md
@@ -1,20 +1,24 @@
 # zipkin-ui
 
-Zipkin-UI is a single-page application that reads configuration from `/config.json`.
+Zipkin-UI is a single-page application mounted at /zipkin. For simplicity,
+assume paths mentioned below are relative to that. For example, the UI
+reads config.json, from the absolute path /zipkin/config.json
 
-When looking at a trace, the browser is sent to the path `/traces/{id}`. For the single-page
-app to serve that route, the server needs to forward the request to `index.html`. The same
-forwarding applies to `/dependencies` and any other routes the UI controls. 
+When looking at a trace, the browser is sent to the path "/traces/{id}".
+For the single-page app to serve that route, the server needs to forward
+the request to "/index.html". The same forwarding applies to "/dependencies"
+and any other routes the UI controls.
 
-Behind the scenes the JavaScript code looks at `window.location` to figure out what the
-UI should do. This is handled by a route api defined in the crossroads library.
+Under the scenes the JavaScript code looks at window.location to figure
+out what the UI should do. This is handled by a route api defined in the
+crossroads library.
 
 The suggested logic for serving the assets of Zipkin-UI is as follows:
 
  1. If the browser is requesting a file with an extension (that is, the last path segment has a `.` in it), then
     serve that file. If it doesn't exist, then return 404.
  1. Otherwise, serve `index.html`.
- 
+
 For an example implementation using Finatra, see [zipkin-query](https://github.com/openzipkin/zipkin/blob/5dec252e4c562b21bac5ac2f9d0b437d90988f79/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala).
 
 Note that in cases where a non-existent resource is requested, this logic returns the contents of `index.html`. When
@@ -63,12 +67,12 @@ copy of zipkin-ui at http://localhost:9090.
 #### What's an easy way to create new spans for testing?
 
 Using this setup, if you open the web UI and find a trace from zipkin-server,
-you can download a JSON blob by right clicking on the JSON button on the trace 
+you can download a JSON blob by right clicking on the JSON button on the trace
 page (top right) and doing a "Save As". Modify the span to your heart's content,
 and then you can submit the span(s) via curl:
 
 ```bash
-$ curl -H "Content-Type: application/json" --data @span.json http://localhost:9411/api/v1/spans 
+$ curl -H "Content-Type: application/json" --data @span.json http://localhost:9411/api/v1/spans
 ```
 
 #### How do I find logs associated with a particular trace

--- a/zipkin-ui/js/component_ui/goToDependency.js
+++ b/zipkin-ui/js/component_ui/goToDependency.js
@@ -5,7 +5,7 @@ export default component(function goToDependency() {
     evt.preventDefault();
     const endTs = document.getElementById('endTs').value;
     const startTs = document.getElementById('startTs').value;
-    window.location.href = `/dependency?endTs=${endTs}&startTs=${startTs}`;
+    window.location.href = `/zipkin/dependency?endTs=${endTs}&startTs=${startTs}`;
   };
 
   this.after('initialize', function() {

--- a/zipkin-ui/js/component_ui/goToTrace.js
+++ b/zipkin-ui/js/component_ui/goToTrace.js
@@ -4,7 +4,7 @@ export default component(function goToTrace() {
   this.navigateToTrace = function(evt) {
     evt.preventDefault();
     const traceId = document.getElementById('traceIdQuery').value;
-    window.location.href = `/traces/${traceId}`;
+    window.location.href = `/zipkin/traces/${traceId}`;
   };
 
   this.after('initialize', function() {

--- a/zipkin-ui/js/main.js
+++ b/zipkin-ui/js/main.js
@@ -13,9 +13,9 @@ loadConfig().then(config => {
 
   CommonUI.attachTo(window.document.body, {config});
 
-  crossroads.addRoute('', () => initializeDefault(config));
-  crossroads.addRoute('traces/{id}', traceId => initializeTrace(traceId, config));
-  crossroads.addRoute('dependency', () => initializeDependency(config));
+  crossroads.addRoute('zipkin/', () => initializeDefault(config));
+  crossroads.addRoute('zipkin/traces/{id}', traceId => initializeTrace(traceId, config));
+  crossroads.addRoute('zipkin/dependency', () => initializeDependency(config));
   crossroads.parse(window.location.pathname);
 }, e => {
   // TODO: better error message, but this is better than a blank screen...

--- a/zipkin-ui/js/page/default.js
+++ b/zipkin-ui/js/page/default.js
@@ -37,7 +37,7 @@ const DefaultPageComponent = component(function DefaultPage() {
 
   this.after('initialize', function() {
     window.document.title = 'Zipkin - Index';
-    this.trigger(document, 'navigate', {route: 'index'});
+    this.trigger(document, 'navigate', {route: 'zipkin/index'});
 
     const query = queryString.parse(window.location.search);
 

--- a/zipkin-ui/js/page/dependency.js
+++ b/zipkin-ui/js/page/dependency.js
@@ -12,7 +12,7 @@ import {dependenciesTemplate} from '../templates';
 const DependencyPageComponent = component(function DependencyPage() {
   this.after('initialize', function() {
     window.document.title = 'Zipkin - Dependency';
-    this.trigger(document, 'navigate', {route: 'dependency'});
+    this.trigger(document, 'navigate', {route: 'zipkin/dependency'});
 
     this.$node.html(dependenciesTemplate());
 

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -83,7 +83,7 @@
   <ul id="traces">
   {{#traces}}
     <li class="trace {{infoClass}}" data-traceId="{{traceId}}" data-duration="{{duration}}" data-timestamp="{{timestamp}}" data-service-percentage="{{servicePercentage}}">
-      <a href="/traces/{{traceId}}">
+      <a href="/zipkin/traces/{{traceId}}">
         <div class="bar-block">
           <span class="bar-graphic" style="width:{{width}}%;"></span>
           <span class="bar-label">{{durationStr}}</span>

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -1,14 +1,14 @@
     <div id='navbar' class='navbar navbar-inverse' role='navigation'>
       <div class='container'>
         <div class='navbar-header'>
-          <a class='navbar-brand' href='/'>
+          <a class='navbar-brand' href='/zipkin/'>
             Zipkin<span class='muted' style='font-size: .75em; padding-left: 10px;'>Investigate system behavior</span>
           </a>
         </div>
         <div class="navbar-left">
           <ul class="nav navbar-nav">
-            <li data-route="index"><a href="/">Find a trace</a></li>
-            <li data-route="dependency"><a href="/dependency">Dependencies</a></li>
+            <li data-route="index"><a href="/zipkin/">Find a trace</a></li>
+            <li data-route="dependency"><a href="/zipkin/dependency">Dependencies</a></li>
           </ul>
         </div>
         <div class="navbar-right" style="width: 50%">

--- a/zipkin-ui/webpack.config.js
+++ b/zipkin-ui/webpack.config.js
@@ -33,7 +33,7 @@ var webpackConfig = {
     output: {
         path: __dirname + '/target/classes/zipkin-ui/',
         filename: 'app-[hash].min.js',
-        publicPath: '/'
+        publicPath: '/zipkin/'
     },
     devtool: 'source-map',
     plugins: [


### PR DESCRIPTION
This moves the zipkin UI under the path /zipkin, adding a redirect for
/ as well. As UI assets look for the api to be relative to it, requests
to /zipkin/api are forwarded to /api, too.

Fixes #1229 #1452