### PR TITLE
Fix to PR 1627

### DIFF
--- a/zipkin-ui/js/config.js
+++ b/zipkin-ui/js/config.js
@@ -7,7 +7,7 @@ const defaults = {
 };
 
 export default function loadConfig() {
-  return $.ajax('/config.json', {
+  return $.ajax('/zipkin/config.json', {
     type: 'GET',
     dataType: 'json'
   }).then(data => function config(key) {


### PR DESCRIPTION
From https://github.com/openzipkin/zipkin/pull/1627, looks like `config.js` was missed.

Without it, you get "Error loading config.json: No message available"
