### PR TITLE
Make all project files consistently require Java 1.8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
     <!-- default bytecode version for src/main -->
-    <main.java.version>1.7</main.java.version>
-    <main.signature.artifact>java17</main.signature.artifact>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
 
     <main.basedir>${project.basedir}</main.basedir>
 

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -28,8 +28,8 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <main.java.version>1.6</main.java.version>
-    <main.signature.artifact>java16</main.signature.artifact>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
One pom.xml required Java 1.6, and another required 1.7.

I discovered this when animal-sniffer flagged Long.max() as invalid.  It was confusing to figure out because most sub-projects assume 1.8.  These two pom.xml's were the only ones that did not.