### PR TITLE
Ignore .gitattributes and bnd.bnd for code style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,7 @@
           <excludes>
             <exclude>.travis.yml</exclude>
             <exclude>.editorconfig</exclude>
+            <exclude>.gitattributes</exclude>
             <exclude>.gitignore</exclude>
             <exclude>.mvn/**</exclude>
             <exclude>mvnw*</exclude>
@@ -583,6 +584,7 @@
             <exclude>**/.idea/**</exclude>
             <exclude>LICENSE</exclude>
             <exclude>**/*.md</exclude>
+            <exclude>bnd.bnd</exclude>
             <exclude>apache-cassandra-*/**</exclude>
             <exclude>elasticsearch-*/**</exclude>
             <exclude>kafka_*/**</exclude>


### PR DESCRIPTION
Small tweak to fix these two warnings you see when running maven:

```
[WARNING] Unknown file extension: /Users/joel/asource/zipkin/zipkin/zipkin/bnd.bnd
[WARNING] Unable to find a comment style definition for some files. You may want to add a custom mapping for the relevant file extensions.
```

and

```
[WARNING] Unknown file extension: /Users/joel/asource/zipkin/zipkin/.gitattributes
[WARNING] Unable to find a comment style definition for some files. You may want to add a custom mapping for the relevant file extensions.
```