### PR TITLE
Refactors in-memory storage so that there's a common type across data sets

### DIFF
--- a/zipkin/src/test/java/zipkin/storage/InMemorySpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/InMemorySpanStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,11 +13,24 @@
  */
 package zipkin.storage;
 
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class InMemorySpanStoreTest extends SpanStoreTest {
   final InMemoryStorage storage = new InMemoryStorage();
 
   @Override protected StorageComponent storage() {
     return storage;
+  }
+
+  /** This shows when spans are sent multiple times. Doing so can reveal instrumentation bugs. */
+  @Test public void getRawTrace_sameSpanTwice(){
+    accept(span1);
+    accept(span1);
+
+    assertThat(store().getRawTrace(span1.traceIdHigh, span1.traceId))
+      .containsExactly(span1, span1);
   }
 
   @Override


### PR DESCRIPTION
This rejigs things so that the pair of (traceID, timestamp) is used consistently
across all data sets that grow unbounded. This should make it easier to support
purging later. For example one implementation could be to iterate
traceIdToTraceIdTimeStamps in reverse (using delegate.descendingKeySet()),
which should give the eldest trace ID and delete that. When weak references are
used elsewhere, GC should clean them up. Other mechanisms besides weak
references could be used as well.

See #1528