### PR TITLE
Fix UI issue

### DIFF
--- a/zipkin-ui/css/trace.css
+++ b/zipkin-ui/css/trace.css
@@ -38,7 +38,6 @@
 }
 
 #trace-container .span .handle {
-  width: 150px;
   overflow: hidden;
   white-space: nowrap;
   float: left;


### PR DESCRIPTION
We found zipkin UI can't display the friendly if there are lots of spans. Looks like the following picture:
![image](https://user-images.githubusercontent.com/8295896/27623821-cf7c552c-5c10-11e7-8d58-8442a9b40493.png)

I just remove the width of the span. It works now. 

please review it. Thanks 