### PR TITLE
Forces build to fail if UI tests fail

### DIFF
--- a/zipkin-ui/pom.xml
+++ b/zipkin-ui/pom.xml
@@ -46,6 +46,7 @@
           <installDirectory>target</installDirectory>
           <nodeVersion>v6.9.2</nodeVersion>
           <npmVersion>3.10.9</npmVersion>
+          <failOnError>true</failOnError>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
This will cause the whole build to fail if a UI test fails, as happened in #1625.

I put the configuration option in the POM at builds/plugins/plugin/configuration for the plugin "frontend-maven-plugin"

It will also work to give the configuration option a narrower scope at builds/plugins/plugin/configuration/executions/execution/configuration for the execution with id "npm run test".  However, I think it makes sense to configure this option for the whole plugin, because I don't know of any failure that should be non-fatal.  (But perhaps there is.)

The only change in behavior I can see is in the test phase of the build.  For completeness, I forced a non-test build failure by deleting node from my maven cache and disabling my network connection.  In this case, the build failed because it couldn't download node, and it failed before and after this change.