### PR TITLE
Deletes empty test.

### DIFF
--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -395,10 +395,6 @@ describe('traceSummariesToMustache', () => {
     model[1].traceId.should.equal(traceId1);
     model[2].traceId.should.equal(traceId3);
   });
-
-  it('should tie-break a sort on duration using trace id', () => {
-
-  });
 });
 
 describe('mkDurationStr', () => {


### PR DESCRIPTION
It looks like the behavior to be tested is covered in the test above:
  'should order traces by duration and tie-break using trace id'