### PR TITLE
In UI, show nothing instead of 'NaN' for null duration

### DIFF
--- a/zipkin-ui/js/component_ui/traceSummary.js
+++ b/zipkin-ui/js/component_ui/traceSummary.js
@@ -209,7 +209,7 @@ export function getServiceDurations(groupedTimestamps) {
 }
 
 export function mkDurationStr(duration) {
-  if (duration === 0) {
+  if (duration === 0 || typeof duration === 'undefined') {
     return '';
   } else if (duration < 1000) {
     return `${duration}μ`;

--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -406,6 +406,10 @@ describe('mkDurationStr', () => {
     mkDurationStr(0).should.equal('');
   });
 
+  it('should return empty string on undefined duration', () => {
+    mkDurationStr().should.equal('');
+  });
+
   it('should format microseconds', () => {
     mkDurationStr(3).should.equal('3μ');
   });


### PR DESCRIPTION
This fixes #1575 for me.

The case where I was seeing NaN was when I had a span with two annotations with the same timestamp, like SR/SS bot at the exact same time.  In this case, the server was returning a span with no duration field, so Javascript sees it as undefined.