### PR TITLE
Refactors codec to reduce redundant list creation

### DIFF
--- a/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,8 @@ import com.google.common.io.ByteStreams;
 import com.twitter.zipkin.thriftjava.Annotation;
 import com.twitter.zipkin.thriftjava.BinaryAnnotation;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
@@ -98,6 +100,9 @@ public class CodecBenchmarks {
   static final byte[] clientSpanThrift = Codec.THRIFT.writeSpan(clientSpan);
   static final com.twitter.zipkin.thriftjava.Span clientSpanLibThrift =
       deserialize(clientSpanThrift);
+  static final List<Span> tenClientSpans = Collections.nCopies(10, clientSpan);
+  static final byte[] tenClientSpansJson = Codec.JSON.writeSpans(tenClientSpans);
+  static final byte[] tenClientSpansThrift = Codec.THRIFT.writeSpans(tenClientSpans);
 
   @Benchmark
   public Span readClientSpan_json_zipkin() {
@@ -105,8 +110,18 @@ public class CodecBenchmarks {
   }
 
   @Benchmark
+  public List<Span> readTenClientSpans_json_zipkin() {
+    return Codec.JSON.readSpans(tenClientSpansJson);
+  }
+
+  @Benchmark
   public Span readClientSpan_thrift_zipkin() {
     return Codec.THRIFT.readSpan(clientSpanThrift);
+  }
+
+  @Benchmark
+  public List<Span> readTenClientSpans_thrift_zipkin() {
+    return Codec.THRIFT.readSpans(tenClientSpansThrift);
   }
 
   @Benchmark
@@ -120,8 +135,18 @@ public class CodecBenchmarks {
   }
 
   @Benchmark
+  public byte[] writeTenClientSpans_json_zipkin() {
+    return Codec.JSON.writeSpans(tenClientSpans);
+  }
+
+  @Benchmark
   public byte[] writeClientSpan_thrift_zipkin() {
     return Codec.THRIFT.writeSpan(clientSpan);
+  }
+
+  @Benchmark
+  public byte[] writeTenClientSpans_thrift_zipkin() {
+    return Codec.THRIFT.writeSpans(tenClientSpans);
   }
 
   @Benchmark
@@ -202,7 +227,7 @@ public class CodecBenchmarks {
   // Convenience main entry-point
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-        .include(".*" + CodecBenchmarks.class.getSimpleName() + ".*")
+        .include(".*" + CodecBenchmarks.class.getSimpleName() + ".*lientSpan.*")
         .build();
 
     new Runner(opt).run();

--- a/benchmarks/src/main/resources/span-client.json
+++ b/benchmarks/src/main/resources/span-client.json
@@ -1,48 +1,79 @@
 {
-  "traceId": "5af7183fb1d4cf5f",
-  "name": "query",
-  "id": "352bff9a74ca9ad2",
-  "parentId": "6b221d5bc9e6496c",
-  "timestamp": 1461750040359000,
-  "duration": 5000,
+  "traceId": "86154a4ba6e91385",
+  "name": "get",
+  "id": "4d1e00c0db9010db",
+  "parentId": "86154a4ba6e91385",
+  "timestamp": 1472470996199000,
+  "duration": 207000,
   "annotations": [
     {
+      "timestamp": 1472470996199000,
+      "value": "cs",
       "endpoint": {
-        "serviceName": "zipkin-server",
-        "ipv4": "172.19.0.3",
-        "port": 9411
-      },
-      "timestamp": 1461750040359000,
-      "value": "cs"
+        "serviceName": "frontend",
+        "ipv4": "127.0.0.1"
+      }
     },
     {
+      "timestamp": 1472470996238000,
+      "value": "ws",
       "endpoint": {
-        "serviceName": "zipkin-server",
-        "ipv4": "172.19.0.3",
-        "port": 9411
-      },
-      "timestamp": 1461750040364000,
-      "value": "cr"
+        "serviceName": "frontend",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "timestamp": 1472470996403000,
+      "value": "wr",
+      "endpoint": {
+        "serviceName": "frontend",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "timestamp": 1472470996406000,
+      "value": "cr",
+      "endpoint": {
+        "serviceName": "frontend",
+        "ipv4": "127.0.0.1"
+      }
     }
   ],
   "binaryAnnotations": [
     {
-      "key": "jdbc.query",
-      "value": "select distinct `zipkin_spans`.`trace_id` from `zipkin_spans` join `zipkin_annotations` on (`zipkin_spans`.`trace_id` = `zipkin_annotations`.`trace_id` and `zipkin_spans`.`id` = `zipkin_annotations`.`span_id`) where (`zipkin_annotations`.`endpoint_service_name` = ? and `zipkin_spans`.`start_ts` between ? and ?) order by `zipkin_spans`.`start_ts` desc limit ?",
+      "key": "ca",
+      "value": true,
       "endpoint": {
-        "serviceName": "zipkin-server",
-        "ipv4": "172.19.0.3",
-        "port": 9411
+        "serviceName": "frontend",
+        "ipv4": "127.0.0.1",
+        "port": 49504
+      }
+    },
+    {
+      "key": "clnt/finagle.version",
+      "value": "6.36.0",
+      "endpoint": {
+        "serviceName": "frontend",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "key": "http.uri",
+      "value": "/api",
+      "endpoint": {
+        "serviceName": "frontend",
+        "ipv4": "127.0.0.1"
       }
     },
     {
       "key": "sa",
       "value": true,
       "endpoint": {
-        "serviceName": "mysql",
-        "ipv4": "172.19.0.2",
-        "port": 3306
+        "serviceName": "backend",
+        "ipv4": "127.0.0.1",
+        "port": 9000
       }
     }
-  ]
+  ],
+  "debug": false
 }

--- a/zipkin/src/main/java/zipkin/internal/Dependencies.java
+++ b/zipkin/src/main/java/zipkin/internal/Dependencies.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import zipkin.DependencyLink;
 
-import static zipkin.internal.ThriftCodec.DEPENDENCY_LINKS_ADAPTER;
+import static zipkin.internal.ThriftCodec.DEPENDENCY_LINK_ADAPTER;
 import static zipkin.internal.ThriftCodec.Field;
 import static zipkin.internal.ThriftCodec.TYPE_I64;
 import static zipkin.internal.ThriftCodec.TYPE_LIST;
@@ -117,7 +117,7 @@ public final class Dependencies {
         } else if (field.isEqualTo(END_TS)) {
           endTs = bytes.getLong();
         } else if (field.isEqualTo(LINKS)) {
-          links = DEPENDENCY_LINKS_ADAPTER.read(bytes);
+          links = ThriftCodec.readList(DEPENDENCY_LINK_ADAPTER, bytes);
         } else {
           skip(bytes, field.type);
         }
@@ -130,7 +130,7 @@ public final class Dependencies {
       int sizeInBytes = 0;
       sizeInBytes += 3 + 8; // START_TS
       sizeInBytes += 3 + 8; // END_TS
-      sizeInBytes += 3 + DEPENDENCY_LINKS_ADAPTER.sizeInBytes(value.links);
+      sizeInBytes += 3 + ThriftCodec.listSizeInBytes(DEPENDENCY_LINK_ADAPTER, value.links);
       sizeInBytes++; //TYPE_STOP
       return sizeInBytes;
     }
@@ -145,7 +145,7 @@ public final class Dependencies {
       buffer.writeLong(value.endTs);
 
       LINKS.write(buffer);
-      DEPENDENCY_LINKS_ADAPTER.write(value.links, buffer);
+      ThriftCodec.writeList(DEPENDENCY_LINK_ADAPTER, value.links, buffer);
 
       buffer.writeByte(TYPE_STOP);
     }

--- a/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -411,13 +411,13 @@ public final class JsonCodecTest extends CodecTest {
   @Test
   public void sizeInBytes_span() throws IOException {
     Span span = TestObjects.LOTS_OF_SPANS[0];
-    assertThat(JsonCodec.SPAN_ADAPTER.sizeInBytes(span))
+    assertThat(JsonCodec.SPAN_WRITER.sizeInBytes(span))
         .isEqualTo(codec().writeSpan(span).length);
   }
 
   @Test
   public void sizeInBytes_link() throws IOException {
-    assertThat(JsonCodec.DEPENDENCY_LINK_ADAPTER.sizeInBytes(TestObjects.LINKS.get(0)))
+    assertThat(JsonCodec.DEPENDENCY_LINK_WRITER.sizeInBytes(TestObjects.LINKS.get(0)))
         .isEqualTo(codec().writeDependencyLink(TestObjects.LINKS.get(0)).length);
   }
 

--- a/zipkin/src/test/java/zipkin/internal/ThriftCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/ThriftCodecTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -45,19 +45,19 @@ public final class ThriftCodecTest extends CodecTest {
   @Test
   public void sizeInBytes_span() throws IOException {
     Span span = TestObjects.LOTS_OF_SPANS[0];
-    assertThat(ThriftCodec.SPAN_ADAPTER.sizeInBytes(span))
+    assertThat(ThriftCodec.SPAN_WRITER.sizeInBytes(span))
         .isEqualTo(codec().writeSpan(span).length);
   }
 
   @Test
   public void sizeInBytes_trace() throws IOException {
-    assertThat(ThriftCodec.SPANS_ADAPTER.sizeInBytes(TestObjects.TRACE))
+    assertThat(ThriftCodec.listSizeInBytes(ThriftCodec.SPAN_WRITER, TestObjects.TRACE))
         .isEqualTo(codec().writeSpans(TestObjects.TRACE).length);
   }
 
   @Test
   public void sizeInBytes_links() throws IOException {
-    assertThat(ThriftCodec.DEPENDENCY_LINKS_ADAPTER.sizeInBytes(TestObjects.LINKS))
+    assertThat(ThriftCodec.listSizeInBytes(ThriftCodec.DEPENDENCY_LINK_ADAPTER, TestObjects.LINKS))
         .isEqualTo(codec().writeDependencyLinks(TestObjects.LINKS).length);
   }
 


### PR DESCRIPTION
This includes cleanups and performance improvements when reading spans.
Notably, this stops recreating lists by re-using Span.Builder

To test this, we use the same client-span json from zipkin-reporter.

Benchmark                                          Mode  Cnt   Score   Error  Units
CodecBenchmarks.readClientSpan_json_zipkin         avgt   15  10.070 ± 0.431  us/op
CodecBenchmarks.readClientSpan_thrift_libthrift    avgt   15   2.633 ± 0.047  us/op
CodecBenchmarks.readClientSpan_thrift_zipkin       avgt   15   2.846 ± 0.059  us/op
CodecBenchmarks.readTenClientSpans_json_zipkin     avgt   15  78.381 ± 2.028  us/op
CodecBenchmarks.readTenClientSpans_thrift_zipkin   avgt   15  28.216 ± 0.365  us/op

After:

Benchmark                                          Mode  Cnt   Score   Error  Units
CodecBenchmarks.readClientSpan_json_zipkin         avgt   15  9.700 ± 0.261  us/op
CodecBenchmarks.readClientSpan_thrift_libthrift    avgt   15   2.367 ± 0.022  us/op
CodecBenchmarks.readClientSpan_thrift_zipkin       avgt   15   2.396 ± 0.034  us/op
CodecBenchmarks.readTenClientSpans_json_zipkin     avgt   15  76.188 ± 1.164  us/op
CodecBenchmarks.readTenClientSpans_thrift_zipkin   avgt   15  23.903 ± 0.404  us/op