### PR TITLE
Drops invalid span data vs counting them in dependency links

### DIFF
--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -447,6 +447,19 @@ public final class Span implements Comparable<Span>, Serializable { // for Spark
     return this.name.compareTo(that.name);
   }
 
+  /** Returns the hex representation of the span's trace ID */
+  public String traceIdString() {
+    if (traceIdHigh != 0) {
+      char[] result = new char[32];
+      writeHexLong(result, 0, traceIdHigh);
+      writeHexLong(result, 16, traceId);
+      return new String(result);
+    }
+    char[] result = new char[16];
+    writeHexLong(result, 0, traceId);
+    return new String(result);
+  }
+
   /** Returns {@code $traceId.$spanId<:$parentId or $spanId} */
   public String idString() {
     int resultLength = (3 * 16) + 3; // 3 ids and the constant delimiters

--- a/zipkin/src/main/java/zipkin/internal/DependencyLinkSpan.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinkSpan.java
@@ -20,6 +20,7 @@ import zipkin.Span;
 
 import static zipkin.internal.Util.checkNotNull;
 import static zipkin.internal.Util.equal;
+import static zipkin.internal.Util.writeHexLong;
 
 /**
  * Internal type used by {@link DependencyLinker linker} that holds the minimum state needed to
@@ -59,6 +60,19 @@ public final class DependencyLinkSpan {
       h *= 1000003;
       h ^= (lo >>> 32) ^ lo;
       return h;
+    }
+
+    /** Returns the hex representation of the span's trace ID */
+    @Override public String toString() {
+      if (hi != 0) {
+        char[] result = new char[32];
+        writeHexLong(result, 0, hi);
+        writeHexLong(result, 16, lo);
+        return new String(result);
+      }
+      char[] result = new char[16];
+      writeHexLong(result, 0, lo);
+      return new String(result);
     }
   }
 

--- a/zipkin/src/test/java/zipkin/SpanTest.java
+++ b/zipkin/src/test/java/zipkin/SpanTest.java
@@ -30,9 +30,31 @@ import static zipkin.Constants.SERVER_SEND;
 import static zipkin.TestObjects.APP_ENDPOINT;
 
 public class SpanTest {
+  @Test
+  public void traceIdString() {
+    Span with128BitId = Span.builder()
+      .traceId(Util.lowerHexToUnsignedLong("48485a3953bb6124"))
+      .id(1)
+      .name("foo").build();
+
+    assertThat(with128BitId.traceIdString())
+      .isEqualTo("48485a3953bb6124");
+  }
 
   @Test
-  public void traceIdHigh() {
+  public void traceIdString_high() {
+    Span with128BitId = Span.builder()
+      .traceId(Util.lowerHexToUnsignedLong("48485a3953bb6124"))
+      .traceIdHigh(Util.lowerHexToUnsignedLong("463ac35c9f6413ad"))
+      .id(1)
+      .name("foo").build();
+
+    assertThat(with128BitId.traceIdString())
+      .isEqualTo("463ac35c9f6413ad48485a3953bb6124");
+  }
+
+  @Test
+  public void idString_traceIdHigh() {
     Span with128BitId = Span.builder()
         .traceId(Util.lowerHexToUnsignedLong("48485a3953bb6124"))
         .traceIdHigh(Util.lowerHexToUnsignedLong("463ac35c9f6413ad"))

--- a/zipkin/src/test/java/zipkin/internal/NodeTest.java
+++ b/zipkin/src/test/java/zipkin/internal/NodeTest.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.Test;
 import zipkin.Span;
 import zipkin.TestObjects;
@@ -25,6 +27,19 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class NodeTest {
+  List<String> messages = new ArrayList<>();
+
+  Logger logger = new Logger("", null) {
+    {
+      setLevel(Level.ALL);
+    }
+
+    @Override public void log(Level level, String msg) {
+      assertThat(level).isEqualTo(Level.FINE);
+      messages.add(msg);
+    }
+  };
+
   @Test(expected = NullPointerException.class)
   public void addValue_nullNotAllowed() {
     new Node<>().value(null);
@@ -79,7 +94,12 @@ public class NodeTest {
 
     Collections.shuffle(copy);
 
-    Node<Span> root = Node.constructTree(copy);
+    Node.TreeBuilder<Span> treeBuilder =
+      new Node.TreeBuilder<>(logger, copy.get(0).traceIdString());
+    for (Span span : copy) {
+      treeBuilder.addNode(span.parentId, span.id, span);
+    }
+    Node<Span> root = treeBuilder.build();
     assertThat(root.value())
         .isEqualTo(TestObjects.TRACE.get(0));
 
@@ -94,43 +114,62 @@ public class NodeTest {
   @Test
   public void constructTree_noChildLeftBehind() {
     List<Span> spans = asList(
-             Span.builder().traceId(137L).id(1L).name("root-0").build(),
-             Span.builder().traceId(137L).parentId(1L).id(2L).name("child-0").build(),
-             Span.builder().traceId(137L).parentId(1L).id(3L).name("child-1").build(),
-             Span.builder().traceId(137L).id(4L).name("lost-0").build(),
-             Span.builder().traceId(137L).id(5L).name("lost-1").build());
+      Span.builder().traceId(137L).id(1L).name("root-0").build(),
+      Span.builder().traceId(137L).parentId(1L).id(2L).name("child-0").build(),
+      Span.builder().traceId(137L).parentId(1L).id(3L).name("child-1").build(),
+      Span.builder().traceId(137L).id(4L).name("lost-0").build(),
+      Span.builder().traceId(137L).id(5L).name("lost-1").build());
     int treeSize = 0;
-    Node<Span> tree = Node.constructTree(spans);
+    Node.TreeBuilder<Span> treeBuilder =
+      new Node.TreeBuilder<>(logger, spans.get(0).traceIdString());
+    for (Span span : spans) {
+      assertThat(treeBuilder.addNode(span.parentId, span.id, span))
+        .isTrue();
+    }
+    Node<Span> tree = treeBuilder.build();
     Iterator<Node<Span>> iter = tree.traverse();
     while (iter.hasNext()) {
       iter.next();
       treeSize++;
     }
     assertThat(treeSize).isEqualTo(spans.size());
+    assertThat(messages).containsExactly(
+      "attributing span missing parent to root: traceId=0000000000000089, rootSpanId=0000000000000001, spanId=0000000000000004",
+      "attributing span missing parent to root: traceId=0000000000000089, rootSpanId=0000000000000001, spanId=0000000000000005"
+    );
   }
 
-  @Test public void constructTree_selfReferencingChildrenGoToRoot() {
-    Span s1 = Span.builder().traceId(137L).id(1L).name("s1").build();
+  @Test public void constructTree_headless() {
     Span s2 = Span.builder().traceId(137L).parentId(1L).id(2L).name("s2").build();
-    Span s3 = Span.builder().traceId(137L).parentId(3L).id(3L).name("s3").build();
-    Span s4 = Span.builder().traceId(137L).parentId(4L).id(4L).name("s4").build();
+    Span s3 = Span.builder().traceId(137L).parentId(1L).id(3L).name("s3").build();
+    Span s4 = Span.builder().traceId(137L).parentId(1L).id(4L).name("s4").build();
 
-    Node<Span> root = Node.constructTree(asList(s1, s2, s3, s4));
-    assertThat(root.value())
-      .isEqualTo(s1);
-    assertThat(root.children()).extracting(Node::value)
-      .containsExactly(s2, s3, s4);
-  }
-
-  @Test public void constructTree_selfReferencingChildrenGoToRoot_headless() {
-    Span s2 = Span.builder().traceId(137L).parentId(1L).id(2L).name("s2").build();
-    Span s3 = Span.builder().traceId(137L).parentId(3L).id(3L).name("s3").build();
-    Span s4 = Span.builder().traceId(137L).parentId(4L).id(4L).name("s4").build();
-
-    Node<Span> root = Node.constructTree(asList(s2, s3, s4));
+    Node.TreeBuilder<Span> treeBuilder = new Node.TreeBuilder<>(logger, s2.traceIdString());
+    for (Span span : asList(s2, s3, s4)) {
+      treeBuilder.addNode(span.parentId, span.id, span);
+    }
+    Node<Span> root = treeBuilder.build();
     assertThat(root.isSyntheticRootForPartialTree())
       .isTrue();
     assertThat(root.children()).extracting(Node::value)
       .containsExactly(s2, s3, s4);
+    assertThat(messages).containsExactly(
+      "substituting dummy node for missing root span: traceId=0000000000000089"
+    );
+  }
+
+  @Test
+  public void addNode_skipsOnCycle() {
+    Span s1 = Span.builder().traceId(137L).parentId(null).id(1L).name("s1").build();
+    Span s2 = Span.builder().traceId(137L).parentId(2L).id(2L).name("s2").build();
+
+    Node.TreeBuilder<Span> treeBuilder = new Node.TreeBuilder<>(logger, s2.traceIdString());
+    treeBuilder.addNode(s1.parentId, s1.id, s1);
+    assertThat(treeBuilder.addNode(s2.parentId, s2.id, s2)).isFalse();
+
+    treeBuilder.build();
+    assertThat(messages).containsExactly(
+      "skipping circular dependency: traceId=0000000000000089, spanId=0000000000000002"
+    );
   }
 }


### PR DESCRIPTION
Previously, I over-fixed an NPE on dependency linking when bad data is
present. Instead of trying to fix cyclical references, this just drops
them. In doing so, the code is easier to maintain.

See #1640