### PR TITLE
Don't use strict ID when processing dependency links (in-memory)

### DIFF
--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/DependencyLinkSpanIterator.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/DependencyLinkSpanIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -76,7 +76,8 @@ final class DependencyLinkSpanIterator implements Iterator<DependencyLinkSpan> {
   @Override
   public boolean hasNext() {
     return delegate.hasNext()
-        && (traceIdHi == null || traceIdHi.equals(traceIdHigh(delegate)))
+        // We don't have a query parameter for strictTraceId when fetching dependency links, so we
+        // ignore traceIdHigh. Otherwise, a single trace can appear as two, doubling callCount.
         && delegate.peek().getValue(ZipkinSpans.ZIPKIN_SPANS.TRACE_ID) == traceIdLo;
   }
 

--- a/zipkin/src/main/java/zipkin/storage/SpanStore.java
+++ b/zipkin/src/main/java/zipkin/storage/SpanStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -110,6 +110,10 @@ public interface SpanStore {
    * <p>Some implementations parse {@link zipkin.internal.DependencyLinkSpan} from storage and call
    * {@link zipkin.internal.DependencyLinker} to aggregate links. The reason is certain graph logic,
    * such as skipping up the tree is difficult to implement as a storage query.
+   *
+   * <p>There's no parameter to indicate how to handle mixed ID length: this operates the same as if
+   * {@link StorageComponent.Builder#strictTraceId(boolean)} was set to false. This ensures call
+   * counts are not incremented twice due to one hop downgrading from 128 to 64-bit trace IDs.
    *
    * @param endTs only return links from spans where {@link Span#timestamp} are at or before this
    * time in epoch milliseconds.

--- a/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/storage/DependenciesTest.java
@@ -95,12 +95,29 @@ public abstract class DependenciesTest {
    */
   @Test
   public void getDependencies_strictTraceId() {
-    List<Span> mixedTrace = new ArrayList<>(TRACE);
-    mixedTrace.set(1, TRACE.get(1).toBuilder().traceIdHigh(2).build());
+    long traceIdHigh = Long.MAX_VALUE;
+    long traceId = Long.MIN_VALUE;
+    List<Span> mixedTrace = asList(
+      Span.builder().traceIdHigh(traceIdHigh).traceId(traceId).id(1L).name("get")
+        .addAnnotation(Annotation.create(TODAY * 1000, SERVER_RECV, WEB_ENDPOINT))
+        .addAnnotation(Annotation.create((TODAY + 350) * 1000, SERVER_SEND, WEB_ENDPOINT))
+        .build(),
+      // the server dropped traceIdHigh
+      Span.builder().traceId(traceId).parentId(1L).id(2L).name("get")
+        .addAnnotation(Annotation.create((TODAY + 100) * 1000, SERVER_RECV, APP_ENDPOINT))
+        .addAnnotation(Annotation.create((TODAY + 250) * 1000, SERVER_SEND, APP_ENDPOINT))
+        .build(),
+      Span.builder().traceIdHigh(traceIdHigh).traceId(traceId).parentId(1L).id(2L).name("get")
+        .addAnnotation(Annotation.create((TODAY + 50) * 1000, CLIENT_SEND, WEB_ENDPOINT))
+        .addAnnotation(Annotation.create((TODAY + 300) * 1000, CLIENT_RECV, WEB_ENDPOINT))
+        .build()
+    );
+
     processDependencies(mixedTrace);
 
-    assertThat(store().getDependencies(TODAY + 1000L, null))
-        .containsOnlyElementsOf(LINKS);
+    assertThat(store().getDependencies(TODAY + 1000L, null)).containsOnly(
+      DependencyLink.create("web", "app", 1)
+    );
   }
 
   /** It should be safe to run dependency link jobs twice */


### PR DESCRIPTION
The existing code inadvertently used strict trace IDs when looking up
dependency link spans. This caused me a lot of head scratching when
trying to figure out why later refactoring caused multiple links on a
mixed trace.