### PR TITLE
Adds errorCount to the dependency graph and colors accordingly

### DIFF
--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ public class ZipkinUiProperties {
   private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);
   private String instrumented = ".*";
   private String logsUrl = null;
+  private Dependency dependency = new Dependency();
 
   public int getDefaultLookback() {
     return defaultLookback;
@@ -64,6 +65,35 @@ public class ZipkinUiProperties {
   public void setLogsUrl(String logsUrl) {
     if (!StringUtils.isEmpty(logsUrl)) {
       this.logsUrl = logsUrl;
+    }
+  }
+
+  public Dependency getDependency() {
+    return dependency;
+  }
+
+  public void setDependency(Dependency dependency) {
+    this.dependency = dependency;
+  }
+
+  public static class Dependency {
+    private float lowErrorRate = 0.5f; // 50% of calls in error turns line yellow
+    private float highErrorRate = 0.75f; // 75% of calls in error turns line red
+
+    public float getLowErrorRate() {
+      return lowErrorRate;
+    }
+
+    public void setLowErrorRate(float lowErrorRate) {
+      this.lowErrorRate = lowErrorRate;
+    }
+
+    public float getHighErrorRate() {
+      return highErrorRate;
+    }
+
+    public void setHighErrorRate(float highErrorRate) {
+      this.highErrorRate = highErrorRate;
     }
   }
 }

--- a/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
@@ -41,7 +41,6 @@ public class ZipkinUiAutoConfigurationTest {
         .isNotNull();
   }
 
-
   @Test
   public void canOverridesProperty_defaultLookback() {
     context = createContextWithOverridenProperty("zipkin.ui.defaultLookback:100");
@@ -49,7 +48,6 @@ public class ZipkinUiAutoConfigurationTest {
     assertThat(context.getBean(ZipkinUiProperties.class).getDefaultLookback())
         .isEqualTo(100);
   }
-
 
   @Test
   public void canOverrideProperty_logsUrl() {
@@ -78,6 +76,22 @@ public class ZipkinUiAutoConfigurationTest {
     context = createContextWithOverridenProperty("zipkin.ui.enabled:false");
 
     context.getBean(ZipkinUiProperties.class);
+  }
+
+  @Test
+  public void canOverrideProperty_dependencyLowErrorRate() {
+    context = createContextWithOverridenProperty("zipkin.ui.dependency.low-error-rate:0.1");
+
+    assertThat(context.getBean(ZipkinUiProperties.class).getDependency().getLowErrorRate())
+      .isEqualTo(0.1f);
+  }
+
+  @Test
+  public void canOverrideProperty_dependencyHighErrorRate() {
+    context = createContextWithOverridenProperty("zipkin.ui.dependency.high-error-rate:0.1");
+
+    assertThat(context.getBean(ZipkinUiProperties.class).getDependency().getHighErrorRate())
+      .isEqualTo(0.1f);
   }
 
   private static AnnotationConfigApplicationContext createContext() {

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -101,6 +101,8 @@ defaultLookback | zipkin.ui.default-lookback | Default duration in millis to loo
 queryLimit | zipkin.ui.query-limit | Default limit for Find Traces. Defaults to 10.
 instrumented | zipkin.ui.instrumented | Which sites this Zipkin UI covers. Regex syntax. e.g. `http:\/\/example.com\/.*` Defaults to match all websites (`.*`).
 logsUrl | zipkin.ui.logs-url | Logs query service url pattern. If specified, a button will appear on the trace page and will replace {traceId} in the url by the traceId. Not required.
+dependency.lowErrorRate | zipkin.ui.dependency.low-error-rate | The rate of error calls on a dependency link that turns it yellow. Defaults to 0.5 (50%) set to >1 to disable.
+dependency.highErrorRate | zipkin.ui.dependency.high-error-rate | The rate of error calls on a dependency link that turns it red. Defaults to 0.75 (75%) set to >1 to disable.
 
 For example, if using docker you can set `ZIPKIN_UI_QUERY_LIMIT=100` to affect `$.queryLimit` in `/config.json`.
 
@@ -225,7 +227,7 @@ to prevent excessive load, service and span name queries are limited by
 today and one for yesterday)
 
 ### HTTP Collector
-The HTTP collector is enabled by default. It accepts spans via `POST /api/v1/spans`. The HTTP 
+The HTTP collector is enabled by default. It accepts spans via `POST /api/v1/spans`. The HTTP
 collector supports the following configuration:
 
 Property | Environment Variable | Description
@@ -241,7 +243,7 @@ The Scribe collector is disabled by default, configured by the following:
 ### Kafka Collector
 This collector remains a Kafka 0.8.x consumer, while Zipkin systems update to 0.9+.
 
-A collector supporting Kafka versions 0.10 and later is available as an external module. See 
+A collector supporting Kafka versions 0.10 and later is available as an external module. See
 [zipkin-autoconfigure/collector-kafka10](../zipkin-autoconfigure/collector-kafka10/).
 
 The following apply when `KAFKA_ZOOKEEPER` is set:

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/JsonAdapters.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/JsonAdapters.java
@@ -259,6 +259,9 @@ final class JsonAdapters {
           case "callCount":
             result.callCount(reader.nextLong());
             break;
+          case "errorCount":
+            result.errorCount(reader.nextLong());
+            break;
           default:
             reader.skipValue();
         }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/JsonAdaptersTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/JsonAdaptersTest.java
@@ -293,6 +293,20 @@ public class JsonAdaptersTest {
   }
 
   @Test
+  public void dependencyLinkRoundTrip_withError() throws IOException {
+    DependencyLink link = DependencyLink.builder()
+      .parent("foo")
+      .child("bar")
+      .callCount(2)
+      .errorCount(1).build();
+
+    Buffer bytes = new Buffer();
+    bytes.write(Codec.JSON.writeDependencyLink(link));
+    assertThat(JsonAdapters.DEPENDENCY_LINK_ADAPTER.fromJson(bytes))
+      .isEqualTo(link);
+  }
+
+  @Test
   public void readsTraceIdHighFromTraceIdField() throws IOException {
     String with128BitTraceId = ("{\n"
         + "  \"traceId\": \"48485a3953bb61246b221d5bc9e6496c\",\n"

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/HasErrorCount.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/HasErrorCount.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.mysql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+
+import static zipkin.storage.mysql.internal.generated.tables.ZipkinDependencies.ZIPKIN_DEPENDENCIES;
+
+final class HasErrorCount {
+  private static final Logger LOG = Logger.getLogger(HasErrorCount.class.getName());
+
+  static boolean test(DataSource datasource, DSLContexts context) {
+    try (Connection conn = datasource.getConnection()) {
+      DSLContext dsl = context.get(conn);
+      dsl.select(ZIPKIN_DEPENDENCIES.ERROR_COUNT).from(ZIPKIN_DEPENDENCIES).limit(1).fetchAny();
+      return true;
+    } catch (DataAccessException e) {
+      if (e.sqlState().equals("42S22")) {
+        LOG.warning("zipkin_dependencies.error_count doesn't exist, so DependencyLink.errorCount is not supported. " +
+            "Execute: alter table zipkin_dependencies add `error_count` BIGINT");
+        return false;
+      }
+      problemReading(e);
+    } catch (SQLException | RuntimeException e) {
+      problemReading(e);
+    }
+    return false;
+  }
+
+  static void problemReading(Exception e) {
+    LOG.log(Level.WARNING, "problem reading zipkin_dependencies.error_count", e);
+  }
+}

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/internal/generated/tables/ZipkinDependencies.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/internal/generated/tables/ZipkinDependencies.java
@@ -48,7 +48,7 @@ import zipkin.storage.mysql.internal.generated.Zipkin;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class ZipkinDependencies extends TableImpl<Record> {
 
-    private static final long serialVersionUID = 2126223781;
+    private static final long serialVersionUID = 162657278;
 
     /**
      * The reference instance of <code>zipkin.zipkin_dependencies</code>
@@ -82,6 +82,11 @@ public class ZipkinDependencies extends TableImpl<Record> {
      * The column <code>zipkin.zipkin_dependencies.call_count</code>.
      */
     public final TableField<Record, Long> CALL_COUNT = createField("call_count", org.jooq.impl.SQLDataType.BIGINT, this, "");
+
+    /**
+     * The column <code>zipkin.zipkin_dependencies.error_count</code>.
+     */
+    public final TableField<Record, Long> ERROR_COUNT = createField("error_count", org.jooq.impl.SQLDataType.BIGINT, this, "");
 
     /**
      * Create a <code>zipkin.zipkin_dependencies</code> table reference

--- a/zipkin-storage/mysql/src/main/resources/mysql.sql
+++ b/zipkin-storage/mysql/src/main/resources/mysql.sql
@@ -41,7 +41,8 @@ CREATE TABLE IF NOT EXISTS zipkin_dependencies (
   `day` DATE NOT NULL,
   `parent` VARCHAR(255) NOT NULL,
   `child` VARCHAR(255) NOT NULL,
-  `call_count` BIGINT
+  `call_count` BIGINT,
+  `error_count` BIGINT
 ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED CHARACTER SET=utf8 COLLATE utf8_general_ci;
 
 ALTER TABLE zipkin_dependencies ADD UNIQUE KEY(`day`, `parent`, `child`);

--- a/zipkin-ui/README.md
+++ b/zipkin-ui/README.md
@@ -91,3 +91,15 @@ where `{traceId}` will be contextually replaced by the trace id.
 If this feature is activated, you'll see on the trace detail page an additional button named `logs`.
 
 ![Logs Button](https://cloud.githubusercontent.com/assets/9842366/20482538/6e35ca66-afed-11e6-90e9-1e28f66d985e.png)
+
+#### How do I adjust the error rates in the dependency graph
+
+By default, the /dependency endpoint colors a link yellow when the error
+rate is 50% or higher, or red when it 75% or higher. You can control
+these rates via the `dependency.low-error-rate` and `dependency.high-error-rate`
+properties:
+
+Ex. To make lines yellow when there's a 10% error rate, set:
+`ZIPKIN_UI_DEPENDENCY_LOW_ERROR_RATE=0.1`
+
+To disable coloring of lines, set both rates to a number higher than 1.

--- a/zipkin-ui/js/component_ui/serviceDataModal.js
+++ b/zipkin-ui/js/component_ui/serviceDataModal.js
@@ -24,6 +24,7 @@ function renderDependencyModal(event, data) {
   $modal.find('#dependencyModalParent').html($parentElement);
   $modal.find('#dependencyModalChild').html($childElement);
   $modal.find('#dependencyCallCount').text(data.callCount);
+  $modal.find('#dependencyErrorCount').text(data.errorCount || 0);
 
   $('#serviceModal').modal('hide');
   $modal.modal('show');

--- a/zipkin-ui/js/config.js
+++ b/zipkin-ui/js/config.js
@@ -3,7 +3,11 @@ import $ from 'jquery';
 const defaults = {
   environment: '',
   queryLimit: 10,
-  defaultLookback: 60 * 60 * 1000 // 1 hour
+  defaultLookback: 60 * 60 * 1000, // 1 hour
+  dependency: {
+    lowErrorRate: 0.5, // 50% of calls in error turns line yellow
+    highErrorRate: 0.75 // 75% of calls in error turns line red
+  }
 };
 
 export default function loadConfig() {

--- a/zipkin-ui/js/page/dependency.js
+++ b/zipkin-ui/js/page/dependency.js
@@ -22,7 +22,7 @@ const DependencyPageComponent = component(function DependencyPage() {
     $('#startTs').val(startTs || moment().valueOf() - 86400000);
 
     DependencyData.attachTo('#dependency-container');
-    DependencyGraphUI.attachTo('#dependency-container');
+    DependencyGraphUI.attachTo('#dependency-container', {config: this.attr.config});
     ServiceDataModal.attachTo('#service-data-modal-container');
     TimeStampUI.attachTo('#end-ts');
     TimeStampUI.attachTo('#start-ts');

--- a/zipkin-ui/templates/dependency.mustache
+++ b/zipkin-ui/templates/dependency.mustache
@@ -72,6 +72,10 @@
               <td>Number of calls</td>
               <td id="dependencyCallCount">?</td>
             </tr>
+            <tr>
+              <td>Number of errors</td>
+              <td id="dependencyErrorCount">?</td>
+            </tr>
             </tbody>
           </table>
         </div>

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -544,6 +544,8 @@ public final class JsonCodec implements Codec {
           result.child(reader.nextString());
         } else if (nextName.equals("callCount")) {
           result.callCount(reader.nextLong());
+        } else if (nextName.equals("errorCount")) {
+          result.errorCount(reader.nextLong());
         } else {
           reader.skipValue();
         }
@@ -563,13 +565,20 @@ public final class JsonCodec implements Codec {
       sizeInBytes += asciiSizeInBytes("{\"parent\":\"") + jsonEscapedSizeInBytes(value.parent);
       sizeInBytes += asciiSizeInBytes("\",\"child\":\"") + jsonEscapedSizeInBytes(value.child);
       sizeInBytes += asciiSizeInBytes("\",\"callCount\":") + asciiSizeInBytes(value.callCount);
+      if (value.errorCount > 0) {
+        sizeInBytes += asciiSizeInBytes(",\"errorCount\":") + asciiSizeInBytes(value.errorCount);
+      }
       return ++sizeInBytes;// end curly-brace
     }
 
     @Override public void write(DependencyLink value, Buffer b) {
       b.writeAscii("{\"parent\":\"").writeJsonEscaped(value.parent);
       b.writeAscii("\",\"child\":\"").writeJsonEscaped(value.child);
-      b.writeAscii("\",\"callCount\":").writeAscii(value.callCount).writeByte('}');
+      b.writeAscii("\",\"callCount\":").writeAscii(value.callCount);
+      if (value.errorCount > 0) {
+        b.writeAscii(",\"errorCount\":").writeAscii(value.errorCount);
+      }
+      b.writeByte('}');
     }
 
     @Override public String toString() {

--- a/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/ThriftCodec.java
@@ -439,6 +439,7 @@ public final class ThriftCodec implements Codec {
     final Field PARENT = new Field(TYPE_STRING, 1);
     final Field CHILD = new Field(TYPE_STRING, 2);
     final Field CALL_COUNT = new Field(TYPE_I64, 4);
+    final Field ERROR_COUNT = new Field(TYPE_I64, 5);
 
     @Override public DependencyLink read(ByteBuffer bytes) {
       DependencyLink.Builder result = DependencyLink.builder();
@@ -454,6 +455,8 @@ public final class ThriftCodec implements Codec {
           result.child(readUtf8(bytes));
         } else if (field.isEqualTo(CALL_COUNT)) {
           result.callCount(bytes.getLong());
+        } else if (field.isEqualTo(ERROR_COUNT)) {
+          result.errorCount(bytes.getLong());
         } else {
           skip(bytes, field.type);
         }
@@ -467,6 +470,7 @@ public final class ThriftCodec implements Codec {
       sizeInBytes += 3 + 4 + Buffer.utf8SizeInBytes(value.parent);
       sizeInBytes += 3 + 4 + Buffer.utf8SizeInBytes(value.child);
       sizeInBytes += 3 + 8; // CALL_COUNT
+      if (value.errorCount > 0) sizeInBytes += 3 + 8; // ERROR_COUNT
       sizeInBytes++; //TYPE_STOP
       return sizeInBytes;
     }
@@ -480,6 +484,11 @@ public final class ThriftCodec implements Codec {
 
       CALL_COUNT.write(buffer);
       buffer.writeLong(value.callCount);
+
+      if (value.errorCount > 0) {
+        ERROR_COUNT.write(buffer);
+        buffer.writeLong(value.errorCount);
+      }
 
       buffer.writeByte(TYPE_STOP);
     }

--- a/zipkin/src/test/java/zipkin/CodecTest.java
+++ b/zipkin/src/test/java/zipkin/CodecTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -171,6 +171,19 @@ public abstract class CodecTest {
   }
 
   @Test
+  public void dependencyLinkRoundTrip_withError() throws IOException {
+    DependencyLink link = DependencyLink.builder()
+      .parent("foo")
+      .child("bar")
+      .callCount(2)
+      .errorCount(1).build();
+
+    byte[] bytes = codec().writeDependencyLink(link);
+    assertThat(codec().readDependencyLink(bytes))
+      .isEqualTo(link);
+  }
+
+  @Test
   public void dependencyLinksRoundTrip() throws IOException {
     List<DependencyLink> links = asList(
         DependencyLink.create("foo", "bar", 2),
@@ -179,6 +192,21 @@ public abstract class CodecTest {
     byte[] bytes = codec().writeDependencyLinks(links);
     assertThat(codec().readDependencyLinks(bytes))
         .isEqualTo(links);
+  }
+
+  @Test
+  public void dependencyLinksRoundTrip_withError() throws IOException {
+    List<DependencyLink> links = asList(
+      DependencyLink.create("foo", "bar", 2),
+      DependencyLink.builder()
+        .parent("bar")
+        .child("baz")
+        .callCount(3)
+        .errorCount(1).build()
+    );
+    byte[] bytes = codec().writeDependencyLinks(links);
+    assertThat(codec().readDependencyLinks(bytes))
+      .isEqualTo(links);
   }
 
   @Test

--- a/zipkin/src/test/java/zipkin/TestObjects.java
+++ b/zipkin/src/test/java/zipkin/TestObjects.java
@@ -77,8 +77,8 @@ public final class TestObjects {
   ).stream().map(ApplyTimestampAndDuration::apply).collect(toList());
 
   public static final List<DependencyLink> LINKS = asList(
-      DependencyLink.builder().parent("web").child("app").callCount(1).build(),
-      DependencyLink.builder().parent("app").child("db").callCount(1).build()
+    DependencyLink.builder().parent("web").child("app").callCount(1L).build(),
+    DependencyLink.builder().parent("app").child("db").callCount(1L).errorCount(1L).build()
   );
   public static final Dependencies DEPENDENCIES = Dependencies.create(TODAY, TODAY + 1000, LINKS);
 

--- a/zipkin/src/test/java/zipkin/internal/DependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependenciesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,8 +25,8 @@ public final class DependenciesTest {
   @Test
   public void dependenciesRoundTrip() throws IOException {
     Dependencies dependencies = Dependencies.create(1L, 2L, asList(
-        DependencyLink.create("foo", "bar", 2),
-        DependencyLink.create("bar", "baz", 3)
+      DependencyLink.builder().parent("foo").child("bar").callCount(2L).build(),
+      DependencyLink.builder().parent("bar").child("baz").callCount(2L).errorCount(1L).build()
     ));
 
     ByteBuffer bytes = dependencies.toThrift();

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
@@ -27,6 +27,7 @@ import zipkin.internal.Span2.Kind;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.Constants.ERROR;
 
 public class DependencyLinkerTest {
   List<String> messages = new ArrayList<>();
@@ -50,8 +51,8 @@ public class DependencyLinkerTest {
   @Test
   public void linksSpans() {
     assertThat(new DependencyLinker().putTrace(TestObjects.TRACE).link()).containsExactly(
-      DependencyLink.create("web", "app", 1L),
-      DependencyLink.create("app", "db", 1L)
+      DependencyLink.builder().parent("web").child("app").callCount(1L).build(),
+      DependencyLink.builder().parent("app").child("db").callCount(1L).errorCount(1L).build()
     );
   }
 
@@ -76,8 +77,8 @@ public class DependencyLinkerTest {
   @Test
   public void linksSpansDirectedByKind() {
     List<Span2> validRootSpans = asList(
-      span2(0L, 1L, null, 1L, Kind.SERVER, "server", "client"),
-      span2(0L, 1L, null, 1L, Kind.CLIENT, "client", "server")
+      span2(1L, null, 1L, Kind.SERVER, "server", "client", false),
+      span2(1L, null, 1L, Kind.CLIENT, "client", "server", false)
     );
 
     for (Span2 span : validRootSpans) {
@@ -90,9 +91,9 @@ public class DependencyLinkerTest {
   @Test
   public void callsAgainstTheSameLinkIncreasesCallCount_span() {
     List<Span2> trace = asList(
-      span2(0L, 1L, null, 1L, Kind.SERVER, "client", null),
-      span2(0L, 1L, 1L, 2L, Kind.CLIENT, null, "server"),
-      span2(0L, 1L, 1L, 3L, Kind.CLIENT, null, "server")
+      span2(1L, null, 1L, Kind.SERVER, "client", null, false),
+      span2(1L, 1L, 2L, Kind.CLIENT, null, "server", false),
+      span2(1L, 1L, 3L, Kind.CLIENT, null, "server", false)
     );
 
     assertThat(new DependencyLinker()
@@ -103,8 +104,8 @@ public class DependencyLinkerTest {
   @Test
   public void callsAgainstTheSameLinkIncreasesCallCount_trace() {
     List<Span2> trace = asList(
-      span2(0L, 1L, null, 1L, Kind.SERVER, "client", null),
-      span2(0L, 1L, 1L, 2L, Kind.CLIENT, null, "server")
+      span2(1L, null, 1L, Kind.SERVER, "client", null, false),
+      span2(1L, 1L, 2L, Kind.CLIENT, null, "server", false)
     );
 
     assertThat(new DependencyLinker()
@@ -120,8 +121,8 @@ public class DependencyLinkerTest {
   @Test
   public void singleHostSpansResultInASingleCallCount() {
     List<Span2> trace = asList(
-      span2(0L, 3L, null, 3L, Kind.CLIENT, "client", null),
-      span2(0L, 3L, 3L, 4L, Kind.SERVER, "server", "client")
+      span2(3L, null, 3L, Kind.CLIENT, "client", null, false),
+      span2(3L, 3L, 4L, Kind.SERVER, "server", null, false)
     );
 
     assertThat(new DependencyLinker()
@@ -130,10 +131,34 @@ public class DependencyLinkerTest {
   }
 
   @Test
+  public void singleHostSpansResultInASingleErrorCount() {
+    List<Span2> trace = asList(
+      span2(3L, null, 3L, Kind.CLIENT, "client", null, true),
+      span2(3L, 3L, 4L, Kind.SERVER, "server", null, true)
+    );
+
+    assertThat(new DependencyLinker().putTrace(trace.iterator()).link()).containsOnly(
+      DependencyLink.builder().parent("client").child("server").callCount(1L).errorCount(1L).build()
+    );
+  }
+
+  @Test
+  public void singleHostSpansResultInASingleErrorCount_sameId() {
+    List<Span2> trace = asList(
+      span2(3L, null, 3L, Kind.CLIENT, "client", null, true),
+      span2(3L, null, 3L, Kind.SERVER, "server", null, true)
+    );
+
+    assertThat(new DependencyLinker().putTrace(trace.iterator()).link()).containsOnly(
+      DependencyLink.builder().parent("client").child("server").callCount(1L).errorCount(1L).build()
+    );
+  }
+
+  @Test
   public void singleHostSpansResultInASingleCallCount_defersNameToServer() {
     List<Span2> trace = asList(
-      span2(0L, 1L, null, 1L, Kind.CLIENT, "client", "server"),
-      span2(0L, 1L, 1L, 2L, Kind.SERVER, "server", null)
+      span2(1L, null, 1L, Kind.CLIENT, "client", "server", false),
+      span2(1L, 1L, 2L, Kind.SERVER, "server", null, false)
     );
 
     assertThat(new DependencyLinker(logger)
@@ -147,22 +172,22 @@ public class DependencyLinkerTest {
   @Test
   public void singleHostSpans_multipleChildren() {
     List<Span2> trace = asList(
-      span2(0L, 4L, null, 4L, Kind.CLIENT, "client", null),
-      span2(0L, 4L, 4L, 5L, Kind.SERVER, "server", "client"),
-      span2(0L, 4L, 4L, 6L, Kind.SERVER, "server", "client")
+      span2(4L, null, 4L, Kind.CLIENT, "client", null, false),
+      span2(4L, 4L, 5L, Kind.SERVER, "server", "client", true),
+      span2(4L, 4L, 6L, Kind.SERVER, "server", "client", false)
     );
 
-    assertThat(new DependencyLinker()
-      .putTrace(trace.iterator()).link())
-      .containsOnly(DependencyLink.create("client", "server", 2L));
+    assertThat(new DependencyLinker().putTrace(trace.iterator()).link()).containsOnly(
+      DependencyLink.builder().parent("client").child("server").callCount(2L).errorCount(1L).build()
+    );
   }
 
   @Test
   public void singleHostSpans_multipleChildren_defersNameToServer() {
     List<Span2> trace = asList(
-      span2(0L, 1L, null, 1L, Kind.CLIENT, "client", "server"),
-      span2(0L, 1L, 1L, 2L, Kind.SERVER, "server", null),
-      span2(0L, 1L, 1L, 3L, Kind.SERVER, "server", null)
+      span2(1L, null, 1L, Kind.CLIENT, "client", "server", false),
+      span2(1L, 1L, 2L, Kind.SERVER, "server", null, false),
+      span2(1L, 1L, 3L, Kind.SERVER, "server", null, false)
     );
 
     assertThat(new DependencyLinker(logger)
@@ -179,11 +204,11 @@ public class DependencyLinkerTest {
   @Test
   public void intermediatedClientSpansMissingLocalServiceNameLinkToNearestServer() {
     List<Span2> trace = asList(
-      span2(0L, 1L, null, 1L, Kind.SERVER, "client", null),
-      span2(0L, 1L, 1L, 2L, null, null, null),
+      span2(1L, null, 1L, Kind.SERVER, "client", null, false),
+      span2(1L, 1L, 2L, null, null, null, false),
       // possibly a local fan-out span
-      span2(0L, 1L, 2L, 3L, Kind.CLIENT, null, "server"),
-      span2(0L, 1L, 2L, 4L, Kind.CLIENT, null, "server")
+      span2(1L, 2L, 3L, Kind.CLIENT, "server", null, false),
+      span2(1L, 2L, 4L, Kind.CLIENT, "server", null, false)
     );
 
     assertThat(new DependencyLinker()
@@ -191,12 +216,67 @@ public class DependencyLinkerTest {
       .containsOnly(DependencyLink.create("client", "server", 2L));
   }
 
+  @Test
+  public void errorsOnUninstrumentedLinks() {
+    List<Span2> trace = asList(
+      span2(1L, null, 1L, Kind.SERVER, "client", null, false),
+      span2(1L, 1L, 2L, null, null, null, false),
+      // there's no remote here, so we shouldn't see any error count
+      span2(1L, 2L, 3L, Kind.CLIENT, "server", null, true),
+      span2(1L, 2L, 4L, Kind.CLIENT, "server", null, true)
+    );
+
+    assertThat(new DependencyLinker()
+      .putTrace(trace.iterator()).link())
+      .containsOnly(DependencyLink.create("client", "server", 2L));
+  }
+
+  @Test
+  public void errorsOnInstrumentedLinks() {
+    List<Span2> trace = asList(
+      span2(1L, null, 1L, Kind.SERVER, "foo", null, false),
+      span2(1L, 1L, 2L, null, null, null, false),
+      span2(1L, 2L, 3L, Kind.CLIENT, "bar", "baz", true),
+      span2(1L, 2L, 4L, Kind.CLIENT, "bar", "baz", false)
+    );
+
+    assertThat(new DependencyLinker().putTrace(trace.iterator()).link()).containsOnly(
+      DependencyLink.builder().parent("foo").child("bar").callCount(2L).build(),
+      DependencyLink.builder().parent("bar").child("baz").callCount(2L).errorCount(1L).build()
+    );
+  }
+
+  @Test
+  public void linkWithErrorIsLogged() {
+    List<Span2> trace = asList(
+      span2(1L, 2L, 3L, Kind.CLIENT, "foo", "bar", true)
+    );
+    new DependencyLinker(logger).putTrace(trace.iterator()).link();
+
+    assertThat(messages).contains(
+      "incrementing error link foo -> bar"
+    );
+  }
+
+  /** Tag indicates a failed span, not an annotation */
+  @Test
+  public void annotationNamedErrorDoesntIncrementErrorCount() {
+    List<Span2> trace = asList(
+      span2(1L, 2L, 3L, Kind.CLIENT, "foo", "bar", false)
+        .toBuilder().addAnnotation(1L, ERROR).build()
+    );
+
+    assertThat(new DependencyLinker().putTrace(trace.iterator()).link()).containsOnly(
+      DependencyLink.builder().parent("foo").child("bar").callCount(1L).build()
+    );
+  }
+
   /** A loopback span is direction-agnostic, so can be linked properly regardless of kind. */
   @Test
   public void linksLoopbackSpans() {
     List<Span2> validRootSpans = asList(
-      span2(0L, 1L, null, 1L, Kind.SERVER, "service", "service"),
-      span2(0L, 2L, null, 2L, Kind.CLIENT, "service", "service")
+      span2(1L, null, 1L, Kind.SERVER, "service", "service", false),
+      span2(2L, null, 2L, Kind.CLIENT, "service", "service", false)
     );
 
     for (Span2 span : validRootSpans) {
@@ -209,14 +289,29 @@ public class DependencyLinkerTest {
   @Test
   public void noSpanKindTreatedSameAsClient() {
     List<Span2> trace = asList(
-      span2(0L, 1L, null, 1L, null, "some-client", "web"),
-      span2(0L, 1L, 1L, 2L, null, "web", "app"),
-      span2(0L, 1L, 2L, 3L, null, "app", "db")
+      span2(1L, null, 1L, null, "some-client", "web", false),
+      span2(1L, 1L, 2L, null, "web", "app", false),
+      span2(1L, 2L, 3L, null, "app", "db", false)
     );
 
     assertThat(new DependencyLinker().putTrace(trace.iterator()).link()).containsOnly(
       DependencyLink.create("some-client", "web", 1L),
       DependencyLink.create("web", "app", 1L),
+      DependencyLink.create("app", "db", 1L)
+    );
+  }
+
+  @Test
+  public void noSpanKindWithError() {
+    List<Span2> trace = asList(
+      span2(1L, null, 1L, null, "some-client", "web", false),
+      span2(1L, 1L, 2L, null, "web", "app", true),
+      span2(1L, 2L, 3L, null, "app", "db", false)
+    );
+
+    assertThat(new DependencyLinker().putTrace(trace.iterator()).link()).containsOnly(
+      DependencyLink.create("some-client", "web", 1L),
+      DependencyLink.builder().parent("web").child("app").callCount(1L).errorCount(1L).build(),
       DependencyLink.create("app", "db", 1L)
     );
   }
@@ -228,12 +323,12 @@ public class DependencyLinkerTest {
   @Test
   public void cannotLinkSingleSpanWithoutBothServiceNames() {
     List<Span2> incompleteRootSpans = asList(
-      span2(0L, 1L, null, 1L, Kind.SERVER, null, null),
-      span2(0L, 1L, null, 1L, Kind.SERVER, "server", null),
-      span2(0L, 1L, null, 1L, Kind.SERVER, null, "client"),
-      span2(0L, 1L, null, 1L, Kind.CLIENT, null, null),
-      span2(0L, 1L, null, 1L, Kind.CLIENT, "client", null),
-      span2(0L, 1L, null, 1L, Kind.CLIENT, null, "server")
+      span2(1L, null, 1L, Kind.SERVER, null, null, false),
+      span2(1L, null, 1L, Kind.SERVER, "server", null, false),
+      span2(1L, null, 1L, Kind.SERVER, null, "client", false),
+      span2(1L, null, 1L, Kind.CLIENT, null, null, false),
+      span2(1L, null, 1L, Kind.CLIENT, "client", null, false),
+      span2(1L, null, 1L, Kind.CLIENT, null, "server", false)
     );
 
     for (Span2 span : incompleteRootSpans) {
@@ -247,8 +342,8 @@ public class DependencyLinkerTest {
   public void doesntLinkUnrelatedSpansWhenMissingRootSpan() {
     long missingParentId = 1;
     List<Span2> trace = asList(
-      span2(0L, 1L, missingParentId, 2L, Kind.SERVER, "service1", null),
-      span2(0L, 1L, missingParentId, 3L, Kind.SERVER, "service2", null)
+      span2(1L, missingParentId, 2L, Kind.SERVER, "service1", null, false),
+      span2(1L, missingParentId, 3L, Kind.SERVER, "service2", null, false)
     );
 
     assertThat(new DependencyLinker(logger)
@@ -264,8 +359,8 @@ public class DependencyLinkerTest {
   public void linksRelatedSpansWhenMissingRootSpan() {
     long missingParentId = 1;
     List<Span2> trace = asList(
-      span2(0L, 1L, missingParentId, 2L, Kind.SERVER, "service1", null),
-      span2(0L, 1L, 2L, 3L, Kind.SERVER, "service2", null)
+      span2(1L, missingParentId, 2L, Kind.SERVER, "service1", null, false),
+      span2(1L, 2L, 3L, Kind.SERVER, "service2", null, false)
     );
 
     assertThat(new DependencyLinker(logger)
@@ -281,8 +376,8 @@ public class DependencyLinkerTest {
   @Test
   public void linksSingleHostSpans() {
     List<Span2> singleHostSpans = asList(
-      span2(0L, 1L, null, 1L, Kind.SERVER, "web", null),
-      span2(0L, 1L, 1L, 2L, Kind.SERVER, "app", null)
+      span2(1L, null, 1L, Kind.CLIENT, "web", null, false),
+      span2(1L, 1L, 2L, Kind.SERVER, "app", null, false)
     );
 
     assertThat(new DependencyLinker()
@@ -290,12 +385,24 @@ public class DependencyLinkerTest {
       .containsOnly(DependencyLink.create("web", "app", 1L));
   }
 
+  @Test
+  public void linksSingleHostSpans_errorOnClient() {
+    List<Span2> trace = asList(
+      span2(1L, null, 1L, Kind.CLIENT, "web", null, true),
+      span2(1L, 1L, 2L, Kind.SERVER, "app", null, false)
+    );
+
+    assertThat(new DependencyLinker().putTrace(trace.iterator()).link()).containsOnly(
+      DependencyLink.builder().parent("web").child("app").callCount(1L).errorCount(1L).build()
+    );
+  }
+
   /** Creates a link when there's a span missing, in this case 2L which is an RPC from web to app */
   @Test
   public void missingSpan() {
     List<Span2> singleHostSpans = asList(
-      span2(0L, 1L, null, 1L, Kind.SERVER, "web", null),
-      span2(0L, 1L, 1L, 2L, Kind.CLIENT, "app", null)
+      span2(1L, null, 1L, Kind.SERVER, "web", null, false),
+      span2(1L, 1L, 2L, Kind.CLIENT, "app", null, false)
     );
 
     assertThat(new DependencyLinker(logger)
@@ -310,6 +417,20 @@ public class DependencyLinkerTest {
   @Test
   public void merge() {
     List<DependencyLink> links = asList(
+      DependencyLink.builder().parent("foo").child("bar").callCount(2L).errorCount(1L).build(),
+      DependencyLink.builder().parent("foo").child("bar").callCount(2L).errorCount(2L).build(),
+      DependencyLink.builder().parent("foo").child("foo").callCount(1L).build()
+    );
+
+    assertThat(DependencyLinker.merge(links)).containsExactly(
+      DependencyLink.builder().parent("foo").child("bar").callCount(4L).errorCount(3L).build(),
+      DependencyLink.builder().parent("foo").child("foo").callCount(1L).build()
+    );
+  }
+
+  @Test
+  public void merge_error() {
+    List<DependencyLink> links = asList(
       DependencyLink.create("client", "server", 2L),
       DependencyLink.create("client", "server", 2L),
       DependencyLink.create("client", "client", 1L)
@@ -321,14 +442,13 @@ public class DependencyLinkerTest {
     );
   }
 
-  static Span2 span2(long traceIdHigh, long traceId, @Nullable Long parentId, long id,
-    @Nullable Kind kind,
-    @Nullable String local, @Nullable String remote) {
+  static Span2 span2(long traceId, @Nullable Long parentId, long id, @Nullable Kind kind,
+    @Nullable String local, @Nullable String remote, boolean isError) {
     Span2.Builder result = Span2.builder();
-    result.traceIdHigh(traceIdHigh).traceId(traceId).parentId(parentId).id(id);
-    result.kind(kind);
+    result.traceId(traceId).parentId(parentId).id(id).kind(kind);
     if (local != null) result.localEndpoint(Endpoint.builder().serviceName(local).build());
     if (remote != null) result.remoteEndpoint(Endpoint.builder().serviceName(remote).build());
+    if (isError) result.putTag(ERROR, "");
     return result.build();
   }
 }

--- a/zipkin/src/test/java/zipkin/internal/ThriftCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/ThriftCodecTest.java
@@ -65,7 +65,11 @@ public final class ThriftCodecTest extends CodecTest {
   public void readDependencyLinksFromByteBuffer() throws IOException {
     List<DependencyLink> links = asList(
         DependencyLink.create("foo", "bar", 2),
-        DependencyLink.create("bar", "baz", 3)
+        DependencyLink.builder()
+          .parent("bar")
+          .child("baz")
+          .callCount(3)
+          .errorCount(1).build()
     );
     byte[] bytes = codec().writeDependencyLinks(links);
     assertThat(codec().readDependencyLinks(ByteBuffer.wrap(bytes)))


### PR DESCRIPTION
Thanks to @hfgbarrigas  for requesting this. This adds errorCount to
dependency links, indicating how many of callCount were in error.
Once merged, an update to the zipkin-api project will follow, documenting
the new field.

MySQL users who want this need to add the `error_count` column:
```sql
alter table zipkin_dependencies add `error_count` BIGINT
```

For the UI, I reused the existing color codes for transient and critical status, coloring yellow when 50% or more calls are in error, and red when 75%

I tested this by making one of the sample apps "backend" throw an error.

Example link detail screen
<img width="622" alt="screen shot 2017-07-28 at 6 25 44 pm" src="https://user-images.githubusercontent.com/64215/28713698-cad45a3c-73c2-11e7-9062-3d6dfa7674e2.png">

Example of when >50% of calls are in error
<img width="425" alt="screen shot 2017-07-28 at 6 25 35 pm" src="https://user-images.githubusercontent.com/64215/28713715-e06f0fe0-73c2-11e7-8a3e-a3e21bc9d09a.png">

Example of when >75% of calls are in error
<img width="419" alt="screen shot 2017-07-28 at 6 25 08 pm" src="https://user-images.githubusercontent.com/64215/28713728-eb65efcc-73c2-11e7-83fa-81ee704b9a72.png">

Fixes #1662