### PR TITLE
Adds messaging span

### DIFF
--- a/zipkin-ui/js/component_ui/traceConstants.js
+++ b/zipkin-ui/js/component_ui/traceConstants.js
@@ -2,19 +2,23 @@ const CLIENT_SEND = 'cs';
 const CLIENT_SEND_FRAGMENT = 'csf';
 const CLIENT_RECEIVE = 'cr';
 const CLIENT_RECEIVE_FRAGMENT = 'crf';
+const MESSAGE_SEND = 'ms';
+const MESSAGE_RECEIVE = 'mr';
 const SERVER_SEND = 'ss';
 const SERVER_SEND_FRAGMENT = 'ssf';
 const SERVER_RECEIVE = 'sr';
 const SERVER_RECEIVE_FRAGMENT = 'srf';
 const SERVER_ADDR = 'sa';
 const CLIENT_ADDR = 'ca';
+const MESSAGE_ADDR = 'ma';
 const WIRE_SEND = 'ws';
 const WIRE_RECEIVE = 'wr';
 const ERROR = 'error';
 const LOCAL_COMPONENT = 'lc';
 const CORE_CLIENT = [CLIENT_RECEIVE, CLIENT_RECEIVE_FRAGMENT, CLIENT_SEND, CLIENT_SEND_FRAGMENT];
+const CORE_MESSAGE = [MESSAGE_SEND, MESSAGE_RECEIVE];
 const CORE_SERVER = [SERVER_RECEIVE, SERVER_RECEIVE_FRAGMENT, SERVER_SEND, SERVER_SEND_FRAGMENT];
-const CORE_ADDRESS = [CLIENT_ADDR, SERVER_ADDR];
+const CORE_ADDRESS = [CLIENT_ADDR, SERVER_ADDR, MESSAGE_ADDR];
 const CORE_WIRE = [WIRE_SEND, WIRE_RECEIVE];
 const CORE_LOCAL = [LOCAL_COMPONENT];
 const CORE_ANNOTATIONS = [...CORE_CLIENT, ...CORE_SERVER, ...CORE_WIRE, ...CORE_LOCAL];
@@ -23,13 +27,17 @@ export const Constants = {
   CLIENT_SEND_FRAGMENT,
   CLIENT_RECEIVE,
   CLIENT_RECEIVE_FRAGMENT,
+  MESSAGE_SEND,
+  MESSAGE_RECEIVE,
   SERVER_SEND,
   SERVER_SEND_FRAGMENT,
   SERVER_RECEIVE,
   SERVER_RECEIVE_FRAGMENT,
   SERVER_ADDR,
   CLIENT_ADDR,
+  MESSAGE_ADDR,
   CORE_CLIENT,
+  CORE_MESSAGE,
   CORE_SERVER,
   ERROR,
   LOCAL_COMPONENT,
@@ -44,11 +52,14 @@ ConstantNames[CLIENT_SEND] = 'Client Send';
 ConstantNames[CLIENT_SEND_FRAGMENT] = 'Client Send Fragment';
 ConstantNames[CLIENT_RECEIVE] = 'Client Receive';
 ConstantNames[CLIENT_RECEIVE_FRAGMENT] = 'Client Receive Fragment';
+ConstantNames[MESSAGE_SEND] = 'Producer Send';
+ConstantNames[MESSAGE_RECEIVE] = 'Consumer Receive';
 ConstantNames[SERVER_SEND] = 'Server Send';
 ConstantNames[SERVER_SEND_FRAGMENT] = 'Server Send Fragment';
 ConstantNames[SERVER_RECEIVE] = 'Server Receive';
 ConstantNames[SERVER_RECEIVE_FRAGMENT] = 'Server Receive Fragment';
 ConstantNames[CLIENT_ADDR] = 'Client Address';
+ConstantNames[MESSAGE_ADDR] = 'Broker Address';
 ConstantNames[SERVER_ADDR] = 'Server Address';
 ConstantNames[WIRE_SEND] = 'Wire Send';
 ConstantNames[WIRE_RECEIVE] = 'Wire Receive';

--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -80,7 +80,7 @@ describe('get service name of a span', () => {
     const testSpan = {
       binaryAnnotations: [{
         key: Constants.SERVER_ADDR,
-        value: 'something',
+        value: '1',
         endpoint: {
           serviceName: 'user-service'
         }
@@ -89,10 +89,47 @@ describe('get service name of a span', () => {
     getServiceName(testSpan).should.equal('user-service');
   });
 
+  it('should get service name from broker addr', () => {
+    const testSpan = {
+      binaryAnnotations: [{
+        key: Constants.MESSAGE_ADDR,
+        value: '1',
+        endpoint: {
+          serviceName: 'kafka'
+        }
+      }]
+    };
+    getServiceName(testSpan).should.equal('kafka');
+  });
+
   it('should get service name from some server annotation', () => {
     const testSpan = {
       annotations: [{
         value: Constants.SERVER_RECEIVE_FRAGMENT,
+        endpoint: {
+          serviceName: 'test-service'
+        }
+      }]
+    };
+    getServiceName(testSpan).should.equal('test-service');
+  });
+
+  it('should get service name from producer annotation', () => {
+    const testSpan = {
+      annotations: [{
+        value: Constants.MESSAGE_SEND,
+        endpoint: {
+          serviceName: 'test-service'
+        }
+      }]
+    };
+    getServiceName(testSpan).should.equal('test-service');
+  });
+
+  it('should get service name from consumer annotation', () => {
+    const testSpan = {
+      annotations: [{
+        value: Constants.MESSAGE_RECEIVE,
         endpoint: {
           serviceName: 'test-service'
         }

--- a/zipkin/src/main/java/zipkin/Constants.java
+++ b/zipkin/src/main/java/zipkin/Constants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -79,6 +79,34 @@ public final class Constants {
    * {@link #CLIENT_ADDR}.
    */
   public static final String SERVER_RECV = "sr";
+
+  /**
+   * Message send ("ms") is a request to send a message to a destination, usually a broker. This may
+   * be the only annotation in a messaging span. If {@link #WIRE_SEND} exists in the same span,it
+   * follows this moment and clarifies delays sending the message, such as batching.
+   *
+   * <p>Unlike RPC annotations like {@link #CLIENT_SEND}, messaging spans never share a span ID. For
+   * example, "ms" should always be the parent of "mr".
+   *
+   * <p>{@link Annotation#endpoint} is not the destination, it is the host which logged the send
+   * event: the producer. When annotating MESSAGE_SEND, instrumentation should also tag the {@link
+   * #MESSAGE_ADDR}.
+   */
+  public static final String MESSAGE_SEND = "ms";
+
+  /**
+   * A consumer received ("mr") a message from a broker. This may be the only annotation in a
+   * messaging span. If {@link #WIRE_RECV} exists in the same span, it precedes this moment and
+   * clarifies any local queuing delay.
+   *
+   * <p>Unlike RPC annotations like {@link #SERVER_RECV}, messaging spans never share a span ID. For
+   * example, "mr" should always be a child of "ms" unless it is a root span.
+   *
+   * <p>{@link Annotation#endpoint} is not the broker, it is the host which logged the receive
+   * event: the consumer.  When annotating MESSAGE_RECV, instrumentation should also tag the {@link
+   * #MESSAGE_ADDR}.
+   */
+  public static final String MESSAGE_RECV = "mr";
 
   /**
    * Optionally logs an attempt to send a message on the wire. Multiple wire send events could
@@ -175,6 +203,9 @@ public final class Constants {
    * fails to a different server ip or port.
    */
   public static final String SERVER_ADDR = "sa";
+
+  /** Indicates the remote address of a messaging span, usually the broker. */
+  public static final String MESSAGE_ADDR = "ma";
 
   /**
    * Zipkin's core annotations indicate when a client or server operation began or ended.

--- a/zipkin/src/main/java/zipkin/internal/Span2.java
+++ b/zipkin/src/main/java/zipkin/internal/Span2.java
@@ -80,7 +80,25 @@ public abstract class Span2 implements Serializable { // for Spark jobs
   /** Indicates the primary span type. */
   public enum Kind {
     CLIENT,
-    SERVER
+    SERVER,
+    /**
+     * When present, {@link #timestamp()} is the moment a producer sent a message to a destination.
+     * {@link #duration()} represents delay sending the message, such as batching, while {@link
+     * #remoteEndpoint()} indicates the destination, such as a broker.
+     *
+     * <p>Unlike {@link #CLIENT}, messaging spans never share a span ID. For example, the {@link
+     * #CONSUMER} of the same message has {@link #parentId()} set to this span's {@link #id()}.
+     */
+    PRODUCER,
+    /**
+     * When present, {@link #timestamp()} is the moment a consumer received a message from an
+     * origin. {@link #duration()} represents delay consuming the message, such as from backlog,
+     * while {@link #remoteEndpoint()} indicates the origin, such as a broker.
+     *
+     * <p>Unlike {@link #SERVER}, messaging spans never share a span ID. For example, the {@link
+     * #PRODUCER} of this message is the {@link #parentId()} of this span.
+     */
+    CONSUMER
   }
 
   /** When present, used to interpret {@link #remoteEndpoint} */


### PR DESCRIPTION
See https://github.com/openzipkin/openzipkin.github.io/pull/82 for docs
See https://github.com/openzipkin/zipkin-api/pull/29 for thrift constants

Here is what work in progress looks like for a single producer, single consumer POV where the remote endpoint (broker) is set to kafka:

```bash
$ curl -X POST -s localhost:9411/api/v1/spans -H 'Content-Type: application/json' -d '[{"traceId":"040c464a2b70a87a","id":"040c464a2b70a87a","name":"","timestamp":1501654414312417,"annotations":[{"timestamp":1501654414312417,"value":"ms","endpoint":{"serviceName":"producer","ipv4":"192.168.1.10"}}],"binaryAnnotations":[{"key":"kafka.key","value":"foo","endpoint":{"serviceName":"producer","ipv4":"192.168.1.10"}},{"key":"kafka.topic","value":"myTopic","endpoint":{"serviceName":"producer","ipv4":"192.168.1.10"}},{"key":"ma","value":true,"endpoint":{"serviceName":"kafka"}}]}]'
$ curl -X POST -s localhost:9411/api/v1/spans -H 'Content-Type: application/json' -d '[{"traceId":"040c464a2b70a87a","id":"b169190ffec10531","name":"","parentId":"040c464a2b70a87a","timestamp":1501654414816112,"annotations":[{"timestamp":1501654414816112,"value":"mr","endpoint":{"serviceName":"consumer","ipv4":"192.168.1.10"}}],"binaryAnnotations":[{"key":"ma","value":true,"endpoint":{"serviceName":"kafka"}}]}]'
```

![screen shot 2017-08-02 at 2 14 41 pm](https://user-images.githubusercontent.com/64215/28860041-5fc88a64-778d-11e7-906c-06b84cbac5ff.png)

![screen shot 2017-08-02 at 2 15 12 pm](https://user-images.githubusercontent.com/64215/28860035-5b218de4-778d-11e7-9bda-4c44f3410212.png)

Fixes #1654