### PR TITLE
Accepts Zipkin v2 Span format in all current transports

### DIFF
--- a/zipkin-collector/kafka/src/main/java/zipkin/collector/kafka/KafkaStreamProcessor.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin/collector/kafka/KafkaStreamProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,10 +13,8 @@
  */
 package zipkin.collector.kafka;
 
-import java.util.Collections;
 import kafka.consumer.ConsumerIterator;
 import kafka.consumer.KafkaStream;
-import zipkin.Codec;
 import zipkin.collector.Collector;
 import zipkin.collector.CollectorMetrics;
 
@@ -47,24 +45,7 @@ final class KafkaStreamProcessor implements Runnable {
         continue;
       }
 
-      // In TBinaryProtocol encoding, the first byte is the TType, in a range 0-16
-      // .. If the first byte isn't in that range, it isn't a thrift.
-      //
-      // When byte(0) == '[' (91), assume it is a list of json-encoded spans
-      //
-      // When byte(0) <= 16, assume it is a TBinaryProtocol-encoded thrift
-      // .. When serializing a Span (Struct), the first byte will be the type of a field
-      // .. When serializing a List[ThriftSpan], the first byte is the member type, TType.STRUCT(12)
-      // .. As ThriftSpan has no STRUCT fields: so, if the first byte is TType.STRUCT(12), it is a list.
-      if (bytes[0] == '[') {
-        collector.acceptSpans(bytes, Codec.JSON, NOOP);
-      } else {
-        if (bytes[0] == 12 /* TType.STRUCT */) {
-          collector.acceptSpans(bytes, Codec.THRIFT, NOOP);
-        } else {
-          collector.acceptSpans(Collections.singletonList(bytes), Codec.THRIFT, NOOP);
-        }
-      }
+      collector.acceptSpans(bytes, NOOP);
     }
   }
 }

--- a/zipkin-collector/kafka/src/test/java/zipkin/collector/kafka/KafkaCollectorTest.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin/collector/kafka/KafkaCollectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
  */
 package zipkin.collector.kafka;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,12 +30,16 @@ import zipkin.Span;
 import zipkin.TestObjects;
 import zipkin.collector.InMemoryCollectorMetrics;
 import zipkin.collector.kafka.KafkaCollector.Builder;
+import zipkin.internal.ApplyTimestampAndDuration;
+import zipkin.internal.Span2Codec;
+import zipkin.internal.Span2Converter;
 import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.AsyncSpanStore;
 import zipkin.storage.SpanStore;
 import zipkin.storage.StorageComponent;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.TestObjects.LOTS_OF_SPANS;
 import static zipkin.TestObjects.TRACE;
 
 public class KafkaCollectorTest {
@@ -128,6 +133,32 @@ public class KafkaCollectorTest {
     assertThat(kafkaMetrics.messages()).isEqualTo(1);
     assertThat(kafkaMetrics.bytes()).isEqualTo(bytes.length);
     assertThat(kafkaMetrics.spans()).isEqualTo(TestObjects.TRACE.size());
+  }
+
+  /** Ensures list encoding works: a version 2 json encoded list of spans */
+  @Test
+  public void messageWithMultipleSpans_json2() throws Exception {
+    Builder builder = builder("multiple_spans_json2");
+
+    List<Span> spans = Arrays.asList(
+      ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[0]),
+      ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[1])
+    );
+
+    byte[] bytes = Span2Codec.JSON.writeSpans(Arrays.asList(
+      Span2Converter.fromSpan(spans.get(0)).get(0),
+      Span2Converter.fromSpan(spans.get(1)).get(0)
+    ));
+
+    producer.send(new KeyedMessage<>(builder.topic, bytes));
+
+    try (KafkaCollector collector = newKafkaTransport(builder, consumer)) {
+      assertThat(recvdSpans.take()).containsAll(spans);
+    }
+
+    assertThat(kafkaMetrics.messages()).isEqualTo(1);
+    assertThat(kafkaMetrics.bytes()).isEqualTo(bytes.length);
+    assertThat(kafkaMetrics.spans()).isEqualTo(spans.size());
   }
 
   /** Ensures malformed spans don't hang the collector */

--- a/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import zipkin.Annotation;
 import zipkin.Codec;
 import zipkin.Span;
+import zipkin.internal.ApplyTimestampAndDuration;
+import zipkin.internal.Span2Codec;
+import zipkin.internal.Span2Converter;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -56,6 +59,30 @@ public class ZipkinRuleTest {
     // read the traces directly
     assertThat(zipkin.getTraces())
         .containsOnly(trace);
+  }
+
+  @Test
+  public void getTraces_storedViaPostVersion2() throws IOException {
+    List<Span> spans = Arrays.asList(
+      ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[0]),
+      ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[1])
+    );
+
+    byte[] bytes = Span2Codec.JSON.writeSpans(Arrays.asList(
+      Span2Converter.fromSpan(spans.get(0)).get(0),
+      Span2Converter.fromSpan(spans.get(1)).get(0)
+    ));
+
+    // write the span to the zipkin using http api v2
+    Response response = client.newCall(new Request.Builder()
+      .url(zipkin.httpUrl() + "/api/v2/spans")
+      .post(RequestBody.create(MediaType.parse("application/json"), bytes)).build()
+    ).execute();
+    assertThat(response.code()).isEqualTo(202);
+
+    // read the traces directly
+    assertThat(zipkin.getTraces())
+      .containsOnly(asList(spans.get(0)), asList(spans.get(1)));
   }
 
   /** The rule is here to help debugging. Even partial spans should be returned */

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
@@ -27,11 +27,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import zipkin.Codec;
+import zipkin.Span;
+import zipkin.SpanDecoder;
 import zipkin.collector.Collector;
 import zipkin.collector.CollectorMetrics;
 import zipkin.collector.CollectorSampler;
 import zipkin.internal.Nullable;
+import zipkin.internal.Span2JsonDecoder;
 import zipkin.storage.Callback;
 import zipkin.storage.StorageComponent;
 
@@ -46,6 +48,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 public class ZipkinHttpCollector {
   static final ResponseEntity<?> SUCCESS = ResponseEntity.accepted().build();
   static final String APPLICATION_THRIFT = "application/x-thrift";
+  static final SpanDecoder JSON2_DECODER = new Span2JsonDecoder();
 
   final CollectorMetrics metrics;
   final Collector collector;
@@ -57,12 +60,20 @@ public class ZipkinHttpCollector {
         .storage(storage).sampler(sampler).metrics(this.metrics).build();
   }
 
+  @RequestMapping(value = "/api/v2/spans", method = POST)
+  public ListenableFuture<ResponseEntity<?>> uploadSpansJson2(
+    @RequestHeader(value = "Content-Encoding", required = false) String encoding,
+    @RequestBody byte[] body
+  ) {
+    return validateAndStoreSpans(encoding, JSON2_DECODER, body);
+  }
+
   @RequestMapping(value = "/api/v1/spans", method = POST)
   public ListenableFuture<ResponseEntity<?>> uploadSpansJson(
       @RequestHeader(value = "Content-Encoding", required = false) String encoding,
       @RequestBody byte[] body
   ) {
-    return validateAndStoreSpans(encoding, Codec.JSON, body);
+    return validateAndStoreSpans(encoding, SpanDecoder.JSON_DECODER, body);
   }
 
   @RequestMapping(value = "/api/v1/spans", method = POST, consumes = APPLICATION_THRIFT)
@@ -70,10 +81,10 @@ public class ZipkinHttpCollector {
       @RequestHeader(value = "Content-Encoding", required = false) String encoding,
       @RequestBody byte[] body
   ) {
-    return validateAndStoreSpans(encoding, Codec.THRIFT, body);
+    return validateAndStoreSpans(encoding, SpanDecoder.THRIFT_DECODER, body);
   }
 
-  ListenableFuture<ResponseEntity<?>> validateAndStoreSpans(String encoding, Codec codec,
+  ListenableFuture<ResponseEntity<?>> validateAndStoreSpans(String encoding, SpanDecoder decoder,
       byte[] body) {
     SettableListenableFuture<ResponseEntity<?>> result = new SettableListenableFuture<>();
     metrics.incrementMessages();
@@ -85,7 +96,7 @@ public class ZipkinHttpCollector {
         result.set(ResponseEntity.badRequest().body("Cannot gunzip spans: " + e.getMessage() + "\n"));
       }
     }
-    collector.acceptSpans(body, codec, new Callback<Void>() {
+    collector.acceptSpans(body, decoder, new Callback<Void>() {
       @Override public void onSuccess(@Nullable Void value) {
         result.set(SUCCESS);
       }

--- a/zipkin/src/main/java/zipkin/Codec.java
+++ b/zipkin/src/main/java/zipkin/Codec.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,20 +20,14 @@ import zipkin.internal.ThriftCodec;
 /**
  * Methods make an attempt to perform codec operations, failing to null.
  */
-public interface Codec {
+public interface Codec extends SpanDecoder {
 
   JsonCodec JSON = new JsonCodec();
   ThriftCodec THRIFT = new ThriftCodec();
 
-  /** throws {@linkplain IllegalArgumentException} if the span couldn't be decoded */
-  Span readSpan(byte[] bytes);
-
   int sizeInBytes(Span value);
 
   byte[] writeSpan(Span value);
-
-  /** throws {@linkplain IllegalArgumentException} if the spans couldn't be decoded */
-  List<Span> readSpans(byte[] bytes);
 
   byte[] writeSpans(List<Span> value);
 

--- a/zipkin/src/main/java/zipkin/SpanDecoder.java
+++ b/zipkin/src/main/java/zipkin/SpanDecoder.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin;
+
+import java.util.List;
+import zipkin.internal.JsonCodec;
+import zipkin.internal.ThriftCodec;
+
+/** Decodes spans from serialized bytes. */
+public interface SpanDecoder {
+  SpanDecoder JSON_DECODER = new JsonCodec();
+  SpanDecoder THRIFT_DECODER = new ThriftCodec();
+
+  /** throws {@linkplain IllegalArgumentException} if a span couldn't be decoded */
+  Span readSpan(byte[] span);
+
+  /** throws {@linkplain IllegalArgumentException} if the spans couldn't be decoded */
+  List<Span> readSpans(byte[] span);
+}

--- a/zipkin/src/main/java/zipkin/internal/Span2JsonDecoder.java
+++ b/zipkin/src/main/java/zipkin/internal/Span2JsonDecoder.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import zipkin.Span;
+import zipkin.SpanDecoder;
+
+/** Decodes a span from zipkin v2 encoding */
+public final class Span2JsonDecoder implements SpanDecoder {
+  @Override public Span readSpan(byte[] span) {
+    return Span2Converter.toSpan(Span2Codec.JSON.readSpan(span));
+  }
+
+  @Override public List<Span> readSpans(byte[] span) {
+    List<Span2> span2s = Span2Codec.JSON.readSpans(span);
+    if (span2s.isEmpty()) return Collections.emptyList();
+    int length = span2s.size();
+    List<Span> result = new ArrayList<>(length);
+    for (int i = 0; i < length; i++) {
+      result.add(Span2Converter.toSpan(span2s.get(i)));
+    }
+    return result;
+  }
+}

--- a/zipkin/src/test/java/zipkin/internal/Span2JsonDecoderTest.java
+++ b/zipkin/src/test/java/zipkin/internal/Span2JsonDecoderTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import org.junit.Test;
+import zipkin.Span;
+import zipkin.SpanDecoder;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.TestObjects.LOTS_OF_SPANS;
+
+public class Span2JsonDecoderTest {
+  Span span1 = ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[0]);
+  Span span2 = ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[1]);
+  Span2 span2_1 = Span2Converter.fromSpan(span1).get(0);
+  Span2 span2_2 = Span2Converter.fromSpan(span2).get(0);
+
+  SpanDecoder decoder = new Span2JsonDecoder();
+
+  @Test public void readSpan() {
+    assertThat(decoder.readSpan(Span2Codec.JSON.writeSpan(span2_1)))
+      .isEqualTo(span1);
+  }
+
+  @Test public void readSpans() {
+    assertThat(decoder.readSpans(Span2Codec.JSON.writeSpans(asList(span2_1, span2_2))))
+      .containsExactly(span1, span2);
+  }
+}


### PR DESCRIPTION
This accepts the json format from #1499 on current transports. It does
so by generalizing format detection from the two Kafka libraries, and
a new `SpanDecoder` interface. Types are still internal, but this allows
us to proceed with other work in #1644, including implementing reporters
in any language.

Concretely, you can send a json list of span2 format as a Kafka or Http
message. If using http, use the /api/v2/spans endpoint like so:

```bash
$ curl -X POST -s localhost:9411/api/v2/spans -H'Content-Type: application/json' -d'[{
  "traceId": "9032b04972e475c5",
  "id": "9032b04972e475c5",
  "kind": "SERVER",
  "name": "get",
  "timestamp": 1502101460678880,
  "duration": 612898,
  "localEndpoint": {
    "serviceName": "brave-webmvc-example",
    "ipv4": "192.168.1.113"
  },
  "remoteEndpoint": {
    "serviceName": "",
    "ipv4": "127.0.0.1",
    "port": 60149
  },
  "tags": {
    "error": "500 Internal Server Error",
    "http.path": "/a"
  }
}]'
```