### PR TITLE
Changes Elasticsearch single-type indexing to work around dotted tags

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumer.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumer.java
@@ -13,9 +13,16 @@
  */
 package zipkin.storage.elasticsearch.http;
 
+import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import okio.Buffer;
+import okio.ByteString;
+import zipkin.Annotation;
 import zipkin.Span;
 import zipkin.internal.Nullable;
 import zipkin.internal.Span2;
@@ -25,11 +32,11 @@ import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.Callback;
 
 import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
-import static zipkin.internal.Util.UTF_8;
 import static zipkin.internal.Util.propagateIfFatal;
 import static zipkin.storage.elasticsearch.http.ElasticsearchHttpSpanStore.SPAN;
 
 class ElasticsearchHttpSpanConsumer implements AsyncSpanConsumer { // not final for testing
+  static final Logger LOG = Logger.getLogger(ElasticsearchHttpSpanConsumer.class.getName());
 
   final ElasticsearchHttpStorage es;
   final IndexNameFormatter indexNameFormatter;
@@ -75,7 +82,6 @@ class ElasticsearchHttpSpanConsumer implements AsyncSpanConsumer { // not final 
     }
   }
 
-
   BulkSpanIndexer newBulkSpanIndexer(ElasticsearchHttpStorage es) {
     return new BulkSpanIndexer(es);
   }
@@ -92,10 +98,7 @@ class ElasticsearchHttpSpanConsumer implements AsyncSpanConsumer { // not final 
     void add(long indexTimestamp, Span span, @Nullable Long timestampMillis) {
       String index = indexNameFormatter.formatTypeAndTimestamp(SPAN, indexTimestamp);
       for (Span2 span2 : Span2Converter.fromSpan(span)) {
-        byte[] document = Span2Codec.JSON.writeSpan(span2);
-        if (timestampMillis != null) {
-          document = prefixWithTimestampMillis(document, timestampMillis);
-        }
+        byte[] document = prefixWithTimestampMillisAndQuery(span2, timestampMillis);
         indexer.add(index, SPAN, document, null /* Allow ES to choose an ID */);
       }
     }
@@ -105,26 +108,63 @@ class ElasticsearchHttpSpanConsumer implements AsyncSpanConsumer { // not final 
     }
   }
 
-  private static final byte[] TIMESTAMP_MILLIS_PREFIX = "{\"timestamp_millis\":".getBytes(UTF_8);
-
   /**
    * In order to allow systems like Kibana to search by timestamp, we add a field "timestamp_millis"
    * when storing. The cheapest way to do this without changing the codec is prefixing it to the
    * json. For example. {"traceId":"... becomes {"timestamp_millis":12345,"traceId":"...
+   *
+   * <p>Tags are stored as a dictionary. Since some tag names will include inconsistent number of
+   * dots (ex "error" and perhaps "error.message"), we cannot index them naturally with
+   * elasticsearch. Instead, we add an index-only (non-source) field of {@code _q} which includes
+   * valid search queries. For example, the tag {@code error -> 500} results in {@code
+   * "_q":["error", "error=500"]}. This matches the input query syntax, and can be checked manually
+   * with curl.
+   *
+   * <p>Ex {@code curl -s localhost:9200/zipkin:span-2017-08-11/_search?q=_q:error=500}
    */
-  static byte[] prefixWithTimestampMillis(byte[] input, long timestampMillis) {
-    String dateAsString = Long.toString(timestampMillis);
-    byte[] newSpanBytes =
-        new byte[TIMESTAMP_MILLIS_PREFIX.length + dateAsString.length() + input.length];
-    int pos = 0;
-    System.arraycopy(TIMESTAMP_MILLIS_PREFIX, 0, newSpanBytes, pos, TIMESTAMP_MILLIS_PREFIX.length);
-    pos += TIMESTAMP_MILLIS_PREFIX.length;
-    for (int i = 0, length = dateAsString.length(); i < length; i++) {
-      newSpanBytes[pos++] = (byte) dateAsString.charAt(i);
+  static byte[] prefixWithTimestampMillisAndQuery(Span2 span, @Nullable Long timestampMillis) {
+    Buffer query = new Buffer();
+    JsonWriter writer = JsonWriter.of(query);
+    try {
+      writer.beginObject();
+
+      if (timestampMillis != null) writer.name("timestamp_millis").value(timestampMillis);
+      if (!span.tags().isEmpty() || !span.annotations().isEmpty()) {
+        writer.name("_q");
+        writer.beginArray();
+        for (Annotation a : span.annotations()) {
+          if (a.value.length() > 255) continue;
+          writer.value(a.value);
+        }
+        for (Map.Entry<String, String> tag : span.tags().entrySet()) {
+          if (tag.getKey().length() + tag.getValue().length() + 1 > 255) continue;
+          writer.value(tag.getKey()); // search is possible by key alone
+          writer.value(tag.getKey() + "=" + tag.getValue());
+        }
+        writer.endArray();
+      }
+      writer.endObject();
+    } catch (IOException e) {
+      // very unexpected to have an IOE for an in-memory write
+      assert false : "Error indexing query for span: " + span;
+      if (LOG.isLoggable(Level.FINE)) {
+        LOG.log(Level.FINE, "Error indexing query for span: " + span, e);
+      }
+      return Span2Codec.JSON.writeSpan(span);
     }
-    newSpanBytes[pos++] = ',';
+    byte[] document = Span2Codec.JSON.writeSpan(span);
+    if (query.rangeEquals(0L, ByteString.of(new byte[] {'{', '}'}))) {
+      return document;
+    }
+    byte[] prefix = query.readByteArray();
+
+    byte[] newSpanBytes = new byte[prefix.length + document.length - 1];
+    int pos = 0;
+    System.arraycopy(prefix, 0, newSpanBytes, pos, prefix.length);
+    pos += prefix.length;
+    newSpanBytes[pos - 1] = ',';
     // starting at position 1 discards the old head of '{'
-    System.arraycopy(input, 1, newSpanBytes, pos, input.length - 1);
+    System.arraycopy(document, 1, newSpanBytes, pos, document.length - 1);
     return newSpanBytes;
   }
 }

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStore.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStore.java
@@ -69,11 +69,11 @@ final class ElasticsearchHttpSpanStore implements AsyncSpanStore {
     }
 
     for (String annotation : request.annotations) {
-      filters.should().addTerm("annotations.value", annotation).addExists("tags." + annotation);
+      filters.addTerm("_q", annotation);
     }
 
     for (Map.Entry<String, String> kv : request.binaryAnnotations.entrySet()) {
-      filters.addTerm("tags." + kv.getKey(), kv.getValue());
+      filters.addTerm("_q", kv.getKey() + "=" + kv.getValue());
     }
 
     if (request.minDuration != null) {

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
@@ -216,7 +216,7 @@ public abstract class ElasticsearchHttpStorage implements StorageComponent {
     float version = ensureIndexTemplates().version();
     if (version >= 6) { // then multi-type (legacy) index isn't possible
       return new ElasticsearchHttpSpanStore(this);
-    } else if (version < 2.4 || !singleTypeIndexingEnabled()) { // don't fan out queries unnecessarily
+    } else if (version < 2 || !singleTypeIndexingEnabled()) { // don't fan out queries unnecessarily
       return new LegacyElasticsearchHttpSpanStore(this);
     } else { // fan out queries as we don't know if old legacy collectors are in use
       return new LenientDoubleCallbackAsyncSpanStore(

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/IndexTemplates.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/IndexTemplates.java
@@ -27,11 +27,9 @@ abstract class IndexTemplates {
   /** null when multi-type indexes are not supported */
   @Nullable abstract String legacy();
 
-  /** null when dots in field names are not supported */
-  @Nullable abstract String span();
+  abstract String span();
 
-  /** null when dots in field names are not supported */
-  @Nullable abstract String dependency();
+  abstract String dependency();
 
   @AutoValue.Builder interface Builder {
     Builder version(float version);

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/internal/client/SearchRequest.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/internal/client/SearchRequest.java
@@ -73,7 +73,7 @@ public final class SearchRequest {
     }
 
     public Filters addTerm(String field, String value) {
-      add(new Terms(field, Collections.singletonList(value)));
+      add(new Term(field, value));
       return this;
     }
 
@@ -166,9 +166,9 @@ public final class SearchRequest {
   }
 
   static class Terms {
-    final Map<String, List<String>> terms;
+    final Map<String, Collection<String>> terms;
 
-    Terms(String field, List<String> values) {
+    Terms(String field, Collection<String> values) {
       this.terms = Collections.singletonMap(field, values);
     }
   }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorageTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorageTest.java
@@ -77,14 +77,14 @@ public class ElasticsearchHttpStorageTest {
     es.takeRequest(); // get dependency template
   }
 
-  @Test public void ensureIndexTemplates_when24OptIntoStoreWithMixedReads() throws Exception {
+  @Test public void ensureIndexTemplates_when2OptIntoStoreWithMixedReads() throws Exception {
     storage.close();
     storage = ElasticsearchHttpStorage.builder()
       .hosts(asList(es.url("").toString()))
       .singleTypeIndexingEnabled(true)
       .build();
 
-    es.enqueue(new MockResponse().setBody("{\"version\":{\"number\":\"2.4.0\"}}"));
+    es.enqueue(new MockResponse().setBody("{\"version\":{\"number\":\"2.2.0\"}}"));
     es.enqueue(new MockResponse()); // get span template
     es.enqueue(new MockResponse()); // get dependency template
 
@@ -109,18 +109,6 @@ public class ElasticsearchHttpStorageTest {
    */
   @Test public void ensureIndexTemplates_when5xSingleTypeIndexSupport() throws Exception {
     checkLegacyComponents(new MockResponse().setBody("{\"version\":{\"number\":\"5.0.0\"}}"));
-  }
-
-  @Test public void ensureIndexTemplates_when22SingleTypeIndexSupportUnsupported()
-    throws Exception {
-    storage.close();
-    storage = ElasticsearchHttpStorage.builder()
-      .hosts(asList(es.url("").toString()))
-      .singleTypeIndexingEnabled(true)
-      .build();
-
-    // Eventhough singleTypeIndexingEnabled, still legacy as Versions before 2.4 do not support "allow_dots_in_name"
-    checkLegacyComponents(new MockResponse().setBody("{\"version\":{\"number\":\"2.2.0\"}}"));
   }
 
   /**

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/LegacyElasticsearchHttpSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/LegacyElasticsearchHttpSpanConsumerTest.java
@@ -36,7 +36,7 @@ import static zipkin.Constants.SERVER_RECV;
 import static zipkin.TestObjects.TODAY;
 import static zipkin.internal.ApplyTimestampAndDuration.guessTimestamp;
 import static zipkin.internal.Util.UTF_8;
-import static zipkin.storage.elasticsearch.http.ElasticsearchHttpSpanConsumer.prefixWithTimestampMillis;
+import static zipkin.storage.elasticsearch.http.LegacyElasticsearchHttpSpanConsumer.prefixWithTimestampMillis;
 
 public class LegacyElasticsearchHttpSpanConsumerTest {
   @Rule public MockWebServer es = new MockWebServer();

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/integration/LazyElasticsearchHttpStorage.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/integration/LazyElasticsearchHttpStorage.java
@@ -51,7 +51,6 @@ class LazyElasticsearchHttpStorage extends LazyCloseable<ElasticsearchHttpStorag
     try {
       container = new GenericContainer(image)
           .withExposedPorts(9200)
-          .withEnv("ES_JAVA_OPTS", "-Dmapper.allow_dots_in_name=true -Xms512m -Xmx512m")
           .waitingFor(new HttpWaitStrategy().forPath("/"));
       container.start();
       if (Boolean.valueOf(System.getenv("ES_DEBUG"))) {

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -1000,6 +1000,20 @@ public abstract class SpanStoreTest {
       .containsExactly(json);
   }
 
+  /** Dots in tag names can create problems in storage which tries to make a tree out of them */
+  @Test
+  public void tagsWithNestedDots() {
+    Span tagsWithNestedDots = span1.toBuilder()
+      .addBinaryAnnotation(BinaryAnnotation.create("http.path", "/api", ep))
+      .addBinaryAnnotation(BinaryAnnotation.create("http.path.morepath", "/api/api", ep))
+      .build();
+
+    accept(tagsWithNestedDots);
+
+    assertThat(store().getRawTrace(span1.traceIdHigh, span1.traceId))
+      .containsExactly(tagsWithNestedDots);
+  }
+
   static long clientDuration(Span span) {
     long[] timestamps = span.annotations.stream()
         .filter(a -> a.value.startsWith("c"))


### PR DESCRIPTION
Tags are stored as a dictionary. Since some tag names will include
inconsistent number of dots (ex "error" and perhaps "error.message"), we
cannot index them naturally with elasticsearch. Instead, we add an
index-only (non-source) field of _q which includes valid search queries.

For example, the tag error -> 500 results in "_q":["error", "error=500"].
This matches the input query syntax, and can be checked manually with curl.

Ex `curl -s localhost:9200/zipkin:span-2017-08-11/_search?q=_q:error=500`