### PR TITLE
Allows span2 json format to omit serviceName instead of setting empty

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/JsonAdapters.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/JsonAdapters.java
@@ -14,23 +14,15 @@
 package zipkin.storage.elasticsearch.http;
 
 import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.JsonDataException;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
-import okio.Buffer;
-import okio.ByteString;
 import zipkin.Annotation;
-import zipkin.BinaryAnnotation;
 import zipkin.DependencyLink;
 import zipkin.Endpoint;
 import zipkin.Span;
 import zipkin.internal.Span2;
 import zipkin.internal.Span2Converter;
-import zipkin.internal.Util;
-
-import static zipkin.internal.Util.UTF_8;
-import static zipkin.internal.Util.lowerHexToUnsignedLong;
 
 /**
  * Read-only json adapters resurrected from before we switched to Java 6 as storage components can
@@ -144,10 +136,15 @@ final class JsonAdapters {
   static final JsonAdapter<Endpoint> ENDPOINT_ADAPTER = new JsonAdapter<Endpoint>() {
     @Override
     public Endpoint fromJson(JsonReader reader) throws IOException {
-      Endpoint.Builder result = Endpoint.builder();
+      Endpoint.Builder result = Endpoint.builder().serviceName("");
       reader.beginObject();
       while (reader.hasNext()) {
-        switch (reader.nextName()) {
+        String nextName = reader.nextName();
+        if (reader.peek() == JsonReader.Token.NULL) {
+          reader.skipValue();
+          continue;
+        }
+        switch (nextName) {
           case "serviceName":
             result.serviceName(reader.nextString());
             break;
@@ -171,88 +168,6 @@ final class JsonAdapters {
       throw new UnsupportedOperationException();
     }
   }.nullSafe();
-
-  static final JsonAdapter<BinaryAnnotation> BINARY_ANNOTATION_ADAPTER = new JsonAdapter<BinaryAnnotation>() {
-    @Override
-    public BinaryAnnotation fromJson(JsonReader reader) throws IOException {
-      BinaryAnnotation.Builder result = BinaryAnnotation.builder();
-      String number = null;
-      String string = null;
-      BinaryAnnotation.Type type = BinaryAnnotation.Type.STRING;
-      reader.beginObject();
-      while (reader.hasNext()) {
-        switch (reader.nextName()) {
-          case "key":
-            result.key(reader.nextString());
-            break;
-          case "value":
-            switch (reader.peek()) {
-              case BOOLEAN:
-                type = BinaryAnnotation.Type.BOOL;
-                result.value(reader.nextBoolean() ? new byte[] {1} : new byte[] {0});
-                break;
-              case STRING:
-                string = reader.nextString();
-                break;
-              case NUMBER:
-                number = reader.nextString();
-                break;
-              default:
-                throw new JsonDataException(
-                    "Expected value to be a boolean, string or number but was " + reader.peek()
-                        + " at path " + reader.getPath());
-            }
-            break;
-          case "type":
-            type = BinaryAnnotation.Type.valueOf(reader.nextString());
-            break;
-          case "endpoint":
-            result.endpoint(ENDPOINT_ADAPTER.fromJson(reader));
-            break;
-          default:
-            reader.skipValue();
-        }
-      }
-      reader.endObject();
-      result.type(type);
-      switch (type) {
-        case BOOL:
-          return result.build();
-        case STRING:
-          return result.value(string.getBytes(UTF_8)).build();
-        case BYTES:
-          return result.value(ByteString.decodeBase64(string).toByteArray()).build();
-        default:
-          break;
-      }
-      Buffer buffer = new Buffer();
-      switch (type) {
-        case I16:
-          buffer.writeShort(Short.parseShort(number));
-          break;
-        case I32:
-          buffer.writeInt(Integer.parseInt(number));
-          break;
-        case I64:
-        case DOUBLE:
-          if (number == null) number = string;
-          long v = type == BinaryAnnotation.Type.I64
-              ? Long.parseLong(number)
-              : Double.doubleToRawLongBits(Double.parseDouble(number));
-          buffer.writeLong(v);
-          break;
-        default:
-          throw new AssertionError(
-              "BinaryAnnotationType " + type + " was added, but not handled");
-      }
-      return result.value(buffer.readByteArray()).build();
-    }
-
-    @Override
-    public void toJson(JsonWriter writer, BinaryAnnotation value) throws IOException {
-      throw new UnsupportedOperationException();
-    }
-  };
 
   static final JsonAdapter<DependencyLink> DEPENDENCY_LINK_ADAPTER = new JsonAdapter<DependencyLink>() {
     @Override

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/JsonAdaptersTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/JsonAdaptersTest.java
@@ -35,7 +35,7 @@ import static zipkin.storage.elasticsearch.http.JsonAdapters.SPAN_ADAPTER;
 
 public class JsonAdaptersTest {
   @Test
-  public void span2_ignoreNull_parentId() throws IOException {
+  public void span_ignoreNull_parentId() throws IOException {
     String json = "{\n"
       + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
       + "  \"name\": \"get-traces\",\n"
@@ -47,7 +47,7 @@ public class JsonAdaptersTest {
   }
 
   @Test
-  public void span2_ignoreNull_timestamp() throws IOException {
+  public void span_ignoreNull_timestamp() throws IOException {
     String json = "{\n"
       + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
       + "  \"name\": \"get-traces\",\n"
@@ -59,7 +59,7 @@ public class JsonAdaptersTest {
   }
 
   @Test
-  public void span2_ignoreNull_duration() throws IOException {
+  public void span_ignoreNull_duration() throws IOException {
     String json = "{\n"
       + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
       + "  \"name\": \"get-traces\",\n"
@@ -71,7 +71,7 @@ public class JsonAdaptersTest {
   }
 
   @Test
-  public void span2_ignoreNull_debug() throws IOException {
+  public void span_ignoreNull_debug() throws IOException {
     String json = "{\n"
       + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
       + "  \"name\": \"get-traces\",\n"
@@ -83,7 +83,7 @@ public class JsonAdaptersTest {
   }
 
   @Test
-  public void span2_ignoreNull_annotation_endpoint() throws IOException {
+  public void span_ignoreNull_annotation_endpoint() throws IOException {
     String json = "{\n"
       + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
       + "  \"name\": \"get-traces\",\n"
@@ -101,7 +101,7 @@ public class JsonAdaptersTest {
   }
 
   @Test
-  public void span2_tag_long_read() throws IOException {
+  public void span_tag_long_read() throws IOException {
     String json = "{\n"
       + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
       + "  \"name\": \"get-traces\",\n"
@@ -117,7 +117,7 @@ public class JsonAdaptersTest {
   }
 
   @Test
-  public void span2_tag_double_read() throws IOException {
+  public void span_tag_double_read() throws IOException {
     String json = "{\n"
       + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
       + "  \"name\": \"get-traces\",\n"
@@ -133,7 +133,7 @@ public class JsonAdaptersTest {
   }
 
   @Test
-  public void span2_roundTrip() throws IOException {
+  public void span_roundTrip() throws IOException {
     Span span = ApplyTimestampAndDuration.apply(TestObjects.LOTS_OF_SPANS[0]);
     Span2 span2 = Span2Converter.fromSpan(span).get(0);
     Buffer bytes = new Buffer();
@@ -147,7 +147,7 @@ public class JsonAdaptersTest {
    * trip-up json don't fail in SPAN_ADAPTER.
    */
   @Test
-  public void span2_specialCharsInJson() throws IOException {
+  public void span_specialCharsInJson() throws IOException {
     // service name is surrounded by control characters
     Endpoint e = Endpoint.create(new String(new char[] {0, 'a', 1}), 0);
     Span2 worstSpanInTheWorld = Span2.builder().traceId(1L).id(1L)
@@ -168,7 +168,7 @@ public class JsonAdaptersTest {
   }
 
   @Test
-  public void span2_endpointHighPort() throws IOException {
+  public void span_endpointHighPort() throws IOException {
     String json = "{\n"
       + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
       + "  \"name\": \"get-traces\",\n"
@@ -185,7 +185,40 @@ public class JsonAdaptersTest {
   }
 
   @Test
-  public void span2_readsTraceIdHighFromTraceIdField() throws IOException {
+  public void span_noServiceName() throws IOException {
+    String json = "{\n"
+      + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+      + "  \"name\": \"get-traces\",\n"
+      + "  \"id\": \"6b221d5bc9e6496c\",\n"
+      + "  \"localEndpoint\": {\n"
+      + "    \"port\": 65535\n"
+      + "  }\n"
+      + "}";
+
+    assertThat(SPAN_ADAPTER.fromJson(json).binaryAnnotations)
+      .containsExactly(BinaryAnnotation.create("lc", "",
+        Endpoint.builder().serviceName("").port(65535).build()));
+  }
+
+  @Test
+  public void span_nullServiceName() throws IOException {
+    String json = "{\n"
+      + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+      + "  \"name\": \"get-traces\",\n"
+      + "  \"id\": \"6b221d5bc9e6496c\",\n"
+      + "  \"localEndpoint\": {\n"
+      + "    \"serviceName\": NULL,\n"
+      + "    \"port\": 65535\n"
+      + "  }\n"
+      + "}";
+
+    assertThat(SPAN_ADAPTER.fromJson(json).binaryAnnotations)
+      .containsExactly(BinaryAnnotation.create("lc", "",
+        Endpoint.builder().serviceName("").port(65535).build()));
+  }
+
+  @Test
+  public void span_readsTraceIdHighFromTraceIdField() throws IOException {
     String with128BitTraceId = ("{\n"
       + "  \"traceId\": \"48485a3953bb61246b221d5bc9e6496c\",\n"
       + "  \"name\": \"get-traces\",\n"

--- a/zipkin/src/test/java/zipkin/internal/Span2JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/Span2JsonCodecTest.java
@@ -305,4 +305,77 @@ public class Span2JsonCodecTest {
 
     codec.readSpan(json.getBytes(UTF_8));
   }
+
+  @Test public void readSpan_localEndpoint_noServiceName() {
+    String json = "{\n"
+      + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+      + "  \"name\": \"get-traces\",\n"
+      + "  \"id\": \"6b221d5bc9e6496c\",\n"
+      + "  \"localEndpoint\": {\n"
+      + "    \"ipv4\": \"127.0.0.1\"\n"
+      + "  }\n"
+      + "}";
+
+    assertThat(codec.readSpan(json.getBytes(UTF_8)).localEndpoint())
+      .isEqualTo(Endpoint.create("", 127 << 24 | 1));
+  }
+
+  @Test public void readSpan_localEndpoint_nullServiceName() {
+    String json = "{\n"
+      + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+      + "  \"name\": \"get-traces\",\n"
+      + "  \"id\": \"6b221d5bc9e6496c\",\n"
+      + "  \"localEndpoint\": {\n"
+      + "    \"serviceName\": null,\n"
+      + "    \"ipv4\": \"127.0.0.1\"\n"
+      + "  }\n"
+      + "}";
+
+    assertThat(codec.readSpan(json.getBytes(UTF_8)).localEndpoint())
+      .isEqualTo(Endpoint.create("", 127 << 24 | 1));
+  }
+
+  @Test public void readSpan_remoteEndpoint_noServiceName() {
+    String json = "{\n"
+      + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+      + "  \"name\": \"get-traces\",\n"
+      + "  \"id\": \"6b221d5bc9e6496c\",\n"
+      + "  \"remoteEndpoint\": {\n"
+      + "    \"ipv4\": \"127.0.0.1\"\n"
+      + "  }\n"
+      + "}";
+
+    assertThat(codec.readSpan(json.getBytes(UTF_8)).remoteEndpoint())
+      .isEqualTo(Endpoint.create("", 127 << 24 | 1));
+  }
+
+  @Test public void readSpan_remoteEndpoint_nullServiceName() {
+    String json = "{\n"
+      + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+      + "  \"name\": \"get-traces\",\n"
+      + "  \"id\": \"6b221d5bc9e6496c\",\n"
+      + "  \"remoteEndpoint\": {\n"
+      + "    \"serviceName\": null,\n"
+      + "    \"ipv4\": \"127.0.0.1\"\n"
+      + "  }\n"
+      + "}";
+
+    assertThat(codec.readSpan(json.getBytes(UTF_8)).remoteEndpoint())
+      .isEqualTo(Endpoint.create("", 127 << 24 | 1));
+  }
+
+  @Test public void spanRoundTrip_noRemoteServiceName() throws IOException {
+    span = span.toBuilder().remoteEndpoint(backend.toBuilder().serviceName("").build()).build();
+    byte[] bytes = codec.writeSpan(span);
+    assertThat(codec.readSpan(bytes))
+      .isEqualTo(span);
+  }
+
+  @Test public void doesntWriteEmptyServiceName() throws IOException {
+    String expected = "{\"ipv4\":\"127.0.0.1\"}";
+    Buffer b = new Buffer(expected.length());
+    Span2JsonCodec.ENDPOINT_WRITER.write(Endpoint.create("", 127 << 24 | 1), b);
+    assertThat(new String(b.toByteArray(), UTF_8))
+      .isEqualTo(expected);
+  }
 }


### PR DESCRIPTION
A snag in the old model was that we needed to pass an empty string for
serviceName because thrift requires the field. In span2 format, we can
act more idiomatic and either leave it out or set it to null.