### PR TITLE
Adds SpanDecoder.DETECTING_DECODER

### DIFF
--- a/zipkin/src/main/java/zipkin/SpanDecoder.java
+++ b/zipkin/src/main/java/zipkin/SpanDecoder.java
@@ -15,6 +15,7 @@
 package zipkin;
 
 import java.util.List;
+import zipkin.internal.DetectingSpanDecoder;
 import zipkin.internal.JsonCodec;
 import zipkin.internal.ThriftCodec;
 
@@ -22,6 +23,8 @@ import zipkin.internal.ThriftCodec;
 public interface SpanDecoder {
   SpanDecoder JSON_DECODER = new JsonCodec();
   SpanDecoder THRIFT_DECODER = new ThriftCodec();
+  /** Detects the format of the encoded spans or throws IllegalArgumentException */
+  SpanDecoder DETECTING_DECODER = new DetectingSpanDecoder();
 
   /** throws {@linkplain IllegalArgumentException} if a span couldn't be decoded */
   Span readSpan(byte[] span);

--- a/zipkin/src/main/java/zipkin/internal/DetectingSpanDecoder.java
+++ b/zipkin/src/main/java/zipkin/internal/DetectingSpanDecoder.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.List;
+import zipkin.Span;
+import zipkin.SpanDecoder;
+
+// In TBinaryProtocol encoding, the first byte is the TType, in a range 0-16
+// .. If the first byte isn't in that range, it isn't a thrift.
+//
+// When byte(0) == '[' (91), assume it is a list of json-encoded spans
+//
+// When byte(0) <= 16, assume it is a TBinaryProtocol-encoded thrift
+// .. When serializing a Span (Struct), the first byte will be the type of a field
+// .. When serializing a List[ThriftSpan], the first byte is the member type, TType.STRUCT(12)
+// .. As ThriftSpan has no STRUCT fields: so, if the first byte is TType.STRUCT(12), it is a list.
+public final class DetectingSpanDecoder implements SpanDecoder {
+  /** zipkin v2 will have this tag, and others won't. */
+  static final byte[] LOCAL_ENDPOINT_TAG = "\"localEndpoint\"".getBytes(Util.UTF_8);
+  static final SpanDecoder JSON2_DECODER = new Span2JsonDecoder();
+
+  @Override public Span readSpan(byte[] span) {
+    if (span[0] == '{') {
+      return detectJsonFormat(span).readSpan(span);
+    } else if (span[0] <= 16 /* assume TBinary */) {
+      return THRIFT_DECODER.readSpan(span);
+    } else {
+      throw new IllegalArgumentException("Could not detect the span format");
+    }
+  }
+
+  @Override public List<Span> readSpans(byte[] span) {
+    if (span[0] == '[') {
+      return detectJsonFormat(span).readSpans(span);
+    } else if (span[0] == 12 /* List[ThriftSpan]*/) {
+      return THRIFT_DECODER.readSpans(span);
+    } else {
+      throw new IllegalArgumentException("Could not detect the span format");
+    }
+  }
+
+  /* Searches for a substring matching zipkin v2 format. Otherwise, assumes it isn't. */
+  static SpanDecoder detectJsonFormat(byte[] bytes) {
+    bytes:
+    for (int i = 0; i < bytes.length - LOCAL_ENDPOINT_TAG.length + 1; i++) {
+      for (int j = 0; j < LOCAL_ENDPOINT_TAG.length; j++) {
+        if (bytes[i + j] != LOCAL_ENDPOINT_TAG[j]) {
+          continue bytes;
+        }
+      }
+      return JSON2_DECODER;
+    }
+    return SpanDecoder.JSON_DECODER;
+  }
+}

--- a/zipkin/src/test/java/zipkin/collector/CollectorTest.java
+++ b/zipkin/src/test/java/zipkin/collector/CollectorTest.java
@@ -14,19 +14,14 @@
 package zipkin.collector;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Test;
-import zipkin.Codec;
 import zipkin.Span;
 import zipkin.internal.ApplyTimestampAndDuration;
-import zipkin.internal.Span2Codec;
-import zipkin.internal.Span2Converter;
 import zipkin.storage.Callback;
 import zipkin.storage.InMemoryStorage;
-import zipkin.storage.QueryRequest;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -122,42 +117,6 @@ public class CollectorTest {
     assertThat(messages)
         .containsExactly(message)
         .containsExactly("Malformed reading spans");
-  }
-
-  @Test
-  public void acceptSpans_detectsThrift() {
-    collector.acceptSpans(Codec.THRIFT.writeSpan(span1), NOOP);
-
-    assertThat(collector.storage.spanStore().getTraces(QueryRequest.builder().build()))
-      .hasSize(1);
-  }
-
-  @Test
-  public void acceptSpans_detectsThriftList() {
-    collector.acceptSpans(Codec.THRIFT.writeSpans(asList(span1, span2)), NOOP);
-
-    assertThat(collector.storage.spanStore().getTraces(QueryRequest.builder().build()))
-      .hasSize(2);
-  }
-
-  @Test
-  public void acceptSpans_detectsJsonList() {
-    collector.acceptSpans(Codec.JSON.writeSpans(asList(span1, span2)), NOOP);
-
-    assertThat(collector.storage.spanStore().getTraces(QueryRequest.builder().build()))
-      .hasSize(2);
-  }
-
-  @Test
-  public void acceptSpans_detectsJson2List() {
-    byte[] bytes = Span2Codec.JSON.writeSpans(Arrays.asList(
-      Span2Converter.fromSpan(span1).get(0),
-      Span2Converter.fromSpan(span2).get(0)
-    ));
-    collector.acceptSpans(bytes, NOOP);
-
-    assertThat(collector.storage.spanStore().getTraces(QueryRequest.builder().build()))
-      .hasSize(2);
   }
 
   @Test

--- a/zipkin/src/test/java/zipkin/internal/DetectingDecoderTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DetectingDecoderTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import org.junit.Test;
+import zipkin.Codec;
+import zipkin.Span;
+import zipkin.SpanDecoder;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.TestObjects.LOTS_OF_SPANS;
+
+public class DetectingDecoderTest {
+  Span span1 = ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[0]);
+  Span span2 = ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[1]);
+  Span2 span2_1 = Span2Converter.fromSpan(span1).get(0);
+  Span2 span2_2 = Span2Converter.fromSpan(span2).get(0);
+
+  SpanDecoder decoder = new DetectingSpanDecoder();
+
+  @Test public void readSpan_json() {
+    assertThat(decoder.readSpan(Codec.JSON.writeSpan(span1)))
+      .isEqualTo(span1);
+  }
+
+  @Test public void readSpans_json() {
+    assertThat(decoder.readSpans(Codec.JSON.writeSpans(asList(span1, span2))))
+      .containsExactly(span1, span2);
+  }
+
+  @Test public void readSpan_thrift() {
+    assertThat(decoder.readSpan(Codec.THRIFT.writeSpan(span1)))
+      .isEqualTo(span1);
+  }
+
+  @Test public void readSpans_thrift() {
+    assertThat(decoder.readSpans(Codec.THRIFT.writeSpans(asList(span1, span2))))
+      .containsExactly(span1, span2);
+  }
+
+  @Test public void readSpan_json2() {
+    assertThat(decoder.readSpan(Span2Codec.JSON.writeSpan(span2_1)))
+      .isEqualTo(span1);
+  }
+
+  @Test public void readSpans_json2() {
+    assertThat(decoder.readSpans(Span2Codec.JSON.writeSpans(asList(span2_1, span2_2))))
+      .containsExactly(span1, span2);
+  }
+
+  @Test(expected = IllegalArgumentException.class) public void readSpan_unknown() {
+    decoder.readSpan(new byte[] {'h'});
+  }
+
+  @Test(expected = IllegalArgumentException.class) public void readSpans_unknown() {
+    decoder.readSpans(new byte[] {'h'});
+  }
+}


### PR DESCRIPTION
A couple things were found integrating zipkin2 json format with existing
collectors.
 * Only Kafka has a legacy encoding of single span per message
   * We shouldn't assume this encoding is supported for others
 * Azure Event Hubs decodes messages decoupled from collection
   * We need to move the detecting decode logic to avoid copy/pasting it