### PR TITLE
Starts preparing v2 Codec package

### DIFF
--- a/benchmarks/src/main/resources/span2.json
+++ b/benchmarks/src/main/resources/span2.json
@@ -1,4 +1,4 @@
-{
+[{
   "traceId": "86154a4ba6e91385",
   "parentId": "86154a4ba6e91385",
   "id": "4d1e00c0db9010db",
@@ -29,4 +29,4 @@
     "http.path": "/api",
     "clnt/finagle.version": "6.45.0"
   }
-}
+}]

--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
@@ -28,7 +28,7 @@ import zipkin.Span;
 import zipkin.SpanDecoder;
 import zipkin.collector.Collector;
 import zipkin.collector.CollectorMetrics;
-import zipkin.internal.Span2JsonDecoder;
+import zipkin.internal.Span2JsonSpanDecoder;
 import zipkin.storage.Callback;
 import zipkin.storage.QueryRequest;
 import zipkin.storage.SpanStore;
@@ -37,7 +37,7 @@ import zipkin.storage.StorageComponent;
 import static zipkin.internal.Util.lowerHexToUnsignedLong;
 
 final class ZipkinDispatcher extends Dispatcher {
-  static final SpanDecoder JSON2_DECODER = new Span2JsonDecoder();
+  static final SpanDecoder JSON2_DECODER = new Span2JsonSpanDecoder();
 
   private final SpanStore store;
   private final Collector consumer;

--- a/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
@@ -31,8 +31,9 @@ import zipkin.Annotation;
 import zipkin.Codec;
 import zipkin.Span;
 import zipkin.internal.ApplyTimestampAndDuration;
-import zipkin.internal.Span2Codec;
 import zipkin.internal.Span2Converter;
+import zipkin.internal.v2.codec.MessageEncoder;
+import zipkin.internal.v2.codec.Encoder;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -68,15 +69,15 @@ public class ZipkinRuleTest {
       ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[1])
     );
 
-    byte[] bytes = Span2Codec.JSON.writeSpans(Arrays.asList(
-      Span2Converter.fromSpan(spans.get(0)).get(0),
-      Span2Converter.fromSpan(spans.get(1)).get(0)
+    byte[] message = MessageEncoder.JSON_BYTES.encode(asList(
+      Encoder.JSON.encode(Span2Converter.fromSpan(spans.get(0)).get(0)),
+      Encoder.JSON.encode(Span2Converter.fromSpan(spans.get(1)).get(0))
     ));
 
     // write the span to the zipkin using http api v2
     Response response = client.newCall(new Request.Builder()
       .url(zipkin.httpUrl() + "/api/v2/spans")
-      .post(RequestBody.create(MediaType.parse("application/json"), bytes)).build()
+      .post(RequestBody.create(MediaType.parse("application/json"), message)).build()
     ).execute();
     assertThat(response.code()).isEqualTo(202);
 

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
@@ -27,13 +27,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import zipkin.Span;
 import zipkin.SpanDecoder;
 import zipkin.collector.Collector;
 import zipkin.collector.CollectorMetrics;
 import zipkin.collector.CollectorSampler;
 import zipkin.internal.Nullable;
-import zipkin.internal.Span2JsonDecoder;
+import zipkin.internal.Span2JsonSpanDecoder;
 import zipkin.storage.Callback;
 import zipkin.storage.StorageComponent;
 
@@ -48,7 +47,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 public class ZipkinHttpCollector {
   static final ResponseEntity<?> SUCCESS = ResponseEntity.accepted().build();
   static final String APPLICATION_THRIFT = "application/x-thrift";
-  static final SpanDecoder JSON2_DECODER = new Span2JsonDecoder();
+  static final SpanDecoder JSON2_DECODER = new Span2JsonSpanDecoder();
 
   final CollectorMetrics metrics;
   final Collector collector;

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
@@ -13,7 +13,6 @@
  */
 package zipkin.server;
 
-import java.util.Collections;
 import okio.Buffer;
 import okio.GzipSink;
 import org.junit.Before;
@@ -33,8 +32,9 @@ import org.springframework.web.context.ConfigurableWebApplicationContext;
 import zipkin.Codec;
 import zipkin.Span;
 import zipkin.internal.ApplyTimestampAndDuration;
-import zipkin.internal.Span2Codec;
 import zipkin.internal.Span2Converter;
+import zipkin.internal.v2.codec.MessageEncoder;
+import zipkin.internal.v2.codec.Encoder;
 import zipkin.storage.InMemoryStorage;
 
 import static java.lang.String.format;
@@ -85,11 +85,11 @@ public class ZipkinServerIntegrationTest {
   public void writeSpans_version2() throws Exception {
     Span span = ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[0]);
 
-    byte[] bytes = Span2Codec.JSON.writeSpans(Collections.singletonList(
-      Span2Converter.fromSpan(span).get(0)
+    byte[] message = MessageEncoder.JSON_BYTES.encode(asList(
+      Encoder.JSON.encode(Span2Converter.fromSpan(span).get(0))
     ));
 
-    performAsync(post("/api/v2/spans").content(bytes))
+    performAsync(post("/api/v2/spans").content(message))
       .andExpect(status().isAccepted());
 
     // sleep as the the storage operation is async

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumer.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumer.java
@@ -26,8 +26,8 @@ import zipkin.Annotation;
 import zipkin.Span;
 import zipkin.internal.Nullable;
 import zipkin.internal.Span2;
-import zipkin.internal.Span2Codec;
 import zipkin.internal.Span2Converter;
+import zipkin.internal.v2.codec.Encoder;
 import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.Callback;
 
@@ -150,9 +150,9 @@ class ElasticsearchHttpSpanConsumer implements AsyncSpanConsumer { // not final 
       if (LOG.isLoggable(Level.FINE)) {
         LOG.log(Level.FINE, "Error indexing query for span: " + span, e);
       }
-      return Span2Codec.JSON.writeSpan(span);
+      return Encoder.JSON.encode(span);
     }
-    byte[] document = Span2Codec.JSON.writeSpan(span);
+    byte[] document = Encoder.JSON.encode(span);
     if (query.rangeEquals(0L, ByteString.of(new byte[] {'{', '}'}))) {
       return document;
     }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/JsonAdaptersTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/JsonAdaptersTest.java
@@ -25,9 +25,9 @@ import zipkin.Span;
 import zipkin.TestObjects;
 import zipkin.internal.ApplyTimestampAndDuration;
 import zipkin.internal.Span2;
-import zipkin.internal.Span2Codec;
 import zipkin.internal.Span2Converter;
 import zipkin.internal.Util;
+import zipkin.internal.v2.codec.Encoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -137,7 +137,7 @@ public class JsonAdaptersTest {
     Span span = ApplyTimestampAndDuration.apply(TestObjects.LOTS_OF_SPANS[0]);
     Span2 span2 = Span2Converter.fromSpan(span).get(0);
     Buffer bytes = new Buffer();
-    bytes.write(Span2Codec.JSON.writeSpan(span2));
+    bytes.write(Encoder.JSON.encode(span2));
     assertThat(SPAN_ADAPTER.fromJson(bytes))
       .isEqualTo(span);
   }
@@ -162,7 +162,7 @@ public class JsonAdaptersTest {
       .build();
 
     Buffer bytes = new Buffer();
-    bytes.write(Span2Codec.JSON.writeSpan(worstSpanInTheWorld));
+    bytes.write(Encoder.JSON.encode(worstSpanInTheWorld));
     assertThat(SPAN_ADAPTER.fromJson(bytes))
       .isEqualTo(Span2Converter.toSpan(worstSpanInTheWorld));
   }

--- a/zipkin/src/main/java/zipkin/Annotation.java
+++ b/zipkin/src/main/java/zipkin/Annotation.java
@@ -13,6 +13,7 @@
  */
 package zipkin;
 
+import java.io.Serializable;
 import zipkin.internal.JsonCodec;
 import zipkin.internal.Nullable;
 
@@ -25,7 +26,8 @@ import static zipkin.internal.Util.equal;
  *
  * <p>Unlike log statements, annotations are often codes: Ex. {@link Constants#SERVER_RECV "sr"}.
  */
-public final class Annotation implements Comparable<Annotation> {
+public final class Annotation implements Comparable<Annotation>, Serializable { // for Spark jobs
+  private static final long serialVersionUID = 0L;
 
   public static Annotation create(long timestamp, String value, @Nullable Endpoint endpoint) {
     return new Annotation(timestamp, value, endpoint);

--- a/zipkin/src/main/java/zipkin/Endpoint.java
+++ b/zipkin/src/main/java/zipkin/Endpoint.java
@@ -13,6 +13,7 @@
  */
 package zipkin;
 
+import java.io.Serializable;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -34,7 +35,8 @@ import static zipkin.internal.Util.checkNotNull;
  * exception allows zipkin to display network context of uninstrumented services, or clients such as
  * web browsers.
  */
-public final class Endpoint {
+public final class Endpoint implements Serializable { // for Spark jobs
+  private static final long serialVersionUID = 0L;
 
   /**
    * @deprecated as leads to null pointer exceptions on port. Use {@link #builder()} instead.

--- a/zipkin/src/main/java/zipkin/internal/Span2Converter.java
+++ b/zipkin/src/main/java/zipkin/internal/Span2Converter.java
@@ -29,9 +29,10 @@ import static zipkin.BinaryAnnotation.Type.BOOL;
 import static zipkin.Constants.CLIENT_ADDR;
 import static zipkin.Constants.LOCAL_COMPONENT;
 import static zipkin.Constants.SERVER_ADDR;
+import static zipkin.internal.Util.writeBase64Url;
 
 /**
- * This converts {@link zipkin.Span} instances to {@link zipkin.internal.Span2} and visa versa.
+ * This converts {@link zipkin.Span} instances to {@link Span2} and visa versa.
  */
 public final class Span2Converter {
 
@@ -209,9 +210,7 @@ public final class Span2Converter {
             currentSpan.putTag(b.key, new String(b.value, Util.UTF_8));
             break;
           case BYTES:
-            Buffer buffer = new Buffer(Buffer.base64UrlSizeInBytes(b.value));
-            String encoded = new String(buffer.writeBase64Url(b.value).toByteArray(), Util.UTF_8);
-            currentSpan.putTag(b.key, encoded);
+            currentSpan.putTag(b.key, writeBase64Url(b.value));
             break;
           case I16:
             currentSpan.putTag(b.key, Short.toString(ByteBuffer.wrap(b.value).getShort()));

--- a/zipkin/src/main/java/zipkin/internal/Span2JsonSpanDecoder.java
+++ b/zipkin/src/main/java/zipkin/internal/Span2JsonSpanDecoder.java
@@ -18,15 +18,16 @@ import java.util.Collections;
 import java.util.List;
 import zipkin.Span;
 import zipkin.SpanDecoder;
+import zipkin.internal.v2.codec.Decoder;
 
 /** Decodes a span from zipkin v2 encoding */
-public final class Span2JsonDecoder implements SpanDecoder {
+public final class Span2JsonSpanDecoder implements SpanDecoder {
   @Override public Span readSpan(byte[] span) {
-    return Span2Converter.toSpan(Span2Codec.JSON.readSpan(span));
+    throw new UnsupportedOperationException("current transports only accept list messages");
   }
 
   @Override public List<Span> readSpans(byte[] span) {
-    List<Span2> span2s = Span2Codec.JSON.readSpans(span);
+    List<Span2> span2s = Decoder.JSON.decodeList(span);
     if (span2s.isEmpty()) return Collections.emptyList();
     int length = span2s.size();
     List<Span> result = new ArrayList<>(length);

--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -152,6 +152,45 @@ public final class Util {
     return new String(data);
   }
 
+  /**
+   * Adapted from okio.Base64 as JRE 6 doesn't have a base64Url encoder
+   *
+   * <p>Original author: Alexander Y. Kleymenov
+   */
+  static String writeBase64Url(byte[] in) {
+    char[] result = new char[(in.length + 2) / 3 * 4];
+    int end = in.length - in.length % 3;
+    int pos = 0;
+    for (int i = 0; i < end; i += 3) {
+      result[pos++] = URL_MAP[(in[i] & 0xff) >> 2];
+      result[pos++] = URL_MAP[((in[i] & 0x03) << 4) | ((in[i + 1] & 0xff) >> 4)];
+      result[pos++] = URL_MAP[((in[i + 1] & 0x0f) << 2) | ((in[i + 2] & 0xff) >> 6)];
+      result[pos++] = URL_MAP[(in[i + 2] & 0x3f)];
+    }
+    switch (in.length % 3) {
+      case 1:
+        result[pos++] = URL_MAP[(in[end] & 0xff) >> 2];
+        result[pos++] = URL_MAP[(in[end] & 0x03) << 4];
+        result[pos++] = '=';
+        result[pos] = '=';
+        break;
+      case 2:
+        result[pos++] = URL_MAP[(in[end] & 0xff) >> 2];
+        result[pos++] = URL_MAP[((in[end] & 0x03) << 4) | ((in[end + 1] & 0xff) >> 4)];
+        result[pos++] = URL_MAP[((in[end + 1] & 0x0f) << 2)];
+        result[pos] = '=';
+        break;
+    }
+    return new String(result);
+  }
+
+  static final char[] URL_MAP = new char[] {
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+    'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+    'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
+    '5', '6', '7', '8', '9', '-', '_'
+  };
+
   /** Inspired by {@code okio.Buffer.writeLong} */
   public static void writeHexLong(char[] data, int pos, long v) {
     writeHexByte(data, pos + 0,  (byte) ((v >>> 56L) & 0xff));

--- a/zipkin/src/main/java/zipkin/internal/v2/codec/Decoder.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/codec/Decoder.java
@@ -11,23 +11,29 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.internal;
+package zipkin.internal.v2.codec;
 
 import java.util.List;
+import zipkin.Span;
+import zipkin.internal.JsonCodec;
+import zipkin.internal.Span2;
 
-/** Utilities for working with {@link Span2} */
-public interface Span2Codec {
-  Span2Codec JSON = new Span2JsonCodec();
+/**
+ * @param <S> type of the span, usually {@link Span}
+ */
+public interface Decoder<S> {
+  Decoder<Span2> JSON = new Decoder<Span2>() {
+    @Override public Encoding encoding() {
+      return Encoding.JSON;
+    }
 
-  /** Serialize a span recorded from instrumentation into its binary form. */
-  byte[] writeSpan(Span2 span);
+    @Override public List<Span2> decodeList(byte[] span) {
+      return JsonCodec.readList(new Span2JsonAdapters.Span2Reader(), span);
+    }
+  };
 
-  /** Serialize a list of spans recorded from instrumentation into their binary form. */
-  byte[] writeSpans(List<Span2> spans);
-
-  /** throws {@linkplain IllegalArgumentException} if a span couldn't be decoded */
-  Span2 readSpan(byte[] bytes);
+  Encoding encoding();
 
   /** throws {@linkplain IllegalArgumentException} if the spans couldn't be decoded */
-  List<Span2> readSpans(byte[] bytes);
+  List<S> decodeList(byte[] span);
 }

--- a/zipkin/src/main/java/zipkin/internal/v2/codec/Encoder.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/codec/Encoder.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.codec;
+
+import zipkin.Span;
+import zipkin.internal.JsonCodec;
+import zipkin.internal.Span2;
+
+import static zipkin.internal.v2.codec.Span2JsonAdapters.SPAN_WRITER;
+
+/**
+ * @param <S> type of the span, usually {@link Span}
+ */
+public interface Encoder<S> {
+  Encoder<Span2> JSON = new Encoder<Span2>() {
+    @Override public Encoding encoding() {
+      return Encoding.JSON;
+    }
+
+    @Override public byte[] encode(Span2 span) {
+      return JsonCodec.write(SPAN_WRITER, span);
+    }
+  };
+
+  Encoding encoding();
+
+  /**
+   * Serialize a span recorded from instrumentation into its binary form.
+   *
+   * @param span cannot be null
+   */
+  byte[] encode(S span);
+}

--- a/zipkin/src/main/java/zipkin/internal/v2/codec/Encoding.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/codec/Encoding.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.codec;
+
+import java.util.List;
+
+public enum Encoding {
+  JSON {
+    /** Encoding overhead is brackets and a comma for each span over 1 */
+    @Override public int listSizeInBytes(List<byte[]> values) {
+      int sizeInBytes = 2; // brackets
+      for (int i = 0, length = values.size(); i < length; ) {
+        sizeInBytes += values.get(i++).length;
+        if (i < length) sizeInBytes++;
+      }
+      return sizeInBytes;
+    }
+  };
+
+  public abstract int listSizeInBytes(List<byte[]> values);
+}

--- a/zipkin/src/main/java/zipkin/internal/v2/codec/MessageEncoder.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/codec/MessageEncoder.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.codec;
+
+import java.util.List;
+
+/**
+ * Senders like Kafka use byte[] message encoding. This provides helpers to concatenate spans into a
+ * list.
+ */
+public interface MessageEncoder<M> {
+  MessageEncoder<byte[]> JSON_BYTES = new MessageEncoder<byte[]>() {
+    @Override public Encoding encoding() {
+      return Encoding.JSON;
+    }
+
+    @Override public byte[] encode(List<byte[]> values) {
+      byte[] buf = new byte[encoding().listSizeInBytes(values)];
+      int pos = 0;
+      buf[pos++] = '[';
+      for (int i = 0, length = values.size(); i < length; ) {
+        byte[] v = values.get(i++);
+        System.arraycopy(v, 0, buf, pos, v.length);
+        pos += v.length;
+        if (i < length) buf[pos++] = ',';
+      }
+      buf[pos] = ']';
+      return buf;
+    }
+  };
+
+  Encoding encoding();
+
+  /**
+   * Combines a list of encoded spans into an encoded list. For example, in json, this would be
+   * comma-separated and enclosed by brackets.
+   *
+   * <p>The primary use of this is batch reporting spans. For example, spans are {@link
+   * Encoder#encode(Object) encoded} one-by-one into a queue. This queue is drained up to a byte
+   * threshold. Then, the list is encoded with this function and reported out-of-process.
+   */
+  M encode(List<byte[]> encodedSpans);
+}

--- a/zipkin/src/test/java/zipkin/internal/BufferTest.java
+++ b/zipkin/src/test/java/zipkin/internal/BufferTest.java
@@ -194,7 +194,7 @@ public class BufferTest {
       stringBuffer.append("a");
     }
     String string = stringBuffer.toString();
-    byte[] buffered = new Buffer(Buffer.asciiSizeInBytes(string)).writeAscii(string).toByteArray();
+    byte[] buffered = new Buffer(string.length()).writeAscii(string).toByteArray();
     assertThat(new String(buffered, "US-ASCII")).isEqualTo(string);
   }
 }

--- a/zipkin/src/test/java/zipkin/internal/Span2JsonSpanDecoderTest.java
+++ b/zipkin/src/test/java/zipkin/internal/Span2JsonSpanDecoderTest.java
@@ -16,26 +16,32 @@ package zipkin.internal;
 import org.junit.Test;
 import zipkin.Span;
 import zipkin.SpanDecoder;
+import zipkin.internal.v2.codec.MessageEncoder;
+import zipkin.internal.v2.codec.Encoder;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin.TestObjects.LOTS_OF_SPANS;
 
-public class Span2JsonDecoderTest {
+public class Span2JsonSpanDecoderTest {
   Span span1 = ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[0]);
   Span span2 = ApplyTimestampAndDuration.apply(LOTS_OF_SPANS[1]);
   Span2 span2_1 = Span2Converter.fromSpan(span1).get(0);
   Span2 span2_2 = Span2Converter.fromSpan(span2).get(0);
 
-  SpanDecoder decoder = new Span2JsonDecoder();
+  SpanDecoder decoder = new Span2JsonSpanDecoder();
 
-  @Test public void readSpan() {
-    assertThat(decoder.readSpan(Span2Codec.JSON.writeSpan(span2_1)))
-      .isEqualTo(span1);
+  @Test(expected = UnsupportedOperationException.class) public void readSpan() {
+    decoder.readSpan(Encoder.JSON.encode(span2_1));
   }
 
   @Test public void readSpans() {
-    assertThat(decoder.readSpans(Span2Codec.JSON.writeSpans(asList(span2_1, span2_2))))
+    byte[] message = MessageEncoder.JSON_BYTES.encode(asList(
+      Encoder.JSON.encode(span2_1),
+      Encoder.JSON.encode(span2_2)
+    ));
+
+    assertThat(decoder.readSpans(message))
       .containsExactly(span1, span2);
   }
 }

--- a/zipkin/src/test/java/zipkin/internal/v2/codec/EncodingTest.java
+++ b/zipkin/src/test/java/zipkin/internal/v2/codec/EncodingTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.codec;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EncodingTest {
+
+  @Test public void emptyList_json() throws IOException {
+    List<byte[]> encoded = Arrays.asList();
+    assertThat(Encoding.JSON.listSizeInBytes(encoded))
+      .isEqualTo(2 /* [] */);
+  }
+
+  @Test public void singletonList_json() throws IOException {
+    List<byte[]> encoded = Arrays.asList(new byte[10]);
+    assertThat(Encoding.JSON.listSizeInBytes(encoded))
+      .isEqualTo(2 /* [] */ + 10);
+  }
+
+  @Test public void multiItemList_json() throws IOException {
+    List<byte[]> encoded = Arrays.asList(new byte[3], new byte[4], new byte[5]);
+    assertThat(Encoding.JSON.listSizeInBytes(encoded))
+      .isEqualTo(2 /* [] */ + 3 + 1 /* , */ + 4 + 1  /* , */ + 5);
+  }
+}

--- a/zipkin/src/test/java/zipkin/internal/v2/codec/MessageEncodingTest.java
+++ b/zipkin/src/test/java/zipkin/internal/v2/codec/MessageEncodingTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.codec;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import zipkin.internal.Util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MessageEncodingTest {
+
+  @Test public void emptyList_jsonBytes() throws IOException {
+    List<byte[]> encoded = Arrays.asList();
+    assertThat(MessageEncoder.JSON_BYTES.encode(encoded))
+      .isEqualTo("[]".getBytes(Util.UTF_8));
+  }
+
+  @Test public void singletonList_jsonBytes() throws IOException {
+    List<byte[]> encoded = Arrays.asList(new byte[] {'1'});
+    assertThat(MessageEncoder.JSON_BYTES.encode(encoded))
+      .isEqualTo("[1]".getBytes(Util.UTF_8));
+  }
+
+  @Test public void multiItemList_jsonBytes() throws IOException {
+    List<byte[]> encoded = Arrays.asList(new byte[] {'3'}, new byte[] {'4'}, new byte[] {'5'});
+    assertThat(MessageEncoder.JSON_BYTES.encode(encoded))
+      .isEqualTo("[3,4,5]".getBytes(Util.UTF_8));
+  }
+}


### PR DESCRIPTION
All current Zipkin codec operations include the following:
* encoding spans one-by-one as reported by instrumentation
* encoding a list of spans ready to send into a bytes message
* decoding a list of spans off a transport message

Zipkin v1 includes legacy encoding, which is a bit different. For
example, old variants of Kafka accepted single-element messages instead
of a list. We don't need to carry-forward this anymore. Moreover,
interfaces of reporter vs collector were split across jars in Zipkin v1
due to the former being defined late.

This introduces the following key interfaces and cleans up some code
around codec.

* `byte[] Encoder.encode(S span)`
* `M MessageEncoder.encode(List<byte[]> encodedSpans)`
* `List<S> Decoder.decodeList(byte[] message)`

All of these are temporarily placed in an internal package until other
code around it stabilizes.