### PR TITLE
Switches CollectorSampler to use (trace ID, debug) vs Span v1 object

### DIFF
--- a/zipkin/src/main/java/zipkin/collector/CollectorComponent.java
+++ b/zipkin/src/main/java/zipkin/collector/CollectorComponent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package zipkin.collector;
 
 import java.util.List;
 import zipkin.Component;
-import zipkin.Span;
 import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.Callback;
 import zipkin.storage.StorageComponent;
@@ -49,8 +48,8 @@ public interface CollectorComponent extends Component {
     Builder metrics(CollectorMetrics metrics);
 
     /**
-     * {@link CollectorSampler#isSampled(Span) samples spans} to reduce load on the storage system.
-     * Defaults to always sample.
+     * {@link CollectorSampler#isSampled(long, Boolean) samples spans} to reduce load on the storage
+     * system. Defaults to always sample.
      */
     Builder sampler(CollectorSampler sampler);
 

--- a/zipkin/src/main/java/zipkin/collector/CollectorMetrics.java
+++ b/zipkin/src/main/java/zipkin/collector/CollectorMetrics.java
@@ -14,16 +14,16 @@
 package zipkin.collector;
 
 import java.util.List;
-import zipkin.storage.AsyncSpanConsumer;
-import zipkin.storage.Callback;
 import zipkin.Codec;
 import zipkin.Span;
+import zipkin.storage.AsyncSpanConsumer;
+import zipkin.storage.Callback;
 
 /**
  * Instrumented applications report spans over a transport such as Kafka. Zipkin collectors receive
- * these messages, {@link Codec#readSpans(byte[]) decoding them into spans}, {@link
- * CollectorSampler#isSampled(Span) apply sampling}, and {@link AsyncSpanConsumer#accept(List,
- * Callback) queue them for storage}.
+ * these messages, {@link Codec#readSpans(byte[]) decoding them into spans},
+ * {@link CollectorSampler# isSampled(long, Boolean) apply sampling}, and
+ * {@link AsyncSpanConsumer#accept(List, Callback) queues them for storage}.
  *
  * <p>Callbacks on this type are invoked by zipkin collectors to improve the visibility of the
  * system. A typical implementation will report metrics to a telemetry system for analysis and
@@ -48,7 +48,7 @@ import zipkin.Span;
  * messages sent from instrumentation.</li>
  * <li>Stored spans <= {@link #incrementSpans(int) Accepted spans} - {@link
  * #incrementSpansDropped(int) Dropped spans}. Alert when this drops below the
- * {@link CollectorSampler#isSampled(Span) collection-tier sample rate}.
+ * {@link CollectorSampler#isSampled(long, Boolean) collection-tier sample rate}.
  * </li>
  * </ul>
  * </pre>

--- a/zipkin/src/main/java/zipkin/storage/AsyncSpanConsumer.java
+++ b/zipkin/src/main/java/zipkin/storage/AsyncSpanConsumer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,10 +28,6 @@ import zipkin.collector.CollectorSampler;
 // @FunctionalInterface
 public interface AsyncSpanConsumer {
 
-  /**
-   * Stores a list of spans {@link Codec#readSpans(byte[]) read} from a transport.
-   *
-   * @param spans may be subject to a {@link CollectorSampler#isSampled(Span) sampling policy}.
-   */
+  /** Stores a list of spans {@link Codec#readSpans(byte[]) read} from a transport. */
   void accept(List<Span> spans, Callback<Void> callback);
 }

--- a/zipkin/src/test/java/zipkin/collector/CollectorSamplerTest.java
+++ b/zipkin/src/test/java/zipkin/collector/CollectorSamplerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,11 +17,11 @@ import java.util.stream.Stream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import zipkin.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static zipkin.TestObjects.LOTS_OF_SPANS;
-import static zipkin.TestObjects.span;
 
 public class CollectorSamplerTest {
 
@@ -36,15 +36,15 @@ public class CollectorSamplerTest {
   public void mostNegativeNumberDefence() {
     CollectorSampler sampler = CollectorSampler.create(0.1f);
 
-    assertThat(sampler.isSampled(span(Long.MIN_VALUE)))
-        .isEqualTo(sampler.isSampled(span(Long.MAX_VALUE)));
+    assertThat(sampler.isSampled(Long.MIN_VALUE, null))
+        .isEqualTo(sampler.isSampled(Long.MAX_VALUE, null));
   }
 
   @Test
   public void debugWins() {
     CollectorSampler sampler = CollectorSampler.create(0.0f);
 
-    assertThat(sampler.isSampled(span(Long.MIN_VALUE).toBuilder().debug(true).build()))
+    assertThat(sampler.isSampled(Long.MIN_VALUE, true))
         .isTrue();
   }
 
@@ -53,9 +53,7 @@ public class CollectorSamplerTest {
     float sampleRate = 0.1f;
     CollectorSampler sampler = CollectorSampler.create(sampleRate);
 
-    long passCount = Stream.of(LOTS_OF_SPANS).parallel().filter(sampler::isSampled).count();
-
-    assertThat(passCount)
+    assertThat(lotsOfSpans().filter(s -> sampler.isSampled(s.traceId, null)).count())
         .isCloseTo((long) (LOTS_OF_SPANS.length * sampleRate), withPercentage(3));
   }
 
@@ -67,15 +65,15 @@ public class CollectorSamplerTest {
     CollectorSampler sampler1 = CollectorSampler.create(0.1f);
     CollectorSampler sampler2 = CollectorSampler.create(0.1f);
 
-    assertThat(Stream.of(LOTS_OF_SPANS).parallel().filter(sampler1::isSampled).toArray())
-        .containsExactly(Stream.of(LOTS_OF_SPANS).parallel().filter(sampler2::isSampled).toArray());
+    assertThat(lotsOfSpans().filter(s -> sampler1.isSampled(s.traceId, null)).toArray())
+      .containsExactly(lotsOfSpans().filter(s -> sampler2.isSampled(s.traceId, null)).toArray());
   }
 
   @Test
   public void zeroMeansDropAllTraces() {
     CollectorSampler sampler = CollectorSampler.create(0.0f);
 
-    assertThat(Stream.of(LOTS_OF_SPANS).parallel().filter(sampler::isSampled).findAny())
+    assertThat(lotsOfSpans().filter(s -> sampler.isSampled(s.traceId, null)))
         .isEmpty();
   }
 
@@ -83,8 +81,8 @@ public class CollectorSamplerTest {
   public void oneMeansKeepAllTraces() {
     CollectorSampler sampler = CollectorSampler.create(1.0f);
 
-    assertThat(Stream.of(LOTS_OF_SPANS).parallel().filter(sampler::isSampled).count())
-        .isEqualTo(LOTS_OF_SPANS.length);
+    assertThat(lotsOfSpans().filter(s -> sampler.isSampled(s.traceId, null)))
+        .hasSize(LOTS_OF_SPANS.length);
   }
 
   @Test
@@ -101,5 +99,9 @@ public class CollectorSamplerTest {
     thrown.expectMessage("rate should be between 0 and 1: was 1.1");
 
     CollectorSampler.create(1.1f);
+  }
+
+  static Stream<Span> lotsOfSpans() {
+    return Stream.of(LOTS_OF_SPANS).parallel();
   }
 }


### PR DESCRIPTION
Currently, transports can decode zipkin2 format, but it has to be
converted to v1 objects prior to storage. Part of the reason is
CollectorSampler (used for load shedding to protect storage), accepts
an object type as opposed to the parameters trace ID and debug. This
deprecates the former in favor of the latter, as trace ID and debug
exist in both formats.
We are switching code to permit use of zipkin2 format in transports.