### PR TITLE
Removes double-conversion when collecting into Elasticsearch

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
@@ -27,7 +27,9 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import zipkin.internal.AsyncSpan2ConsumerAdapter;
 import zipkin.internal.Nullable;
+import zipkin.internal.Span2Component;
 import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.AsyncSpanStore;
 import zipkin.storage.SpanStore;
@@ -42,8 +44,7 @@ import static zipkin.storage.elasticsearch.http.ElasticsearchHttpSpanStore.DEPEN
 import static zipkin.storage.elasticsearch.http.ElasticsearchHttpSpanStore.SPAN;
 
 @AutoValue
-public abstract class ElasticsearchHttpStorage implements StorageComponent {
-
+public abstract class ElasticsearchHttpStorage extends Span2Component implements StorageComponent {
   /**
    * A list of elasticsearch nodes to connect to, in http://host:port or https://host:port
    * format. Note this value is only read once.
@@ -222,6 +223,10 @@ public abstract class ElasticsearchHttpStorage implements StorageComponent {
   }
 
   @Override public AsyncSpanConsumer asyncSpanConsumer() {
+    return AsyncSpan2ConsumerAdapter.create(asyncSpan2Consumer());
+  }
+
+  @Override protected zipkin.internal.v2.storage.AsyncSpanConsumer asyncSpan2Consumer() {
     ensureIndexTemplates();
     return new ElasticsearchHttpSpanConsumer(this);
   }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorageTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorageTest.java
@@ -80,7 +80,7 @@ public class ElasticsearchHttpStorageTest {
     es.enqueue(new MockResponse()); // get dependency template
 
     // check this isn't the legacy consumer
-    assertThat(storage.asyncSpanConsumer())
+    assertThat(storage.asyncSpan2Consumer())
       .isInstanceOf(ElasticsearchHttpSpanConsumer.class);
     // check this isn't the double reading span store
     assertThat(storage.asyncSpanStore())
@@ -101,9 +101,6 @@ public class ElasticsearchHttpStorageTest {
     es.enqueue(new MockResponse()); // get span template
     es.enqueue(new MockResponse()); // get dependency template
 
-    // check this isn't the legacy consumer
-    assertThat(storage.asyncSpanConsumer())
-      .isInstanceOf(ElasticsearchHttpSpanConsumer.class);
     // check that we do double-reads on the legacy and new format
     assertThat(storage.asyncSpanStore())
       .isInstanceOf(LenientDoubleCallbackAsyncSpanStore.class);
@@ -124,9 +121,6 @@ public class ElasticsearchHttpStorageTest {
     es.enqueue(new MockResponse()); // get span template
     es.enqueue(new MockResponse()); // get dependency template
 
-    // check this isn't the legacy consumer
-    assertThat(storage.asyncSpanConsumer())
-      .isInstanceOf(ElasticsearchHttpSpanConsumer.class);
     // check this isn't the double reading span store
     assertThat(storage.asyncSpanStore())
       .isInstanceOf(ElasticsearchHttpSpanStore.class);

--- a/zipkin/src/main/java/zipkin/internal/AsyncSpan2ConsumerAdapter.java
+++ b/zipkin/src/main/java/zipkin/internal/AsyncSpan2ConsumerAdapter.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import zipkin.Span;
+import zipkin.storage.AsyncSpanConsumer;
+import zipkin.storage.Callback;
+
+public final class AsyncSpan2ConsumerAdapter implements AsyncSpanConsumer {
+
+  public static AsyncSpanConsumer create(zipkin.internal.v2.storage.AsyncSpanConsumer delegate) {
+    return new AsyncSpan2ConsumerAdapter(delegate);
+  }
+
+  final zipkin.internal.v2.storage.AsyncSpanConsumer delegate;
+
+  AsyncSpan2ConsumerAdapter(zipkin.internal.v2.storage.AsyncSpanConsumer delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public void accept(List<Span> spans, Callback<Void> callback) {
+    int length = spans.size();
+    List<Span2> linkSpans = new ArrayList<>(length);
+    for (int i = 0; i < length; i++) {
+      linkSpans.addAll(Span2Converter.fromSpan(spans.get(i)));
+    }
+    delegate.accept(linkSpans, callback);
+  }
+}

--- a/zipkin/src/main/java/zipkin/internal/Collector2.java
+++ b/zipkin/src/main/java/zipkin/internal/Collector2.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.List;
+import java.util.logging.Logger;
+import zipkin.collector.CollectorMetrics;
+import zipkin.collector.CollectorSampler;
+import zipkin.internal.v2.codec.Decoder;
+import zipkin.storage.Callback;
+
+import static zipkin.internal.Util.checkNotNull;
+
+public final class Collector2 extends Collector<Decoder<Span2>, Span2> {
+  final Span2Component storage;
+  final CollectorSampler sampler;
+
+  public Collector2(Logger logger, @Nullable CollectorMetrics metrics,
+    @Nullable CollectorSampler sampler, Span2Component storage) {
+    super(logger, metrics);
+    this.storage = checkNotNull(storage, "storage");
+    this.sampler = sampler == null ? CollectorSampler.ALWAYS_SAMPLE : sampler;
+  }
+
+  @Override
+  public void acceptSpans(byte[] serializedSpans, Decoder<Span2> decoder, Callback<Void> callback) {
+    super.acceptSpans(serializedSpans, decoder, callback);
+  }
+
+  @Override protected List<Span2> decodeList(Decoder<Span2> decoder, byte[] serialized) {
+    return decoder.decodeList(serialized);
+  }
+
+  @Override protected boolean isSampled(Span2 span) {
+    return sampler.isSampled(span.traceId(), span.debug());
+  }
+
+  @Override protected void record(List<Span2> sampled, Callback<Void> callback) {
+    storage.asyncSpan2Consumer().accept(sampled, callback);
+  }
+
+  @Override protected String idString(Span2 span) {
+    return span.idString();
+  }
+}

--- a/zipkin/src/main/java/zipkin/internal/Span2Component.java
+++ b/zipkin/src/main/java/zipkin/internal/Span2Component.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import zipkin.internal.v2.storage.AsyncSpanConsumer;
+
+// temporary type until other classes around this complete
+public abstract class Span2Component {
+  protected abstract AsyncSpanConsumer asyncSpan2Consumer();
+}

--- a/zipkin/src/main/java/zipkin/internal/v2/storage/AsyncSpanConsumer.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/storage/AsyncSpanConsumer.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.storage;
+
+import java.util.List;
+import zipkin.internal.Span2;
+import zipkin.storage.Callback;
+
+// @FunctionalInterface
+public interface AsyncSpanConsumer {
+
+  void accept(List<Span2> spans, Callback<Void> callback);
+}


### PR DESCRIPTION
Before, when accepting span2 format, we needlessly converted data to and
from the legacy Span format. This removes the double-conversion in favor
of a version 2 native span consumer.

Before:
```
             ┌──────────────────────────────────────────────────┐
             │           ┌──────────────┐        KafkaCollector │
             │           │ Kafka Message│                       │
             │           └──────┬───────┘                       │
             │┌─────────────────┼───────────────────┐           │
             ││           ┌─────┴───────┐  Collector│           │
             ││           │ byte array  │           │           │
             ││           └─────┬───────┘           │           │
             ││              .──▼──.                │           │
             ││             ╱       ╲               │           │
             ││       ┌────( decode  )────┐         │           │
             ││    ┌──┴───┐ `.     ,' ┌───┴──┐      │           │
             ││    │json2 │   `───'   │thrift│      │           │
             ││    └──┬───┘       │   └───┬──┘      │           │
             ││       │           │       │         │           │
             ││       │         ┌─┴────┐  │         │           │
             ││       ▼         │ json │  │         │           │
             ││┌────────────┐   └─┬────┘  │         │           │
             │││List<Span2> │     │       │         │           │
             ││└────┬───────┘     │       │         │           │
┌────────────┴┴─────┼─────────────┼───────┼───┐     │           │
│                   ▼             ▼       ▼   │     │           │
│               .───────.       ┌────────────┐│     │           │
│              ( convert )─────▶│ List<Span> ││     │           │
│               `───────'       └──────┬─────┘│     │           │
│ This double converts when input      │      ├─────┘           │
│ is already in span2 format           │      ├─────────────────┘
│                                      │      ├─────────────────┐
│              ┌────────────┐      .───▼───.  │Elasticsearch    │
│              │List<Span2> │◀────( convert ) │AsyncSpanConsumer│
│              └─────┬──────┘      `───────'  │                 │
│                    │                        │                 │
└────────────┬───────▼────────────────────────┘                 │
             │  .───────.       ┌────────────┐                  │
             │ ( convert )─────▶│BulkRequest │                  │
             │  `───────'       └──────┬─────┘                  │
             └─────────────────────────┼────────────────────────┘
                                       ▼                         
                               ┌──────────────┐                  
                               │ Elasticsearch│                  
                               └──────────────┘                  
```

Now, the storage layer is simpler and only converts when required

```
               ││              .─────.                │      │   
               ││             ╱       ╲               │      │   
               ││       ┌────( decode  )────┐         │      │   
               ││    ┌──┴───┐ `.     ,' ┌───┴──┐      │      │   
               ││    │json2 │   `───'   │thrift│      │      │   
               ││    └──┬───┘       │   └───┬──┘      │      │   
               ││       │           │       │         │      │   
               ││       │         ┌─┴────┐  │         │      │   
               ││       │         │ json │  │         │      │   
               ││       │         └─┬────┘  │         │      │   
               ││       │           │       │         │      │   
               ││       ▼           ▼       ▼         │      │   
               ││ ┌────────────┐  ┌────────────┐      │      │   
               ││ │List<Span2> │  │ List<Span> │──────┼─┐    │   
               ││ └─────┬──────┘  └────────────┘      │ │    │   
               │└───────┼─────────────────────────────┘ │    │   
               └────────┼───────────────────────────────┼────┘   
┌───────────────────────┼───────┐ ┌─────────────────────┼───────┐
│                   .───▼───.   │ │ ┌────────────┐  .───▼───.   │
│                  ( convert )◀─┼─┼─│List<Span2> ◀── convert )  │
│ Elasticsearch     `───┬───'   │ │ └────────────┘  `───────'   │
│ AsyncSpanConsumer     │       │ │  Conditional conversion     │
│                 ┌─────▼──────┐│ └─────────────────────────────┘
│                 │BulkRequest ││                                
│                 └─────┬──────┘│                                
└───────────────────────┼───────┘                                
                        ▼                                        
                ┌──────────────┐                                 
                │ Elasticsearch│                                 
                └──────────────┘                                 
```