### PR TITLE
Adds v2 Call interface based on okhttp and retrofit

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
@@ -29,6 +29,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okio.Buffer;
 import zipkin.internal.V2StorageComponent;
+import zipkin.internal.v2.storage.SpanConsumer;
 import zipkin.storage.AsyncSpanStore;
 import zipkin.storage.SpanStore;
 import zipkin.storage.StorageAdapters;
@@ -220,7 +221,7 @@ public abstract class ElasticsearchHttpStorage extends V2StorageComponent
     }
   }
 
-  @Override protected zipkin.internal.v2.storage.AsyncSpanConsumer v2AsyncSpanConsumer() {
+  @Override protected SpanConsumer v2AsyncSpanConsumer() {
     ensureIndexTemplates();
     return new ElasticsearchHttpSpanConsumer(this);
   }

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkIndexer.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/HttpBulkIndexer.java
@@ -69,7 +69,7 @@ final class HttpBulkIndexer {
   }
 
   /** Creates a bulk request when there is more than one object to store */
-  void execute(Callback<Void> callback) {
+  HttpCall<Void> newCall(){
     HttpUrl url = pipeline != null
         ? http.baseUrl.newBuilder("_bulk").addQueryParameter("pipeline", pipeline).build()
         : http.baseUrl.resolve("_bulk");
@@ -77,7 +77,7 @@ final class HttpBulkIndexer {
     Request request = new Request.Builder().url(url).tag(tag)
         .post(RequestBody.create(APPLICATION_JSON, body.readByteString())).build();
 
-    http.<Void>newCall(request, b -> {
+    return http.newCall(request, b -> {
       String content = b.readUtf8();
       if (content.indexOf("\"errors\":true") != -1) {
         throw new IllegalStateException(content);
@@ -85,7 +85,7 @@ final class HttpBulkIndexer {
       if (indices.isEmpty()) return null;
       ElasticsearchHttpStorage.flush(http, join(indices));
       return null;
-    }).submit(callback);
+    });
   }
 
   static String join(Collection<String> parts) {

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import zipkin.TestObjects;
-import zipkin.internal.CallbackCaptor;
 import zipkin.internal.v2.Span;
 import zipkin.internal.v2.Span.Kind;
 import zipkin.internal.v2.codec.Decoder;
@@ -213,8 +212,6 @@ public class ElasticsearchHttpSpanConsumerTest {
   }
 
   void accept(Span... spans) throws Exception {
-    CallbackCaptor<Void> callback = new CallbackCaptor<>();
-    storage.v2AsyncSpanConsumer().accept(asList(spans), callback);
-    callback.get();
+    storage.v2AsyncSpanConsumer().accept(asList(spans)).execute();
   }
 }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/InternalForTests.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/InternalForTests.java
@@ -14,6 +14,7 @@
 package zipkin.storage.elasticsearch.http;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import zipkin.Codec;
 import zipkin.DependencyLink;
@@ -32,9 +33,11 @@ public class InternalForTests {
       byte[] document = Codec.JSON.writeDependencyLink(link);
       indexer.add(index, DEPENDENCY, document, link.parent + "|" + link.child); // Unique constraint
     }
-    CallbackCaptor<Void> callback = new CallbackCaptor<>();
-    indexer.execute(callback);
-    callback.get();
+    try {
+      indexer.newCall().execute();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   public static void clear(ElasticsearchHttpStorage es) throws IOException {

--- a/zipkin/src/main/java/zipkin/internal/V2CallbackAdapter.java
+++ b/zipkin/src/main/java/zipkin/internal/V2CallbackAdapter.java
@@ -11,14 +11,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.internal.v2.storage;
+package zipkin.internal;
 
-import java.util.List;
-import zipkin.internal.v2.Span;
+import javax.annotation.Nullable;
 import zipkin.storage.Callback;
 
-// @FunctionalInterface
-public interface AsyncSpanConsumer {
+final class V2CallbackAdapter implements zipkin.internal.v2.Callback<Void> {
+  private final Callback<Void> callback;
 
-  void accept(List<Span> spans, Callback<Void> callback);
+  V2CallbackAdapter(Callback<Void> callback) {
+    this.callback = callback;
+  }
+
+  @Override public void onSuccess(@Nullable Void value) {
+    callback.onSuccess(value);
+  }
+
+  @Override public void onError(Throwable t) {
+    callback.onError(t);
+  }
 }

--- a/zipkin/src/main/java/zipkin/internal/V2Collector.java
+++ b/zipkin/src/main/java/zipkin/internal/V2Collector.java
@@ -49,7 +49,7 @@ public final class V2Collector extends Collector<Decoder<Span>, Span> {
   }
 
   @Override protected void record(List<Span> sampled, Callback<Void> callback) {
-    storage.v2AsyncSpanConsumer().accept(sampled, callback);
+    storage.v2AsyncSpanConsumer().accept(sampled).enqueue(new V2CallbackAdapter(callback));
   }
 
   @Override protected String idString(Span span) {

--- a/zipkin/src/main/java/zipkin/internal/V2StorageComponent.java
+++ b/zipkin/src/main/java/zipkin/internal/V2StorageComponent.java
@@ -15,7 +15,9 @@ package zipkin.internal;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import zipkin.internal.v2.Span;
+import zipkin.internal.v2.storage.SpanConsumer;
 import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.Callback;
 import zipkin.storage.StorageComponent;
@@ -25,12 +27,12 @@ public abstract class V2StorageComponent implements StorageComponent {
     return new V2AsyncSpanConsumerAdapter(v2AsyncSpanConsumer());
   }
 
-  protected abstract zipkin.internal.v2.storage.AsyncSpanConsumer v2AsyncSpanConsumer();
+  protected abstract SpanConsumer v2AsyncSpanConsumer();
 
   static class V2AsyncSpanConsumerAdapter implements AsyncSpanConsumer {
-    final zipkin.internal.v2.storage.AsyncSpanConsumer delegate;
+    final SpanConsumer delegate;
 
-    V2AsyncSpanConsumerAdapter(zipkin.internal.v2.storage.AsyncSpanConsumer delegate) {
+    V2AsyncSpanConsumerAdapter(SpanConsumer delegate) {
       this.delegate = delegate;
     }
 
@@ -40,7 +42,7 @@ public abstract class V2StorageComponent implements StorageComponent {
       for (int i = 0; i < length; i++) {
         linkSpans.addAll(V2SpanConverter.fromSpan(spans.get(i)));
       }
-      delegate.accept(linkSpans, callback);
+      delegate.accept(linkSpans).enqueue(new V2CallbackAdapter(callback));
     }
   }
 }

--- a/zipkin/src/main/java/zipkin/internal/v2/Call.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/Call.java
@@ -111,6 +111,7 @@ public abstract class Call<V> implements Cloneable {
         if (executed) throw new IllegalStateException("Already Executed");
         executed = true;
       }
+      if (canceled) throw new IOException("Canceled");
       return v;
     }
 
@@ -119,7 +120,11 @@ public abstract class Call<V> implements Cloneable {
         if (executed) throw new IllegalStateException("Already Executed");
         executed = true;
       }
-      callback.onSuccess(v);
+      if (canceled) {
+        callback.onError(new IOException("Canceled"));
+      } else {
+        callback.onSuccess(v);
+      }
     }
 
     @Override public void cancel() {

--- a/zipkin/src/main/java/zipkin/internal/v2/Call.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/Call.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * This captures a (usually remote) request and can be used once, either {@link #execute()
+ * synchronously} or {@link #enqueue(Callback) asynchronously}. At any time, from any thread, you
+ * can call {@linkplain #cancel()}, which might stop an in-flight request or prevent one from
+ * occurring.
+ *
+ * <p>Implementations should prepare a call such that there's little or no likelihood of late
+ * runtime exceptions. For example, if the call is to get a trace, the call to {@code listSpans}
+ * should propagate input errors vs delay them until a call to {@linkplain #execute()} or
+ * {@linkplain #enqueue(Callback)}.
+ *
+ * <p>Ex.
+ * <pre>{@code
+ * // Any translation of an input request to remote parameters should happen here, and any related
+ * // errors should propagate here.
+ * Call<List<List<Span>>> listTraces = spanStore.listTraces(request);
+ * // When this executes, it should simply run the remote request.
+ * List<Span> trace = getTraceCall.execute();
+ * }</pre>
+ *
+ * <p>An instance of call cannot be invoked more than once, but you can {@linkplain #clone()} an
+ * instance if you need to replay the call. There is no relationship between a call and a number of
+ * remote requests. For example, an implementation that stores spans may make hundreds of remote
+ * requests, possibly retrying on your behalf.
+ *
+ * <p>This type owes its design to {@code retrofit2.Call}, which is nearly the same, except limited
+ * to HTTP transports.
+ *
+ * @param <V> the success type, only null when {@code V} is {@linkplain Void}.
+ */
+public abstract class Call<V> implements Cloneable {
+
+  /**
+   * Returns a completed call which has the supplied value. This is useful when input parameters
+   * imply there's no call needed. For example, an empty input might always result in an empty
+   * output.
+   */
+  public static <V> Call<V> create(@Nullable V v) {
+    return new Constant<>(v);
+  }
+
+  /**
+   * Invokes a request, returning a success value or propagating an error to the caller. Invoking
+   * this more than once will result in an error. To repeat a call, make a copy with {@linkplain
+   * #clone()}.
+   *
+   * <p>Eventhough this is a blocking call, implementations may honor calls to {@linkplain
+   * #cancel()} from a different thread.
+   *
+   * @return a success value. Null is unexpected, except when {@code V} is {@linkplain Void}.
+   */
+  @Nullable public abstract V execute() throws IOException;
+
+  /**
+   * Invokes a request asynchronously, signaling the {@code callback} when complete. Invoking this
+   * more than once will result in an error. To repeat a call, make a copy with {@linkplain
+   * #clone()}.
+   */
+  public abstract void enqueue(Callback<V> callback);
+
+  /**
+   * Requests to cancel this call, even if some implementations may not support it. For example, a
+   * blocking call is sometimes not cancelable.
+   */
+  // Boolean isn't returned because some implementations may cancel asynchronously.
+  // Implementing might throw an IOException on execute or callback.onError(IOException)
+  public abstract void cancel();
+
+  /**
+   * Returns true if {@linkplain #cancel()} was called.
+   *
+   * <p>Calls can fail before being canceled, so true does always mean cancelation caused a call to
+   * fail. That said, successful cancellation does result in a failure.
+   */
+  // isCanceled exists while isExecuted does not because you do not need the latter to implement
+  // asynchronous bindings, such as rxjava2
+  public abstract boolean isCanceled();
+
+  /** Returns a copy of this object, so you can make an identical follow-up request. */
+  public abstract Call<V> clone();
+
+  static final class Constant<V> extends Call<V> {
+    @Nullable final V v;
+    volatile boolean canceled;
+    boolean executed; // guarded by this
+
+    Constant(@Nullable V v) {
+      this.v = v;
+    }
+
+    @Override public V execute() throws IOException {
+      synchronized (this) {
+        if (executed) throw new IllegalStateException("Already Executed");
+        executed = true;
+      }
+      return v;
+    }
+
+    @Override public void enqueue(Callback<V> callback) {
+      synchronized (this) {
+        if (executed) throw new IllegalStateException("Already Executed");
+        executed = true;
+      }
+      callback.onSuccess(v);
+    }
+
+    @Override public void cancel() {
+      canceled = true;
+    }
+
+    @Override public boolean isCanceled() {
+      return canceled;
+    }
+
+    @Override public Call<V> clone() {
+      return new Constant<>(v);
+    }
+  }
+}

--- a/zipkin/src/main/java/zipkin/internal/v2/Callback.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/Callback.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2;
+
+import javax.annotation.Nullable;
+
+/**
+ * A callback of a single result or error.
+ *
+ * <p>This is a bridge to async libraries such as CompletableFuture complete, completeExceptionally.
+ *
+ * <p>Implementations will call either {@link #onSuccess} or {@link #onError}, but not both.
+ */
+public interface Callback<V> {
+
+  /**
+   * Invoked when computation produces its potentially null value successfully.
+   *
+   * <p>When this is called, {@link #onError} won't be.
+   */
+  void onSuccess(@Nullable V value);
+
+  /**
+   * Invoked when computation produces a possibly null value successfully.
+   *
+   * <p>When this is called, {@link #onSuccess} won't be.
+   */
+  void onError(Throwable t);
+}

--- a/zipkin/src/main/java/zipkin/internal/v2/storage/SpanConsumer.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/storage/SpanConsumer.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.storage;
+
+import java.util.List;
+import zipkin.internal.v2.Call;
+import zipkin.internal.v2.Span;
+import zipkin.storage.Callback;
+
+// @FunctionalInterface
+public interface SpanConsumer {
+  Call<Void> accept(List<Span> spans);
+}

--- a/zipkin/src/test/java/zipkin/collector/CollectorTest.java
+++ b/zipkin/src/test/java/zipkin/collector/CollectorTest.java
@@ -24,8 +24,7 @@ import zipkin.internal.V2StorageComponent;
 import zipkin.internal.v2.Span;
 import zipkin.internal.v2.codec.Encoder;
 import zipkin.internal.v2.codec.MessageEncoder;
-import zipkin.internal.v2.storage.AsyncSpanConsumer;
-import zipkin.storage.Callback;
+import zipkin.internal.v2.storage.SpanConsumer;
 
 import static java.util.Arrays.asList;
 import static org.mockito.ArgumentMatchers.any;
@@ -99,10 +98,10 @@ public class CollectorTest {
    */
   @Test public void routesToSpan2Collector() {
     abstract class WithSpan2 extends V2StorageComponent implements zipkin.storage.StorageComponent {
-      @Override public abstract zipkin.internal.v2.storage.AsyncSpanConsumer v2AsyncSpanConsumer();
+      @Override public abstract SpanConsumer v2AsyncSpanConsumer();
     }
     WithSpan2 storage = mock(WithSpan2.class);
-    AsyncSpanConsumer span2Consumer = mock(AsyncSpanConsumer.class);
+    SpanConsumer span2Consumer = mock(SpanConsumer.class);
     when(storage.v2AsyncSpanConsumer()).thenReturn(span2Consumer);
 
     collector = spy(Collector.builder(Collector.class)
@@ -112,6 +111,6 @@ public class CollectorTest {
     collector.acceptSpans(bytes, SpanDecoder.DETECTING_DECODER, NOOP);
 
     verify(collector, never()).isSampled(any(zipkin.Span.class)); // skips v1 processing
-    verify(span2Consumer).accept(eq(asList(span2_1)), any(Callback.class)); // goes to v2 instead
+    verify(span2Consumer).accept(eq(asList(span2_1))); // goes to v2 instead
   }
 }

--- a/zipkin/src/test/java/zipkin/internal/v2/CallTest.java
+++ b/zipkin/src/test/java/zipkin/internal/v2/CallTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+
+public class CallTest {
+
+  @Rule public MockitoRule mocks = MockitoJUnit.rule();
+
+  @Mock Callback callback;
+
+  @Test public void constant_execute() throws Exception {
+    Call<String> call = Call.create("foo");
+
+    assertThat(call.execute())
+      .isEqualTo("foo");
+  }
+
+  @Test public void constant_submit() throws Exception {
+    Call<String> call = Call.create("foo");
+
+    call.enqueue(callback);
+
+    verify(callback).onSuccess("foo");
+  }
+
+  @Test public void constant_execute_null() throws Exception {
+    Call<Void> call = Call.create(null);
+
+    assertThat(call.execute()).isNull();
+  }
+
+  @Test public void constant_submit_null() throws Exception {
+    Call<Void> call = Call.create(null);
+
+    call.enqueue(callback);
+
+    verify(callback).onSuccess(isNull());
+  }
+
+  @Test public void constant_submit_cancel() throws Exception {
+    Call<Void> call = Call.create(null);
+    call.cancel();
+
+    assertThat(call.isCanceled()).isTrue();
+
+    call.enqueue(callback);
+
+    verify(callback).onError(isA(IOException.class));
+  }
+
+  @Test public void executesOnce() throws Exception {
+    Call<Void> call = Call.create(null);
+    call.execute();
+
+    try {
+      call.execute();
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException e) {
+
+    }
+
+    try {
+      call.enqueue(callback);
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException e) {
+
+    }
+  }
+
+  @Test public void enqueuesOnce() throws Exception {
+    Call<Void> call = Call.create(null);
+    call.enqueue(callback);
+
+    try {
+      call.enqueue(callback);
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException e) {
+    }
+
+    try {
+      call.execute();
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException e) {
+    }
+  }
+
+  @Test(timeout = 1000L)
+  public void concurrent_executesOrSubmitsOnce() throws InterruptedException {
+    Call<Void> call = Call.create(null);
+
+    int tryCount = 100;
+
+    AtomicInteger executeOrSubmit = new AtomicInteger();
+
+    callback = new Callback() {
+      @Override public void onSuccess(@Nullable Object value) {
+        executeOrSubmit.incrementAndGet();
+      }
+
+      @Override public void onError(Throwable t) {
+
+      }
+    };
+
+    ExecutorService exec = Executors.newFixedThreadPool(10);
+    List<Runnable> tries = new ArrayList<>(tryCount);
+    for (int i = 0; i < tryCount; i++) {
+      tries.add(i % 2 == 0 ? () -> {
+        try {
+          call.execute();
+          executeOrSubmit.incrementAndGet();
+        } catch (Exception e) {
+        }
+      } : () -> call.enqueue(callback));
+    }
+
+    tries.stream().forEach(exec::execute);
+    exec.shutdown();
+    exec.awaitTermination(1, TimeUnit.SECONDS);
+
+    assertThat(executeOrSubmit.get()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
In Zipkin v1, we had a pair of SPI interfaces: `SpanConsumer`
and `AsyncSpanConsumer`.

For example, this would define the same thing twice:

```java
void SpanConsumer.accept(List<Span> spans);

// and

void AsyncSpanConsumer.accept(List<Span> spans, Callback<Void> spans);
```

in v2, it looks like this (inspired by Retrofit and OkHttp's call):

```java
Call<Void> accept(List<Span> spans);

// then make a call like this..
call = spanConsumer.accept(spans);

// to do a blocking call..
call.execute();

// to do an async call..
call.enqueue(callback);

// to cancel
call.cancel();
```

The important part of this design is that it reduces the redundant
interfaces. We end up making less work for users and implementors
at the cost of an intermediary type: Call.

This design is near identical to [Retrofit's Call](https://github.com/square/retrofit/blob/master/retrofit/src/main/java/retrofit2/Call.java), which is itself similar to
[OkHttp's call](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/Call.java). The mild difference here is that the underlying remote
work may not always be http even if the first impl (elasticsearch)
happens to be.

Many thanks to @JakeWharton and @swankjesse for the prior art.

