### PR TITLE
Adds v2 SpanStore and a bridging adapter to v1

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorage.java
@@ -28,12 +28,12 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import zipkin.internal.LenientDoubleCallbackAsyncSpanStore;
 import zipkin.internal.V2StorageComponent;
 import zipkin.internal.v2.storage.SpanConsumer;
 import zipkin.storage.AsyncSpanStore;
 import zipkin.storage.SpanStore;
 import zipkin.storage.StorageAdapters;
-import zipkin.storage.elasticsearch.http.internal.LenientDoubleCallbackAsyncSpanStore;
 import zipkin.storage.elasticsearch.http.internal.client.HttpCall;
 
 import static zipkin.internal.Util.checkNotNull;
@@ -205,6 +205,10 @@ public abstract class ElasticsearchHttpStorage extends V2StorageComponent
 
   abstract boolean legacyReadsEnabled();
 
+  @Override public zipkin.internal.v2.storage.SpanStore v2SpanStore() {
+    throw new UnsupportedOperationException("TODO");
+  }
+
   @Override public SpanStore spanStore() {
     return StorageAdapters.asyncToBlocking(asyncSpanStore());
   }
@@ -221,7 +225,7 @@ public abstract class ElasticsearchHttpStorage extends V2StorageComponent
     }
   }
 
-  @Override protected SpanConsumer v2AsyncSpanConsumer() {
+  @Override public SpanConsumer v2SpanConsumer() {
     ensureIndexTemplates();
     return new ElasticsearchHttpSpanConsumer(this);
   }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanConsumerTest.java
@@ -212,6 +212,6 @@ public class ElasticsearchHttpSpanConsumerTest {
   }
 
   void accept(Span... spans) throws Exception {
-    storage.v2AsyncSpanConsumer().accept(asList(spans)).execute();
+    storage.v2SpanConsumer().accept(asList(spans)).execute();
   }
 }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorageTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorageTest.java
@@ -23,7 +23,7 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import zipkin.Component;
-import zipkin.storage.elasticsearch.http.internal.LenientDoubleCallbackAsyncSpanStore;
+import zipkin.internal.LenientDoubleCallbackAsyncSpanStore;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/zipkin/src/main/java/zipkin/internal/LenientDoubleCallback.java
+++ b/zipkin/src/main/java/zipkin/internal/LenientDoubleCallback.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.storage.elasticsearch.http.internal;
+package zipkin.internal;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -33,7 +33,7 @@ abstract class LenientDoubleCallback<V> implements Callback<V> {
     this.delegate = delegate;
   }
 
-  abstract V merge(V v1, V v2);
+  abstract @Nullable V merge(@Nullable V v1, @Nullable V v2);
 
   @Override synchronized final public void onSuccess(@Nullable V value) {
     if (t != null) {

--- a/zipkin/src/main/java/zipkin/internal/LenientDoubleCallbackAsyncSpanStore.java
+++ b/zipkin/src/main/java/zipkin/internal/LenientDoubleCallbackAsyncSpanStore.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.storage.elasticsearch.http.internal;
+package zipkin.internal;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -21,8 +21,6 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import zipkin.DependencyLink;
 import zipkin.Span;
-import zipkin.internal.DependencyLinker;
-import zipkin.internal.MergeById;
 import zipkin.storage.AsyncSpanStore;
 import zipkin.storage.Callback;
 import zipkin.storage.QueryRequest;
@@ -31,6 +29,7 @@ import zipkin.storage.QueryRequest;
  * This makes redundant read commands, concatenating results if two answers come back, or accepting
  * one if there's an error on the other.
  */
+// TODO: temporarily public until elasticsearch-http transitions to V2 SpanStore
 public final class LenientDoubleCallbackAsyncSpanStore implements AsyncSpanStore {
   final AsyncSpanStore left;
   final AsyncSpanStore right;

--- a/zipkin/src/main/java/zipkin/internal/V2CallbackAdapter.java
+++ b/zipkin/src/main/java/zipkin/internal/V2CallbackAdapter.java
@@ -16,14 +16,14 @@ package zipkin.internal;
 import javax.annotation.Nullable;
 import zipkin.storage.Callback;
 
-final class V2CallbackAdapter implements zipkin.internal.v2.Callback<Void> {
-  private final Callback<Void> callback;
+final class V2CallbackAdapter<T> implements zipkin.internal.v2.Callback<T> {
+  final Callback<T> callback;
 
-  V2CallbackAdapter(Callback<Void> callback) {
+  V2CallbackAdapter(Callback<T> callback) {
     this.callback = callback;
   }
 
-  @Override public void onSuccess(@Nullable Void value) {
+  @Override public void onSuccess(@Nullable T value) {
     callback.onSuccess(value);
   }
 

--- a/zipkin/src/main/java/zipkin/internal/V2Collector.java
+++ b/zipkin/src/main/java/zipkin/internal/V2Collector.java
@@ -49,7 +49,7 @@ public final class V2Collector extends Collector<Decoder<Span>, Span> {
   }
 
   @Override protected void record(List<Span> sampled, Callback<Void> callback) {
-    storage.v2AsyncSpanConsumer().accept(sampled).enqueue(new V2CallbackAdapter(callback));
+    storage.v2SpanConsumer().accept(sampled).enqueue(new V2CallbackAdapter(callback));
   }
 
   @Override protected String idString(Span span) {

--- a/zipkin/src/main/java/zipkin/internal/V2SpanConsumerAdapter.java
+++ b/zipkin/src/main/java/zipkin/internal/V2SpanConsumerAdapter.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import zipkin.internal.v2.Span;
+import zipkin.internal.v2.storage.SpanConsumer;
+import zipkin.storage.AsyncSpanConsumer;
+import zipkin.storage.Callback;
+
+final class V2SpanConsumerAdapter implements AsyncSpanConsumer {
+  final SpanConsumer delegate;
+
+  V2SpanConsumerAdapter(SpanConsumer delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public void accept(List<zipkin.Span> spans, Callback<Void> callback) {
+    delegate.accept(fromSpans(spans)).enqueue(new V2CallbackAdapter<>(callback));
+  }
+
+  static List<Span> fromSpans(List<zipkin.Span> spans) {
+    if (spans.isEmpty()) return Collections.emptyList();
+    int length = spans.size();
+    List<Span> span2s = new ArrayList<>(length);
+    for (int i = 0; i < length; i++) {
+      span2s.addAll(V2SpanConverter.fromSpan(spans.get(i)));
+    }
+    return span2s;
+  }
+}

--- a/zipkin/src/main/java/zipkin/internal/V2SpanStoreAdapter.java
+++ b/zipkin/src/main/java/zipkin/internal/V2SpanStoreAdapter.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+import zipkin.DependencyLink;
+import zipkin.internal.v2.Call;
+import zipkin.internal.v2.Call.Mapper;
+import zipkin.internal.v2.Span;
+import zipkin.internal.v2.internal.Platform;
+import zipkin.internal.v2.storage.QueryRequest;
+import zipkin.internal.v2.storage.SpanStore;
+import zipkin.storage.AsyncSpanStore;
+import zipkin.storage.Callback;
+
+import static zipkin.internal.GroupByTraceId.TRACE_DESCENDING;
+
+final class V2SpanStoreAdapter implements zipkin.storage.SpanStore, AsyncSpanStore {
+  final SpanStore delegate;
+
+  V2SpanStoreAdapter(SpanStore delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public List<List<zipkin.Span>> getTraces(zipkin.storage.QueryRequest request) {
+    try {
+      return getTracesCall(request).execute();
+    } catch (IOException e) {
+      throw Platform.get().uncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public void getTraces(zipkin.storage.QueryRequest request,
+    Callback<List<List<zipkin.Span>>> callback) {
+    getTracesCall(request).enqueue(new V2CallbackAdapter<>(callback));
+  }
+
+  Call<List<List<zipkin.Span>>> getTracesCall(zipkin.storage.QueryRequest v1Request) {
+    return delegate.getTraces(convert(v1Request)).map(getTracesMapper);
+  }
+
+  @Nullable @Override public List<zipkin.Span> getTrace(long traceIdHigh, long traceIdLow) {
+    try {
+      return getTraceCall(traceIdHigh, traceIdLow).execute();
+    } catch (IOException e) {
+      throw Platform.get().uncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public void getTrace(long traceIdHigh, long traceIdLow, Callback<List<zipkin.Span>> callback) {
+    getTraceCall(traceIdHigh, traceIdLow).enqueue(new V2CallbackAdapter<>(callback));
+  }
+
+  Call<List<zipkin.Span>> getTraceCall(long traceIdHigh, long traceIdLow) {
+    return delegate.getTrace(traceIdHigh, traceIdLow).map(getTraceMapper);
+  }
+
+  @Nullable @Override public List<zipkin.Span> getRawTrace(long traceIdHigh, long traceIdLow) {
+    try {
+      return getRawTraceCall(traceIdHigh, traceIdLow).execute();
+    } catch (IOException e) {
+      throw Platform.get().uncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public void getRawTrace(long traceIdHigh, long traceIdLow,
+    Callback<List<zipkin.Span>> callback) {
+    getRawTraceCall(traceIdHigh, traceIdLow).enqueue(new V2CallbackAdapter<>(callback));
+  }
+
+  Call<List<zipkin.Span>> getRawTraceCall(long traceIdHigh, long traceIdLow) {
+    return delegate.getTrace(traceIdHigh, traceIdLow).map(getRawTraceMapper);
+  }
+
+  @Override public List<String> getServiceNames() {
+    try {
+      return delegate.getServiceNames().execute();
+    } catch (IOException e) {
+      throw Platform.get().uncheckedIOException(e);
+    }
+  }
+
+  @Override public void getServiceNames(Callback<List<String>> callback) {
+    delegate.getServiceNames().enqueue(new V2CallbackAdapter<>(callback));
+  }
+
+  @Override public List<String> getSpanNames(String serviceName) {
+    try {
+      return delegate.getSpanNames(serviceName).execute();
+    } catch (IOException e) {
+      throw Platform.get().uncheckedIOException(e);
+    }
+  }
+
+  @Override public void getSpanNames(String serviceName, Callback<List<String>> callback) {
+    delegate.getSpanNames(serviceName).enqueue(new V2CallbackAdapter<>(callback));
+  }
+
+  @Override public List<DependencyLink> getDependencies(long endTs, @Nullable Long lookback) {
+    try {
+      return getDependenciesCall(endTs, lookback).execute();
+    } catch (IOException e) {
+      throw Platform.get().uncheckedIOException(e);
+    }
+  }
+
+  @Override public void getDependencies(long endTs, @Nullable Long lookback,
+    Callback<List<DependencyLink>> callback) {
+    getDependenciesCall(endTs, lookback).enqueue(new V2CallbackAdapter<>(callback));
+  }
+
+  Call<List<DependencyLink>> getDependenciesCall(long endTs, @Nullable Long lookback) {
+    return delegate.getDependencies(endTs, lookback != null ? lookback : endTs);
+  }
+
+  @Nullable @Override public List<zipkin.Span> getTrace(long traceId) {
+    return getTrace(0L, traceId);
+  }
+
+  @Override public void getTrace(long id, Callback<List<zipkin.Span>> callback) {
+    getTrace(0L, id, callback);
+  }
+
+  @Nullable @Override public List<zipkin.Span> getRawTrace(long traceId) {
+    return getRawTrace(0L, traceId);
+  }
+
+  @Override public void getRawTrace(long traceId, Callback<List<zipkin.Span>> callback) {
+    getRawTrace(0L, traceId, callback);
+  }
+
+  static final Mapper<List<List<Span>>, List<List<zipkin.Span>>> getTracesMapper = (trace2s) -> {
+    if (trace2s.isEmpty()) return Collections.emptyList();
+    int length = trace2s.size();
+    List<List<zipkin.Span>> trace1s = new ArrayList<>(length);
+    for (int i = 0; i < length; i++) {
+      trace1s.add(CorrectForClockSkew.apply(MergeById.apply(convert(trace2s.get(i)))));
+    }
+    Collections.sort(trace1s, TRACE_DESCENDING);
+    return trace1s;
+  };
+
+  static final Mapper<List<Span>, List<zipkin.Span>> getTraceMapper = (spans) -> {
+    List<zipkin.Span> span1s = CorrectForClockSkew.apply(MergeById.apply(convert(spans)));
+    return (span1s.isEmpty()) ? null : span1s;
+  };
+
+  static final Mapper<List<Span>, List<zipkin.Span>> getRawTraceMapper = (spans) -> {
+    List<zipkin.Span> span1s = convert(spans);
+    return (span1s.isEmpty()) ? null : span1s;
+  };
+
+  static QueryRequest convert(zipkin.storage.QueryRequest v1Request) {
+    return QueryRequest.newBuilder()
+      .serviceName(v1Request.serviceName)
+      .spanName(v1Request.spanName)
+      .parseAnnotationQuery(v1Request.toAnnotationQuery())
+      .minDuration(v1Request.minDuration)
+      .maxDuration(v1Request.maxDuration)
+      .endTs(v1Request.endTs)
+      .lookback(v1Request.lookback)
+      .limit(v1Request.limit).build();
+  }
+
+  static List<zipkin.Span> convert(List<zipkin.internal.v2.Span> spans) {
+    if (spans.isEmpty()) return Collections.emptyList();
+    int length = spans.size();
+    List<zipkin.Span> span1s = new ArrayList<>(length);
+    for (int i = 0; i < length; i++) {
+      span1s.add(V2SpanConverter.toSpan(spans.get(i)));
+    }
+    return span1s;
+  }
+}

--- a/zipkin/src/main/java/zipkin/internal/V2StorageComponent.java
+++ b/zipkin/src/main/java/zipkin/internal/V2StorageComponent.java
@@ -13,36 +13,39 @@
  */
 package zipkin.internal;
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nullable;
-import zipkin.internal.v2.Span;
 import zipkin.internal.v2.storage.SpanConsumer;
+import zipkin.internal.v2.storage.SpanStore;
 import zipkin.storage.AsyncSpanConsumer;
-import zipkin.storage.Callback;
+import zipkin.storage.AsyncSpanStore;
+import zipkin.storage.StorageAdapters;
 import zipkin.storage.StorageComponent;
 
 public abstract class V2StorageComponent implements StorageComponent {
+  @Override public zipkin.storage.SpanStore spanStore() {
+    if (legacyAsyncSpanStore() != null) {
+      return StorageAdapters.asyncToBlocking(asyncSpanStore());
+    }
+    return new V2SpanStoreAdapter(v2SpanStore());
+  }
+
+  @Override public AsyncSpanStore asyncSpanStore() {
+    V2SpanStoreAdapter v2 = new V2SpanStoreAdapter(v2SpanStore());
+    AsyncSpanStore legacy = legacyAsyncSpanStore();
+    if (legacy == null) return v2;
+    // fan out queries as we don't know if old legacy collectors are in use
+    return new LenientDoubleCallbackAsyncSpanStore(v2, legacy);
+  }
+
+  @Nullable protected AsyncSpanStore legacyAsyncSpanStore() {
+    return null;
+  }
+
+  public abstract SpanStore v2SpanStore();
+
   @Override public final AsyncSpanConsumer asyncSpanConsumer() {
-    return new V2AsyncSpanConsumerAdapter(v2AsyncSpanConsumer());
+    return new V2SpanConsumerAdapter(v2SpanConsumer());
   }
 
-  protected abstract SpanConsumer v2AsyncSpanConsumer();
-
-  static class V2AsyncSpanConsumerAdapter implements AsyncSpanConsumer {
-    final SpanConsumer delegate;
-
-    V2AsyncSpanConsumerAdapter(SpanConsumer delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override public void accept(List<zipkin.Span> spans, Callback<Void> callback) {
-      int length = spans.size();
-      List<Span> linkSpans = new ArrayList<>(length);
-      for (int i = 0; i < length; i++) {
-        linkSpans.addAll(V2SpanConverter.fromSpan(spans.get(i)));
-      }
-      delegate.accept(linkSpans).enqueue(new V2CallbackAdapter(callback));
-    }
-  }
+  public abstract SpanConsumer v2SpanConsumer();
 }

--- a/zipkin/src/main/java/zipkin/internal/v2/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/storage/QueryRequest.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.storage;
+
+import com.google.auto.value.AutoValue;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import zipkin.Annotation;
+import zipkin.Endpoint;
+import zipkin.internal.v2.Span;
+
+/**
+ * Invoking this request retrieves traces matching the below filters.
+ *
+ * <p> Results should be filtered against {@link #endTs}, subject to {@link #limit} and {@link
+ * #lookback}. For example, if endTs is 10:20 today, limit is 10, and lookback is 7 days, traces
+ * returned should be those nearest to 10:20 today, not 10:20 a week ago.
+ *
+ * <p> Time units of {@link #endTs} and {@link #lookback} are milliseconds as opposed to
+ * microseconds, the grain of {@link Span#timestamp()}. Milliseconds is a more familiar and
+ * supported granularity for query, index and windowing functions.
+ */
+@AutoValue
+public abstract class QueryRequest {
+
+  /**
+   * When present, corresponds to {@link zipkin.Endpoint#serviceName} and constrains all other
+   * parameters.
+   */
+  @Nullable public abstract String serviceName();
+
+  /** When present, only include traces with this {@link Span#name} */
+  @Nullable public abstract String spanName();
+
+  /**
+   * When an input value is the empty string, include traces whose {@link Span#annotations()}
+   * include a value in this set, or where {@link Span#tags()} include a key is in this set. When
+   * not, include traces whose {@link Span#tags()} an entry in this map.
+   *
+   * <p>Multiple entries are combined with AND, and AND against other conditions.
+   */
+  public abstract Map<String, String> annotationQuery();
+
+  /**
+   * Only return traces whose {@link Span#duration()} is greater than or equal to minDuration
+   * microseconds.
+   */
+  @Nullable public abstract Long minDuration();
+
+  /**
+   * Only return traces whose {@link Span#duration()} is less than or equal to maxDuration
+   * microseconds. Only valid with {@link #minDuration}.
+   */
+  @Nullable public abstract Long maxDuration();
+
+  /**
+   * Only return traces where all {@link Span#timestamp()} are at or before this time in epoch
+   * milliseconds. Defaults to current time.
+   */
+  public abstract long endTs();
+
+  /**
+   * Only return traces where all {@link Span#timestamp()} are at or after (endTs - lookback) in
+   * milliseconds. Defaults to endTs.
+   */
+  public abstract long lookback();
+
+  /** Maximum number of traces to return. Defaults to 10 */
+  public abstract int limit();
+
+  /**
+   * Corresponds to query parameter "annotationQuery". Ex. "http.method=GET and error"
+   *
+   * @see QueryRequest.Builder#parseAnnotationQuery(String)
+   */
+  @Nullable public String annotationQueryString() {
+    StringBuilder result = new StringBuilder();
+
+    for (Iterator<Map.Entry<String, String>> i = annotationQuery().entrySet().iterator();
+      i.hasNext(); ) {
+      Map.Entry<String, String> next = i.next();
+      result.append(next.getKey());
+      if (!next.getValue().isEmpty()) result.append('=').append(next.getValue());
+      if (i.hasNext()) result.append(" and ");
+    }
+
+    return result.length() > 0 ? result.toString() : null;
+  }
+
+  public abstract Builder toBuilder();
+
+  public static Builder newBuilder() {
+    return new AutoValue_QueryRequest.Builder().annotationQuery(Collections.emptyMap());
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    /** @see QueryRequest#serviceName() */
+    public abstract Builder serviceName(@Nullable String serviceName);
+
+    /**
+     * This ignores the reserved span name "all".
+     *
+     * @see QueryRequest#spanName()
+     */
+    public abstract Builder spanName(@Nullable String spanName);
+
+    /**
+     * Corresponds to query parameter "annotationQuery". Ex. "http.method=GET and error"
+     *
+     * @see QueryRequest#annotationQueryString()
+     */
+    public Builder parseAnnotationQuery(@Nullable String annotationQuery) {
+      if (annotationQuery == null || annotationQuery.isEmpty()) return this;
+      Map<String, String> map = new LinkedHashMap<>();
+      for (String ann : annotationQuery.split(" and ")) {
+        int idx = ann.indexOf('=');
+        if (idx == -1) {
+          map.put(ann, "");
+        } else {
+          String[] keyValue = ann.split("=");
+          map.put(ann.substring(0, idx), keyValue.length < 2 ? "" : ann.substring(idx + 1));
+        }
+      }
+      return annotationQuery(map);
+    }
+
+    /** @see QueryRequest#annotationQuery() */
+    public abstract Builder annotationQuery(Map<String, String> annotationQuery);
+
+    /** @see QueryRequest#minDuration() */
+    public abstract Builder minDuration(@Nullable Long minDuration);
+
+    /** @see QueryRequest#maxDuration() */
+    public abstract Builder maxDuration(@Nullable Long maxDuration);
+
+    /** @see QueryRequest#endTs() */
+    public abstract Builder endTs(long endTs);
+
+    /** @see QueryRequest#lookback() */
+    public abstract Builder lookback(long lookback);
+
+    /** @see QueryRequest#limit() */
+    public abstract Builder limit(int limit);
+
+    // getters for validation
+    @Nullable abstract String serviceName();
+
+    @Nullable abstract String spanName();
+
+    abstract Map<String, String> annotationQuery();
+
+    @Nullable abstract Long minDuration();
+
+    @Nullable abstract Long maxDuration();
+
+    abstract long endTs();
+
+    abstract int limit();
+
+    abstract QueryRequest autoBuild();
+
+    public final QueryRequest build() {
+      // coerce service and span names to lowercase
+      if (serviceName() != null) serviceName(serviceName().toLowerCase(Locale.ROOT));
+      if (spanName() != null) spanName(spanName().toLowerCase(Locale.ROOT));
+
+      // remove any accidental empty strings
+      annotationQuery().remove("");
+      if ("".equals(serviceName())) serviceName(null);
+      if ("".equals(spanName()) || "all".equals(spanName())) spanName(null);
+
+      if (endTs() <= 0) throw new IllegalArgumentException("endTs <= 0");
+      if (limit() <= 0) throw new IllegalArgumentException("limit <= 0");
+      if (minDuration() != null) {
+        if (minDuration() <= 0) throw new IllegalArgumentException("minDuration <= 0");
+        if (maxDuration() != null && maxDuration() < minDuration()) {
+          throw new IllegalArgumentException("maxDuration < minDuration");
+        }
+      } else if (maxDuration() != null) {
+        throw new IllegalArgumentException("maxDuration is only valid with minDuration");
+      }
+      return autoBuild();
+    }
+
+    Builder() {
+    }
+  }
+
+  /**
+   * Tests the supplied trace against the current request.
+   *
+   * <p>This is used when the backend cannot fully refine a trace query.
+   */
+  public boolean test(List<Span> spans) {
+    Long timestamp = spans.get(0).timestamp();
+    if (timestamp == null ||
+      timestamp < (endTs() - lookback()) * 1000 ||
+      timestamp > endTs() * 1000) {
+      return false;
+    }
+    Set<String> serviceNames = new LinkedHashSet<>();
+    boolean testedDuration = minDuration() == null && maxDuration() == null;
+
+    String spanNameToMatch = spanName();
+    Map<String, String> annotationQueryRemaining = new LinkedHashMap<>(annotationQuery());
+
+    for (Span span : spans) {
+      Endpoint localEndpoint = span.localEndpoint();
+      String localServiceName = localEndpoint != null ? localEndpoint.serviceName : null;
+
+      if (localServiceName != null) serviceNames.add(localServiceName);
+
+      if (serviceName() == null || serviceName().equals(localServiceName)) {
+        for (Annotation a : span.annotations()) {
+          if ("".equals(annotationQueryRemaining.get(a.value))) {
+            annotationQueryRemaining.remove(a.value);
+          }
+        }
+        annotationQueryRemaining.entrySet().removeAll(span.tags().entrySet());
+        if (spanNameToMatch == null || spanNameToMatch.equals(span.name())) {
+          spanNameToMatch = null;
+        }
+      }
+
+      if ((serviceName() == null || serviceName().equals(localServiceName)) && !testedDuration) {
+        if (minDuration() != null && maxDuration() != null) {
+          testedDuration = span.duration() >= minDuration() && span.duration() <= maxDuration();
+        } else if (minDuration() != null) {
+          testedDuration = span.duration() >= minDuration();
+        }
+      }
+    }
+    return (serviceName() == null || serviceNames.contains(serviceName()))
+      && spanNameToMatch == null
+      && annotationQueryRemaining.isEmpty()
+      && testedDuration;
+  }
+
+  QueryRequest() {
+  }
+}

--- a/zipkin/src/main/java/zipkin/internal/v2/storage/SpanStore.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/storage/SpanStore.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.storage;
+
+import java.util.List;
+import zipkin.DependencyLink;
+import zipkin.Endpoint;
+import zipkin.internal.v2.Call;
+import zipkin.internal.v2.Span;
+import zipkin.storage.StorageComponent;
+
+/**
+ * Queries data derived from {@link SpanConsumer}.
+ *
+ * <p>Note: This is not considered a user-level Api, rather an Spi that can be used to bind
+ * user-level abstractions such as futures or observables.
+ */
+public interface SpanStore {
+
+  /**
+   * Retrieves spans grouped by trace ID from the storage system with no ordering expectation.
+   *
+   * <p>If {@link StorageComponent.Builder#strictTraceId(boolean)} is enabled, spans with the same
+   * 64-bit trace ID will be grouped together.
+   */
+  Call<List<List<Span>>> getTraces(QueryRequest request);
+
+  /**
+   * Retrieves spans that share a 128-bit trace id with no ordering expectation or empty if none are
+   * found.
+   *
+   * <p>When {@link StorageComponent.Builder#strictTraceId(boolean)} is true, spans with the same
+   * {@code traceIdLow} are returned even if the {@code traceIdHigh is different}.
+   *
+   * @param traceIdHigh The upper 64-bits of the trace ID. See {@link Span#traceIdHigh()}
+   * @param traceIdLow The lower 64-bits of the trace ID. See {@link Span#traceId()}
+   */
+  Call<List<Span>> getTrace(long traceIdHigh, long traceIdLow);
+
+  /**
+   * Retrieves all {@link Span#localEndpoint() local} and {@link Span#remoteEndpoint() remote}
+   * {@link Endpoint#serviceName service names}, sorted lexicographically.
+   */
+  Call<List<String>> getServiceNames();
+
+  /**
+   * Retrieves all {@link Span#name() span names} recorded by a {@link Span#localEndpoint()
+   * service}, sorted lexicographically.
+   */
+  Call<List<String>> getSpanNames(String serviceName);
+
+  /**
+   * Returns dependency links derived from spans in an interval contained by (endTs - lookback) or
+   * empty if none are found.
+   *
+   * <p>Implementations may bucket aggregated data, for example daily. When this is the case, endTs
+   * may be floored to align with that bucket, for example midnight if daily. lookback applies to
+   * the original endTs, even when bucketed. Using the daily example, if endTs was 11pm and lookback
+   * was 25 hours, the implementation would query against 2 buckets.
+   *
+   * <p>Some implementations parse spans from storage and call {@link
+   * zipkin.internal.DependencyLinker} to aggregate links. The reason is certain graph logic, such
+   * as skipping up the tree is difficult to implement as a storage query.
+   *
+   * <p>There's no parameter to indicate how to handle mixed ID length: this operates the same as if
+   * {@link StorageComponent.Builder#strictTraceId(boolean)} was set to false. This ensures call
+   * counts are not incremented twice due to one hop downgrading from 128 to 64-bit trace IDs.
+   *
+   * @param endTs only return links from spans where {@link Span#timestamp} are at or before this
+   * time in epoch milliseconds.
+   * @param lookback only return links from spans where {@link Span#timestamp} are at or after
+   * (endTs - lookback) in milliseconds.
+   */
+  Call<List<DependencyLink>> getDependencies(long endTs, long lookback);
+}

--- a/zipkin/src/test/java/zipkin/collector/CollectorTest.java
+++ b/zipkin/src/test/java/zipkin/collector/CollectorTest.java
@@ -98,11 +98,11 @@ public class CollectorTest {
    */
   @Test public void routesToSpan2Collector() {
     abstract class WithSpan2 extends V2StorageComponent implements zipkin.storage.StorageComponent {
-      @Override public abstract SpanConsumer v2AsyncSpanConsumer();
+      @Override public abstract SpanConsumer v2SpanConsumer();
     }
     WithSpan2 storage = mock(WithSpan2.class);
     SpanConsumer span2Consumer = mock(SpanConsumer.class);
-    when(storage.v2AsyncSpanConsumer()).thenReturn(span2Consumer);
+    when(storage.v2SpanConsumer()).thenReturn(span2Consumer);
 
     collector = spy(Collector.builder(Collector.class)
       .storage(storage).build());

--- a/zipkin/src/test/java/zipkin/internal/LenientDoubleCallbackAsyncSpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/internal/LenientDoubleCallbackAsyncSpanStoreTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.storage.elasticsearch.http.internal;
+package zipkin.internal;
 
 import java.util.function.Consumer;
 import org.junit.Before;

--- a/zipkin/src/test/java/zipkin/internal/LenientDoubleCallbackTest.java
+++ b/zipkin/src/test/java/zipkin/internal/LenientDoubleCallbackTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import zipkin.storage.Callback;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class LenientDoubleCallbackTest {
+
+  @Rule public MockitoRule mocks = MockitoJUnit.rule();
+
+  @Mock Logger log;
+  @Mock Callback delegate;
+  LenientDoubleCallback callback;
+
+  @Before public void setUp() {
+    callback = spy(new LenientDoubleCallback(log, delegate) {
+      @Override Object merge(Object v1, Object v2) {
+        return v1;
+      }
+    });
+  }
+
+  @Test public void merges() throws Exception {
+    callback.onSuccess("1");
+    callback.onSuccess("2");
+
+    verify(delegate).onSuccess("1");
+    verify(callback).merge("1", "2");
+  }
+
+  @Test public void okWhenLeftFails() throws Exception {
+    RuntimeException throwable = new RuntimeException();
+    callback.onError(throwable);
+    callback.onSuccess("2");
+
+    verify(log).log(Level.INFO, "first error", throwable);
+    verify(delegate).onSuccess("2");
+    verifyNoMoreInteractions(log);
+  }
+
+  @Test public void okWhenRightFails() throws Exception {
+    callback.onSuccess("1");
+    callback.onError(new RuntimeException());
+
+    verify(delegate).onSuccess("1");
+    verifyNoMoreInteractions(log);
+  }
+
+  @Test public void exceptionWhenBothFail() throws Exception {
+    IllegalArgumentException exception1 = new IllegalArgumentException();
+    IllegalStateException exception2 = new IllegalStateException();
+    callback.onError(exception1);
+    callback.onError(exception2);
+
+    verify(log).log(Level.INFO, "first error", exception1);
+    verify(delegate).onError(exception2);
+  }
+}

--- a/zipkin/src/test/java/zipkin/internal/V2SpanConsumerAdapterTest.java
+++ b/zipkin/src/test/java/zipkin/internal/V2SpanConsumerAdapterTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import zipkin.TestObjects;
+import zipkin.internal.v2.Call;
+import zipkin.internal.v2.storage.SpanConsumer;
+import zipkin.storage.AsyncSpanConsumer;
+import zipkin.storage.Callback;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class V2SpanConsumerAdapterTest {
+
+  @Rule public MockitoRule mocks = MockitoJUnit.rule();
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Mock SpanConsumer delegate;
+  @Mock Call<Void> call;
+  @Mock Callback<Void> callback;
+
+  AsyncSpanConsumer asyncSpanConsumer;
+
+  @Before public void setUp() {
+    asyncSpanConsumer = new V2SpanConsumerAdapter(delegate);
+    when(delegate.accept(any(List.class))).thenReturn(call);
+  }
+
+  @Test public void accept_success() {
+    doNothing().when(call).enqueue(any(zipkin.internal.v2.Callback.class));
+
+    asyncSpanConsumer.accept(TestObjects.TRACE, callback);
+
+    verify(call).enqueue(any(zipkin.internal.v2.Callback.class));
+  }
+
+  @Test public void accept_exception() {
+    IllegalStateException throwable = new IllegalStateException("failed");
+    doAnswer(invocation -> {
+      ((zipkin.internal.v2.Callback) invocation.getArguments()[0]).onError(throwable);
+      return invocation;
+    }).when(call).enqueue(any(zipkin.internal.v2.Callback.class));
+
+    asyncSpanConsumer.accept(TestObjects.TRACE, callback);
+
+    verify(callback).onError(throwable);
+  }
+}

--- a/zipkin/src/test/java/zipkin/internal/V2SpanStoreAdapterTest.java
+++ b/zipkin/src/test/java/zipkin/internal/V2SpanStoreAdapterTest.java
@@ -1,0 +1,437 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import zipkin.Annotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.internal.v2.Call;
+import zipkin.internal.v2.Span;
+import zipkin.internal.v2.storage.SpanStore;
+import zipkin.storage.Callback;
+import zipkin.storage.QueryRequest;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static zipkin.TestObjects.TODAY;
+
+public class V2SpanStoreAdapterTest {
+  @Rule public MockitoRule mocks = MockitoJUnit.rule();
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Mock SpanStore spanStore;
+  @Mock Call call;
+  @Mock Callback callback;
+
+  Endpoint frontend = Endpoint.create("frontend", 192 << 24 | 168 << 16 | 2);
+  Endpoint backend = Endpoint.create("backend", 192 << 24 | 168 << 16 | 3);
+  Span.Builder builder = Span.builder()
+    .traceId("7180c278b62e8f6a5b4185666d50f68b")
+    .id("5b4185666d50f68b")
+    .name("get");
+
+  List<Span> skewedTrace2 = asList(
+    builder.clone()
+      .kind(Span.Kind.CLIENT)
+      .localEndpoint(frontend)
+      .timestamp((TODAY + 200) * 1000)
+      .duration(120_000L)
+      .build(),
+    builder.clone()
+      .kind(Span.Kind.SERVER)
+      .shared(true)
+      .localEndpoint(backend)
+      .timestamp((TODAY + 100) * 1000) // received before sent!
+      .duration(60_000L)
+      .build()
+  );
+
+  List<zipkin.Span> rawSkewedTrace = asList(
+    zipkin.Span.builder()
+      .traceIdHigh(Util.lowerHexToUnsignedLong("7180c278b62e8f6a"))
+      .traceId(Util.lowerHexToUnsignedLong("5b4185666d50f68b"))
+      .id(Util.lowerHexToUnsignedLong("5b4185666d50f68b"))
+      .name("get")
+      .timestamp((TODAY + 200) * 1000) // retains client timestamp/duration
+      .duration(120_000L)
+      .addAnnotation(Annotation.create((TODAY + 200) * 1000, Constants.CLIENT_SEND, frontend))
+      .addAnnotation(Annotation.create((TODAY + 320) * 1000, Constants.CLIENT_RECV, frontend))
+      .build(),
+    zipkin.Span.builder()
+      .traceIdHigh(Util.lowerHexToUnsignedLong("7180c278b62e8f6a"))
+      .traceId(Util.lowerHexToUnsignedLong("5b4185666d50f68b"))
+      .id(Util.lowerHexToUnsignedLong("5b4185666d50f68b"))
+      .name("get")
+      .addAnnotation(Annotation.create((TODAY + 100) * 1000, Constants.SERVER_RECV, backend))
+      .addAnnotation(Annotation.create((TODAY + 160) * 1000, Constants.SERVER_SEND, backend))
+      .build()
+  );
+
+  List<zipkin.Span> adjustedTrace = asList(zipkin.Span.builder()
+    .traceIdHigh(Util.lowerHexToUnsignedLong("7180c278b62e8f6a"))
+    .traceId(Util.lowerHexToUnsignedLong("5b4185666d50f68b"))
+    .id(Util.lowerHexToUnsignedLong("5b4185666d50f68b"))
+    .name("get")
+    .timestamp((TODAY + 200) * 1000) // retains client timestamp/duration
+    .duration(120_000L)
+    .addAnnotation(Annotation.create((TODAY + 200) * 1000, Constants.CLIENT_SEND, frontend))
+    .addAnnotation(Annotation.create((TODAY + 230) * 1000, Constants.SERVER_RECV, backend))
+    .addAnnotation(Annotation.create((TODAY + 290) * 1000, Constants.SERVER_SEND, backend))
+    .addAnnotation(Annotation.create((TODAY + 320) * 1000, Constants.CLIENT_RECV, frontend))
+    .build());
+
+  V2SpanStoreAdapter adapter;
+
+  @Before public void setUp() {
+    adapter = new V2SpanStoreAdapter(spanStore);
+  }
+
+  @Test public void getTraces_sync_callsExecute() throws IOException {
+    when(spanStore.getTraces(any(zipkin.internal.v2.storage.QueryRequest.class)))
+      .thenReturn(call);
+    when(call.execute())
+      .thenReturn(Collections.emptyList());
+
+    assertThat(adapter.getTraces(QueryRequest.builder().build()))
+      .isEmpty();
+
+    verify(call).execute();
+  }
+
+  @Test(expected = UncheckedIOException.class)
+  public void getTraces_sync_wrapsIOE() throws IOException {
+    when(spanStore.getTraces(any(zipkin.internal.v2.storage.QueryRequest.class)))
+      .thenReturn(call);
+    when(call.execute())
+      .thenThrow(IOException.class);
+
+    adapter.getTraces(QueryRequest.builder().build());
+  }
+
+  @Test public void getTraces_async_callsEnqueue() {
+    when(spanStore.getTraces(any(zipkin.internal.v2.storage.QueryRequest.class)))
+      .thenReturn(call);
+    doEnqueue(c -> c.onSuccess(Collections.emptyList()));
+
+    adapter.getTraces(QueryRequest.builder().build(), callback);
+
+    verify(callback).onSuccess(Collections.emptyList());
+  }
+
+  @Test public void getTraces_async_doesntWrapIOE() {
+    IOException throwable = new IOException();
+    when(spanStore.getTraces(any(zipkin.internal.v2.storage.QueryRequest.class)))
+      .thenReturn(call);
+    doEnqueue(c -> c.onError(throwable));
+
+    adapter.getTraces(QueryRequest.builder().build(), callback);
+
+    verify(callback).onError(throwable);
+  }
+
+  @Test public void getTrace_sync_callsExecute() throws IOException {
+    when(spanStore.getTrace(3L, 4L))
+      .thenReturn(call);
+    when(call.execute())
+      .thenReturn(Collections.emptyList());
+
+    assertThat(adapter.getTrace(3L, 4L))
+      .isNull();
+
+    verify(call).execute();
+  }
+
+  @Test(expected = UncheckedIOException.class)
+  public void getTrace_sync_wrapsIOE() throws IOException {
+    when(spanStore.getTrace(3L, 4L))
+      .thenReturn(call);
+    when(call.execute())
+      .thenThrow(IOException.class);
+
+    adapter.getTrace(3L, 4L);
+  }
+
+  @Test public void getTrace_async_callsEnqueue() {
+    when(spanStore.getTrace(3L, 4L))
+      .thenReturn(call);
+    doEnqueue(c -> c.onSuccess(Collections.emptyList()));
+
+    adapter.getTrace(3L, 4L, callback);
+
+    verify(callback).onSuccess(null);
+  }
+
+  @Test public void getTrace_async_doesntWrapIOE() {
+    IOException throwable = new IOException();
+    when(spanStore.getTrace(3L, 4L))
+      .thenReturn(call);
+    doEnqueue(c -> c.onError(throwable));
+
+    adapter.getTrace(3L, 4L, callback);
+
+    verify(callback).onError(throwable);
+  }
+
+  @Test public void getRawTrace_sync_callsExecute() throws IOException {
+    when(spanStore.getTrace(3L, 4L))
+      .thenReturn(call);
+    when(call.execute())
+      .thenReturn(Collections.emptyList());
+
+    assertThat(adapter.getRawTrace(3L, 4L))
+      .isNull();
+
+    verify(call).execute();
+  }
+
+  @Test(expected = UncheckedIOException.class)
+  public void getRawTrace_sync_wrapsIOE() throws IOException {
+    when(spanStore.getTrace(3L, 4L))
+      .thenReturn(call);
+    when(call.execute())
+      .thenThrow(IOException.class);
+
+    adapter.getRawTrace(3L, 4L);
+  }
+
+  @Test public void getRawTrace_async_callsEnqueue() {
+    when(spanStore.getTrace(3L, 4L))
+      .thenReturn(call);
+    doEnqueue(c -> c.onSuccess(Collections.emptyList()));
+
+    adapter.getRawTrace(3L, 4L, callback);
+
+    verify(callback).onSuccess(null);
+  }
+
+  @Test public void getRawTrace_async_doesntWrapIOE() {
+    IOException throwable = new IOException();
+    when(spanStore.getTrace(3L, 4L))
+      .thenReturn(call);
+    doEnqueue(c -> c.onError(throwable));
+
+    adapter.getRawTrace(3L, 4L, callback);
+
+    verify(callback).onError(throwable);
+  }
+
+  @Test public void getServiceNames_sync_callsExecute() throws IOException {
+    when(spanStore.getServiceNames())
+      .thenReturn(call);
+    when(call.execute())
+      .thenReturn(Collections.emptyList());
+
+    assertThat(adapter.getServiceNames())
+      .isEmpty();
+
+    verify(call).execute();
+  }
+
+  @Test(expected = UncheckedIOException.class)
+  public void getServiceNames_sync_wrapsIOE() throws IOException {
+    when(spanStore.getServiceNames())
+      .thenReturn(call);
+    when(call.execute())
+      .thenThrow(IOException.class);
+
+    adapter.getServiceNames();
+  }
+
+  @Test public void getServiceNames_async_callsEnqueue() {
+    when(spanStore.getServiceNames())
+      .thenReturn(call);
+    doEnqueue(c -> c.onSuccess(Collections.emptyList()));
+
+    adapter.getServiceNames(callback);
+
+    verify(callback).onSuccess(Collections.emptyList());
+  }
+
+  @Test public void getServiceNames_async_doesntWrapIOE() {
+    IOException throwable = new IOException();
+    when(spanStore.getServiceNames())
+      .thenReturn(call);
+    doEnqueue(c -> c.onError(throwable));
+
+    adapter.getServiceNames(callback);
+
+    verify(callback).onError(throwable);
+  }
+
+  @Test public void getSpanNames_sync_callsExecute() throws IOException {
+    when(spanStore.getSpanNames("service1"))
+      .thenReturn(call);
+    when(call.execute())
+      .thenReturn(Collections.emptyList());
+
+    assertThat(adapter.getSpanNames("service1"))
+      .isEmpty();
+
+    verify(call).execute();
+  }
+
+  @Test(expected = UncheckedIOException.class)
+  public void getSpanNames_sync_wrapsIOE() throws IOException {
+    when(spanStore.getSpanNames("service1"))
+      .thenReturn(call);
+    when(call.execute())
+      .thenThrow(IOException.class);
+
+    adapter.getSpanNames("service1");
+  }
+
+  @Test public void getSpanNames_async_callsEnqueue() {
+    when(spanStore.getSpanNames("service1"))
+      .thenReturn(call);
+    doEnqueue(c -> c.onSuccess(Collections.emptyList()));
+
+    adapter.getSpanNames("service1", callback);
+
+    verify(callback).onSuccess(Collections.emptyList());
+  }
+
+  @Test public void getSpanNames_async_doesntWrapIOE() {
+    IOException throwable = new IOException();
+    when(spanStore.getSpanNames("service1"))
+      .thenReturn(call);
+    doEnqueue(c -> c.onError(throwable));
+
+    adapter.getSpanNames("service1", callback);
+
+    verify(callback).onError(throwable);
+  }
+
+  @Test public void getDependencies_sync_callsExecute() throws IOException {
+    when(spanStore.getDependencies(3L, 2L))
+      .thenReturn(call);
+    when(call.execute())
+      .thenReturn(Collections.emptyList());
+
+    assertThat(adapter.getDependencies(3L, 2L))
+      .isEmpty();
+
+    verify(call).execute();
+  }
+
+  @Test(expected = UncheckedIOException.class)
+  public void getDependencies_sync_wrapsIOE() throws IOException {
+    when(spanStore.getDependencies(3L, 2L))
+      .thenReturn(call);
+    when(call.execute())
+      .thenThrow(IOException.class);
+
+    adapter.getDependencies(3L, 2L);
+  }
+
+  @Test public void getDependencies_async_callsEnqueue() {
+    when(spanStore.getDependencies(3L, 2L))
+      .thenReturn(call);
+    doEnqueue(c -> c.onSuccess(Collections.emptyList()));
+
+    adapter.getDependencies(3L, 2L, callback);
+
+    verify(callback).onSuccess(Collections.emptyList());
+  }
+
+  @Test public void getDependencies_async_doesntWrapIOE() {
+    IOException throwable = new IOException();
+    when(spanStore.getDependencies(3L, 2L))
+      .thenReturn(call);
+    doEnqueue(c -> c.onError(throwable));
+
+    adapter.getDependencies(3L, 2L, callback);
+
+    verify(callback).onError(throwable);
+  }
+
+  @Test public void getTracesMapper_adjustsTraces() {
+    assertThat(V2SpanStoreAdapter.getTracesMapper.map(asList(skewedTrace2)))
+      .containsOnly(adjustedTrace); // merged and clock-skew corrected
+  }
+
+  @Test public void getTracesMapper_descendingOrder() {
+    assertThat(V2SpanStoreAdapter.getTracesMapper.map(asList(
+      asList(builder.traceId(1L).timestamp((TODAY + 1) * 1000).build()),
+      asList(builder.traceId(2L).timestamp((TODAY + 2) * 1000).build())
+    ))).flatExtracting(s -> s)
+      .extracting(s -> s.timestamp)
+      .containsExactly((TODAY + 2) * 1000, (TODAY + 1) * 1000);
+  }
+
+  @Test public void getTraceMapper_adjustsTrace() {
+    assertThat(V2SpanStoreAdapter.getTraceMapper.map(skewedTrace2))
+      .isEqualTo(adjustedTrace); // merged and clock-skew corrected
+  }
+
+  @Test public void getTraceMapper_emptyToNull() {
+    assertThat(V2SpanStoreAdapter.getTraceMapper.map(Collections.emptyList()))
+      .isNull();
+  }
+
+  @Test public void getRawTraceMapper_doesntAdjustTrace() {
+    assertThat(V2SpanStoreAdapter.getRawTraceMapper.map(skewedTrace2))
+      .isEqualTo(rawSkewedTrace); // merged and clock-skew corrected
+  }
+
+  @Test public void getRawTraceMapper_emptyToNull() {
+    assertThat(V2SpanStoreAdapter.getRawTraceMapper.map(Collections.emptyList()))
+      .isNull();
+  }
+
+  @Test public void convert_queryRequest() {
+    assertThat(V2SpanStoreAdapter.convert(QueryRequest.builder()
+      .serviceName("service")
+      .spanName("span")
+      .parseAnnotationQuery("annotation and tag=value")
+      .minDuration(1L)
+      .maxDuration(2L)
+      .endTs(1000L)
+      .lookback(60L)
+      .limit(100)
+      .build()))
+      .isEqualTo(zipkin.internal.v2.storage.QueryRequest.newBuilder()
+        .serviceName("service")
+        .spanName("span")
+        .parseAnnotationQuery("annotation and tag=value")
+        .minDuration(1L)
+        .maxDuration(2L)
+        .endTs(1000L)
+        .lookback(60L)
+        .limit(100)
+        .build());
+  }
+
+  void doEnqueue(Consumer<zipkin.internal.v2.Callback> answer) {
+    doAnswer(invocation -> {
+      answer.accept((zipkin.internal.v2.Callback) invocation.getArguments()[0]);
+      return invocation;
+    }).when(call).enqueue(any(zipkin.internal.v2.Callback.class));
+  }
+}

--- a/zipkin/src/test/java/zipkin/internal/v2/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin/internal/v2/storage/QueryRequestTest.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.storage;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.Constants;
+import zipkin.internal.v2.Span;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.TestObjects.APP_ENDPOINT;
+import static zipkin.TestObjects.TODAY;
+import static zipkin.TraceKeys.HTTP_METHOD;
+
+public class QueryRequestTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  QueryRequest.Builder queryBuilder = QueryRequest.newBuilder().endTs(TODAY).lookback(60).limit(10);
+  Span span = Span.builder().traceId(10L).id(10L).name("receive")
+    .localEndpoint(APP_ENDPOINT)
+    .kind(Span.Kind.CONSUMER)
+    .timestamp(TODAY * 1000)
+    .build();
+
+  @Test public void serviceNameCanBeNull() {
+    assertThat(queryBuilder.build().serviceName())
+      .isNull();
+  }
+
+  @Test public void serviceName_coercesEmptyToNull() {
+    assertThat(queryBuilder.serviceName("").build().serviceName())
+      .isNull();
+  }
+
+  @Test public void spanName_coercesAllToNull() {
+    assertThat(queryBuilder.spanName("all").build().spanName())
+      .isNull();
+  }
+
+  @Test public void spanName_coercesEmptyToNull() {
+    assertThat(queryBuilder.spanName("").build().spanName())
+      .isNull();
+  }
+
+  @Test public void annotationQuerySkipsEmptyKeys() {
+    Map<String, String> query = new LinkedHashMap<>();
+    query.put("", "bar");
+
+    assertThat(queryBuilder.annotationQuery(query).build().annotationQuery())
+      .isEmpty();
+  }
+
+  @Test public void endTsMustBePositive() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("endTs <= 0");
+
+    queryBuilder.endTs(0L).build();
+  }
+
+  @Test public void limitMustBePositive() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("limit <= 0");
+
+    queryBuilder.limit(0).build();
+  }
+
+  @Test public void annotationQuery_roundTrip() {
+    String annotationQuery = "http.method=GET and error";
+
+    QueryRequest request = queryBuilder
+      .serviceName("security-service")
+      .parseAnnotationQuery(annotationQuery)
+      .build();
+
+    assertThat(request.annotationQuery())
+      .containsEntry(Constants.ERROR, "")
+      .containsEntry(HTTP_METHOD, "GET");
+
+    assertThat(request.annotationQueryString())
+      .isEqualTo(annotationQuery);
+  }
+
+  @Test public void annotationQuery_missingValue() {
+    String annotationQuery = "http.method=";
+
+    QueryRequest request = queryBuilder
+      .serviceName("security-service")
+      .parseAnnotationQuery(annotationQuery)
+      .build();
+
+    assertThat(request.annotationQuery())
+      .containsKey(HTTP_METHOD);
+  }
+
+  @Test public void annotationQueryWhenNoInputIsEmpty() {
+    assertThat(queryBuilder.build().annotationQuery())
+      .isEmpty();
+  }
+
+  @Test public void minDuration_mustBePositive() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("minDuration <= 0");
+
+    queryBuilder.minDuration(0L).build();
+  }
+
+  @Test public void maxDuration_onlyWithMinDuration() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("maxDuration is only valid with minDuration");
+
+    queryBuilder.maxDuration(0L).build();
+  }
+
+  @Test public void maxDuration_greaterThanOrEqualToMinDuration() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("maxDuration < minDuration");
+
+    queryBuilder.minDuration(1L).maxDuration(0L).build();
+  }
+
+  @Test public void test_matchesTimestamp() {
+    QueryRequest request = queryBuilder
+      .build();
+
+    assertThat(request.test(asList(span)))
+      .isTrue();
+  }
+
+  @Test public void test_noTimestamp() {
+    QueryRequest request = queryBuilder
+      .build();
+
+    assertThat(request.test(asList(span.toBuilder().timestamp(null).build())))
+      .isFalse();
+  }
+
+  @Test public void test_timestampPastLookback() {
+    QueryRequest request = queryBuilder
+      .endTs(TODAY + 70)
+      .build();
+
+    assertThat(request.test(asList(span)))
+      .isFalse();
+  }
+
+  @Test public void test_wrongServiceName() {
+    QueryRequest request = queryBuilder
+      .serviceName("aloha")
+      .build();
+
+    assertThat(request.test(asList(span)))
+      .isFalse();
+  }
+
+  @Test public void test_spanName() {
+    QueryRequest request = queryBuilder
+      .spanName("aloha")
+      .build();
+
+    assertThat(request.test(asList(span)))
+      .isFalse();
+
+    assertThat(request.test(asList(span.toBuilder().name("aloha").build())))
+      .isTrue();
+  }
+
+  @Test public void test_minDuration() {
+    QueryRequest request = queryBuilder
+      .minDuration(100L)
+      .build();
+
+    assertThat(request.test(asList(span.toBuilder().duration(99L).build())))
+      .isFalse();
+
+    assertThat(request.test(asList(span.toBuilder().duration(100L).build())))
+      .isTrue();
+  }
+
+  @Test public void test_maxDuration() {
+    QueryRequest request = queryBuilder
+      .minDuration(100L)
+      .maxDuration(110L)
+      .build();
+
+    assertThat(request.test(asList(span.toBuilder().duration(99L).build())))
+      .isFalse();
+
+    assertThat(request.test(asList(span.toBuilder().duration(100L).build())))
+      .isTrue();
+
+    assertThat(request.test(asList(span.toBuilder().duration(111L).build())))
+      .isFalse();
+  }
+}


### PR DESCRIPTION
This represents the minimal read apis needed for Zipkin

As discussed earlier on gitter w/ @basvanbeek, we no longer do
adjustment at storage layer. Essentially, all operations are "raw",
which reduces the responsibility of implementors. This also midly
changes the `getTrace` call, disallowing it from returning null (as
empty will suffice).

This adds SpanStore which returns Call objects as opposed to replicating
signatures for synchronous and asynchronous invocations. Unlike before,
this does not support "adjustments" rather assumes they happen at a
layer above storage. This decision refines the storage query api to the
following:

```java
Call<List<List<Span>>> getTraces(QueryRequest request);

Call<List<Span>> getTrace(long traceIdHigh, long traceIdLow);

Call<List<String>> getServiceNames();

Call<List<String>> getSpanNames(String serviceName);

Call<List<DependencyLink>> getDependencies(long endTs, long lookback);
```

A later change might replace the getTrace call with a hex string 
parameter.
