### PR TITLE
Elasticsearch integration of v2 SpanStore Api

### DIFF
--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/BodyConverters.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/BodyConverters.java
@@ -19,9 +19,9 @@ import java.util.List;
 import java.util.Set;
 import okio.BufferedSource;
 import zipkin.DependencyLink;
-import zipkin.Span;
 import zipkin.internal.DependencyLinker;
 import zipkin.internal.Util;
+import zipkin.internal.v2.Span;
 import zipkin.storage.elasticsearch.http.internal.client.HttpCall.BodyConverter;
 import zipkin.storage.elasticsearch.http.internal.client.SearchResultConverter;
 
@@ -34,8 +34,6 @@ final class BodyConverters {
   };
   static final BodyConverter<List<Span>> SPANS =
       SearchResultConverter.create(JsonAdapters.SPAN_ADAPTER);
-  static final BodyConverter<List<Span>> NULLABLE_SPANS =
-      SearchResultConverter.create(JsonAdapters.SPAN_ADAPTER).defaultToNull();
   static final BodyConverter<List<DependencyLink>> DEPENDENCY_LINKS =
       new SearchResultConverter<DependencyLink>(JsonAdapters.DEPENDENCY_LINK_ADAPTER) {
         @Override public List<DependencyLink> convert(BufferedSource content) throws IOException {

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStore.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStore.java
@@ -13,29 +13,31 @@
  */
 package zipkin.storage.elasticsearch.http;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import javax.annotation.Nullable;
 import zipkin.DependencyLink;
-import zipkin.Span;
-import zipkin.internal.CorrectForClockSkew;
-import zipkin.internal.GroupByTraceId;
-import zipkin.internal.MergeById;
+import zipkin.internal.Pair;
 import zipkin.internal.Util;
-import zipkin.storage.AsyncSpanStore;
-import zipkin.storage.Callback;
-import zipkin.storage.QueryRequest;
+import zipkin.internal.v2.Call;
+import zipkin.internal.v2.Span;
+import zipkin.internal.v2.storage.QueryRequest;
+import zipkin.internal.v2.storage.SpanStore;
 import zipkin.storage.elasticsearch.http.internal.client.Aggregation;
 import zipkin.storage.elasticsearch.http.internal.client.HttpCall;
+import zipkin.storage.elasticsearch.http.internal.client.HttpCall.BodyConverter;
 import zipkin.storage.elasticsearch.http.internal.client.SearchCallFactory;
 import zipkin.storage.elasticsearch.http.internal.client.SearchRequest;
 
 import static java.util.Arrays.asList;
 
-final class ElasticsearchHttpSpanStore implements AsyncSpanStore {
+final class ElasticsearchHttpSpanStore implements SpanStore {
 
   static final String SPAN = "span";
   static final String DEPENDENCY = "dependency";
@@ -56,30 +58,30 @@ final class ElasticsearchHttpSpanStore implements AsyncSpanStore {
     this.namesLookback = es.namesLookback();
   }
 
-  @Override public void getTraces(QueryRequest request, Callback<List<List<Span>>> callback) {
-    long endMillis = request.endTs;
-    long beginMillis = Math.max(endMillis - request.lookback, EARLIEST_MS);
+  @Override public Call<List<List<Span>>> getTraces(QueryRequest request) {
+    long endMillis = request.endTs();
+    long beginMillis = Math.max(endMillis - request.lookback(), EARLIEST_MS);
 
     SearchRequest.Filters filters = new SearchRequest.Filters();
     filters.addRange("timestamp_millis", beginMillis, endMillis);
-    if (request.serviceName != null) {
-      filters.addTerm("localEndpoint.serviceName", request.serviceName);
+    if (request.serviceName() != null) {
+      filters.addTerm("localEndpoint.serviceName", request.serviceName());
     }
 
-    if (request.spanName != null) {
-      filters.addTerm("name", request.spanName);
+    if (request.spanName() != null) {
+      filters.addTerm("name", request.spanName());
     }
 
-    for (String annotation : request.annotations) {
-      filters.addTerm("_q", annotation);
+    for (Map.Entry<String, String> kv : request.annotationQuery().entrySet()) {
+      if (kv.getValue().isEmpty()) {
+        filters.addTerm("_q", kv.getKey());
+      } else {
+        filters.addTerm("_q", kv.getKey() + "=" + kv.getValue());
+      }
     }
 
-    for (Map.Entry<String, String> kv : request.binaryAnnotations.entrySet()) {
-      filters.addTerm("_q", kv.getKey() + "=" + kv.getValue());
-    }
-
-    if (request.minDuration != null) {
-      filters.addRange("duration", request.minDuration, request.maxDuration);
+    if (request.minDuration() != null) {
+      filters.addRange("duration", request.minDuration(), request.maxDuration());
     }
 
     // We need to filter to traces that contain at least one span that matches the request,
@@ -89,15 +91,12 @@ final class ElasticsearchHttpSpanStore implements AsyncSpanStore {
     // So we fudge and order on the first span among the filtered spans - in practice, there should
     // be no significant difference in user experience since span start times are usually very
     // close to each other in human time.
-    Aggregation traceIdTimestamp = Aggregation.terms("traceId", request.limit)
+    Aggregation traceIdTimestamp = Aggregation.terms("traceId", request.limit())
         .addSubAggregation(Aggregation.min("timestamp_millis"))
         .orderBy("timestamp_millis", "desc");
 
     List<String> indices = indexNameFormatter.formatTypeAndRange(SPAN, beginMillis, endMillis);
-    if (indices.isEmpty()) {
-      callback.onSuccess(Collections.emptyList());
-      return;
-    }
+    if (indices.isEmpty()) return Call.emptyList();
 
     SearchRequest esRequest = SearchRequest.create(indices)
         .filters(filters).addAggregation(traceIdTimestamp);
@@ -105,82 +104,43 @@ final class ElasticsearchHttpSpanStore implements AsyncSpanStore {
     HttpCall<List<String>> traceIdsCall = search.newCall(esRequest, BodyConverters.SORTED_KEYS);
 
     // When we receive span results, we need to group them by trace ID
-    Callback<List<Span>> successCallback = new Callback<List<Span>>() {
-      @Override public void onSuccess(@Nullable List<Span> input) {
-        List<List<Span>> traces = GroupByTraceId.apply(input, strictTraceId, true);
+    BodyConverter<List<List<Span>>> converter = content -> {
+      BodyConverter<List<Span>> input = BodyConverters.SPANS;
+      List<List<Span>> traces = groupByTraceId(input.convert(content), strictTraceId);
 
-        // Due to tokenization of the trace ID, our matches are imprecise on Span.traceIdHigh
-        for (Iterator<List<Span>> trace = traces.iterator(); trace.hasNext(); ) {
-          List<Span> next = trace.next();
-          if (next.get(0).traceIdHigh != 0 && !request.test(next)) {
-            trace.remove();
-          }
+      // Due to tokenization of the trace ID, our matches are imprecise on Span.traceIdHigh
+      for (Iterator<List<Span>> trace = traces.iterator(); trace.hasNext(); ) {
+        List<Span> next = trace.next();
+        if (next.get(0).traceIdHigh() != 0 && !request.test(next)) {
+          trace.remove();
         }
-        callback.onSuccess(traces);
       }
-
-      @Override public void onError(Throwable t) {
-        callback.onError(t);
-      }
+      return traces;
     };
 
-    // Fire off the query to get spans once we have trace ids
-    traceIdsCall.submit(new Callback<List<String>>() {
-      @Override public void onSuccess(@Nullable List<String> traceIds) {
-        if (traceIds == null || traceIds.isEmpty()) {
-          callback.onSuccess(Collections.emptyList());
-          return;
-        }
-        SearchRequest request = SearchRequest.create(indices).terms("traceId", traceIds);
-        search.newCall(request, BodyConverters.SPANS).submit(successCallback);
-      }
+    return traceIdsCall.flatMap(input -> {
+      if (input.isEmpty()) return Call.emptyList();
 
-      @Override public void onError(Throwable t) {
-        callback.onError(t);
-      }
+      SearchRequest getTraces = SearchRequest.create(indices).terms("traceId", input);
+      return search.newCall(getTraces, converter);
     });
   }
 
-  @Override public void getTrace(long id, Callback<List<Span>> callback) {
-    getTrace(0L, id, callback);
-  }
-
-  @Override public void getTrace(long traceIdHigh, long traceIdLow, Callback<List<Span>> callback) {
-    getRawTrace(traceIdHigh, traceIdLow, new Callback<List<Span>>() {
-      @Override public void onSuccess(@Nullable List<Span> value) {
-        List<Span> result = CorrectForClockSkew.apply(MergeById.apply(value));
-        callback.onSuccess(result.isEmpty() ? null : result);
-      }
-
-      @Override public void onError(Throwable t) {
-        callback.onError(t);
-      }
-    });
-  }
-
-  @Override public void getRawTrace(long traceId, Callback<List<Span>> callback) {
-    getRawTrace(0L, traceId, callback);
-  }
-
-  @Override
-  public void getRawTrace(long traceIdHigh, long traceIdLow, Callback<List<Span>> callback) {
+  @Override public Call<List<Span>> getTrace(long traceIdHigh, long traceIdLow) {
     String traceIdHex = Util.toLowerHex(strictTraceId ? traceIdHigh : 0L, traceIdLow);
 
     SearchRequest request = SearchRequest.create(asList(allSpanIndices))
         .term("traceId", traceIdHex);
 
-    search.newCall(request, BodyConverters.NULLABLE_SPANS).submit(callback);
+    return search.newCall(request, BodyConverters.SPANS);
   }
 
-  @Override public void getServiceNames(Callback<List<String>> callback) {
+  @Override public Call<List<String>> getServiceNames() {
     long endMillis = System.currentTimeMillis();
     long beginMillis = endMillis - namesLookback;
 
     List<String> indices = indexNameFormatter.formatTypeAndRange(SPAN, beginMillis, endMillis);
-    if (indices.isEmpty()) {
-      callback.onSuccess(Collections.emptyList());
-      return;
-    }
+    if (indices.isEmpty()) return Call.emptyList();
 
     // Service name queries include both local and remote endpoints. This is different than
     // Span name, as a span name can only be on a local endpoint.
@@ -190,23 +150,17 @@ final class ElasticsearchHttpSpanStore implements AsyncSpanStore {
         .filters(filters)
         .addAggregation(Aggregation.terms("localEndpoint.serviceName", Integer.MAX_VALUE))
         .addAggregation(Aggregation.terms("remoteEndpoint.serviceName", Integer.MAX_VALUE));
-    search.newCall(request, BodyConverters.SORTED_KEYS).submit(callback);
+    return search.newCall(request, BodyConverters.SORTED_KEYS);
   }
 
-  @Override public void getSpanNames(String serviceName, Callback<List<String>> callback) {
-    if (serviceName == null || "".equals(serviceName)) {
-      callback.onSuccess(Collections.emptyList());
-      return;
-    }
+  @Override public Call<List<String>> getSpanNames(String serviceName) {
+    if ("".equals(serviceName)) return Call.emptyList();
 
     long endMillis = System.currentTimeMillis();
     long beginMillis = endMillis - namesLookback;
 
     List<String> indices = indexNameFormatter.formatTypeAndRange(SPAN, beginMillis, endMillis);
-    if (indices.isEmpty()) {
-      callback.onSuccess(Collections.emptyList());
-      return;
-    }
+    if (indices.isEmpty()) return Call.emptyList();
 
     // A span name is only valid on a local endpoint, as a span name is defined locally
     SearchRequest.Filters filters = new SearchRequest.Filters()
@@ -216,22 +170,32 @@ final class ElasticsearchHttpSpanStore implements AsyncSpanStore {
     SearchRequest request = SearchRequest.create(indices)
         .filters(filters)
         .addAggregation(Aggregation.terms("name", Integer.MAX_VALUE));
-    search.newCall(request, BodyConverters.SORTED_KEYS).submit(callback);
+
+    return search.newCall(request, BodyConverters.SORTED_KEYS);
   }
 
-  @Override public void getDependencies(long endTs, @Nullable Long lookback,
-      Callback<List<DependencyLink>> callback) {
-
-    long beginMillis = lookback != null ? Math.max(endTs - lookback, EARLIEST_MS) : EARLIEST_MS;
+  @Override public Call<List<DependencyLink>> getDependencies(long endTs, long lookback) {
+    long beginMillis = Math.max(endTs - lookback, EARLIEST_MS);
 
     // We just return all dependencies in the days that fall within endTs and lookback as
     // dependency links themselves don't have timestamps.
     List<String> indices = indexNameFormatter.formatTypeAndRange(DEPENDENCY, beginMillis, endTs);
-    if (indices.isEmpty()) {
-      callback.onSuccess(Collections.emptyList());
-      return;
-    }
+    if (indices.isEmpty()) return Call.emptyList();
 
-    search.newCall(SearchRequest.create(indices), BodyConverters.DEPENDENCY_LINKS).submit(callback);
+    return search.newCall(SearchRequest.create(indices), BodyConverters.DEPENDENCY_LINKS);
+  }
+
+  static List<List<Span>> groupByTraceId(Collection<Span> input, boolean strictTraceId) {
+    if (input.isEmpty()) return Collections.emptyList();
+
+    Map<Pair<Long>, List<Span>> groupedByTraceId = new LinkedHashMap<>();
+    for (Span span : input) {
+      Pair<Long> traceId = Pair.create(strictTraceId ? span.traceIdHigh() : 0L, span.traceId());
+      if (!groupedByTraceId.containsKey(traceId)) {
+        groupedByTraceId.put(traceId, new LinkedList<>());
+      }
+      groupedByTraceId.get(traceId).add(span);
+    }
+    return new ArrayList<>(groupedByTraceId.values());
   }
 }

--- a/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/JsonAdapters.java
+++ b/zipkin-storage/elasticsearch-http/src/main/java/zipkin/storage/elasticsearch/http/JsonAdapters.java
@@ -23,16 +23,15 @@ import zipkin.Annotation;
 import zipkin.DependencyLink;
 import zipkin.Endpoint;
 import zipkin.internal.v2.Span;
-import zipkin.internal.V2SpanConverter;
 
 /**
  * Read-only json adapters resurrected from before we switched to Java 6 as storage components can
  * be Java 7+
  */
 final class JsonAdapters {
-  static final JsonAdapter<zipkin.Span> SPAN_ADAPTER = new JsonAdapter<zipkin.Span>() {
+  static final JsonAdapter<Span> SPAN_ADAPTER = new JsonAdapter<Span>() {
     @Override @Nonnull
-    public zipkin.Span fromJson(JsonReader reader) throws IOException {
+    public Span fromJson(JsonReader reader) throws IOException {
       Span.Builder result = Span.builder();
       reader.beginObject();
       while (reader.hasNext()) {
@@ -95,11 +94,11 @@ final class JsonAdapters {
         }
       }
       reader.endObject();
-      return V2SpanConverter.toSpan(result.build());
+      return result.build();
     }
 
     @Override
-    public void toJson(JsonWriter writer, @Nullable zipkin.Span value) throws IOException {
+    public void toJson(JsonWriter writer, @Nullable Span value) throws IOException {
       throw new UnsupportedOperationException();
     }
   };

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStoreTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpSpanStoreTest.java
@@ -21,7 +21,6 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
-import zipkin.internal.CallbackCaptor;
 import zipkin.internal.Util;
 
 import static java.util.Arrays.asList;
@@ -44,14 +43,14 @@ public class ElasticsearchHttpSpanStoreTest {
 
   @Test public void serviceNames_defaultsTo24HrsAgo_6x() throws Exception {
     es.enqueue(new MockResponse().setBody(SERVICE_NAMES));
-    spanStore.getServiceNames(new CallbackCaptor<>());
+    spanStore.getServiceNames().execute();
 
     requestLimitedTo2DaysOfIndices_singleTypeIndex();
   }
 
   @Test public void spanNames_defaultsTo24HrsAgo_6x() throws Exception {
     es.enqueue(new MockResponse().setBody(SPAN_NAMES));
-    spanStore.getSpanNames("foo", new CallbackCaptor<>());
+    spanStore.getSpanNames("foo").execute();
 
     requestLimitedTo2DaysOfIndices_singleTypeIndex();
   }

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorageTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchHttpStorageTest.java
@@ -23,7 +23,6 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import zipkin.Component;
-import zipkin.internal.LenientDoubleCallbackAsyncSpanStore;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,8 +79,8 @@ public class ElasticsearchHttpStorageTest {
     es.enqueue(new MockResponse()); // get dependency template
 
     // check this isn't the double reading span store
-    assertThat(storage.asyncSpanStore())
-      .isInstanceOf(ElasticsearchHttpSpanStore.class);
+    assertThat(storage.asyncSpanStore().getClass().getSimpleName())
+      .isEqualTo("V2SpanStoreAdapter");
 
     es.takeRequest(); // get version
     es.takeRequest(); // get span template
@@ -99,8 +98,8 @@ public class ElasticsearchHttpStorageTest {
     es.enqueue(new MockResponse()); // get dependency template
 
     // check that we do double-reads on the legacy and new format
-    assertThat(storage.asyncSpanStore())
-      .isInstanceOf(LenientDoubleCallbackAsyncSpanStore.class);
+    assertThat(storage.asyncSpanStore().getClass().getSimpleName())
+      .isEqualTo("LenientDoubleCallbackAsyncSpanStore");
 
     es.takeRequest(); // get version
     es.takeRequest(); // get span template
@@ -119,8 +118,8 @@ public class ElasticsearchHttpStorageTest {
     es.enqueue(new MockResponse()); // get dependency template
 
     // check this isn't the double reading span store
-    assertThat(storage.asyncSpanStore())
-      .isInstanceOf(ElasticsearchHttpSpanStore.class);
+    assertThat(storage.asyncSpanStore().getClass().getSimpleName())
+      .isEqualTo("V2SpanStoreAdapter");
 
     es.takeRequest(); // get version
     es.takeRequest(); // get span template

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/JsonAdaptersTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/JsonAdaptersTest.java
@@ -14,10 +14,8 @@
 package zipkin.storage.elasticsearch.http;
 
 import java.io.IOException;
-import java.util.List;
 import okio.Buffer;
 import org.junit.Test;
-import zipkin.BinaryAnnotation;
 import zipkin.Codec;
 import zipkin.DependencyLink;
 import zipkin.Endpoint;
@@ -110,8 +108,8 @@ public class JsonAdaptersTest {
       + "  }"
       + "}";
 
-    List<Span> spans = V2SpanConverter.fromSpan(JsonAdapters.SPAN_ADAPTER.fromJson(json));
-    assertThat(spans.get(0).tags())
+    Span span = JsonAdapters.SPAN_ADAPTER.fromJson(json);
+    assertThat(span.tags())
       .containsExactly(entry("num", "9223372036854775807"));
   }
 
@@ -126,8 +124,8 @@ public class JsonAdaptersTest {
       + "  }"
       + "}";
 
-    List<Span> spans = V2SpanConverter.fromSpan(JsonAdapters.SPAN_ADAPTER.fromJson(json));
-    assertThat(spans.get(0).tags())
+    Span span = JsonAdapters.SPAN_ADAPTER.fromJson(json);
+    assertThat(span.tags())
       .containsExactly(entry("num", "1.23456789"));
   }
 
@@ -138,7 +136,7 @@ public class JsonAdaptersTest {
     Buffer bytes = new Buffer();
     bytes.write(Encoder.JSON.encode(span2));
     assertThat(SPAN_ADAPTER.fromJson(bytes))
-      .isEqualTo(span);
+      .isEqualTo(span2);
   }
 
   /**
@@ -163,7 +161,7 @@ public class JsonAdaptersTest {
     Buffer bytes = new Buffer();
     bytes.write(Encoder.JSON.encode(worstSpanInTheWorld));
     assertThat(SPAN_ADAPTER.fromJson(bytes))
-      .isEqualTo(V2SpanConverter.toSpan(worstSpanInTheWorld));
+      .isEqualTo(worstSpanInTheWorld);
   }
 
   @Test
@@ -178,9 +176,8 @@ public class JsonAdaptersTest {
       + "  }\n"
       + "}";
 
-    assertThat(SPAN_ADAPTER.fromJson(json).binaryAnnotations)
-      .containsExactly(BinaryAnnotation.create("lc", "",
-        Endpoint.builder().serviceName("service").port(65535).build()));
+    assertThat(SPAN_ADAPTER.fromJson(json).localEndpoint())
+      .isEqualTo(Endpoint.builder().serviceName("service").port(65535).build());
   }
 
   @Test
@@ -194,9 +191,8 @@ public class JsonAdaptersTest {
       + "  }\n"
       + "}";
 
-    assertThat(SPAN_ADAPTER.fromJson(json).binaryAnnotations)
-      .containsExactly(BinaryAnnotation.create("lc", "",
-        Endpoint.builder().serviceName("").port(65535).build()));
+    assertThat(SPAN_ADAPTER.fromJson(json).localEndpoint())
+      .isEqualTo(Endpoint.builder().serviceName("").port(65535).build());
   }
 
   @Test
@@ -211,9 +207,8 @@ public class JsonAdaptersTest {
       + "  }\n"
       + "}";
 
-    assertThat(SPAN_ADAPTER.fromJson(json).binaryAnnotations)
-      .containsExactly(BinaryAnnotation.create("lc", "",
-        Endpoint.builder().serviceName("").port(65535).build()));
+    assertThat(SPAN_ADAPTER.fromJson(json).localEndpoint())
+      .isEqualTo(Endpoint.builder().serviceName("").port(65535).build());
   }
 
   @Test

--- a/zipkin/src/main/java/zipkin/internal/LenientDoubleCallbackAsyncSpanStore.java
+++ b/zipkin/src/main/java/zipkin/internal/LenientDoubleCallbackAsyncSpanStore.java
@@ -29,12 +29,11 @@ import zipkin.storage.QueryRequest;
  * This makes redundant read commands, concatenating results if two answers come back, or accepting
  * one if there's an error on the other.
  */
-// TODO: temporarily public until elasticsearch-http transitions to V2 SpanStore
-public final class LenientDoubleCallbackAsyncSpanStore implements AsyncSpanStore {
+final class LenientDoubleCallbackAsyncSpanStore implements AsyncSpanStore {
   final AsyncSpanStore left;
   final AsyncSpanStore right;
 
-  public LenientDoubleCallbackAsyncSpanStore(AsyncSpanStore left, AsyncSpanStore right) {
+  LenientDoubleCallbackAsyncSpanStore(AsyncSpanStore left, AsyncSpanStore right) {
     this.left = left;
     this.right = right;
   }


### PR DESCRIPTION
this makes Elasticsearch use the v2 format natively for reads.