### PR TITLE
Adds Platform for wrapping IOExceptions properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,8 @@
          from other projects. For example, cassandra and spring boot set guava versions -->
     <guava.version>19.0</guava.version>
     <junit.version>4.12</junit.version>
-    <mockito.version>2.8.9</mockito.version>
+    <!-- to match powermock and spring testing -->
+    <mockito.version>1.10.19</mockito.version>
     <assertj.version>3.8.0</assertj.version>
     <hamcrest.version>1.3</hamcrest.version>
     <okhttp.version>3.8.1</okhttp.version>

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/integration/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/integration/CassandraSpanConsumerTest.java
@@ -20,6 +20,7 @@ import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
 import zipkin.Annotation;
 import zipkin.Span;
@@ -91,8 +92,13 @@ abstract class CassandraSpanConsumerTest {
   }
 
   private static Object considerSwitchStrategyLog() {
-    return argThat(argument -> ((LoggingEvent) argument).getFormattedMessage()
-      .contains("If this happens a lot consider switching back to SizeTieredCompactionStrategy"));
+    return argThat(new ArgumentMatcher<LoggingEvent>() {
+      @Override public boolean matches(Object argument) {
+        return ((LoggingEvent) argument).getFormattedMessage()
+          .contains(
+            "If this happens a lot consider switching back to SizeTieredCompactionStrategy");
+      }
+    });
   }
 
   /**

--- a/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/internal/LenientDoubleCallbackAsyncSpanStoreTest.java
+++ b/zipkin-storage/elasticsearch-http/src/test/java/zipkin/storage/elasticsearch/http/internal/LenientDoubleCallbackAsyncSpanStoreTest.java
@@ -27,8 +27,8 @@ import zipkin.storage.Callback;
 import zipkin.storage.QueryRequest;
 
 import static java.util.Arrays.asList;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static zipkin.TestObjects.DAY;

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -30,12 +30,21 @@
     <main.basedir>${project.basedir}/..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
+    <powermock.version>1.7.1</powermock.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jvnet</groupId>
+      <artifactId>animal-sniffer-annotation</artifactId>
+      <version>1.0</version>
+      <!-- annotations are not runtime retention, so don't need a runtime dep -->
       <scope>provided</scope>
     </dependency>
 
@@ -55,6 +64,20 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- to mock Platform calls -->
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/zipkin/src/main/java/zipkin/internal/v2/Call.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/Call.java
@@ -145,7 +145,7 @@ public abstract class Call<V> implements Cloneable {
   public abstract boolean isCanceled();
 
   /** Returns a copy of this object, so you can make an identical follow-up request. */
-  public abstract Call<V> clone();
+  @Override public abstract Call<V> clone();
 
   static final class Constant<V> extends Base<V> {
     final V v;

--- a/zipkin/src/main/java/zipkin/internal/v2/internal/Platform.java
+++ b/zipkin/src/main/java/zipkin/internal/v2/internal/Platform.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.internal;
+
+import java.io.IOException;
+import org.jvnet.animal_sniffer.IgnoreJRERequirement;
+
+/**
+ * Provides access to platform-specific features.
+ *
+ * <p>Originally designed by OkHttp team, derived from {@code okhttp3.internal.platform.Platform}
+ */
+public abstract class Platform {
+  private static final Platform PLATFORM = findPlatform();
+
+  Platform() {
+  }
+
+  public RuntimeException uncheckedIOException(IOException e) {
+    return new RuntimeException(e);
+  }
+
+  public static Platform get() {
+    return PLATFORM;
+  }
+
+  /** Attempt to match the host runtime to a capable Platform implementation. */
+  static Platform findPlatform() {
+    Platform jre8 = Jre8.buildIfSupported();
+
+    if (jre8 != null) return jre8;
+
+    Platform jre7 = Jre7.buildIfSupported();
+
+    if (jre7 != null) return jre7;
+
+    // compatible with JRE 6
+    return Jre6.build();
+  }
+
+  static final class Jre8 extends Platform {
+    static Jre8 buildIfSupported() {
+      // Find JRE 8 new types
+      try {
+        Class.forName("java.io.UncheckedIOException");
+        return new Jre8();
+      } catch (ClassNotFoundException e) {
+        // pre JRE 8
+      }
+      return null;
+    }
+
+    @IgnoreJRERequirement @Override public RuntimeException uncheckedIOException(IOException e) {
+      return new java.io.UncheckedIOException(e);
+    }
+  }
+
+  static final class Jre7 extends Platform {
+    static Jre7 buildIfSupported() {
+      // Find JRE 7 new types
+      try {
+        Class.forName("java.util.concurrent.ThreadLocalRandom");
+        return new Jre7();
+      } catch (ClassNotFoundException e) {
+        // pre JRE 7
+      }
+      return null;
+    }
+  }
+
+  static final class Jre6 extends Platform {
+    static Jre6 build() {
+      return new Jre6();
+    }
+  }
+}

--- a/zipkin/src/test/java/zipkin/collector/CollectorTest.java
+++ b/zipkin/src/test/java/zipkin/collector/CollectorTest.java
@@ -27,8 +27,8 @@ import zipkin.internal.v2.codec.MessageEncoder;
 import zipkin.internal.v2.storage.SpanConsumer;
 
 import static java.util.Arrays.asList;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;

--- a/zipkin/src/test/java/zipkin/internal/CollectorTest.java
+++ b/zipkin/src/test/java/zipkin/internal/CollectorTest.java
@@ -23,8 +23,8 @@ import zipkin.storage.Callback;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/zipkin/src/test/java/zipkin/internal/v2/CallTest.java
+++ b/zipkin/src/test/java/zipkin/internal/v2/CallTest.java
@@ -29,8 +29,8 @@ import org.mockito.junit.MockitoRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.verify;
 
 public class CallTest {

--- a/zipkin/src/test/java/zipkin/internal/v2/internal/PlatformTest.java
+++ b/zipkin/src/test/java/zipkin/internal/v2/internal/PlatformTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal.v2.internal;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+// Added to declutter console: tells power mock not to mess with implicit classes we aren't testing
+@PowerMockIgnore({"org.apache.logging.*", "javax.script.*"})
+@PrepareForTest(Platform.class)
+public class PlatformTest {
+
+  @Test public void findPlatform_jre8Wins() throws ClassNotFoundException {
+    mockStatic(Class.class);
+    when(Class.forName("java.io.UncheckedIOException"))
+      .thenReturn(null);
+
+    assertThat(Platform.findPlatform())
+      .isInstanceOf(Platform.Jre8.class);
+  }
+
+  @Test public void findPlatform_fallsBackToJre7() throws ClassNotFoundException {
+    mockStatic(Class.class);
+    when(Class.forName("java.io.UncheckedIOException"))
+      .thenThrow(new ClassNotFoundException());
+    when(Class.forName("java.util.concurrent.ThreadLocalRandom"))
+      .thenReturn(null);
+
+    assertThat(Platform.findPlatform())
+      .isInstanceOf(Platform.Jre7.class);
+  }
+
+  @Test public void findPlatform_fallsBackToJre6() throws ClassNotFoundException {
+    mockStatic(Class.class);
+    when(Class.forName("java.io.UncheckedIOException"))
+      .thenThrow(new ClassNotFoundException());
+    when(Class.forName("java.util.concurrent.ThreadLocalRandom"))
+      .thenThrow(new ClassNotFoundException());
+
+    assertThat(Platform.findPlatform())
+      .isInstanceOf(Platform.Jre6.class);
+  }
+}


### PR DESCRIPTION
This is used for pending work in SpanStore v2. Note: this downgrades
mockito as it conflicts with powermock and spring boot versions.