### PR TITLE
Fixes autowire problem caught in server integration tests

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServerConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.metrics.buffer.CounterBuffers;
 import org.springframework.boot.actuate.metrics.buffer.GaugeBuffers;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -57,16 +56,6 @@ public class ZipkinServerConfiguration {
     // MetricsDropwizardAutoConfiguration can be manually excluded either, as Cassandra metrics won't be recorded.
     return new ActuateCollectorMetrics(counterBuffers.orElse(new CounterBuffers()),
                                        gaugeBuffers.orElse(new GaugeBuffers()));
-  }
-
-  @Configuration
-  @ConditionalOnProperty(name = "zipkin.query.enabled", matchIfMissing = true)
-  // ConditionalOnBean won't work in a public type as StorageComponent isn't loaded in that scope
-  @ConditionalOnBean(V2StorageComponent.class)
-  static class ZipkinQueryApiV2Configuration {
-    ZipkinQueryApiV2 queryV2(ZipkinQueryApiV2 api){ // inject and configure
-      return api;
-    }
   }
 
   @Configuration

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
@@ -13,7 +13,6 @@
  */
 package zipkin.server;
 
-import java.io.IOException;
 import java.util.List;
 import okio.Buffer;
 import okio.GzipSink;
@@ -38,7 +37,6 @@ import zipkin.internal.V2InMemoryStorage;
 import zipkin.internal.V2SpanConverter;
 import zipkin.internal.v2.codec.Encoder;
 import zipkin.internal.v2.codec.MessageEncoder;
-import zipkin.storage.InMemoryStorage;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerQueryDisabledTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerQueryDisabledTest.java
@@ -45,6 +45,7 @@ public class ZipkinServerQueryDisabledTest {
   @Test(expected = NoSuchBeanDefinitionException.class)
   public void disabledQueryBean() throws Exception {
     context.getBean(ZipkinQueryApiV1.class);
+    context.getBean(ZipkinQueryApiV2.class);
   }
 
   @Test(expected = NoSuchBeanDefinitionException.class)
@@ -56,6 +57,8 @@ public class ZipkinServerQueryDisabledTest {
     MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build();
     mockMvc.perform(get("/api/v1/traces"))
         .andExpect(status().isNotFound());
+    mockMvc.perform(get("/api/v2/traces"))
+      .andExpect(status().isNotFound());
     mockMvc.perform(get("/index.html"))
         .andExpect(status().isNotFound());
 


### PR DESCRIPTION
The `@ConditionalOnBean(V2StorageComponent.class)` wasn't preventing the rest controller from being instantiated otherwise. We have an integration test to ensure that custom servers work, and this failed.

This introduces a temporary hack to make read apis return 404 when storage v2 isn't supported yet. Tested manually on mysql (not v2 native) and elasticsearch (v2 native) to make sure it works. A future change will adapt old storage apis to the degree possible. This will be done later in a patch.