### PR TITLE
Redirect /config.json to /zipkin/config.json in order to work with the chrome extension

### DIFF
--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -148,4 +148,9 @@ public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
   public ModelAndView redirectRoot() {
     return new ModelAndView("redirect:/zipkin/");
   }
+
+  @RequestMapping(value = "/config.json", method = GET)
+  public ModelAndView redirectConfig() {
+    return new ModelAndView("redirect:/zipkin/config.json");
+  }
 }


### PR DESCRIPTION
For some reason the path is cut off when added to the chrome extension, meaning I can't specify`/zipkin` there.

Hopefully the extension follows redirects...

https://github.com/openzipkin/zipkin-browser-extension