### PR TITLE
Support for running Zipkin behind a reverse proxy

### DIFF
--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -13,8 +13,10 @@
  */
 package zipkin.autoconfigure.ui;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -25,6 +27,8 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -145,7 +149,9 @@ public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
 
   /** Make sure users who aren't familiar with /zipkin get to the right path */
   @RequestMapping(value = "/", method = GET)
-  public ModelAndView redirectRoot() {
-    return new ModelAndView("redirect:/zipkin/");
+  public void redirectRoot(HttpServletResponse response) throws IOException {
+    // return 'Location: ./zipkin/' header (this wouldn't work with ModelAndView's 'redirect:./zipkin/')
+    response.setHeader(HttpHeaders.LOCATION, "./zipkin/");
+    response.setStatus(HttpStatus.FOUND.value());
   }
 }

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
@@ -317,7 +317,7 @@ public class ZipkinServerIntegrationTest {
 
     // Redirect header should be the proxy, not the backed IP/port
     assertThat(response.header("Location"))
-      .isEqualTo("https://zipkin.com:444/zipkin/");
+      .isEqualTo("./zipkin/");
   }
 
   ResultActions performAsync(MockHttpServletRequestBuilder request) throws Exception {

--- a/zipkin-ui/css/style-loader.js
+++ b/zipkin-ui/css/style-loader.js
@@ -1,3 +1,9 @@
 // We use this file to let webpack generate
 // a css bundle from our stylesheets.
+
+// read the public path from the <base> tag where it has to be set anyway because of
+// html-webpack-plugin limitations: https://github.com/jantimon/html-webpack-plugin/issues/119
+// otherwise it could be: window.location.pathname.replace(/(.*)\/zipkin\/.*/, '$1/zipkin/')
+__webpack_public_path__ = $('base').attr('href'); // eslint-disable-line camelcase, no-undef
+
 require('./main.scss');

--- a/zipkin-ui/css/style-loader.js
+++ b/zipkin-ui/css/style-loader.js
@@ -1,9 +1,10 @@
 // We use this file to let webpack generate
 // a css bundle from our stylesheets.
 
-// read the public path from the <base> tag where it has to be set anyway because of
-// html-webpack-plugin limitations: https://github.com/jantimon/html-webpack-plugin/issues/119
-// otherwise it could be: window.location.pathname.replace(/(.*)\/zipkin\/.*/, '$1/zipkin/')
-__webpack_public_path__ = $('base').attr('href'); // eslint-disable-line camelcase, no-undef
+// The import of 'publicPath' module has to be the first statement in this entry point file
+// so that '__webpack_public_path__' (see https://webpack.github.io/docs/configuration.html#output-publicpath)
+// is set soon enough.
+// In the same time, 'contextRoot' is made available as the context root path reference.
+import {contextRoot} from '../js/publicPath';
 
 require('./main.scss');

--- a/zipkin-ui/index.ejs
+++ b/zipkin-ui/index.ejs
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!--
+      add 'base' tag to work around the fact that 'html-webpack-plugin' does not work
+      with '__webpack_public_path__' being set as reported at https://github.com/jantimon/html-webpack-plugin/issues/119
+    -->
+    <base href="/zipkin/">
+
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+
+    <meta charset="UTF-8">
+    <title><%= htmlWebpackPlugin.options.title %></title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/zipkin-ui/index.ejs
+++ b/zipkin-ui/index.ejs
@@ -5,7 +5,7 @@
       add 'base' tag to work around the fact that 'html-webpack-plugin' does not work
       with '__webpack_public_path__' being set as reported at https://github.com/jantimon/html-webpack-plugin/issues/119
     -->
-    <base href="/zipkin/">
+    <base href="<%= htmlWebpackPlugin.options.contextRoot %>">
 
     <link rel="icon" type="image/x-icon" href="favicon.ico">
 

--- a/zipkin-ui/js/component_data/default.js
+++ b/zipkin-ui/js/component_data/default.js
@@ -21,7 +21,8 @@ export default component(function DefaultData() {
     const query = convertToApiQuery(window.location.search);
     const serviceName = query.serviceName;
     if (serviceName) {
-      const apiURL = `/zipkin/api/v1/traces?${queryString.stringify(query)}`;
+      // eslint-disable-next-line camelcase, no-undef
+      const apiURL = `${__webpack_public_path__}api/v1/traces?${queryString.stringify(query)}`;
       $.ajax(apiURL, {
         type: 'GET',
         dataType: 'json'

--- a/zipkin-ui/js/component_data/default.js
+++ b/zipkin-ui/js/component_data/default.js
@@ -3,6 +3,7 @@ import {errToStr} from '../../js/component_ui/error';
 import $ from 'jquery';
 import queryString from 'query-string';
 import {traceSummary, traceSummariesToMustache} from '../component_ui/traceSummary';
+import {contextRoot} from '../publicPath';
 
 export function convertToApiQuery(windowLocationSearch) {
   const query = queryString.parse(windowLocationSearch);
@@ -21,8 +22,7 @@ export default component(function DefaultData() {
     const query = convertToApiQuery(window.location.search);
     const serviceName = query.serviceName;
     if (serviceName) {
-      // eslint-disable-next-line camelcase, no-undef
-      const apiURL = `${__webpack_public_path__}api/v1/traces?${queryString.stringify(query)}`;
+      const apiURL = `${contextRoot}api/v1/traces?${queryString.stringify(query)}`;
       $.ajax(apiURL, {
         type: 'GET',
         dataType: 'json'

--- a/zipkin-ui/js/component_data/default.js
+++ b/zipkin-ui/js/component_data/default.js
@@ -3,7 +3,6 @@ import {errToStr} from '../../js/component_ui/error';
 import $ from 'jquery';
 import queryString from 'query-string';
 import {traceSummary, traceSummariesToMustache} from '../component_ui/traceSummary';
-import {contextRoot} from '../publicPath';
 
 export function convertToApiQuery(windowLocationSearch) {
   const query = queryString.parse(windowLocationSearch);
@@ -22,7 +21,7 @@ export default component(function DefaultData() {
     const query = convertToApiQuery(window.location.search);
     const serviceName = query.serviceName;
     if (serviceName) {
-      const apiURL = `${contextRoot}api/v1/traces?${queryString.stringify(query)}`;
+      const apiURL = `api/v1/traces?${queryString.stringify(query)}`;
       $.ajax(apiURL, {
         type: 'GET',
         dataType: 'json'

--- a/zipkin-ui/js/component_data/dependency.js
+++ b/zipkin-ui/js/component_data/dependency.js
@@ -7,7 +7,8 @@ export default component(function dependency() {
   let dependencies = {};
 
   this.getDependency = function(endTs, lookback) {
-    let url = `/zipkin/api/v1/dependencies?endTs=${endTs}`;
+    // eslint-disable-next-line camelcase, no-undef
+    let url = `${__webpack_public_path__}api/v1/dependencies?endTs=${endTs}`;
     if (lookback) {
       url += `&lookback=${lookback}`;
     }

--- a/zipkin-ui/js/component_data/dependency.js
+++ b/zipkin-ui/js/component_data/dependency.js
@@ -1,14 +1,14 @@
 import {component} from 'flightjs';
 import moment from 'moment';
 import $ from 'jquery';
+import {contextRoot} from '../publicPath';
 
 export default component(function dependency() {
   let services = {};
   let dependencies = {};
 
   this.getDependency = function(endTs, lookback) {
-    // eslint-disable-next-line camelcase, no-undef
-    let url = `${__webpack_public_path__}api/v1/dependencies?endTs=${endTs}`;
+    let url = `${contextRoot}api/v1/dependencies?endTs=${endTs}`;
     if (lookback) {
       url += `&lookback=${lookback}`;
     }

--- a/zipkin-ui/js/component_data/dependency.js
+++ b/zipkin-ui/js/component_data/dependency.js
@@ -1,14 +1,13 @@
 import {component} from 'flightjs';
 import moment from 'moment';
 import $ from 'jquery';
-import {contextRoot} from '../publicPath';
 
 export default component(function dependency() {
   let services = {};
   let dependencies = {};
 
   this.getDependency = function(endTs, lookback) {
-    let url = `${contextRoot}api/v1/dependencies?endTs=${endTs}`;
+    let url = `api/v1/dependencies?endTs=${endTs}`;
     if (lookback) {
       url += `&lookback=${lookback}`;
     }

--- a/zipkin-ui/js/component_data/serviceNames.js
+++ b/zipkin-ui/js/component_data/serviceNames.js
@@ -4,7 +4,8 @@ import $ from 'jquery';
 
 export default component(function serviceNames() {
   this.updateServiceNames = function(ev, lastServiceName) {
-    $.ajax('/zipkin/api/v1/services', {
+    // eslint-disable-next-line camelcase, no-undef
+    $.ajax(`${__webpack_public_path__}api/v1/services`, {
       type: 'GET',
       dataType: 'json'
     }).done(names => {

--- a/zipkin-ui/js/component_data/serviceNames.js
+++ b/zipkin-ui/js/component_data/serviceNames.js
@@ -1,11 +1,10 @@
 import {component} from 'flightjs';
 import {getError} from '../../js/component_ui/error';
 import $ from 'jquery';
-import {contextRoot} from '../publicPath';
 
 export default component(function serviceNames() {
   this.updateServiceNames = function(ev, lastServiceName) {
-    $.ajax(`${contextRoot}api/v1/services`, {
+    $.ajax('api/v1/services', {
       type: 'GET',
       dataType: 'json'
     }).done(names => {

--- a/zipkin-ui/js/component_data/serviceNames.js
+++ b/zipkin-ui/js/component_data/serviceNames.js
@@ -1,11 +1,11 @@
 import {component} from 'flightjs';
 import {getError} from '../../js/component_ui/error';
 import $ from 'jquery';
+import {contextRoot} from '../publicPath';
 
 export default component(function serviceNames() {
   this.updateServiceNames = function(ev, lastServiceName) {
-    // eslint-disable-next-line camelcase, no-undef
-    $.ajax(`${__webpack_public_path__}api/v1/services`, {
+    $.ajax(`${contextRoot}api/v1/services`, {
       type: 'GET',
       dataType: 'json'
     }).done(names => {

--- a/zipkin-ui/js/component_data/spanNames.js
+++ b/zipkin-ui/js/component_data/spanNames.js
@@ -8,7 +8,8 @@ export default component(function spanNames() {
       this.trigger('dataSpanNames', {spans: []});
       return;
     }
-    $.ajax(`/zipkin/api/v1/spans?serviceName=${serviceName}`, {
+    // eslint-disable-next-line camelcase, no-undef
+    $.ajax(`${__webpack_public_path__}api/v1/spans?serviceName=${serviceName}`, {
       type: 'GET',
       dataType: 'json'
     }).done(spans => {

--- a/zipkin-ui/js/component_data/spanNames.js
+++ b/zipkin-ui/js/component_data/spanNames.js
@@ -1,5 +1,6 @@
 import {component} from 'flightjs';
 import {getError} from '../../js/component_ui/error';
+import {contextRoot} from '../publicPath';
 import $ from 'jquery';
 
 export default component(function spanNames() {
@@ -8,8 +9,7 @@ export default component(function spanNames() {
       this.trigger('dataSpanNames', {spans: []});
       return;
     }
-    // eslint-disable-next-line camelcase, no-undef
-    $.ajax(`${__webpack_public_path__}api/v1/spans?serviceName=${serviceName}`, {
+    $.ajax(`${contextRoot}api/v1/spans?serviceName=${serviceName}`, {
       type: 'GET',
       dataType: 'json'
     }).done(spans => {

--- a/zipkin-ui/js/component_data/spanNames.js
+++ b/zipkin-ui/js/component_data/spanNames.js
@@ -1,6 +1,5 @@
 import {component} from 'flightjs';
 import {getError} from '../../js/component_ui/error';
-import {contextRoot} from '../publicPath';
 import $ from 'jquery';
 
 export default component(function spanNames() {
@@ -9,7 +8,7 @@ export default component(function spanNames() {
       this.trigger('dataSpanNames', {spans: []});
       return;
     }
-    $.ajax(`${contextRoot}api/v1/spans?serviceName=${serviceName}`, {
+    $.ajax(`api/v1/spans?serviceName=${serviceName}`, {
       type: 'GET',
       dataType: 'json'
     }).done(spans => {

--- a/zipkin-ui/js/component_data/trace.js
+++ b/zipkin-ui/js/component_data/trace.js
@@ -14,7 +14,8 @@ export default component(function TraceData() {
   this.after('initialize', function() {
     const traceId = this.attr.traceId;
     const logsUrl = toContextualLogsUrl(this.attr.logsUrl, traceId);
-    $.ajax(`/zipkin/api/v1/trace/${traceId}`, {
+    // eslint-disable-next-line camelcase, no-undef
+    $.ajax(`${__webpack_public_path__}api/v1/trace/${traceId}`, {
       type: 'GET',
       dataType: 'json'
     }).done(trace => {

--- a/zipkin-ui/js/component_data/trace.js
+++ b/zipkin-ui/js/component_data/trace.js
@@ -2,6 +2,7 @@ import {component} from 'flightjs';
 import $ from 'jquery';
 import {getError} from '../../js/component_ui/error';
 import traceToMustache from '../../js/component_ui/traceToMustache';
+import {contextRoot} from '../publicPath';
 
 export function toContextualLogsUrl(logsUrl, traceId) {
   if (logsUrl) {
@@ -14,8 +15,7 @@ export default component(function TraceData() {
   this.after('initialize', function() {
     const traceId = this.attr.traceId;
     const logsUrl = toContextualLogsUrl(this.attr.logsUrl, traceId);
-    // eslint-disable-next-line camelcase, no-undef
-    $.ajax(`${__webpack_public_path__}api/v1/trace/${traceId}`, {
+    $.ajax(`${contextRoot}api/v1/trace/${traceId}`, {
       type: 'GET',
       dataType: 'json'
     }).done(trace => {

--- a/zipkin-ui/js/component_data/trace.js
+++ b/zipkin-ui/js/component_data/trace.js
@@ -2,7 +2,6 @@ import {component} from 'flightjs';
 import $ from 'jquery';
 import {getError} from '../../js/component_ui/error';
 import traceToMustache from '../../js/component_ui/traceToMustache';
-import {contextRoot} from '../publicPath';
 
 export function toContextualLogsUrl(logsUrl, traceId) {
   if (logsUrl) {
@@ -15,7 +14,7 @@ export default component(function TraceData() {
   this.after('initialize', function() {
     const traceId = this.attr.traceId;
     const logsUrl = toContextualLogsUrl(this.attr.logsUrl, traceId);
-    $.ajax(`${contextRoot}api/v1/trace/${traceId}`, {
+    $.ajax(`api/v1/trace/${traceId}`, {
       type: 'GET',
       dataType: 'json'
     }).done(trace => {

--- a/zipkin-ui/js/component_ui/goToDependency.js
+++ b/zipkin-ui/js/component_ui/goToDependency.js
@@ -5,7 +5,8 @@ export default component(function goToDependency() {
     evt.preventDefault();
     const endTs = document.getElementById('endTs').value;
     const startTs = document.getElementById('startTs').value;
-    window.location.href = `/zipkin/dependency?endTs=${endTs}&startTs=${startTs}`;
+    // eslint-disable-next-line camelcase, no-undef
+    window.location.href = `${__webpack_public_path__}dependency?endTs=${endTs}&startTs=${startTs}`;
   };
 
   this.after('initialize', function() {

--- a/zipkin-ui/js/component_ui/goToDependency.js
+++ b/zipkin-ui/js/component_ui/goToDependency.js
@@ -1,3 +1,4 @@
+import {contextRoot} from '../publicPath';
 import {component} from 'flightjs';
 
 export default component(function goToDependency() {
@@ -5,8 +6,7 @@ export default component(function goToDependency() {
     evt.preventDefault();
     const endTs = document.getElementById('endTs').value;
     const startTs = document.getElementById('startTs').value;
-    // eslint-disable-next-line camelcase, no-undef
-    window.location.href = `${__webpack_public_path__}dependency?endTs=${endTs}&startTs=${startTs}`;
+    window.location.href = `${contextRoot}dependency?endTs=${endTs}&startTs=${startTs}`;
   };
 
   this.after('initialize', function() {

--- a/zipkin-ui/js/component_ui/goToTrace.js
+++ b/zipkin-ui/js/component_ui/goToTrace.js
@@ -4,7 +4,8 @@ export default component(function goToTrace() {
   this.navigateToTrace = function(evt) {
     evt.preventDefault();
     const traceId = document.getElementById('traceIdQuery').value;
-    window.location.href = `/zipkin/traces/${traceId}`;
+    // eslint-disable-next-line camelcase, no-undef
+    window.location.href = `${__webpack_public_path__}traces/${traceId}`;
   };
 
   this.after('initialize', function() {

--- a/zipkin-ui/js/component_ui/goToTrace.js
+++ b/zipkin-ui/js/component_ui/goToTrace.js
@@ -1,11 +1,11 @@
 import {component} from 'flightjs';
+import {contextRoot} from '../publicPath';
 
 export default component(function goToTrace() {
   this.navigateToTrace = function(evt) {
     evt.preventDefault();
     const traceId = document.getElementById('traceIdQuery').value;
-    // eslint-disable-next-line camelcase, no-undef
-    window.location.href = `${__webpack_public_path__}traces/${traceId}`;
+    window.location.href = `${contextRoot}traces/${traceId}`;
   };
 
   this.after('initialize', function() {

--- a/zipkin-ui/js/config.js
+++ b/zipkin-ui/js/config.js
@@ -11,7 +11,8 @@ const defaults = {
 };
 
 export default function loadConfig() {
-  return $.ajax('/zipkin/config.json', {
+  // eslint-disable-next-line camelcase, no-undef
+  return $.ajax(`${__webpack_public_path__}config.json`, {
     type: 'GET',
     dataType: 'json'
   }).then(data => function config(key) {

--- a/zipkin-ui/js/config.js
+++ b/zipkin-ui/js/config.js
@@ -1,4 +1,3 @@
-import {contextRoot} from './publicPath';
 import $ from 'jquery';
 
 const defaults = {
@@ -12,7 +11,7 @@ const defaults = {
 };
 
 export default function loadConfig() {
-  return $.ajax(`${contextRoot}config.json`, {
+  return $.ajax('config.json', {
     type: 'GET',
     dataType: 'json'
   }).then(data => function config(key) {

--- a/zipkin-ui/js/config.js
+++ b/zipkin-ui/js/config.js
@@ -1,3 +1,4 @@
+import {contextRoot} from './publicPath';
 import $ from 'jquery';
 
 const defaults = {
@@ -11,8 +12,7 @@ const defaults = {
 };
 
 export default function loadConfig() {
-  // eslint-disable-next-line camelcase, no-undef
-  return $.ajax(`${__webpack_public_path__}config.json`, {
+  return $.ajax(`${contextRoot}config.json`, {
     type: 'GET',
     dataType: 'json'
   }).then(data => function config(key) {

--- a/zipkin-ui/js/main.js
+++ b/zipkin-ui/js/main.js
@@ -1,3 +1,8 @@
+// read the public path from the <base> tag where it has to be set anyway because of
+// html-webpack-plugin limitations: https://github.com/jantimon/html-webpack-plugin/issues/119
+// otherwise it could be: window.location.pathname.replace(/(.*)\/zipkin\/.*/, '$1/zipkin/')
+__webpack_public_path__ = $('base').attr('href'); // eslint-disable-line camelcase, no-undef
+
 import {compose, registry, advice, debug} from 'flightjs';
 import crossroads from 'crossroads';
 import initializeDefault from './page/default';
@@ -13,9 +18,10 @@ loadConfig().then(config => {
 
   CommonUI.attachTo(window.document.body, {config});
 
-  crossroads.addRoute('zipkin/', () => initializeDefault(config));
-  crossroads.addRoute('zipkin/traces/{id}', traceId => initializeTrace(traceId, config));
-  crossroads.addRoute('zipkin/dependency', () => initializeDependency(config));
+  const root = __webpack_public_path__; // eslint-disable-line camelcase, no-undef
+  crossroads.addRoute(root, () => initializeDefault(config));
+  crossroads.addRoute(`${root}traces/{id}`, traceId => initializeTrace(traceId, config));
+  crossroads.addRoute(`${root}dependency`, () => initializeDependency(config));
   crossroads.parse(window.location.pathname);
 }, e => {
   // TODO: better error message, but this is better than a blank screen...

--- a/zipkin-ui/js/main.js
+++ b/zipkin-ui/js/main.js
@@ -1,7 +1,8 @@
-// read the public path from the <base> tag where it has to be set anyway because of
-// html-webpack-plugin limitations: https://github.com/jantimon/html-webpack-plugin/issues/119
-// otherwise it could be: window.location.pathname.replace(/(.*)\/zipkin\/.*/, '$1/zipkin/')
-__webpack_public_path__ = $('base').attr('href'); // eslint-disable-line camelcase, no-undef
+// The import of 'publicPath' module has to be the first statement in this entry point file
+// so that '__webpack_public_path__' (see https://webpack.github.io/docs/configuration.html#output-publicpath)
+// is set soon enough.
+// In the same time, 'contextRoot' is made available as the context root path reference.
+import {contextRoot} from './publicPath';
 
 import {compose, registry, advice, debug} from 'flightjs';
 import crossroads from 'crossroads';
@@ -18,10 +19,9 @@ loadConfig().then(config => {
 
   CommonUI.attachTo(window.document.body, {config});
 
-  const root = __webpack_public_path__; // eslint-disable-line camelcase, no-undef
-  crossroads.addRoute(root, () => initializeDefault(config));
-  crossroads.addRoute(`${root}traces/{id}`, traceId => initializeTrace(traceId, config));
-  crossroads.addRoute(`${root}dependency`, () => initializeDependency(config));
+  crossroads.addRoute(contextRoot, () => initializeDefault(config));
+  crossroads.addRoute(`${contextRoot}traces/{id}`, traceId => initializeTrace(traceId, config));
+  crossroads.addRoute(`${contextRoot}dependency`, () => initializeDependency(config));
   crossroads.parse(window.location.pathname);
 }, e => {
   // TODO: better error message, but this is better than a blank screen...

--- a/zipkin-ui/js/page/common.js
+++ b/zipkin-ui/js/page/common.js
@@ -7,7 +7,8 @@ import GoToTraceUI from '../component_ui/goToTrace';
 
 export default component(function CommonUI() {
   this.after('initialize', function() {
-    this.$node.html(layoutTemplate());
+    // eslint-disable-next-line camelcase, no-undef
+    this.$node.html(layoutTemplate({contextRoot: __webpack_public_path__}));
     NavbarUI.attachTo('#navbar');
     ErrorUI.attachTo('#errorPanel');
     EnvironmentUI.attachTo('#environment', {config: this.attr.config});

--- a/zipkin-ui/js/page/common.js
+++ b/zipkin-ui/js/page/common.js
@@ -4,11 +4,11 @@ import ErrorUI from '../component_ui/error';
 import NavbarUI from '../component_ui/navbar';
 import {layoutTemplate} from '../templates';
 import GoToTraceUI from '../component_ui/goToTrace';
+import {contextRoot} from '../publicPath';
 
 export default component(function CommonUI() {
   this.after('initialize', function() {
-    // eslint-disable-next-line camelcase, no-undef
-    this.$node.html(layoutTemplate({contextRoot: __webpack_public_path__}));
+    this.$node.html(layoutTemplate({contextRoot}));
     NavbarUI.attachTo('#navbar');
     ErrorUI.attachTo('#errorPanel');
     EnvironmentUI.attachTo('#environment', {config: this.attr.config});

--- a/zipkin-ui/js/page/default.js
+++ b/zipkin-ui/js/page/default.js
@@ -58,6 +58,7 @@ const DefaultPageComponent = component(function DefaultPage() {
         serviceName,
         annotationQuery,
         queryWasPerformed,
+        contextRoot: __webpack_public_path__, // eslint-disable-line no-undef
         count: modelView.traces.length,
         sortOrderOptions: sortOptions,
         sortOrderSelected: sortSelected(sortOrder),

--- a/zipkin-ui/js/page/default.js
+++ b/zipkin-ui/js/page/default.js
@@ -15,6 +15,7 @@ import TracesUI from '../component_ui/traces';
 import TimeStampUI from '../component_ui/timeStamp';
 import BackToTop from '../component_ui/backToTop';
 import {defaultTemplate} from '../templates';
+import {contextRoot} from '../publicPath';
 
 const DefaultPageComponent = component(function DefaultPage() {
   const sortOptions = [
@@ -58,7 +59,7 @@ const DefaultPageComponent = component(function DefaultPage() {
         serviceName,
         annotationQuery,
         queryWasPerformed,
-        contextRoot: __webpack_public_path__, // eslint-disable-line no-undef
+        contextRoot,
         count: modelView.traces.length,
         sortOrderOptions: sortOptions,
         sortOrderSelected: sortSelected(sortOrder),

--- a/zipkin-ui/js/page/trace.js
+++ b/zipkin-ui/js/page/trace.js
@@ -20,7 +20,10 @@ const TracePageComponent = component(function TracePage() {
       logsUrl: this.attr.config('logsUrl')
     });
     this.on(document, 'tracePageModelView', function(ev, data) {
-      this.$node.html(traceTemplate(data.modelview));
+      this.$node.html(traceTemplate({
+        contextRoot: __webpack_public_path__, // eslint-disable-line no-undef
+        ...data.modelview
+      }));
 
       FilterAllServicesUI.attachTo('#filterAllServices', {
         totalServices: $('.trace-details.services span').length
@@ -35,9 +38,12 @@ const TracePageComponent = component(function TracePage() {
 
       this.$node.find('#traceJsonLink').click(e => {
         e.preventDefault();
-        this.trigger('uiRequestJsonPanel', {title: `Trace ${this.attr.traceId}`,
-                                            obj: data.trace,
-                                            link: `/api/v1/trace/${this.attr.traceId}`});
+        this.trigger('uiRequestJsonPanel', {
+          title: `Trace ${this.attr.traceId}`,
+          obj: data.trace,
+          // eslint-disable-next-line camelcase, no-undef
+          link: `${__webpack_public_path__}api/v1/trace/${this.attr.traceId}`
+        });
       });
 
       $('.annotation:not(.core)').tooltip({placement: 'left'});

--- a/zipkin-ui/js/page/trace.js
+++ b/zipkin-ui/js/page/trace.js
@@ -10,6 +10,7 @@ import TraceUI from '../component_ui/trace';
 import FilterLabelUI from '../component_ui/filterLabel';
 import ZoomOut from '../component_ui/zoomOutSpans';
 import {traceTemplate} from '../templates';
+import {contextRoot} from '../publicPath';
 
 const TracePageComponent = component(function TracePage() {
   this.after('initialize', function() {
@@ -21,7 +22,7 @@ const TracePageComponent = component(function TracePage() {
     });
     this.on(document, 'tracePageModelView', function(ev, data) {
       this.$node.html(traceTemplate({
-        contextRoot: __webpack_public_path__, // eslint-disable-line no-undef
+        contextRoot,
         ...data.modelview
       }));
 
@@ -41,8 +42,7 @@ const TracePageComponent = component(function TracePage() {
         this.trigger('uiRequestJsonPanel', {
           title: `Trace ${this.attr.traceId}`,
           obj: data.trace,
-          // eslint-disable-next-line camelcase, no-undef
-          link: `${__webpack_public_path__}api/v1/trace/${this.attr.traceId}`
+          link: `${contextRoot}api/v1/trace/${this.attr.traceId}`
         });
       });
 

--- a/zipkin-ui/js/publicPath.js
+++ b/zipkin-ui/js/publicPath.js
@@ -3,7 +3,8 @@ import $ from 'jquery';
 // read the public path from the <base> tag where it has to be set anyway because of
 // html-webpack-plugin limitations: https://github.com/jantimon/html-webpack-plugin/issues/119
 // otherwise it could be: window.location.pathname.replace(/(.*)\/zipkin\/.*/, '$1/zipkin/')
-const contextRoot = $('base').attr('href');
+let contextRoot = $('base').attr('href') || '/zipkin/';
+contextRoot += contextRoot.endsWith('/') ? '' : '/';
 
 // set dynamically 'output.publicPath' as per https://webpack.github.io/docs/configuration.html#output-publicpath
 __webpack_public_path__ = contextRoot; // eslint-disable-line camelcase, no-undef

--- a/zipkin-ui/js/publicPath.js
+++ b/zipkin-ui/js/publicPath.js
@@ -1,0 +1,11 @@
+import $ from 'jquery';
+
+// read the public path from the <base> tag where it has to be set anyway because of
+// html-webpack-plugin limitations: https://github.com/jantimon/html-webpack-plugin/issues/119
+// otherwise it could be: window.location.pathname.replace(/(.*)\/zipkin\/.*/, '$1/zipkin/')
+const contextRoot = $('base').attr('href');
+
+// set dynamically 'output.publicPath' as per https://webpack.github.io/docs/configuration.html#output-publicpath
+__webpack_public_path__ = contextRoot; // eslint-disable-line camelcase, no-undef
+
+export {contextRoot};

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -83,7 +83,7 @@
   <ul id="traces">
   {{#traces}}
     <li class="trace {{infoClass}}" data-traceId="{{traceId}}" data-duration="{{duration}}" data-timestamp="{{timestamp}}" data-service-percentage="{{servicePercentage}}">
-      <a href="/zipkin/traces/{{traceId}}">
+      <a href="{{contextRoot}}traces/{{traceId}}">
         <div class="bar-block">
           <span class="bar-graphic" style="width:{{width}}%;"></span>
           <span class="bar-label">{{durationStr}}</span>

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -1,14 +1,14 @@
     <div id='navbar' class='navbar navbar-inverse' role='navigation'>
       <div class='container'>
         <div class='navbar-header'>
-          <a class='navbar-brand' href='/zipkin/'>
+          <a class='navbar-brand' href='{{contextRoot}}'>
             Zipkin<span class='muted' style='font-size: .75em; padding-left: 10px;'>Investigate system behavior</span>
           </a>
         </div>
         <div class="navbar-left">
           <ul class="nav navbar-nav">
-            <li data-route="index"><a href="/zipkin/">Find a trace</a></li>
-            <li data-route="dependency"><a href="/zipkin/dependency">Dependencies</a></li>
+            <li data-route="index"><a href="{{contextRoot}}">Find a trace</a></li>
+            <li data-route="dependency"><a href="{{contextRoot}}dependency/">Dependencies</a></li>
           </ul>
         </div>
         <div class="navbar-right" style="width: 50%">

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -7,7 +7,7 @@
     {{#logsUrl}}
     <li class='navbar-right'><a href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-primary btn-xs badge'>Logs</span></a></li>
     {{/logsUrl}}
-    <li class='navbar-right'><a href='/api/v1/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
+    <li class='navbar-right'><a href='{{ contextRoot }}api/v1/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
   </ul>
 
   <form class='form-inline' role='form'>

--- a/zipkin-ui/webpack.config.js
+++ b/zipkin-ui/webpack.config.js
@@ -32,8 +32,10 @@ var webpackConfig = {
     },
     output: {
         path: __dirname + '/target/classes/zipkin-ui/',
-        filename: 'app-[hash].min.js',
-        publicPath: '/zipkin/'
+        filename: 'app-[hash].min.js'
+        // 'publicPath' must not be set here in order to support Zipkin running in any context root.
+        // '__webpack_public_path__' has to be set dynamically as per
+        // https://webpack.github.io/docs/configuration.html#output-publicpath
     },
     devtool: 'source-map',
     plugins: [
@@ -42,7 +44,9 @@ var webpackConfig = {
             jQuery: "jquery"
         }),
         new ExtractTextPlugin("app-[hash].min.css", {allChunks: true}),
-        new HtmlWebpackPlugin(),
+        new HtmlWebpackPlugin({
+          template: __dirname + '/index.ejs'
+        }),
         new CopyWebpackPlugin([
             { from: 'static' }
         ])

--- a/zipkin-ui/webpack.config.js
+++ b/zipkin-ui/webpack.config.js
@@ -3,6 +3,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 
+var isDevServer = process.argv.find(v => v.includes('webpack-dev-server'));
 var proxyURL = process.env.proxy || "http://localhost:8080/";
 console.log("API requests are forwarded to " + proxyURL);
 
@@ -45,7 +46,8 @@ var webpackConfig = {
         }),
         new ExtractTextPlugin("app-[hash].min.css", {allChunks: true}),
         new HtmlWebpackPlugin({
-          template: __dirname + '/index.ejs'
+          template: __dirname + '/index.ejs',
+          contextRoot: isDevServer ? '/' : '/zipkin/'
         }),
         new CopyWebpackPlugin([
             { from: 'static' }

--- a/zipkin-ui/webpack.config.js
+++ b/zipkin-ui/webpack.config.js
@@ -34,7 +34,7 @@ var webpackConfig = {
         path: __dirname + '/target/classes/zipkin-ui/',
         filename: 'app-[hash].min.js'
         // 'publicPath' must not be set here in order to support Zipkin running in any context root.
-        // '__webpack_public_path__' has to be set dynamically as per
+        // '__webpack_public_path__' has to be set dynamically (see './publicPath.js' module file) as per
         // https://webpack.github.io/docs/configuration.html#output-publicpath
     },
     devtool: 'source-map',


### PR DESCRIPTION
 - subfolder 'zipkin' is enforced
 - rewrite of the 'base' tag in the 'index.html' file is required

This implements the #1731 