### PR TITLE
Leniently coerses Endpoint.Builder.port(-1) to null

### DIFF
--- a/zipkin2/src/main/java/zipkin2/Endpoint.java
+++ b/zipkin2/src/main/java/zipkin2/Endpoint.java
@@ -177,8 +177,8 @@ public abstract class Endpoint implements Serializable { // for Spark jobs
       }
       Integer port = port();
       if (port != null) {
-        if (port < 0 || port > 0xffff) throw new IllegalArgumentException("invalid port " + port);
-        if (port == 0) port(null);
+        if (port > 0xffff) throw new IllegalArgumentException("invalid port " + port);
+        if (port <= 0) port(null);
       }
       return autoBuild();
     }

--- a/zipkin2/src/test/java/zipkin2/EndpointTest.java
+++ b/zipkin2/src/test/java/zipkin2/EndpointTest.java
@@ -30,6 +30,12 @@ public class EndpointTest {
       .isNull();
   }
 
+  /** Many getPort operations return -1 by default. Leniently coerse to null. */
+  @Test public void newBuilderWithPort_NegativeCoercesToNull() {
+    assertThat(Endpoint.newBuilder().port(-1).build().port())
+      .isNull();
+  }
+
   @Test public void newBuilderWithPort_0CoercesToNull() {
     assertThat(Endpoint.newBuilder().port(0).build().port())
       .isNull();
@@ -173,11 +179,11 @@ public class EndpointTest {
   }
 
   /** The integer arg of port should be a whole number */
-  @Test public void newBuilderWithPort_negativeIsInvalid() {
+  @Test public void newBuilderWithPort_tooLargeIsInvalid() {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("invalid port -1");
+    thrown.expectMessage("invalid port 65536");
 
-    assertThat(Endpoint.newBuilder().port(-1).build().port()).isNull();
+    assertThat(Endpoint.newBuilder().port(65536).build().port()).isNull();
   }
 
   /** The integer arg of port should fit in a 16bit unsigned value */


### PR DESCRIPTION
Many getPort operations return -1 by default. Leniently coerse to null.