### PR TITLE
Ensures each span has a service name unless there was none

### DIFF
--- a/zipkin-ui/js/component_ui/traceSummary.js
+++ b/zipkin-ui/js/component_ui/traceSummary.js
@@ -97,13 +97,15 @@ export function getServiceName(span) {
     return brokerAddressServiceName;
   }
 
-  // Finally is the label of the local component's endpoint
+  // Then is the label of the local component's endpoint
   const localServiceName = findServiceNameForBinaryAnnotation(span, Constants.LOCAL_COMPONENT);
   if (localServiceName) {
     return localServiceName;
   }
 
-  return null;
+  // Finally, anything so that the service name isn't blank!
+  const allServiceNames = getServiceNames(span);
+  return allServiceNames.length === 0 ? null : allServiceNames[0];
 }
 
 function getSpanTimestamps(spans) {

--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -175,6 +175,23 @@ describe('get service name of a span', () => {
     };
     getServiceName(testSpan).should.equal('localservice');
   });
+
+  it('should get service name from any binary annotation', () => {
+    const testSpan = {
+      binaryAnnotations: [{
+        key: 'user',
+        value: 'grpc-client-example',
+        endpoint: {
+          serviceName: 'echecklist-localdev'
+        }
+      }]
+    };
+    getServiceName(testSpan).should.equal('echecklist-localdev');
+  });
+
+  it('should handle no annotations', () => {
+    expect(getServiceName({})).to.equal(null);
+  });
 });
 
 describe('getTraceErrorType', () => {


### PR DESCRIPTION
Before, we only displayed "prioritized names", like the service name
of the "lc" binary annotation. This allows non-standard spans to also
display the service name.