### PR TITLE
Logs trace ID before processing dependency links

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -47,7 +47,7 @@ By default, zipkin writes log messages to the console at INFO level and above. Y
 For example, if you want to enable debug logging for all zipkin categories, you can start the server like so:
 
 ```bash
-$ java -jar zipkin.jar --logging.level.zipkin=DEBUG
+$ java -jar zipkin.jar --logging.level.zipkin=DEBUG --logging.level.zipkin2=DEBUG
 ```
 
 Under the covers, the server uses [Spring Boot - Logback integration](http://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-configure-logback-for-logging). For example, you can add `--logging.exception-conversion-word=%wEx{full}` to dump full stack traces instead of truncated ones.

--- a/zipkin2/src/test/java/zipkin2/internal/DependencyLinkerTest.java
+++ b/zipkin2/src/test/java/zipkin2/internal/DependencyLinkerTest.java
@@ -63,6 +63,15 @@ public class DependencyLinkerTest {
     );
   }
 
+  /** In case of a late error, we should know which trace ID is being processed */
+  @Test
+  public void logsTraceId() {
+    new DependencyLinker(logger).putTrace(TRACE.iterator());
+
+    assertThat(messages)
+      .contains("linking trace 000000000000000a");
+  }
+
   @Test
   public void dropsSelfReferencingSpans() {
     List<Span> trace = TRACE.stream()


### PR DESCRIPTION
This is to help solve

```
17/09/19 08:56:21 DEBUG DependencyLinker: deferring link to rpc child span
17/09/19 08:56:21 DEBUG DependencyLinker: processing {"traceId":"286e50766f8acb1f","parentId":"c550575b4836f968","id":"42bae4ccfc548848","name":"http:/oauth/token","timestamp":1505796330986000,"duration":20,"localEndpoint":{"serviceName":"authorizationserver","ipv4":"172.16.124.51","port":8080},"tags":{"lc":"unknown"}}
17/09/19 08:56:21 DEBUG DependencyLinker: non-rpc span; skipping
17/09/19 08:56:21 DEBUG DependencyLinker: skipping circular dependency: traceId=500bab7eaccc2345, spanId=500bab7eaccc2345
17/09/19 08:56:21 DEBUG DependencyLinker: skipping circular dependency: traceId=500bab7eaccc2345, spanId=500bab7eaccc2345
17/09/19 08:56:21 DEBUG DependencyLinker: skipping circular dependency: traceId=500bab7eaccc2345, spanId=500bab7eaccc2345
17/09/19 08:56:21 DEBUG DependencyLinker: traversing trace tree, breadth-first
17/09/19 08:56:21 DEBUG DependencyLinker: processing null
17/09/19 08:56:21 ERROR Executor: Exception in task 0.0 in stage 1.0 (TID 12)
java.lang.NullPointerException
```

thanks to @doernbrackandre for the help