### PR TITLE
Backfills tests of late or lost parent ID

### DIFF
--- a/zipkin-lens/src/zipkin/span-cleaner.test.js
+++ b/zipkin-lens/src/zipkin/span-cleaner.test.js
@@ -382,9 +382,8 @@ describe('mergeV2ById', () => {
   });
 
   /*
-   * Some don't propagate the server's parent ID which creates a race condition. Try to unwind it.
-   *
-   * See https://github.com/openzipkin/zipkin/pull/1745
+   * This test shows that if a parent ID is stored late (ex because it wasn't propagated), it can be
+   * backfilled during cleanup.
    */
   it('should backfill missing parent id on shared span', () => {
     const spans = mergeV2ById([


### PR DESCRIPTION
This starts to investigate impact of a missing or late parentId in a shared span. This could happen if a client doesn't propagate the `X-B3-ParentId` by mistake or by some signal loss.

cc @jcarres-mdsol @bogdandrutu @basvanbeek 