### PR TITLE
Keep a separate stress schema cql file, as stress can't use use UDTs

### DIFF
--- a/zipkin-storage/cassandra3/src/test/resources/cassandra3-test-schema.cql
+++ b/zipkin-storage/cassandra3/src/test/resources/cassandra3-test-schema.cql
@@ -1,0 +1,60 @@
+CREATE KEYSPACE IF NOT EXISTS stress_zipkin3 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
+
+//-- same schema but remove all UDTs (as cassandra-stress doesn't support them)
+
+CREATE TABLE IF NOT EXISTS stress_zipkin3.traces (
+    trace_id            bigint,
+    ts_uuid             timeuuid,
+    id                  bigint,
+    ts                  bigint,
+    span_name           text,
+    parent_id           bigint,
+    duration            bigint,
+    all_annotations     text, //-- can't do SASI on set<text>: comma-joined until CASSANDRA-11182
+    PRIMARY KEY (trace_id, ts_uuid, id)
+)
+    WITH CLUSTERING ORDER BY (ts_uuid DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND default_time_to_live =  604800;
+
+
+CREATE TABLE IF NOT EXISTS stress_zipkin3.trace_by_service_span (
+    service_name  text,             //-- service name
+    span_name     text,             //-- span name, or blank for queries without span name
+    bucket        int,              //-- time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1 day.
+    ts            timeuuid,         //-- start timestamp of the span, truncated to millisecond precision
+    trace_id      bigint,           //-- trace ID
+    duration      bigint,           //-- span duration, in microseconds
+    PRIMARY KEY ((service_name, span_name, bucket), ts)
+)
+   WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND default_time_to_live =  259200;
+
+CREATE TABLE IF NOT EXISTS stress_zipkin3.span_name_by_service (
+    service_name text,
+    span_name    text,
+    PRIMARY KEY (service_name, span_name)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND default_time_to_live =  259200;
+
+CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin3.traces (all_annotations) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {
+    'mode': 'CONTAINS',
+    'analyzed': 'true',
+    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.NonTokenizingAnalyzer',
+    'case_sensitive': 'false'
+   };
+
+CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin3.trace_by_service_span (duration) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {'mode': 'PREFIX'};
+
+
+CREATE TABLE IF NOT EXISTS stress_zipkin3.dependencies (
+    day          timestamp,
+    links        blob,
+    PRIMARY KEY (day)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND default_time_to_live =  259200;

--- a/zipkin-storage/cassandra3/src/test/resources/span_name_by_service-stress.yaml
+++ b/zipkin-storage/cassandra3/src/test/resources/span_name_by_service-stress.yaml
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 The OpenZipkin Authors
+#    Copyright 2015-2017 The OpenZipkin Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #    in compliance with the License. You may obtain a copy of the License at
@@ -11,18 +11,19 @@
 #    the License.
 #
 ###
-### Stress test for zipkin3 service_span_name_index table
+### Stress test for stress_zipkin3.service_span_name_index table
 ###
 ### Stress testing is done using the `cassandra-stress` tool
 ###
 ### For example
-###  cassandra-stress  user profile=span_name_by_service-stress.yaml ops\(insert=1\)  duration=1m  -rate threads=4 throttle=50/s
+###  cqlsh -f cassandra3-test-schema.cql
+###  cassandra-stress  user profile=span_name_by_service-stress.yaml ops\(insert=1\) no-warmup duration=1m  -rate threads=4 throttle=50/s
 ###
 ### after a benchmark has been run with only writes, a mixed read-write benchmark can be run with
 ###  cassandra-stress  user profile=span_name_by_service-stress.yaml ops\(insert=1,select=1,select_span_names=1\)  duration=1m  -rate threads=4 throttle=50/s
 
 # Keyspace Name
-keyspace: zipkin3
+keyspace: stress_zipkin3
 
 # Table name
 table: span_name_by_service

--- a/zipkin-storage/cassandra3/src/test/resources/trace-stress.yaml
+++ b/zipkin-storage/cassandra3/src/test/resources/trace-stress.yaml
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 The OpenZipkin Authors
+#    Copyright 2015-2017 The OpenZipkin Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #    in compliance with the License. You may obtain a copy of the License at
@@ -10,18 +10,19 @@
 #    or implied. See the License for the specific language governing permissions and limitations under
 #    the License.
 #
-### Stress test for zipkin3 traces table
+### Stress test for stress_zipkin3.traces table
 ###
 ### Stress testing is done using the `cassandra-stress` tool
 ###
 ### For example
-###  cassandra-stress  user profile=trace-stress.yaml ops\(insert=1\)  duration=1m  -rate threads=4 throttle=50/s
+###  cqlsh -f cassandra3-test-schema.cql
+###  cassandra-stress  user profile=trace-stress.yaml ops\(insert=1\) no-warmup duration=1m  -rate threads=4 throttle=50/s
 ###
 ### after a benchmark has been run with only writes, a mixed read-write benchmark can be run with
 ###  cassandra-stress  user profile=trace-stress.yaml ops\(insert=1,by_trace=1,by_trace_ts_id=1,by_annotation=1\)  duration=1m  -rate threads=4 throttle=50/s
 
 # Keyspace Name
-keyspace: zipkin3
+keyspace: stress_zipkin3
 
 # Table name
 table: traces
@@ -29,7 +30,6 @@ table: traces
 
 ### Column Distribution Specifications ###
 #
-# the UDT columns must be dropped before running stress
 
 columnspec:
   - name: trace_id

--- a/zipkin-storage/cassandra3/src/test/resources/trace_by_service_span-stress.yaml
+++ b/zipkin-storage/cassandra3/src/test/resources/trace_by_service_span-stress.yaml
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 The OpenZipkin Authors
+#    Copyright 2015-2017 The OpenZipkin Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #    in compliance with the License. You may obtain a copy of the License at
@@ -11,18 +11,19 @@
 #    the License.
 #
 ###
-### Stress test for zipkin3 service_span_name_index table
+### Stress test for stress_zipkin3.service_span_name_index table
 ###
 ### Stress testing is done using the `cassandra-stress` tool
 ###
 ### For example
-###  cassandra-stress  user profile=trace_by_service_span-stress.yaml ops\(insert=1\)  duration=1m  -rate threads=4 throttle=50/s
+###  cqlsh -f cassandra3-test-schema.cql
+###  cassandra-stress  user profile=trace_by_service_span-stress.yaml ops\(insert=1\) no-warmup duration=1m  -rate threads=4 throttle=50/s
 ###
 ### after a benchmark has been run with only writes, a mixed read-write benchmark can be run with
 ###  cassandra-stress  user profile=trace_by_service_span-stress.yaml ops\(insert=1,select=1,by_duration=1\)  duration=1m  -rate threads=4 throttle=50/s
 
 # Keyspace Name
-keyspace: zipkin3
+keyspace: stress_zipkin3
 
 # Table name
 table: trace_by_service_span


### PR DESCRIPTION
For safety, create the stress schema in a different keyspace.