### PR TITLE
In Cassandra3 storage, only use consistency level LOCAL_ONE if a local_dc has been defined, otherwise use ONE

### DIFF
--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/CassandraSpanStore.java
@@ -97,7 +97,6 @@ final class CassandraSpanStore implements GuavaSpanStore {
   private final Function<Row, String> rowToServiceName;
   private final Function<Row, Span> rowToSpan;
   private final Function<List<Map<TraceIdUDT, Long>>, Map<TraceIdUDT, Long>> collapseTraceIdMaps;
-  private final int traceTtl;
   private final int indexTtl;
 
   CassandraSpanStore(Session session, int maxTraceCols, int indexFetchMultiplier,
@@ -212,7 +211,6 @@ final class CassandraSpanStore implements GuavaSpanStore {
     };
 
     KeyspaceMetadata md = Schema.getKeyspaceMetadata(session);
-    this.traceTtl = md.getTable(TABLE_TRACES).getOptions().getDefaultTimeToLive();
     this.indexTtl = md.getTable(TABLE_TRACE_BY_SERVICE_SPAN).getOptions().getDefaultTimeToLive();
   }
 

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
@@ -127,10 +127,10 @@ final class DefaultSessionFactory implements Cassandra3Storage.SessionFactory {
     ));
 
     builder.withQueryOptions(
-                new QueryOptions()
-                        .setConsistencyLevel(
-                                null != cassandra.localDc ? ConsistencyLevel.LOCAL_ONE : ConsistencyLevel.ONE)
-                        .setDefaultIdempotence(true));
+      new QueryOptions()
+        .setConsistencyLevel(
+          null != cassandra.localDc ? ConsistencyLevel.LOCAL_ONE : ConsistencyLevel.ONE)
+        .setDefaultIdempotence(true));
 
     if (cassandra.useSsl) {
       builder = builder.withSSL();

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
@@ -128,8 +128,10 @@ final class DefaultSessionFactory implements Cassandra3Storage.SessionFactory {
 
     builder.withQueryOptions(
       new QueryOptions()
+        // if local_dc isn't defined LOCAL_ONE incorrectly sticks to first seed host that connects
         .setConsistencyLevel(
           null != cassandra.localDc ? ConsistencyLevel.LOCAL_ONE : ConsistencyLevel.ONE)
+        // all zipkin cql writes are idempotent
         .setDefaultIdempotence(true));
 
     if (cassandra.useSsl) {

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/DefaultSessionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,10 +14,12 @@
 package zipkin.storage.cassandra3;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.QueryLogger;
+import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
@@ -123,6 +125,13 @@ final class DefaultSessionFactory implements Cassandra3Storage.SessionFactory {
     builder.withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(
         HostDistance.LOCAL, cassandra.maxConnections
     ));
+
+    builder.withQueryOptions(
+                new QueryOptions()
+                        .setConsistencyLevel(
+                                null != cassandra.localDc ? ConsistencyLevel.LOCAL_ONE : ConsistencyLevel.ONE)
+                        .setDefaultIdempotence(true));
+
     if (cassandra.useSsl) {
       builder = builder.withSSL();
     }

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/ZipkinRetryPolicy.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/ZipkinRetryPolicy.java
@@ -14,6 +14,7 @@
 
 package zipkin.storage.cassandra3;
 
+import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.WriteType;
@@ -67,7 +68,7 @@ final class ZipkinRetryPolicy implements RetryPolicy {
   }
 
   @Override
-  public void init(com.datastax.driver.core.Cluster cluster) {
+  public void init(Cluster cluster) {
   }
 
   @Override

--- a/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/ZipkinRetryPolicy.java
+++ b/zipkin-storage/cassandra3/src/main/java/zipkin/storage/cassandra3/ZipkinRetryPolicy.java
@@ -29,54 +29,48 @@ final class ZipkinRetryPolicy implements RetryPolicy {
   private ZipkinRetryPolicy() {
   }
 
-    @Override
-    public RetryDecision onReadTimeout(
-        Statement stmt,
-        ConsistencyLevel cl,
-        int required,
-        int received,
-        boolean retrieved,
-        int retry) {
+  @Override
+  public RetryDecision onReadTimeout(Statement stmt, ConsistencyLevel cl, int required,
+    int received, boolean retrieved, int retry) {
 
-      if (retry > 1) {
-        try {
-          Thread.sleep(100);
-        } catch (InterruptedException expected) { }
+    if (retry > 1) {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException expected) {
       }
-      return stmt.isIdempotent()
-          ? retry < 10 ? RetryDecision.retry(cl) : RetryDecision.rethrow()
-          : DefaultRetryPolicy.INSTANCE.onReadTimeout(stmt, cl, required, received, retrieved, retry);
     }
+    return stmt.isIdempotent()
+      ? retry < 10 ? RetryDecision.retry(cl) : RetryDecision.rethrow()
+      : DefaultRetryPolicy.INSTANCE.onReadTimeout(stmt, cl, required, received, retrieved, retry);
+  }
 
-    @Override
-    public RetryDecision onWriteTimeout(
-        Statement stmt,
-        ConsistencyLevel cl,
-        WriteType type,
-        int required,
-        int received,
-        int retry) {
+  @Override
+  public RetryDecision onWriteTimeout(Statement stmt, ConsistencyLevel cl, WriteType type,
+    int required, int received, int retry) {
 
-      return stmt.isIdempotent()
-          ? RetryDecision.retry(cl)
-          : DefaultRetryPolicy.INSTANCE.onWriteTimeout(stmt, cl, type, required, received, retry);
-    }
+    return stmt.isIdempotent()
+      ? RetryDecision.retry(cl)
+      : DefaultRetryPolicy.INSTANCE.onWriteTimeout(stmt, cl, type, required, received, retry);
+  }
 
-    @Override
-    public RetryDecision onUnavailable(Statement stmt, ConsistencyLevel cl, int required, int aliveReplica, int retry) {
-      return DefaultRetryPolicy.INSTANCE.onUnavailable(stmt, cl, required, aliveReplica, retry == 1 ? 0 : retry);
-    }
+  @Override
+  public RetryDecision onUnavailable(Statement stmt, ConsistencyLevel cl, int required,
+    int aliveReplica, int retry) {
+    return DefaultRetryPolicy.INSTANCE.onUnavailable(stmt, cl, required, aliveReplica,
+      retry == 1 ? 0 : retry);
+  }
 
-    @Override
-    public RetryDecision onRequestError(Statement stmt, ConsistencyLevel cl, DriverException ex, int nbRetry) {
-      return DefaultRetryPolicy.INSTANCE.onRequestError(stmt, cl, ex, nbRetry);
-    }
+  @Override
+  public RetryDecision onRequestError(Statement stmt, ConsistencyLevel cl, DriverException ex,
+    int nbRetry) {
+    return DefaultRetryPolicy.INSTANCE.onRequestError(stmt, cl, ex, nbRetry);
+  }
 
-    @Override
-    public void init(com.datastax.driver.core.Cluster cluster) {
-    }
+  @Override
+  public void init(com.datastax.driver.core.Cluster cluster) {
+  }
 
-    @Override
-    public void close() {
-    }
+  @Override
+  public void close() {
+  }
 }


### PR DESCRIPTION
Also…

 - Mark all writes as idempotent.
 - Update the retry policy, honouring idempotence, consistency level, and applying appropriate back-pressure.