### PR TITLE
Allows STORAGE_TYPE to be empty (defaulting to mem)

### DIFF
--- a/zipkin-server/src/it/minimal-dependencies/src/test/java/zipkin/minimal/ZipkinServerTest.java
+++ b/zipkin-server/src/it/minimal-dependencies/src/test/java/zipkin/minimal/ZipkinServerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 The OpenZipkin Authors
+ * Copyright 2015-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -43,7 +43,7 @@ import static zipkin.Constants.SERVER_RECV;
 @SpringBootTest(classes = ZipkinServer.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@TestPropertySource(properties = {"zipkin.storage.type=mem", "zipkin.collector.scribe.enabled=false", "spring.config.name=zipkin-server"})
+@TestPropertySource(properties = "spring.config.name=zipkin-server")
 public class ZipkinServerTest {
 
   @Autowired

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerCORSTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerCORSTest.java
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = ZipkinServer.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@TestPropertySource(properties = {"zipkin.storage.type=mem", "spring.config.name=zipkin-server", "zipkin.query.allowed-origins=foo.example.com"})
+@TestPropertySource(properties = {"spring.config.name=zipkin-server", "zipkin.query.allowed-origins=foo.example.com"})
 public class ZipkinServerCORSTest {
 
   @Autowired

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerHttpCollectorDisabledTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerHttpCollectorDisabledTest.java
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * associated assets 404 instead of allowing creation of spans.
  */
 @SpringBootTest(classes = ZipkinServer.class, properties = {
-  "zipkin.storage.type=mem",
+  "zipkin.storage.type=", // cheat and test empty storage type
   "spring.config.name=zipkin-server",
   "zipkin.collector.http.enabled=false"
 })

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
@@ -61,7 +61,7 @@ import static zipkin.internal.Util.UTF_8;
   webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @RunWith(SpringJUnit4ClassRunner.class)
-@TestPropertySource(properties = {"zipkin.store.type=mem", "spring.config.name=zipkin-server"})
+@TestPropertySource(properties = "spring.config.name=zipkin-server")
 public class ZipkinServerIntegrationTest {
 
   @Autowired

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerQueryDisabledTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerQueryDisabledTest.java
@@ -32,7 +32,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * associated assets 404 vs throw exceptions.
  */
 @SpringBootTest(classes = ZipkinServer.class, properties = {
-    "zipkin.storage.type=mem",
     "spring.config.name=zipkin-server",
     "zipkin.query.enabled=false",
     "zipkin.ui.enabled=false"

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerSelfTracingTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerSelfTracingTest.java
@@ -26,7 +26,6 @@ import zipkin.storage.StorageComponent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = ZipkinServer.class, properties = {
-    "zipkin.storage.type=mem",
     "spring.config.name=zipkin-server",
     "zipkin.self-tracing.enabled=true"
 })


### PR DESCRIPTION
Before, not setting STORAGE_TYPE implied in-memory, but empty string
did not. Now, STORAGE_TYPE empty is the same as in-memory.

Fixes #1601