### PR TITLE
Allows kafka overrides via properties

### DIFF
--- a/zipkin-collector/kafka/src/main/java/zipkin/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin/collector/kafka/KafkaCollector.java
@@ -116,7 +116,7 @@ public final class KafkaCollector implements CollectorComponent {
      *
      * @see org.apache.kafka.clients.consumer.ConsumerConfig
      */
-    public final Builder overrides(Map<String, String> overrides) {
+    public final Builder overrides(Map<String, ?> overrides) {
       properties.putAll(checkNotNull(overrides, "overrides"));
       return this;
     }

--- a/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollector.java
+++ b/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollector.java
@@ -117,7 +117,7 @@ public final class KafkaCollector implements CollectorComponent {
      *
      * @see org.apache.kafka.clients.consumer.ConsumerConfig
      */
-    public final Builder overrides(Map<String, String> overrides) {
+    public final Builder overrides(Map<String, ?> overrides) {
       properties.putAll(checkNotNull(overrides, "overrides"));
       return this;
     }


### PR DESCRIPTION
Before, you couldn't override with a Properties object, which is commonly used in Kafka