### PR TITLE
Bounds the amount of data dumped to the WARN category

### DIFF
--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
@@ -143,7 +143,7 @@ public class ZipkinServerIntegrationTest {
     byte[] body = {'h', 'e', 'l', 'l', 'o'};
     performAsync(post("/api/v1/spans").content(body))
         .andExpect(status().isBadRequest())
-        .andExpect(content().string(startsWith("Malformed reading List<Span> from json: hello")));
+        .andExpect(content().string(startsWith("Malformed reading List<Span> from json")));
   }
 
   @Test

--- a/zipkin/src/main/java/zipkin/internal/Collector.java
+++ b/zipkin/src/main/java/zipkin/internal/Collector.java
@@ -43,8 +43,8 @@ public abstract class Collector<D, S> {
 
   protected abstract String idString(S span);
 
-  void warn(String message, Throwable e) {
-    logger.log(WARNING, message, e);
+  void warn(String message) {
+    logger.log(WARNING, message);
   }
 
   protected void acceptSpans(byte[] serializedSpans, D decoder, Callback<Void> callback) {
@@ -131,21 +131,25 @@ public abstract class Collector<D, S> {
   RuntimeException doError(String message, Throwable e) {
     String exceptionMessage = e.getMessage() != null ? e.getMessage() : "";
     if (e instanceof RuntimeException && exceptionMessage.startsWith("Malformed")) {
-      warn(exceptionMessage, e);
+      warn(exceptionMessage);
       return (RuntimeException) e;
     } else {
       message = format("%s due to %s(%s)", message, e.getClass().getSimpleName(), exceptionMessage);
-      warn(message, e);
+      warn(message);
       return new RuntimeException(message, e);
     }
   }
 
   StringBuilder appendSpanIds(List<S> spans, StringBuilder message) {
     message.append("[");
-    for (Iterator<S> iterator = spans.iterator(); iterator.hasNext(); ) {
+    int i = 0;
+    Iterator<S> iterator = spans.iterator();
+    while (iterator.hasNext() && i++ < 3) {
       message.append(idString(iterator.next()));
       if (iterator.hasNext()) message.append(", ");
     }
+    if (iterator.hasNext()) message.append("...");
+
     return message.append("]");
   }
 }

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -665,7 +665,7 @@ public final class JsonCodec implements Codec {
     try {
       return adapter.fromJson(jsonReader(bytes));
     } catch (Exception e) {
-      throw exceptionReading(adapter.toString(), bytes, e);
+      throw exceptionReading(adapter.toString(), e);
     }
   }
 
@@ -682,7 +682,7 @@ public final class JsonCodec implements Codec {
       reader.endArray();
       return result;
     } catch (Exception e) {
-      throw exceptionReading("List<" + adapter + ">", bytes, e);
+      throw exceptionReading("List<" + adapter + ">", e);
     }
   }
 
@@ -709,10 +709,10 @@ public final class JsonCodec implements Codec {
     writeHexByte(b, (byte) (v & 0xff));
   }
 
-  static IllegalArgumentException exceptionReading(String type, byte[] bytes, Exception e) {
+  static IllegalArgumentException exceptionReading(String type, Exception e) {
     String cause = e.getMessage() == null ? "Error" : e.getMessage();
     if (cause.indexOf("malformed") != -1) cause = "Malformed";
-    String message = format("%s reading %s from json: %s", cause, type, new String(bytes, UTF_8));
+    String message = format("%s reading %s from json", cause, type);
     throw new IllegalArgumentException(message, e);
   }
 }

--- a/zipkin/src/test/java/zipkin/internal/CollectorTest.java
+++ b/zipkin/src/test/java/zipkin/internal/CollectorTest.java
@@ -58,7 +58,7 @@ public class CollectorTest {
         return "1";
       }
 
-      @Override void warn(String message, Throwable e) {
+      @Override void warn(String message) {
       }
     });
   }
@@ -72,13 +72,19 @@ public class CollectorTest {
   }
 
   @Test
+  public void acceptSpansCallback_toStringIncludesSpanIds_noMoreThan3() {
+    assertThat(collector.acceptSpansCallback(asList(span1, span1, span1, span1)))
+      .hasToString("AcceptSpans([1, 1, 1, ...])");
+  }
+
+  @Test
   public void acceptSpansCallback_onErrorWithNullMessage() {
     Callback<Void> callback = collector.acceptSpansCallback(asList(span1));
 
     RuntimeException exception = new RuntimeException();
     callback.onError(exception);
 
-    verify(collector).warn("Cannot store spans [1] due to RuntimeException()", exception);
+    verify(collector).warn("Cannot store spans [1] due to RuntimeException()");
   }
 
   @Test
@@ -88,7 +94,7 @@ public class CollectorTest {
     callback.onError(exception);
 
     verify(collector)
-      .warn("Cannot store spans [1] due to IllegalArgumentException(no beer)", exception);
+      .warn("Cannot store spans [1] due to IllegalArgumentException(no beer)");
   }
 
   @Test

--- a/zipkin2/src/main/java/zipkin2/codec/DependencyLinkBytesDecoder.java
+++ b/zipkin2/src/main/java/zipkin2/codec/DependencyLinkBytesDecoder.java
@@ -31,7 +31,7 @@ public enum DependencyLinkBytesDecoder implements BytesDecoder<DependencyLink> {
       return JsonCodec.read(READER, link, out);
     }
 
-    @Nullable public DependencyLink decodeOne(byte[] link) {
+    @Override @Nullable public DependencyLink decodeOne(byte[] link) {
       return JsonCodec.readOne(READER, link);
     }
 

--- a/zipkin2/src/main/java/zipkin2/codec/SpanBytesDecoder.java
+++ b/zipkin2/src/main/java/zipkin2/codec/SpanBytesDecoder.java
@@ -38,12 +38,12 @@ public enum SpanBytesDecoder implements BytesDecoder<Span> {
     }
 
     /** Visible for testing. This returns the first span parsed from the serialized object or null */
-    @Nullable public Span decodeOne(byte[] span) {
+    @Override @Nullable public Span decodeOne(byte[] span) {
       return JsonCodec.readOne(new V2SpanReader(), span);
     }
 
     /** Convenience method for {@link #decode(byte[], Collection)} */
-    public List<Span> decodeList(byte[] spans) {
+    @Override public List<Span> decodeList(byte[] spans) {
       return JsonCodec.readList(new V2SpanReader(), spans);
     }
   }

--- a/zipkin2/src/main/java/zipkin2/internal/JsonCodec.java
+++ b/zipkin2/src/main/java/zipkin2/internal/JsonCodec.java
@@ -30,10 +30,13 @@ import static java.lang.String.format;
  * This explicitly constructs instances of model classes via manual parsing for a number of
  * reasons.
  *
- * <ul> <li>Eliminates the need to keep separate model classes for thrift vs json</li> <li>Avoids
- * magic field initialization which, can miss constructor guards</li> <li>Allows us to safely re-use
- * the json form in toString methods</li> <li>Encourages logic to be based on the thrift shape of
- * objects</li> <li>Ensures the order and naming of the fields in json is stable</li> </ul>
+ * <ul>
+ *   <li>Eliminates the need to keep separate model classes for thrift vs json</li>
+ *   <li>Avoids magic field initialization which, can miss constructor guards</li>
+ *   <li>Allows us to safely re-use the json form in toString methods</li>
+ *   <li>Encourages logic to be based on the thrift shape of objects</li>
+ *   <li>Ensures the order and naming of the fields in json is stable</li>
+ * </ul>
  *
  * <p> There is the up-front cost of creating this, and maintenance of this to consider. However,
  * this should be easy to justify as these objects don't change much at all.
@@ -100,7 +103,7 @@ public final class JsonCodec {
       return delegate.peek() == com.google.gson.stream.JsonToken.NULL;
     }
 
-    public String toString() {
+    @Override public String toString() {
       return delegate.toString();
     }
   }
@@ -117,7 +120,7 @@ public final class JsonCodec {
       out.add(adapter.fromJson(new JsonReader(bytes)));
       return true;
     } catch (Exception e) {
-      throw exceptionReading(adapter.toString(), bytes, e);
+      throw exceptionReading(adapter.toString(), e);
     }
   }
 
@@ -138,7 +141,7 @@ public final class JsonCodec {
       reader.endArray();
       return true;
     } catch (Exception e) {
-      throw exceptionReading("List<" + adapter + ">", bytes, e);
+      throw exceptionReading("List<" + adapter + ">", e);
     }
   }
 
@@ -221,10 +224,10 @@ public final class JsonCodec {
     b.writeByte(']');
   }
 
-  static IllegalArgumentException exceptionReading(String type, byte[] bytes, Exception e) {
+  static IllegalArgumentException exceptionReading(String type, Exception e) {
     String cause = e.getMessage() == null ? "Error" : e.getMessage();
     if (cause.indexOf("malformed") != -1) cause = "Malformed";
-    String message = format("%s reading %s from json: %s", cause, type, new String(bytes, UTF_8));
+    String message = format("%s reading %s from json", cause, type);
     throw new IllegalArgumentException(message, e);
   }
 }


### PR DESCRIPTION
Before, when there were problems, the entire input json and any trace
IDs ended up in the server logs. This by itself can take out the server.

This takes a conservative step forward, leaving warning level, but
significantly reducing the output.