### PR TITLE
Prevents backlog when writing to Elasticsearch

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -302,7 +302,7 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
         .build();
     ok.dispatcher().setMaxRequests(maxRequests());
     ok.dispatcher().setMaxRequestsPerHost(maxRequests());
-    return new HttpCall.Factory(ok, maxRequests(), HttpUrl.parse(hosts.get(0)));
+    return new HttpCall.Factory(ok, HttpUrl.parse(hosts.get(0)));
   }
 
   @Override public void close() {

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -107,7 +107,13 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
      */
     public abstract Builder hostsSupplier(HostsSupplier hosts);
 
-    /** Sets maximum in-flight requests from this process to any Elasticsearch host. Defaults to 64 */
+    /**
+     * Sets maximum in-flight requests from this process to any Elasticsearch host. Defaults to 64
+     *
+     * <p>A backlog is not permitted. Once this number of requests are in-flight, future requests
+     * will drop until we are under maxRequests again. This allows the server to remain up during a
+     * traffic surge.
+     */
     public abstract Builder maxRequests(int maxRequests);
 
     /**
@@ -296,7 +302,7 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
         .build();
     ok.dispatcher().setMaxRequests(maxRequests());
     ok.dispatcher().setMaxRequestsPerHost(maxRequests());
-    return new HttpCall.Factory(ok, HttpUrl.parse(hosts.get(0)));
+    return new HttpCall.Factory(ok, maxRequests(), HttpUrl.parse(hosts.get(0)));
   }
 
   @Override public void close() {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchSpanConsumerTest.java
@@ -14,7 +14,9 @@
 package zipkin2.elasticsearch;
 
 import java.io.IOException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -22,6 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import zipkin2.Callback;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.Span.Kind;
@@ -187,6 +190,35 @@ public class ElasticsearchSpanConsumerTest {
     RecordedRequest request = es.takeRequest();
     assertThat(request.getPath())
       .isEqualTo("/_bulk?pipeline=zipkin");
+  }
+
+  @Test public void dropsWhenBacklog() throws Exception {
+    close();
+
+    storage = ElasticsearchStorage.newBuilder()
+      .hosts(asList(es.url("").toString()))
+      .maxRequests(1)
+      .build();
+    ensureIndexTemplate();
+    es.enqueue(new MockResponse().setBodyDelay(1, TimeUnit.SECONDS));
+
+    final LinkedBlockingQueue<Object> q = new LinkedBlockingQueue<>();
+    Callback<Void> callback = new Callback<Void>() {
+      @Override public void onSuccess(@Nullable Void value) {
+        q.add("success");
+      }
+
+      @Override public void onError(Throwable t) {
+        q.add(t);
+      }
+    };
+    // one request is delayed
+    storage.spanConsumer().accept(asList(TestObjects.CLIENT_SPAN)).enqueue(callback);
+    // this request is dropped
+    storage.spanConsumer().accept(asList(TestObjects.CLIENT_SPAN)).enqueue(callback);
+
+    assertThat(q.take())
+      .isInstanceOf(IllegalStateException.class);
   }
 
   @Test public void choosesTypeSpecificIndex() throws Exception {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
@@ -36,7 +36,7 @@ public class HttpCallTest {
   @Rule
   public MockWebServer mws = new MockWebServer();
 
-  HttpCall.Factory http = new HttpCall.Factory(new OkHttpClient(), 1, mws.url(""));
+  HttpCall.Factory http = new HttpCall.Factory(new OkHttpClient(), mws.url(""));
   Request request = new Request.Builder().url(http.baseUrl).build();
 
   @After

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
@@ -36,7 +36,7 @@ public class HttpCallTest {
   @Rule
   public MockWebServer mws = new MockWebServer();
 
-  HttpCall.Factory http = new HttpCall.Factory(new OkHttpClient(), mws.url(""));
+  HttpCall.Factory http = new HttpCall.Factory(new OkHttpClient(), 1, mws.url(""));
   Request request = new Request.Builder().url(http.baseUrl).build();
 
   @After

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchCallFactoryTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchCallFactoryTest.java
@@ -29,7 +29,7 @@ public class SearchCallFactoryTest {
   public MockWebServer es = new MockWebServer();
 
   SearchCallFactory client =
-      new SearchCallFactory(new HttpCall.Factory(new OkHttpClient(), es.url("")));
+    new SearchCallFactory(new HttpCall.Factory(new OkHttpClient(), 1, es.url("")));
 
   @After
   public void close() throws IOException {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchCallFactoryTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchCallFactoryTest.java
@@ -29,7 +29,7 @@ public class SearchCallFactoryTest {
   public MockWebServer es = new MockWebServer();
 
   SearchCallFactory client =
-    new SearchCallFactory(new HttpCall.Factory(new OkHttpClient(), 1, es.url("")));
+    new SearchCallFactory(new HttpCall.Factory(new OkHttpClient(), es.url("")));
 
   @After
   public void close() throws IOException {


### PR DESCRIPTION
In the past, delayed or otherwise unhealthy elasticsearch clusters could
create a backlog leading to a OOM arising from the http dispatcher ready
queue. This chooses to prevent a ready queue instead. This means we drop
spans when the backend isn't responding instead of crashing the server.

Fixes #1760