### PR TITLE
Moves log messages behind drop messages to debug level

### DIFF
--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -165,12 +165,14 @@ logging:
   level:
     # Silence Invalid method name: '__can__finagle__trace__v3__'
     com.facebook.swift.service.ThriftServiceProcessor: 'OFF'
-#     # investigate /api/v1/dependencies
-#     zipkin.internal.DependencyLinker: 'DEBUG'
+#     # investigate /api/v1/dependencies or /api/v2/dependencies
+#     zipkin2.internal.DependencyLinker: 'DEBUG'
 #     # log cassandra queries (DEBUG is without values)
 #     com.datastax.driver.core.QueryLogger: 'TRACE'
 #     # log cassandra trace propagation
 #     com.datastax.driver.core.Message: 'TRACE'
+#     # log reason behind http collector dropped messages
+#     zipkin.server.ZipkinHttpCollector: 'DEBUG'
 
 management:
   security:

--- a/zipkin/src/test/java/zipkin/internal/CollectorTest.java
+++ b/zipkin/src/test/java/zipkin/internal/CollectorTest.java
@@ -58,7 +58,11 @@ public class CollectorTest {
         return "1";
       }
 
-      @Override void warn(String message) {
+      @Override boolean shouldWarn() {
+        return true;
+      }
+
+      @Override void warn(String message, Throwable e) {
       }
     });
   }
@@ -84,7 +88,7 @@ public class CollectorTest {
     RuntimeException exception = new RuntimeException();
     callback.onError(exception);
 
-    verify(collector).warn("Cannot store spans [1] due to RuntimeException()");
+    verify(collector).warn("Cannot store spans [1] due to RuntimeException()", exception);
   }
 
   @Test
@@ -94,7 +98,7 @@ public class CollectorTest {
     callback.onError(exception);
 
     verify(collector)
-      .warn("Cannot store spans [1] due to IllegalArgumentException(no beer)");
+      .warn("Cannot store spans [1] due to IllegalArgumentException(no beer)", exception);
   }
 
   @Test


### PR DESCRIPTION
Otherwise, we get at least one line in the server log per message, which can fill up disks during a surge. The alternative is to watch server metrics and enable logging level as needed.

See https://github.com/openzipkin/docker-zipkin/pull/135