### PR TITLE
Backfills missing tests where duration query applies to annotationQuery

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraSpanStore.java
@@ -186,6 +186,7 @@ public final class CassandraSpanStore implements GuavaSpanStore {
    */
   @Override
   public ListenableFuture<List<List<Span>>> getTraces(final QueryRequest request) {
+    checkArgument(request.minDuration == null, "getTraces with duration is unsupported");
     // Over fetch on indexes as they don't return distinct (trace id, timestamp) rows.
     final int traceIndexFetchSize = request.limit * indexFetchMultiplier;
     ListenableFuture<Map<Long, Long>> traceIdToTimestamp;

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraSpanStoreTest.java
@@ -32,6 +32,7 @@ import zipkin.storage.SpanStoreTest;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 abstract class CassandraSpanStoreTest extends SpanStoreTest {
 
@@ -128,10 +129,22 @@ abstract class CassandraSpanStoreTest extends SpanStoreTest {
     return storage().session().execute("SELECT COUNT(*) from " + table).one().getLong(0);
   }
 
-  @Test
-  @Override
-  public void getTraces_duration() {
-    throw new AssumptionViolatedException("Upgrade to cassandra3 if you want duration queries");
+  @Override public void getTraces_duration() {
+    try {
+      super.getTraces_duration();
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      throw new AssumptionViolatedException("Upgrade to cassandra3 if you want duration queries");
+    }
+  }
+
+  @Override public void getTraces_duration_allServices() {
+    try {
+      super.getTraces_duration_allServices();
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      throw new AssumptionViolatedException("Upgrade to cassandra3 if you want duration queries");
+    }
   }
 
   @Override protected void accept(Span... spans) {

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/ITCassandraStorage.java
@@ -15,14 +15,17 @@ package zipkin.storage.cassandra;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static zipkin.storage.cassandra.SessionFactory.Default.buildCluster;
 
 @RunWith(Enclosed.class)

--- a/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/integration/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra3/src/test/java/zipkin/storage/cassandra3/integration/CassandraSpanStoreTest.java
@@ -16,6 +16,7 @@ package zipkin.storage.cassandra3.integration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
+import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import zipkin.Annotation;
 import zipkin.BinaryAnnotation;
@@ -31,6 +32,7 @@ import zipkin.storage.cassandra3.InternalForTests;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 abstract class CassandraSpanStoreTest extends SpanStoreTest {
 
@@ -108,6 +110,15 @@ abstract class CassandraSpanStoreTest extends SpanStoreTest {
                     .limit(queryLimit)
                     .build();
     assertThat(store().getTraces(queryRequest)).hasSize(queryLimit);
+  }
+
+  @Override public void getTraces_duration_allServices() {
+    try {
+      super.getTraces_duration_allServices();
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      throw new AssumptionViolatedException("duration queries across all services is unsupported");
+    }
   }
 
   /** Makes sure the test cluster doesn't fall over on BusyPoolException */

--- a/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/storage/SpanStoreTest.java
@@ -43,6 +43,7 @@ import static zipkin.Constants.LOCAL_COMPONENT;
 import static zipkin.Constants.SERVER_RECV;
 import static zipkin.Constants.SERVER_SEND;
 import static zipkin.TestObjects.APP_ENDPOINT;
+import static zipkin.TestObjects.DAY;
 import static zipkin.TestObjects.TODAY;
 import static zipkin.TestObjects.WEB_ENDPOINT;
 
@@ -373,58 +374,95 @@ public abstract class SpanStoreTest {
   /** Shows that duration queries go against the root span, not the child */
   @Test
   public void getTraces_duration() {
+    setupDurationData();
+
+    QueryRequest.Builder q = QueryRequest.builder().lookback(DAY); // instead of since epoch
+    QueryRequest query;
+
+    // Min duration is inclusive and is applied by service.
+    query = q.serviceName("service1").minDuration(200_000L).build();
+    assertThat(store().getTraces(query)).extracting(t -> t.get(0).traceId)
+      .containsExactly(1L);
+
+    query = q.serviceName("service3").minDuration(200_000L).build();
+    assertThat(store().getTraces(query)).extracting(t -> t.get(0).traceId)
+      .containsExactly(2L);
+
+    // Duration bounds aren't limited to root spans: they apply to all spans by service in a trace
+    query = q.serviceName("service2").minDuration(50_000L).maxDuration(150_000L).build();
+    assertThat(store().getTraces(query)).extracting(t -> t.get(0).traceId)
+      .containsExactly(3L, 2L, 1L); // service2 root of trace 3, but middle of 1 and 2.
+
+    // Span name should apply to the duration filter
+    query = q.serviceName("service2").spanName("zip").maxDuration(50_000L).build();
+    assertThat(store().getTraces(query)).extracting(t -> t.get(0).traceId)
+      .containsExactly(3L);
+
+    // Max duration should filter our longer spans from the same service
+    query = q.serviceName("service2").minDuration(50_000L).maxDuration(50_000L).build();
+    assertThat(store().getTraces(query)).extracting(t -> t.get(0).traceId)
+      .containsExactly(3L);
+  }
+
+  @Test
+  public void getTraces_duration_allServices() {
+    setupDurationData();
+
+    QueryRequest query;
+
+    // Annotation value name should apply to the duration filter
+    query = QueryRequest.builder().lookback(DAY) // reset to query across all services
+      .addAnnotation("zip").minDuration(50_000L).build();
+    assertThat(store().getTraces(query)).extracting(t -> t.get(0).traceId)
+      .containsExactly(3L);
+
+    // Binary annotation value should apply to the duration filter
+    query = QueryRequest.builder().lookback(DAY) // reset to query across all services
+      .addBinaryAnnotation(LOCAL_COMPONENT, "archiver-v2").minDuration(50_000L).build();
+    assertThat(store().getTraces(query)).extracting(t -> t.get(0).traceId)
+      .containsExactly(2L);
+  }
+
+  void setupDurationData() {
     Endpoint service1 = Endpoint.create("service1", 127 << 24 | 1);
     Endpoint service2 = Endpoint.create("service2", 127 << 24 | 2);
     Endpoint service3 = Endpoint.create("service3", 127 << 24 | 3);
 
-    BinaryAnnotation.Builder component = BinaryAnnotation.builder().key(LOCAL_COMPONENT).value("archiver");
-    BinaryAnnotation archiver1 = component.endpoint(service1).build();
-    BinaryAnnotation archiver2 = component.endpoint(service2).build();
-    BinaryAnnotation archiver3 = component.endpoint(service3).build();
+    BinaryAnnotation.Builder component = BinaryAnnotation.builder().key(LOCAL_COMPONENT);
+    BinaryAnnotation archiver1 = component.value("archiver").endpoint(service1).build();
+    BinaryAnnotation archiver2 = component.value("archiver").endpoint(service2).build();
+    BinaryAnnotation archiver3 = component.value("archiver").endpoint(service3).build();
 
+    long offsetMicros = (TODAY - 3) * 1000L; // to make sure queries look back properly
     Span targz = Span.builder().traceId(1L).id(1L)
-        .name("targz").timestamp(TODAY * 1000 + 100L).duration(200_000L).addBinaryAnnotation(archiver1).build();
+      .name("targz").timestamp(offsetMicros + 100L).duration(200_000L)
+      .addBinaryAnnotation(archiver1).build();
     Span tar = Span.builder().traceId(1L).id(2L).parentId(1L)
-        .name("tar").timestamp(TODAY * 1000 + 200L).duration(150_000L).addBinaryAnnotation(archiver2).build();
+      .name("tar").timestamp(offsetMicros + 200L).duration(150_000L)
+      .addBinaryAnnotation(archiver2).build();
     Span gz = Span.builder().traceId(1L).id(3L).parentId(1L)
-        .name("gz").timestamp(TODAY * 1000 + 250L).duration(50_000L).addBinaryAnnotation(archiver3).build();
+      .name("gz").timestamp(offsetMicros + 250L).duration(50_000L)
+      .addBinaryAnnotation(archiver3).build();
     Span zip = Span.builder().traceId(3L).id(3L)
-        .name("zip").timestamp(TODAY * 1000 + 130L).duration(50_000L).addBinaryAnnotation(archiver2).build();
+      .name("zip").timestamp(offsetMicros + 130L).duration(50_000L)
+      .addAnnotation(Annotation.builder().timestamp(offsetMicros + 130L).value("zip").build())
+      .addBinaryAnnotation(archiver2).build();
 
     List<Span> trace1 = asList(targz, tar, gz);
     List<Span> trace2 = asList(
-        targz.toBuilder().traceId(2L).timestamp(TODAY * 1000 + 110L).binaryAnnotations(asList(archiver3)).build(),
-        tar.toBuilder().traceId(2L).timestamp(TODAY * 1000 + 210L).binaryAnnotations(asList(archiver2)).build(),
-        gz.toBuilder().traceId(2L).timestamp(TODAY * 1000 + 260L).binaryAnnotations(asList(archiver1)).build());
+      targz.toBuilder().traceId(2L).timestamp(offsetMicros + 110L)
+        .binaryAnnotations(asList(
+          component.value("archiver-v2").endpoint(service3).build()
+        )).build(),
+      tar.toBuilder().traceId(2L).timestamp(offsetMicros + 210L)
+        .binaryAnnotations(asList(archiver2)).build(),
+      gz.toBuilder().traceId(2L).timestamp(offsetMicros + 260L)
+        .binaryAnnotations(asList(archiver1)).build());
     List<Span> trace3 = asList(zip);
 
     accept(trace1.toArray(new Span[0]));
     accept(trace2.toArray(new Span[0]));
     accept(trace3.toArray(new Span[0]));
-
-    long lookback = 12L * 60 * 60 * 1000; // 12hrs, instead of 7days
-    long endTs = TODAY + 1; // greater than all timestamps above
-    QueryRequest.Builder q = QueryRequest.builder().serviceName("service1").lookback(lookback).endTs(endTs);
-
-    // Min duration is inclusive and is applied by service.
-    assertThat(store().getTraces(q.serviceName("service1").minDuration(targz.duration).build()))
-        .containsExactly(trace1);
-
-    assertThat(store().getTraces(q.serviceName("service3").minDuration(targz.duration).build()))
-        .containsExactly(trace2);
-
-    // Duration bounds aren't limited to root spans: they apply to all spans by service in a trace
-    assertThat(store().getTraces(q.serviceName("service2").minDuration(zip.duration).maxDuration(tar.duration).build()))
-        .containsExactly(trace3, trace2, trace1); // service2 is in the middle of trace1 and 2, but root of trace3
-
-    // Span name should apply to the duration filter
-    assertThat(
-        store().getTraces(q.serviceName("service2").spanName("zip").maxDuration(zip.duration).build()))
-        .containsExactly(trace3);
-
-    // Max duration should filter our longer spans from the same service
-    assertThat(store().getTraces(q.serviceName("service2").minDuration(gz.duration).maxDuration(zip.duration).build()))
-        .containsExactly(trace3);
   }
 
   /**


### PR DESCRIPTION
Before, we couldn't tell that some backends didn't support this.