### PR TITLE
Uses shaded netty in server jar to avoid downstream conflicts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,17 +312,6 @@
         <version>${project.version}</version>
       </dependency>
 
-      <!-- Needs to be defined here or else spring-boot-dependencies will override it -->
-      <dependency>
-        <groupId>com.datastax.cassandra</groupId>
-        <artifactId>cassandra-driver-core</artifactId>
-        <version>${cassandra-driver-core.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.datastax.cassandra</groupId>
-        <artifactId>cassandra-driver-mapping</artifactId>
-        <version>${cassandra-driver-core.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.jooq</groupId>
         <artifactId>jooq</artifactId>
@@ -450,7 +439,7 @@
   <build>
     <pluginManagement>
       <plugins>
-        <!-- mvn -N io.takari:maven:wrapper -Dmaven=3.5.0 -->
+        <!-- mvn -N io.takari:maven:wrapper -Dmaven=3.5.2 -->
         <plugin>
           <groupId>io.takari</groupId>
           <artifactId>maven</artifactId>

--- a/zipkin-collector/scribe/pom.xml
+++ b/zipkin-collector/scribe/pom.xml
@@ -53,6 +53,11 @@
           <groupId>io.airlift</groupId>
           <artifactId>configuration</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- interferes with netty-tcnative-boringssl-static versions -->
+          <groupId>com.facebook.nifty</groupId>
+          <artifactId>nifty-ssl</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -87,6 +87,38 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-autoconfigure-storage-cassandra</artifactId>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.datastax.cassandra</groupId>
+          <artifactId>cassandra-driver-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- shaded to not interfere with netty 4.1 and boringssl. [JAVA-1241] -->
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>${cassandra-driver-core.version}</version>
+      <classifier>shaded</classifier>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-mapping</artifactId>
+      <version>${cassandra-driver-core.version}</version>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.datastax.cassandra</groupId>
+          <artifactId>cassandra-driver-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Cassandra 3 backend -->
@@ -94,6 +126,16 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-autoconfigure-storage-cassandra3</artifactId>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.datastax.cassandra</groupId>
+          <artifactId>cassandra-driver-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.datastax.cassandra</groupId>
+          <artifactId>cassandra-driver-mapping</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Elasticsearch http backend -->

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -44,6 +44,7 @@
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
+      <version>${cassandra-driver-core.version}</version>
     </dependency>
 
     <dependency>

--- a/zipkin-storage/cassandra3/pom.xml
+++ b/zipkin-storage/cassandra3/pom.xml
@@ -44,11 +44,13 @@
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
+      <version>${cassandra-driver-core.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-mapping</artifactId>
+      <version>${cassandra-driver-core.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
gRPC uses Netty 4.1 and `netty-tcnative-boringssl-static`, which is
sensitive to Netty versions. DataStax Cassandra driver 4.0 uses Netty
4.1, but the driver isn't out, yet. By using the published shaded jar,
we can dodge the conflict for now.

I've verified that we can connect to google cloud services after this
change. I've also verified that there's no significant jar size change.

See https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
See https://github.com/GoogleCloudPlatform/stackdriver-zipkin/issues/45