### PR TITLE
Fixes accidental hot partition with empty service name

### DIFF
--- a/zipkin-storage/zipkin2_cassandra/README.md
+++ b/zipkin-storage/zipkin2_cassandra/README.md
@@ -78,14 +78,14 @@ span in trace ID 1 named "get" created by "service1", taking 20 milliseconds
 results in the following rows:
 
 1. `service=service1, span=targz, trace_id=1, duration=200`
-2. `service=, span=targz, trace_id=1, duration=200`
-3. `service=, span=, trace_id=1, duration=200`
+2. `service=service1, span=, trace_id=1, duration=200`
 
 Here are corresponding queries that relate to the above rows:
 1. `GET /api/v2/traces?serviceName=service1&spanName=targz`
 1. `GET /api/v2/traces?serviceName=service1&spanName=targz&minDuration=200000`
+1. `GET /api/v2/traces?serviceName=service1&minDuration=200000`
 2. `GET /api/v2/traces?spanName=targz`
-3. `GET /api/v2/traces?duration=199500`
+2. `GET /api/v2/traces?duration=199500`
 
 As you'll notice, the duration component is optional, and stored in
 millisecond resolution as opposed to microsecond (which the query represents).
@@ -95,6 +95,10 @@ The reason we can query on `duration` is due to a SASI index. Eventhough the
 search granularity is millisecond, original duration data remains microsecond
 granularity. Meanwhile, write performance is dramatically better than writing
 discrete values, due to fewer distinct writes.
+
+You might wonder how the last two queries work, considering they don't know
+the service name associated with index rows. When needed, this implementation
+performs a service name fetch, resulting in a fan-out composition over row 2.
 
 ### Time-To_live
 Time-To-Live is default now at the table level. It can not be overridden in write requests.

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/CassandraUtil.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/CassandraUtil.java
@@ -106,7 +106,7 @@ final class CassandraUtil {
       for (Map.Entry<String, Long> entry : map.entrySet()) {
         BigInteger uncollided = BigInteger.valueOf(entry.getValue())
           .multiply(OFFSET)
-          .add(BigInteger.valueOf(RAND.nextInt()));
+          .add(BigInteger.valueOf(RAND.nextInt() & Integer.MAX_VALUE));
         sorted.put(uncollided, entry.getKey());
       }
       return new LinkedHashSet<>(sorted.values());

--- a/zipkin-storage/zipkin2_cassandra/src/test/java/zipkin2/storage/cassandra/CassandraUtilTest.java
+++ b/zipkin-storage/zipkin2_cassandra/src/test/java/zipkin2/storage/cassandra/CassandraUtilTest.java
@@ -13,6 +13,8 @@
  */
 package zipkin2.storage.cassandra;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
@@ -129,5 +131,19 @@ public class CassandraUtilTest {
     // neither is 10 years from now
     assertThat(CassandraUtil.durationIndexBucket((TODAY + TimeUnit.DAYS.toMillis(3654)) * 1000L))
       .isNotNegative();
+  }
+
+  @Test public void traceIdsSortedByDescTimestamp_doesntCollideOnSameTimestamp() {
+    Set<String> sortedTraceIds = CassandraUtil.traceIdsSortedByDescTimestamp().map(ImmutableMap.of(
+      "a", 1L,
+      "b", 1L,
+      "c", 2L
+    ));
+
+    try {
+      assertThat(sortedTraceIds).containsExactly("c", "b", "a");
+    } catch (AssertionError e) {
+      assertThat(sortedTraceIds).containsExactly("c", "a", "b");
+    }
   }
 }


### PR DESCRIPTION
In porting over the all-services query, I accidentally created a piping
hot partition. This re-instates code similar to what we had in the old
schema, except that we can avoid an all-service fan out in more cases.