### PR TITLE
Require JDK 8 with enforcer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The [ElasticsearchHttpStorage](zipkin-storage/elasticsearch-http) component is t
 The [zipkin server](zipkin-server)
 receives spans via HTTP POST and respond to queries from its UI. It can also run collectors, such as Scribe or Kafka.
 
-To run the server from the currently checked out source, enter the following.
+To run the server from the currently checked out source, enter the following. JDK 8 is required.
 ```bash
 # Build the server and also make its dependencies
 $ ./mvnw -DskipTests --also-make -pl zipkin-server clean install

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
     <maven-failsafe-plugin.version>2.20.1</maven-failsafe-plugin.version>
+    <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
 
     <!-- Catch common Java mistakes as compile-time errors -->
     <plexus-compiler-javac-errorprone.version>2.8.2</plexus-compiler-javac-errorprone.version>
@@ -695,6 +696,26 @@
         <configuration>
           <packageName>zipkin</packageName>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven-enforcer-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.8,9)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
To avoid confusing failure messages when a version of JDK that doesn't work with the code is used, this requires JDK 8 using the enforcer-plugin, which will output a sensible error message in case an incompatible JDK version is used. Notes the JDK 8 requirement in the README where instructions for building from source are.

See documentation at: https://maven.apache.org/enforcer/enforcer-rules/requireJavaVersion.html

Note that the version scheme changed with Java 9, such that it is not `1.9`.

I tested this with JDK 9 and it outputs an error like the following:

```
[INFO] ------------------------------------------------------------------------
[INFO] Building Zipkin (Parent) 2.3.2-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ parent ---
[INFO] 
[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce-java) @ parent ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 9.0.1 is not in the allowed range [1.8,9).
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Zipkin (Parent) .................................... FAILURE [  2.583 s]
[INFO] Zipkin v2 .......................................... SKIPPED
[INFO] Zipkin ............................................. SKIPPED
[INFO] Zipkin UI .......................................... SKIPPED
[INFO] Zipkin JUnit ....................................... SKIPPED
[INFO] Guava support library .............................. SKIPPED
[INFO] Auto Configuration ................................. SKIPPED
[INFO] Auto Configuration: Ui ............................. SKIPPED
[INFO] Storage ............................................ SKIPPED
[INFO] Storage: Cassandra ................................. SKIPPED
[INFO] Auto Configuration: Cassandra Storage .............. SKIPPED
[INFO] Storage: Cassandra (Zipkin V2) ..................... SKIPPED
[INFO] Auto Configuration: Cassandra 3 Storage ............ SKIPPED
[INFO] Storage: Elasticsearch (V2) ........................ SKIPPED
[INFO] Storage: Elasticsearch (HTTP) ...................... SKIPPED
[INFO] Auto Configuration: Elasticsearch Storage (HTTP) ... SKIPPED
[INFO] Auto Configuration: Elasticsearch Storage (AWS) .... SKIPPED
[INFO] Storage: MySQL ..................................... SKIPPED
[INFO] Auto Configuration: MySQL Storage .................. SKIPPED
[INFO] Zipkin Collectors .................................. SKIPPED
[INFO] Collector: Kafka ................................... SKIPPED
[INFO] Auto Configuration: Kafka Collector ................ SKIPPED
[INFO] Collector: RabbitMQ ................................ SKIPPED
[INFO] Auto Configuration: RabbitMQ Collector ............. SKIPPED
[INFO] Collector: Scribe .................................. SKIPPED
[INFO] Auto Configuration: Scribe Collector ............... SKIPPED
[INFO] Auto Configuration: Prometheus Metrics ............. SKIPPED
[INFO] Zipkin Server ...................................... SKIPPED
[INFO] Benchmarks ......................................... SKIPPED
[INFO] ZooKeeper support library .......................... SKIPPED
[INFO] Collector: Kafka 0.10 .............................. SKIPPED
[INFO] Auto Configuration: Kafka 0.10 Collector ........... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.706 s
[INFO] Finished at: 2017-11-17T19:47:23+09:00
[INFO] Final Memory: 16M/53M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.4.1:enforce (enforce-java) on project parent: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```