### PR TITLE
Prevent's "Brian's bomb" by manually clearing metrics on each test class

### DIFF
--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerCORSTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerCORSTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin.server;
 
+import io.prometheus.client.CollectorRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +52,8 @@ public class ZipkinServerCORSTest {
 
   @Before
   public void init() {
+    // prevent "brian's bomb" https://github.com/openzipkin/zipkin/issues/1811
+    CollectorRegistry.defaultRegistry.clear();
     mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
   }
 

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerConfigurationTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin.server;
 
+import io.prometheus.client.CollectorRegistry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,6 +42,8 @@ public class ZipkinServerConfigurationTest
   public void init()
   {
     context = new AnnotationConfigApplicationContext();
+    // prevent "brian's bomb" https://github.com/openzipkin/zipkin/issues/1811
+    CollectorRegistry.defaultRegistry.clear();
   }
 
   @After

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerHttpCollectorDisabledTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerHttpCollectorDisabledTest.java
@@ -13,6 +13,8 @@
  */
 package zipkin.server;
 
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -40,6 +42,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class ZipkinServerHttpCollectorDisabledTest {
 
   @Autowired ConfigurableWebApplicationContext context;
+
+  @Before
+  public void init() {
+    // prevent "brian's bomb" https://github.com/openzipkin/zipkin/issues/1811
+    CollectorRegistry.defaultRegistry.clear();
+  }
 
   @Test(expected = NoSuchBeanDefinitionException.class)
   public void disabledHttpCollectorBean() throws Exception {

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin.server;
 
+import io.prometheus.client.CollectorRegistry;
 import java.util.List;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -77,6 +78,8 @@ public class ZipkinServerIntegrationTest {
 
   @Before
   public void init() {
+    // prevent "brian's bomb" https://github.com/openzipkin/zipkin/issues/1811
+    CollectorRegistry.defaultRegistry.clear();
     mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
     storage.clear();
     metrics.forTransport("http").reset();

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerQueryDisabledTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerQueryDisabledTest.java
@@ -13,6 +13,8 @@
  */
 package zipkin.server;
 
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -40,6 +42,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class ZipkinServerQueryDisabledTest {
 
   @Autowired ConfigurableWebApplicationContext context;
+
+  @Before
+  public void init() {
+    // prevent "brian's bomb" https://github.com/openzipkin/zipkin/issues/1811
+    CollectorRegistry.defaultRegistry.clear();
+  }
 
   @Test(expected = NoSuchBeanDefinitionException.class)
   public void disabledQueryBean() throws Exception {

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerSelfTracingTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerSelfTracingTest.java
@@ -13,6 +13,8 @@
  */
 package zipkin.server;
 
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +36,12 @@ public class ZipkinServerSelfTracingTest {
 
   @Autowired
   ConfigurableWebApplicationContext context;
+
+  @Before
+  public void init() {
+    // prevent "brian's bomb" https://github.com/openzipkin/zipkin/issues/1811
+    CollectorRegistry.defaultRegistry.clear();
+  }
 
   @Test
   @Ignore // TODO: be able to self-trace V2StorageComponent


### PR DESCRIPTION
As discussed in https://github.com/openzipkin/zipkin/issues/1811, the
current prometheus client isn't fit for usage in tests until
@brian-brazil changes his mind. This copy/pastes bomb prevention where
bomb is the application failing to start due to prometheus state error
on duplicate metric registration (the dupe is because a servlet filter
creates and hides a metric).