### PR TITLE
Forwards api base for the UI

### DIFF
--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -135,7 +135,7 @@ public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
   }
 
   /** The UI looks for the api relative to where it is mounted, under /zipkin */
-  @RequestMapping(value = "/zipkin/api/v1/**", method = GET)
+  @RequestMapping(value = "/zipkin/api/**", method = GET)
   public ModelAndView forwardApi(HttpServletRequest request) {
     String path = (String) request.getAttribute(PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
     return new ModelAndView("forward:" + path.replaceFirst("/zipkin", ""));

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTest.java
@@ -318,8 +318,8 @@ public class ZipkinServerIntegrationTest {
   }
 
   @Test public void forwardsApiForUi() throws Exception {
-    Response response = get("/zipkin/api/v1/traces");
-    assertThat(response.isSuccessful()).isTrue();
+    assertThat(get("/zipkin/api/v1/traces").isSuccessful()).isTrue();
+    assertThat(get("/zipkin/api/v2/traces").isSuccessful()).isTrue();
   }
 
   /** Simulate a proxy which forwards / to zipkin as opposed to resolving / -> /zipkin first */


### PR DESCRIPTION
This forwards /api -> /zipkin/api so the UI can start using the v2 api.

See #1802