### PR TITLE
Shaves 3.7MiB of unused deps in scribe

### DIFF
--- a/zipkin-collector/scribe/pom.xml
+++ b/zipkin-collector/scribe/pom.xml
@@ -58,6 +58,40 @@
           <groupId>com.facebook.nifty</groupId>
           <artifactId>nifty-ssl</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.facebook.nifty</groupId>
+          <artifactId>nifty-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- huge and unused -->
+          <groupId>org.weakref</groupId>
+          <artifactId>jmxutils</artifactId>
+        </exclusion>
+        <!-- trying to reduce size -->
+        <exclusion>
+          <groupId>io.airlift</groupId>
+          <artifactId>stats</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.inject.extensions</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.inject</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
Before
```bash
$ du -k ./zipkin-server/target/zipkin-server-*exec.jar
53612	./zipkin-server/target/zipkin-server-2.3.2-SNAPSHOT-exec.jar
```

After
```bash
$ du -k ./zipkin-server/target/zipkin-server-*exec.jar
49928	./zipkin-server/target/zipkin-server-2.3.2-SNAPSHOT-exec.jar
```