### PR TITLE
Uses curl-sh for top-level quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This project includes a dependency-free library and a [spring-boot](http://proje
 
 The quickest way to get started is to fetch the [latest released server](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec) as a self-contained executable jar. Note that the Zipkin server requires minimum JRE 8. For example:
 
-```
-wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+```bash
+curl -sSL https://zipkin.io/quickstart.sh | bash -s
 java -jar zipkin.jar
 ```
 
 You can also start Zipkin via Docker.
-```
+```bash
 docker run -d -p 9411:9411 openzipkin/zipkin
 ```
 

--- a/zipkin-autoconfigure/collector-kafka10/README.md
+++ b/zipkin-autoconfigure/collector-kafka10/README.md
@@ -1,7 +1,7 @@
 # Kafka 0.10+ Collector Auto-configure Module
 
-This module provides support for running the kafak10 collector as a component of Zipkin server. To 
-activate this collector, reference the module jar when running the Zipkin server 
+This module provides support for running the kafak10 collector as a component of Zipkin server. To
+activate this collector, reference the module jar when running the Zipkin server
 and configure one or more bootstrap brokers via the `KAFKA_BOOTSTRAP_SERVERS` environment
 variable or `zipkin.collector.kafka.bootstrap-servers` property.
 
@@ -10,48 +10,48 @@ variable or `zipkin.collector.kafka.bootstrap-servers` property.
 JRE 8 is required to run Zipkin server. Note: The Kafka 0.10+ collector and this auto-configure
 module are compatible with Java 7 and later when used independent of Zipkin server.
 
-Fetch the latest released 
+Fetch the latest released
 [executable jar for Zipkin server](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec)
-and 
+and
 [autoconfigure module jar for the kafka10 collector](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-autoconfigure-collector-kafka10&v=LATEST&c=module).
 Run Zipkin server with the Kafka 0.10+ collector enabled.
 
 For example:
 
 ```bash
-$ wget -O zipkin-server-exec.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
-$ wget -O zipkin-autoconfigure-collector-kafka10-module.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-autoconfigure-collector-kafka10&v=LATEST&c=module'
+$ curl -sSL https://zipkin.io/quickstart.sh | bash -s
+$ curl -sSL https://zipkin.io/quickstart.sh | bash -s io.zipkin.java:zipkin-autoconfigure-collector-kafka10:LATEST:module kafka10.jar
 $ KAFKA_BOOTSTRAP_SERVERS=127.0.0.1:9092 \
     java \
-    -Dloader.path='zipkin-autoconfigure-collector-kafka10-module.jar,zipkin-autoconfigure-collector-kafka10-module.jar!/lib' \
+    -Dloader.path='kafka10.jar,kafka10.jar!/lib' \
     -Dspring.profiles.active=kafka \
-    -cp zipkin-server-exec.jar \
+    -cp zipkin.jar \
     org.springframework.boot.loader.PropertiesLauncher
 ```
 
-After executing these steps, the Zipkin UI will be available 
+After executing these steps, the Zipkin UI will be available
 [http://localhost:9411](http://localhost:9411) or port 9411 of the remote host the Zipkin server
 was started on.
 
-The Zipkin server can be further configured as described in the 
+The Zipkin server can be further configured as described in the
 [Zipkin server documentation](../../zipkin-server/README.md).
 
 ## How this works
 
 The Zipkin server executable jar and the autoconfigure module jar for the kafka10 collector are
 required. The module jar contains the code for loading and configuring the kafka10 collector, and
-any dependencies that are not already packaged in the Zipkin server jar (e.g. 
+any dependencies that are not already packaged in the Zipkin server jar (e.g.
 zipkin-collector-kafka10, kafka-clients).
 
 Using PropertiesLauncher as the main class runs the Zipkin server executable jar the same as it
-would be if executed using `java -jar zipkin-server-exec.jar`, except it provides the option to
+would be if executed using `java -jar zipkin.jar`, except it provides the option to
 load resources from outside the executable jar into the classpath. Those external resources are
 specified using the `loader.path` system property. In this case, it is configured to load the
 kafka10 collector module jar (`zipkin-autoconfigure-collector-kafka10-module.jar`) and the jar files
-contained in the `lib/` directory within that module jar 
+contained in the `lib/` directory within that module jar
 (`zipkin-autoconfigure-collector-kafka10-module.jar!/lib`).
 
-The `spring.profiles=kafka` system property causes configuration from 
+The `spring.profiles=kafka` system property causes configuration from
 [zipkin-server-kafka.yml](src/main/resources/zipkin-server-kafka.yml) to be loaded.
 
 For more information on how this works, see [Spring Boot's documentation on the executable jar
@@ -61,10 +61,10 @@ has more detail on how the external module jar and the libraries it contains are
 
 ## Configuration
 
-The following configuration points apply apply when `KAFKA_BOOTSTRAP_SERVERS` or 
+The following configuration points apply apply when `KAFKA_BOOTSTRAP_SERVERS` or
 `zipkin.collector.kafka.bootstrap-servers` is set. They can be configured by setting an environment
-variable or by setting a java system property using the `-Dproperty.name=value` command line 
-argument. Some settings correspond to "New Consumer Configs" in 
+variable or by setting a java system property using the `-Dproperty.name=value` command line
+argument. Some settings correspond to "New Consumer Configs" in
 [Kafka documentation](https://kafka.apache.org/documentation/#newconsumerconfigs).
 
 Environment Variable | Property | New Consumer Config | Description
@@ -75,9 +75,9 @@ Environment Variable | Property | New Consumer Config | Description
 `KAFKA_STREAMS` | `zipkin.collector.kafka.streams` | N/A | Count of threads consuming the topic. Defaults to `1`
 
 ### Other Kafka consumer properties
-You may need to set other 
-[Kafka consumer properties](https://kafka.apache.org/documentation/#newconsumerconfigs), in 
-addition to the ones with explicit properties defined by the collector. In this case, you need to 
+You may need to set other
+[Kafka consumer properties](https://kafka.apache.org/documentation/#newconsumerconfigs), in
+addition to the ones with explicit properties defined by the collector. In this case, you need to
 prefix that property name with `zipkin.collector.kafka.overrides` and pass it as a system property
 argument.
 
@@ -87,10 +87,10 @@ For example, to override `auto.offset.reset`, you can set a system property name
 ```bash
 $ KAFKA_BOOTSTRAP_SERVERS=127.0.0.1:9092 \
     java \
-    -Dloader.path='zipkin-autoconfigure-collector-kafka10-module.jar,zipkin-autoconfigure-collector-kafka10-module.jar!/lib' \
+    -Dloader.path='kafka10.jar,kafka10.jar!/lib' \
     -Dspring.profiles.active=kafka \
     -Dzipkin.collector.kafka.overrides.auto.offset.reset=latest \
-    -cp zipkin-server-exec.jar \
+    -cp zipkin.jar \
     org.springframework.boot.loader.PropertiesLauncher
 ```
 
@@ -101,9 +101,9 @@ Multiple bootstrap servers:
 ```bash
 $ KAFKA_BOOTSTRAP_SERVERS=broker1:9092.local,broker2.local:9092 \
     java \
-    -Dloader.path='zipkin-autoconfigure-collector-kafka10-module.jar,zipkin-autoconfigure-collector-kafka10-module.jar!/lib' \
+    -Dloader.path='kafka10.jar,kafka10.jar!/lib' \
     -Dspring.profiles.active=kafka \
-    -cp zipkin-server-exec.jar \
+    -cp zipkin.jar \
     org.springframework.boot.loader.PropertiesLauncher
 ```
 
@@ -112,10 +112,10 @@ Alternate topic name(s):
 ```bash
 $ KAFKA_BOOTSTRAP_SERVERS=127.0.0.1:9092 \
     java \
-    -Dloader.path='zipkin-autoconfigure-collector-kafka10-module.jar,zipkin-autoconfigure-collector-kafka10-module.jar!/lib' \
+    -Dloader.path='kafka10.jar,kafka10.jar!/lib' \
     -Dspring.profiles.active=kafka \
     -Dzipkin.collector.kafka.topic=zapkin,zipken \
-    -cp zipkin-server-exec.jar \
+    -cp zipkin.jar \
     org.springframework.boot.loader.PropertiesLauncher
 ```
 
@@ -123,10 +123,10 @@ Specifying bootstrap servers as a system property, instead of an environment var
 
 ```bash
 $ java \
-    -Dloader.path='zipkin-autoconfigure-collector-kafka10-module.jar,zipkin-autoconfigure-collector-kafka10-module.jar!/lib' \
+    -Dloader.path='kafka10.jar,kafka10.jar!/lib' \
     -Dspring.profiles.active=kafka \
-    -Dzipkin.collector.kafka.bootstrap-servers=127.0.0.1:9092
-    -cp zipkin-server-exec.jar \
+    -Dzipkin.collector.kafka.bootstrap-servers=127.0.0.1:9092 \
+    -cp zipkin.jar \
     org.springframework.boot.loader.PropertiesLauncher
 ```
 

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -9,9 +9,9 @@ and the server listens on port 9411.
 
 The quickest way to get started is to fetch the [latest released server](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec) as a self-contained executable jar. Note that the Zipkin server requires minimum JRE 8. For example:
 
-```
-wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
-java -jar zipkin.jar
+```bash
+$ curl -sSL https://zipkin.io/quickstart.sh | bash -s
+$ java -jar zipkin.jar
 ```
 
 Once you've started, browse to http://your_host:9411 to find traces!


### PR DESCRIPTION
Thanks to @abesto, here's how to get the latest zipkin jar

```bash
$ curl -sSL https://zipkin.io/quickstart.sh | bash -s
```

And here's how to get a module, like our kafka10+ addon
```bash
$ curl -sSL https://zipkin.io/quickstart.sh | bash -s io.zipkin.java:zipkin-autoconfigure-collector-kafka10:LATEST:module kafka10.jar
```

See https://github.com/openzipkin/openzipkin.github.io/pull/90