### PR TITLE
Option to use SSL with RabbitMQ

### DIFF
--- a/zipkin-autoconfigure/collector-rabbitmq/src/main/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorAutoConfiguration.java
+++ b/zipkin-autoconfigure/collector-rabbitmq/src/main/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorAutoConfiguration.java
@@ -13,6 +13,8 @@
  */
 package zipkin.autoconfigure.collector.rabbitmq;
 
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Condition;
@@ -35,7 +37,8 @@ public class ZipkinRabbitMQCollectorAutoConfiguration {
 
   @Bean(initMethod = "start") RabbitMQCollector rabbitMq(
     ZipkinRabbitMQCollectorProperties properties,
-    CollectorSampler sampler, CollectorMetrics metrics, StorageComponent storage) {
+    CollectorSampler sampler, CollectorMetrics metrics, StorageComponent storage)
+    throws NoSuchAlgorithmException, KeyManagementException {
     return properties.toBuilder().sampler(sampler).metrics(metrics).storage(storage).build();
   }
 

--- a/zipkin-autoconfigure/collector-rabbitmq/src/main/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorProperties.java
+++ b/zipkin-autoconfigure/collector-rabbitmq/src/main/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorProperties.java
@@ -14,6 +14,8 @@
 package zipkin.autoconfigure.collector.rabbitmq;
 
 import com.rabbitmq.client.ConnectionFactory;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.collector.rabbitmq.RabbitMQCollector;
@@ -38,6 +40,8 @@ public class ZipkinRabbitMQCollectorProperties {
   private String username;
   /** RabbitMQ virtual host */
   private String virtualHost;
+  /** Flag to use SSL */
+  private Boolean useSsl;
 
   public List<String> getAddresses() {
     return addresses;
@@ -95,7 +99,16 @@ public class ZipkinRabbitMQCollectorProperties {
     this.virtualHost = virtualHost;
   }
 
-  public RabbitMQCollector.Builder toBuilder() {
+  public Boolean getUseSsl() {
+    return useSsl;
+  }
+
+  public void setUseSsl(Boolean useSsl) {
+    this.useSsl = useSsl;
+  }
+
+  public RabbitMQCollector.Builder toBuilder()
+    throws KeyManagementException, NoSuchAlgorithmException {
     final RabbitMQCollector.Builder result = RabbitMQCollector.builder();
     ConnectionFactory connectionFactory = new ConnectionFactory();
     if (addresses != null) result.addresses(addresses);
@@ -105,8 +118,8 @@ public class ZipkinRabbitMQCollectorProperties {
     if (queue != null) result.queue(queue);
     if (username != null) connectionFactory.setUsername(username);
     if (virtualHost != null) connectionFactory.setVirtualHost(virtualHost);
+    if (useSsl != null && useSsl) connectionFactory.useSslProtocol();
     result.connectionFactory(connectionFactory);
     return result;
   }
-
 }

--- a/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
+++ b/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
@@ -13,6 +13,8 @@
  */
 package zipkin.collector.rabbitmq;
 
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -70,7 +72,10 @@ public class ZipkinRabbitMQCollectorPropertiesOverrideTest {
             builder -> builder.connectionFactory.getUsername()),
         parameters("virtualHost", "/hello",
             ZipkinRabbitMQCollectorProperties::getVirtualHost,
-            builder -> builder.connectionFactory.getVirtualHost())
+            builder -> builder.connectionFactory.getVirtualHost()),
+        parameters("useSsl", true,
+          ZipkinRabbitMQCollectorProperties::getUseSsl,
+          builder -> builder.connectionFactory.isSSL())
     );
   }
 
@@ -98,7 +103,8 @@ public class ZipkinRabbitMQCollectorPropertiesOverrideTest {
   }
 
   @Test
-  public void propertyTransferredToCollectorBuilder() {
+  public void propertyTransferredToCollectorBuilder()
+    throws NoSuchAlgorithmException, KeyManagementException {
     addEnvironment(context, property + ":" + value);
 
     context.register(

--- a/zipkin-collector/rabbitmq/README.md
+++ b/zipkin-collector/rabbitmq/README.md
@@ -12,11 +12,12 @@ Property | Environment Variable | Description
 --- | --- | ---
 `zipkin.collector.rabbitmq.addresses` | `RABBIT_ADDRESSES` | Comma-separated list of RabbitMQ addresses, ex. `localhost:5672,localhost:5673`
 `zipkin.collector.rabbitmq.concurrency` | `RABBIT_CONCURRENCY` | Number of concurrent consumers. Defaults to `1`
-`zipkin.collector.rabbitmq.connectionTimeout` | `RABBIT_CONNECTION_TIMEOUT` | Milliseconds to wait establishing a connection. Defaults to `60000` (1 minute)
+`zipkin.collector.rabbitmq.connection-timeout` | `RABBIT_CONNECTION_TIMEOUT` | Milliseconds to wait establishing a connection. Defaults to `60000` (1 minute)
 `zipkin.collector.rabbitmq.password` | `RABBIT_PASSWORD`| Password to use when connecting to RabbitMQ. Defaults to `guest`
 `zipkin.collector.rabbitmq.queue` | `RABBIT_QUEUE` | Queue from which to collect span messages. Defaults to `zipkin`
 `zipkin.collector.rabbitmq.username` | `RABBIT_USER` | Username to use when connecting to RabbitMQ. Defaults to `guest`
-`zipkin.collector.rabbitmq.virtualHost` | `RABBIT_VIRTUAL_HOST` | RabbitMQ virtual host to use. Defaults to `/`
+`zipkin.collector.rabbitmq.virtual-host` | `RABBIT_VIRTUAL_HOST` | RabbitMQ virtual host to use. Defaults to `/`
+`zipkin.collector.rabbitmq.use-ssl` | `RABBIT_USE_SSL` | Set to `true` to use SSL when connecting to RabbitMQ
 
 ### Caveats
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -37,6 +37,7 @@ zipkin:
       queue: ${RABBIT_QUEUE:zipkin}
       username: ${RABBIT_USER:guest}
       virtual-host: ${RABBIT_VIRTUAL_HOST:/}
+      useSsl: ${RABBIT_USE_SSL:false}
   query:
     enabled: ${QUERY_ENABLED:true}
     # 1 day in millis


### PR DESCRIPTION
Allows users to set a flag to use SSL when connecting to the RabbitMQ server via AMQPS.

See #1827