### PR TITLE
Special cases single-element encoded size

### DIFF
--- a/zipkin2/src/main/java/zipkin2/codec/Encoding.java
+++ b/zipkin2/src/main/java/zipkin2/codec/Encoding.java
@@ -17,6 +17,11 @@ import java.util.List;
 
 public enum Encoding {
   JSON {
+    /** Encoding overhead of a single element is brackets */
+    @Override public int listSizeInBytes(int encodedSizeInBytes) {
+      return 2 + encodedSizeInBytes;
+    }
+
     /** Encoding overhead is brackets and a comma for each span over 1 */
     @Override public int listSizeInBytes(List<byte[]> values) {
       int sizeInBytes = 2; // brackets
@@ -27,6 +32,9 @@ public enum Encoding {
       return sizeInBytes;
     }
   };
+
+  /** Like {@link #listSizeInBytes(List)}, except for a single element. */
+  public abstract int listSizeInBytes(int encodedSizeInBytes);
 
   public abstract int listSizeInBytes(List<byte[]> values);
 }

--- a/zipkin2/src/test/java/zipkin2/codec/EncodingTest.java
+++ b/zipkin2/src/test/java/zipkin2/codec/EncodingTest.java
@@ -30,9 +30,13 @@ public class EncodingTest {
 
   @Test public void singletonList_json() throws IOException {
     List<byte[]> encoded = Arrays.asList(new byte[10]);
+
+    assertThat(Encoding.JSON.listSizeInBytes(encoded.get(0).length))
+      .isEqualTo(2 /* [] */ + 10);
     assertThat(Encoding.JSON.listSizeInBytes(encoded))
       .isEqualTo(2 /* [] */ + 10);
   }
+
 
   @Test public void multiItemList_json() throws IOException {
     List<byte[]> encoded = Arrays.asList(new byte[3], new byte[4], new byte[5]);


### PR DESCRIPTION
This adds a utility for deriving the size of a single-element list. This
allows zipkin-reporter to defer encoding off the calling thread.

See https://github.com/openzipkin/zipkin-reporter-java/pull/84