### PR TITLE
Fixes bad partitioning of data in the v1 memory store

### DIFF
--- a/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/storage/InMemorySpanStore.java
@@ -330,7 +330,11 @@ public final class InMemorySpanStore implements SpanStore {
     @Override public int compare(Pair<Long> left, Pair<Long> right) {
       long x = left._2, y = right._2;
       int result = (x < y) ? -1 : ((x == y) ? 0 : 1); // Long.compareTo is JRE 7+
-      return -result; // use negative as we are descending
+      if (result != 0) return -result; // use negative as we are descending
+      // secondary compare as TreeMap is in use
+      x = left._1;
+      y = right._1;
+      return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 
     @Override public String toString() {


### PR DESCRIPTION
*Note* this only affects people using the v1 in-memory component. The
in-memory option of zipkin-server does not use this even if v1 format is
accepted.

This fixes a partitioning messup where all spans for the same timestamp
filed under the same key.