### PR TITLE
zipkin-ui: improve page rendering time by re-configuring jquery-i18n-properties

### DIFF
--- a/zipkin-ui/js/component_ui/i18n.js
+++ b/zipkin-ui/js/component_ui/i18n.js
@@ -3,11 +3,16 @@ import $ from 'jquery';
 import {contextRoot} from '../publicPath';
 
 export function i18nInit(file) {
+  // https://github.com/jquery-i18n-properties/jquery-i18n-properties
   $.i18n.properties({
     name: file,
     path: contextRoot,
     mode: 'map',
+    // do not append a unix timestamp when requesting the language (.properties) files
+    // this allows them to be cached by the browser
     cache: true,
+    // do not perform blocking XHR requests, as it blocks the entire browser, including
+    // rendering
     async: true,
     callback: () => {
       $('[data-i18n]').each((index, item) => {

--- a/zipkin-ui/js/component_ui/i18n.js
+++ b/zipkin-ui/js/component_ui/i18n.js
@@ -7,6 +7,8 @@ export function i18nInit(file) {
     name: file,
     path: contextRoot,
     mode: 'map',
+    cache: true,
+    async: true,
     callback: () => {
       $('[data-i18n]').each((index, item) => {
         if (item.tagName === 'INPUT' || item.tagName === 'SELECT') {


### PR DESCRIPTION
By default the `jquery-i18n-properties` plugin appends the current timestamp every time it requests the language `.properties` file, which requires the file to be loaded on every page load and prevents it from being served from cache.

By enabling the [`cache` option](https://github.com/jquery-i18n-properties/jquery-i18n-properties#options), that will no longer happen.

Another factor is the loading of several language files that is attempted. In my case `traces.properties`, `traces_en.properties`, `traces_en_US.properties`. The first one succeeds, the other 2 return a 404. That 404 cannot be cached by the browser.

The `async` option defers the loading of additional files, which should also improve time to render.