### PR TITLE
zipkin-ui: fix jumpiness on "more info" button

### DIFF
--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -139,14 +139,16 @@
         <button class="btn btn-info btn-xs pull-right" type="button" data-toggle="collapse"
                 data-target="#moreInfo" aria-expanded="false" aria-controls="moreInfo" data-i18n="trace.more">More Info</button>
         <hr/>
-        <table id='moreInfo' class='table table-striped collapse'>
-          <tbody>
-            <tr>
-              <td class='key' data-key='key'></td>
-              <td class='value' data-key='value'></td>
-            </tr>
-          </tbody>
-        </table>
+        <div id='moreInfo' class='collapse'>
+          <table class='table table-striped'>
+            <tbody>
+              <tr>
+                <td class='key' data-key='key'></td>
+                <td class='value' data-key='value'></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -139,6 +139,7 @@
         <button class="btn btn-info btn-xs pull-right" type="button" data-toggle="collapse"
                 data-target="#moreInfo" aria-expanded="false" aria-controls="moreInfo" data-i18n="trace.more">More Info</button>
         <hr/>
+        <div class='clearfix'></div>
         <div id='moreInfo' class='collapse'>
           <table class='table table-striped'>
             <tbody>


### PR DESCRIPTION
The "more info" button on the span detail view is all jumpy. Upon clicking the button, the appearing table gets squished together.

This happens because the `display` CSS property gets set to `block`. Where in this case it should really be `table`.

We can avoid the issue by wrapping the table in an extra div, as the div does not mind the `display: block`.

The clearfix ensures the table is positioned below the "more info" button, fixing some more jumpiness during the sliding animation.

![screen shot 2017-12-16 at 22 05 05](https://user-images.githubusercontent.com/11158255/34074349-3cb0ede2-e2ad-11e7-8eda-94fe05ed7a97.png)
