### PR TITLE
zipkin-ui: include minimal header on page load

### DIFF
--- a/zipkin-ui/index.ejs
+++ b/zipkin-ui/index.ejs
@@ -13,5 +13,17 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>
+
+    <div class='navbar navbar-inverse' role='navigation'>
+      <div class='container'>
+        <div class='navbar-header'>
+          <a class='navbar-brand' href='#'>
+            Zipkin<span class='muted' style='font-size: .75em; padding-left: 10px;' data-i18n="nav.inves">Investigate system behavior</span>
+          </a>
+        </div>
+        </div><!--/.nav-collapse -->
+      </div>
+    </div>
+
   </body>
 </html>

--- a/zipkin-ui/index.ejs
+++ b/zipkin-ui/index.ejs
@@ -14,6 +14,8 @@
   </head>
   <body>
 
+    <!-- we include a reduced header on page load, as this makes the page load feel much smoother -->
+
     <div class='navbar navbar-inverse' role='navigation'>
       <div class='container'>
         <div class='navbar-header'>


### PR DESCRIPTION
One of the reasons why the zipkin-ui _feels_ slow is because when you click a link, the page is first rendered as blank, and then re-rendered with the page content.

This can be improved significantly by rendering the header as part of the original `index.html` page load. This is much less visually disruptive, and makes everything feel a lot snappier.

I copied the navbar code from `layout.mustache`.