### PR TITLE
Fix SelectFromSpan with 128bit TraceIDs and strict-trace-id=false

### DIFF
--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
@@ -49,7 +49,7 @@ class CassandraSpanConsumer implements SpanConsumer { // not final for testing
     Schema.readMetadata(session);
 
     insertSpan = new InsertSpan.Factory(session, strictTraceId);
-    insertTraceByServiceSpan = new InsertTraceByServiceSpan.Factory(session);
+    insertTraceByServiceSpan = new InsertTraceByServiceSpan.Factory(session, strictTraceId);
     insertServiceSpanName = new InsertServiceSpan.Factory(session, WRITTEN_NAMES_TTL);
   }
 

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
@@ -169,12 +169,8 @@ class CassandraSpanStore implements SpanStore { // not final for testing
 
   @Override public Call<List<Span>> getTrace(String traceId) {
     // make sure we have a 16 or 32 character trace ID
-    traceId = Span.normalizeTraceId(traceId);
-
-    // Unless we are strict, truncate the trace ID to 64bit (encoded as 16 characters)
-    if (!strictTraceId && traceId.length() == 32) traceId = traceId.substring(16);
-
-    return spans.newCall(traceId);
+    String normalizedTraceId = Span.normalizeTraceId(traceId);
+    return spans.newCall(normalizedTraceId);
   }
 
   @Override public Call<List<String>> getServiceNames() {

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
@@ -33,6 +33,10 @@ import zipkin2.storage.StorageComponent;
  * is enabled via SLF4J. Trace level includes bound values.
  *
  * <p>Schema is installed by default from "/zipkin2-schema.cql"
+ *
+ * <p>When {@link StorageComponent.Builder#strictTraceId(boolean)} is disabled, span and index data
+ * are uniformly written with 64-bit trace ID length. When retrieving data, an extra "trace_id_high"
+ * field clarifies if a 128-bit trace ID was sent.
  */
 @AutoValue
 public abstract class CassandraStorage extends StorageComponent {

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
@@ -65,8 +65,18 @@ final class SelectFromSpan extends ResultSetFutureCall {
 
     Call<List<Span>> newCall(String traceId) {
       checkNotNull(traceId, "traceId");
+      // Unless we are strict, truncate the trace ID to 64bit (encoded as 16 characters)
+      Set<String> traceIds;
+      if (!strictTraceId && traceId.length() == 32) {
+        traceIds = new LinkedHashSet<>();
+        traceIds.add(traceId);
+        traceIds.add(traceId.substring(16));
+      } else {
+        traceIds = Collections.singleton(traceId);
+      }
+
       return new SelectFromSpan(this,
-        Collections.singleton(traceId),
+        traceIds,
         maxTraceCols // amount of spans per trace is almost always larger than trace IDs
       ).flatMap(accumulateSpans);
     }


### PR DESCRIPTION
In `span` table, Trace IDs are stored in two fields: `trace_id` and `trace_id_high`, both of which are 16 characters long.

cc @adriancole 