### PR TITLE
Fixes packaging problems found in OSGi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,28 @@
           <version>${maven-shade-plugin.version}</version>
         </plugin>
 
+        <!-- Need to block import of shaded packages in bnd.bnd as maven bundle plugin analyzes the unshaded jar -->
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <!-- Travis cannot resolve 3.3.0-->
+          <version>3.2.0</version>
+          <configuration>
+            <obrRepository>NONE</obrRepository>
+            <instructions>
+              <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            </instructions>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>process-classes</phase>
+              <goals>
+                <goal>manifest</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>

--- a/zipkin/bnd.bnd
+++ b/zipkin/bnd.bnd
@@ -4,5 +4,5 @@ Import-Package: \
 Export-Package: \
 	zipkin,\
 	zipkin.collector,\
-	zipkin.internal,\
-	zipkin.storage
+	zipkin.storage,\
+	zipkin.internal;zipkininternal=true;mandatory:=zipkininternal

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -85,22 +85,11 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <!-- Travis cannot resolve 3.3.0-->
-        <version>3.2.0</version>
         <configuration>
-          <obrRepository>NONE</obrRepository>
           <instructions>
             <_include>-bnd.bnd</_include>
           </instructions>
         </configuration>
-        <executions>
-          <execution>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <!-- Use of gson is internal only -->
       <plugin>
@@ -114,6 +103,11 @@
             <configuration>
               <shadeTestJar>false</shadeTestJar>
               <minimizeJar>true</minimizeJar>
+              <artifactSet>
+                <excludes>
+                  <exclude>io.zipkin.zipkin2:zipkin</exclude>
+                </excludes>
+              </artifactSet>
               <filters>
                 <filter>
                   <artifact>com.google.code.gson:gson</artifact>
@@ -123,13 +117,6 @@
                     <include>com/google/gson/stream/MalformedJsonException.class</include>
                     <include>com/google/gson/internal/JsonReaderInternalAccess.class</include>
                   </includes>
-                </filter>
-                <filter>
-                  <!-- don't include pom files, some are kilobytes -->
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                  </excludes>
                 </filter>
               </filters>
               <relocations>

--- a/zipkin2/bnd.bnd
+++ b/zipkin2/bnd.bnd
@@ -4,5 +4,5 @@ Import-Package: \
 Export-Package: \
 	zipkin2,\
 	zipkin2.codec,\
-	zipkin2.internal,\
-	zipkin2.storage
+	zipkin2.storage,\
+	zipkin2.internal;zipkin2internal=true;mandatory:=zipkin2internal

--- a/zipkin2/pom.xml
+++ b/zipkin2/pom.xml
@@ -87,22 +87,11 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <!-- Travis cannot resolve 3.3.0-->
-        <version>3.2.0</version>
         <configuration>
-          <obrRepository>NONE</obrRepository>
           <instructions>
             <_include>-bnd.bnd</_include>
           </instructions>
         </configuration>
-        <executions>
-          <execution>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <!-- Use of gson is internal only -->
       <plugin>
@@ -125,13 +114,6 @@
                     <include>com/google/gson/stream/MalformedJsonException.class</include>
                     <include>com/google/gson/internal/JsonReaderInternalAccess.class</include>
                   </includes>
-                </filter>
-                <filter>
-                  <!-- don't include pom files, some are kilobytes -->
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                  </excludes>
                 </filter>
               </filters>
               <relocations>


### PR DESCRIPTION
This fixes packaging where zipkin2 types were in the zipkin 1 jar.
It also restores the missing MANIFEST.MF file needed for OSGi to
work properly.

See https://github.com/apache/camel/pull/2151