### PR TITLE
Moves some spring tests to be integration tests to break circle less

### DIFF
--- a/zipkin-server/src/test/java/zipkin/server/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin/server/ITZipkinServer.java
@@ -52,7 +52,7 @@ import static zipkin.internal.Util.UTF_8;
   properties = "spring.config.name=zipkin-server"
 )
 @RunWith(SpringRunner.class)
-public class ZipkinServerIntegrationTest {
+public class ITZipkinServer {
 
   @Autowired InMemoryStorage storage;
   @Autowired ActuateCollectorMetrics metrics;

--- a/zipkin-server/src/test/java/zipkin/server/ITZipkinServerCORS.java
+++ b/zipkin-server/src/test/java/zipkin/server/ITZipkinServerCORS.java
@@ -36,11 +36,11 @@ import static org.assertj.core.api.Assertions.assertThat;
   webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
   properties = {
     "spring.config.name=zipkin-server",
-    "zipkin.query.allowed-origins=" + ZipkinServerCORSTest.ALLOWED_ORIGIN
+    "zipkin.query.allowed-origins=" + ITZipkinServerCORS.ALLOWED_ORIGIN
   }
 )
 @RunWith(SpringRunner.class)
-public class ZipkinServerCORSTest {
+public class ITZipkinServerCORS {
   static final String ALLOWED_ORIGIN = "http://foo.example.com";
   static final String DISALLOWED_ORIGIN = "http://bar.example.com";
 


### PR DESCRIPTION
CircleCI tends to kill our process during server tests. This moves
some to be integration tests, which hopefully can keep it alive longer.
Travis still runs these tests.