### PR TITLE
removes listing dupe tags from UI (only if both key & value are the same

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -19,11 +19,11 @@ function escapeHtml(string) {
 
 export function isDupeBinaryAnnotation(tagMap, anno) {
   if (!tagMap[anno.key]) {
-    tagMap[anno.key] = anno.value
+    tagMap[anno.key] = anno.value; // eslint-disable-line no-param-reassign
   } else if (tagMap[anno.key] === anno.value) {
-    return true
+    return true;
   }
-  return false
+  return false;
 }
 
 // Annotation values that contain the word "error" hint of a transient error.
@@ -70,7 +70,8 @@ export default component(function spanPanel() {
   this.$moreInfoTemplate = null;
 
   this.show = function(e, span) {
-    const self = this, tagMap = {};
+    const self = this;
+    const tagMap = {};
 
     this.$node.find('.modal-title').text(
       `${span.serviceName}.${span.spanName}: ${span.durationStr}`);
@@ -100,9 +101,7 @@ export default component(function spanPanel() {
 
     const $binAnnoBody = this.$node.find('#binaryAnnotations tbody').text('');
     $.each((span.binaryAnnotations || []), (i, anno) => {
-      if (isDupeBinaryAnnotation(tagMap, anno)) {
-        return
-      }
+      if (isDupeBinaryAnnotation(tagMap, anno)) return;
       const $row = self.$binaryAnnotationTemplate.clone();
       if (anno.key === Constants.ERROR) {
         $row.addClass('anno-error-critical');

--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -90,7 +90,13 @@ export default component(function spanPanel() {
     });
 
     const $binAnnoBody = this.$node.find('#binaryAnnotations tbody').text('');
+    var tagMap = {}
     $.each((span.binaryAnnotations || []), (i, anno) => {
+      if (!tagMap[anno.key]) {
+        tagMap[anno.key] = anno.value
+      } else if (tagMap[anno.key] == anno.value) {
+        return
+      }
       const $row = self.$binaryAnnotationTemplate.clone();
       if (anno.key === Constants.ERROR) {
         $row.addClass('anno-error-critical');

--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -17,6 +17,15 @@ function escapeHtml(string) {
   return String(string).replace(/[&<>"'`=\/]/g, s => entityMap[s]);
 }
 
+export function isDupeBinaryAnnotation(tagMap, anno) {
+  if (!tagMap[anno.key]) {
+    tagMap[anno.key] = anno.value
+  } else if (tagMap[anno.key] === anno.value) {
+    return true
+  }
+  return false
+}
+
 // Annotation values that contain the word "error" hint of a transient error.
 // This adds a class when that's the case.
 export function maybeMarkTransientError(row, anno) {
@@ -61,7 +70,7 @@ export default component(function spanPanel() {
   this.$moreInfoTemplate = null;
 
   this.show = function(e, span) {
-    const self = this;
+    const self = this, tagMap = {};
 
     this.$node.find('.modal-title').text(
       `${span.serviceName}.${span.spanName}: ${span.durationStr}`);
@@ -90,11 +99,8 @@ export default component(function spanPanel() {
     });
 
     const $binAnnoBody = this.$node.find('#binaryAnnotations tbody').text('');
-    var tagMap = {}
     $.each((span.binaryAnnotations || []), (i, anno) => {
-      if (!tagMap[anno.key]) {
-        tagMap[anno.key] = anno.value
-      } else if (tagMap[anno.key] == anno.value) {
+      if (isDupeBinaryAnnotation(tagMap, anno)) {
         return
       }
       const $row = self.$binaryAnnotationTemplate.clone();

--- a/zipkin-ui/test/component_ui/spanPanel.test.js
+++ b/zipkin-ui/test/component_ui/spanPanel.test.js
@@ -124,17 +124,17 @@ describe('formatBinaryAnnotationValue', () => {
 });
 
 describe('isDupeBinaryAnnotation', () => {
-  var tagMap = {}
+  const tagMap = {};
 
   it('should return false on new key', () => {
-    isDupeBinaryAnnotation(tagMap, {key: "key-1", value: "value-1"}).should.equal(false)
+    isDupeBinaryAnnotation(tagMap, {key: 'key-1', value: 'value-1'}).should.equal(false);
   });
 
   it('should return true on dupe key with exact matched value', () => {
-    isDupeBinaryAnnotation(tagMap, {key: "key-1", value: "value-1"}).should.equal(true)
+    isDupeBinaryAnnotation(tagMap, {key: 'key-1', value: 'value-1'}).should.equal(true);
   });
 
   it('should return false on dupe key with different value', () => {
-    isDupeBinaryAnnotation(tagMap, {key: "key-1", value: "value-2"}).should.equal(false)
+    isDupeBinaryAnnotation(tagMap, {key: 'key-1', value: 'value-2'}).should.equal(false);
   });
 });

--- a/zipkin-ui/test/component_ui/spanPanel.test.js
+++ b/zipkin-ui/test/component_ui/spanPanel.test.js
@@ -2,7 +2,8 @@ import {Constants} from '../../js/component_ui/traceConstants';
 import {
   maybeMarkTransientError,
   formatAnnotationValue,
-  formatBinaryAnnotationValue
+  formatBinaryAnnotationValue,
+  isDupeBinaryAnnotation
 } from '../../js/component_ui/spanPanel';
 import {endpoint, annotation} from './traceTestHelpers';
 
@@ -119,5 +120,21 @@ describe('formatBinaryAnnotationValue', () => {
     formatBinaryAnnotationValue('<script>alert(1)</script>').should.equal(
       '&lt;script&gt;alert(1)&lt;&#x2F;script&gt;'
     );
+  });
+});
+
+describe('isDupeBinaryAnnotation', () => {
+  var tagMap = {}
+
+  it('should return false on new key', () => {
+    isDupeBinaryAnnotation(tagMap, {key: "key-1", value: "value-1"}).should.equal(false)
+  });
+
+  it('should return true on dupe key with exact matched value', () => {
+    isDupeBinaryAnnotation(tagMap, {key: "key-1", value: "value-1"}).should.equal(true)
+  });
+
+  it('should return false on dupe key with different value', () => {
+    isDupeBinaryAnnotation(tagMap, {key: "key-1", value: "value-2"}).should.equal(false)
   });
 });


### PR DESCRIPTION
In shared spans mode it is easy to wind up with duplicate tags (binary annotations). Some instrumentation has tried to avoid this collision by either removing this information from their client side or server side instrumentation at the expense of losing this information if one of the sides is not instrumented. 

By deduping tags in the UI view when both key and value are exactly the same we'll have all information available if one side is not instrumented while only showing dupe tags if client side and server side have different values (which can be valuable information to have and avoids us making an estimated decision on which tags are more important from either client or server side).