### PR TITLE
zipkin-ui: make dropdowns resize-friendly

### DIFF
--- a/zipkin-ui/js/component_ui/serviceName.js
+++ b/zipkin-ui/js/component_ui/serviceName.js
@@ -40,6 +40,8 @@ export default component(function serviceName() {
     this.triggerChange(name);
 
     this.$node.chosen({search_contains: true});
+    this.$node.next('.chosen-container').css('width', '100%');
+
     this.on('change', this.onChange);
     this.on(document, 'dataServiceNames', this.updateServiceNameDropdown);
   });

--- a/zipkin-ui/js/component_ui/spanName.js
+++ b/zipkin-ui/js/component_ui/spanName.js
@@ -30,6 +30,8 @@ export default component(function spanName() {
     this.$node.chosen({
       search_contains: true
     });
+    this.$node.next('.chosen-container').css('width', '100%');
+
     this.on(document, 'dataSpanNames', this.updateSpans);
   });
 });


### PR DESCRIPTION
the jquery chosen plugin that is used for pretty dropdowns assigns the container element it creates a fixed width. this width is not updated on window resize, which can create strange effects.

this patch overrides the width style attribute of that element to be 100%, which means it will take up the full space of its container.

before (when resizing):

![screen shot 2018-01-06 at 20 05 05](https://user-images.githubusercontent.com/11158255/34643240-1be40ec6-f321-11e7-94a5-9b1c3838a886.png)

after:

![screen shot 2018-01-06 at 20 30 00](https://user-images.githubusercontent.com/11158255/34643241-20447faa-f321-11e7-984e-3ffdc08f2ec3.png)
