### PR TITLE
zipkin-ui: relative interval-based lookback

### DIFF
--- a/zipkin-ui/js/component_ui/lookback.js
+++ b/zipkin-ui/js/component_ui/lookback.js
@@ -1,0 +1,30 @@
+/* eslint-disable prefer-template */
+import {component} from 'flightjs';
+import $ from 'jquery';
+import queryString from 'query-string';
+
+export default component(function lookback() {
+  this.onChange = function () {
+    if (this.$node.val() === 'custom') {
+      $('#custom-lookback').show();
+    } else {
+      $('#custom-lookback').hide();
+    }
+  };
+
+  this.render = function () {
+    const selectedLookback = queryString.parse(window.location.search).lookback;
+    this.$node.find('option').each((i, option) => {
+      const $option = $(option);
+      if ($option.val() == selectedLookback) {
+        $option.prop('selected', true);
+      }
+    });
+  };
+
+  this.after('initialize', function () {
+    this.render();
+
+    this.on('change', this.onChange);
+  });
+});

--- a/zipkin-ui/js/component_ui/lookback.js
+++ b/zipkin-ui/js/component_ui/lookback.js
@@ -4,7 +4,7 @@ import $ from 'jquery';
 import queryString from 'query-string';
 
 export default component(function lookback() {
-  this.onChange = function () {
+  this.onChange = function() {
     if (this.$node.val() === 'custom') {
       $('#custom-lookback').show();
     } else {
@@ -12,17 +12,17 @@ export default component(function lookback() {
     }
   };
 
-  this.render = function () {
+  this.render = function() {
     const selectedLookback = queryString.parse(window.location.search).lookback;
     this.$node.find('option').each((i, option) => {
       const $option = $(option);
-      if ($option.val() == selectedLookback) {
+      if ($option.val() === selectedLookback) {
         $option.prop('selected', true);
       }
     });
   };
 
-  this.after('initialize', function () {
+  this.after('initialize', function() {
     this.render();
 
     this.on('change', this.onChange);

--- a/zipkin-ui/js/page/default.js
+++ b/zipkin-ui/js/page/default.js
@@ -7,6 +7,7 @@ import SpanNamesData from '../component_data/spanNames';
 import ServiceNamesData from '../component_data/serviceNames';
 import ServiceNameUI from '../component_ui/serviceName';
 import SpanNameUI from '../component_ui/spanName';
+import LookbackUI from '../component_ui/lookback';
 import InfoPanelUI from '../component_ui/infoPanel';
 import InfoButtonUI from '../component_ui/infoButton';
 import JsonPanelUI from '../component_ui/jsonPanel';
@@ -72,6 +73,7 @@ const DefaultPageComponent = component(function DefaultPage() {
       ServiceNamesData.attachTo(document);
       ServiceNameUI.attachTo('#serviceName');
       SpanNameUI.attachTo('#spanName');
+      LookbackUI.attachTo('#lookback');
       InfoPanelUI.attachTo('#infoPanel');
       InfoButtonUI.attachTo('button.info-request');
       JsonPanelUI.attachTo('#jsonPanel');

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -17,6 +17,26 @@
         </div>
       </div>
 
+      <div class="form-group col-md-6">
+        <label for="lookback" data-i18n="traces.lookback">Lookback</label>
+        <div class="clearfix">
+          <select class="form-control input-sm" name="lookback" id="lookback">
+            <option value="3600000" data-i18n="traces.lookback.1hour">1 hour</option>
+            <option value="10800000" data-i18n="traces.lookback.3hours">3 hours</option>
+            <option value="21600000" data-i18n="traces.lookback.6hours">6 hours</option>
+            <option value="43200000" data-i18n="traces.lookback.12hours">12 hours</option>
+            <option value="86400000" data-i18n="traces.lookback.1day">1 day</option>
+            <option value="172800000" data-i18n="traces.lookback.2days">2 days</option>
+            <option value="604800000" data-i18n="traces.lookback.7days">7 days</option>
+            <option value="custom" data-i18n="traces.lookback.custom">Custom</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <div class="row" id="custom-lookback" style="display: none;">
+      <div class="col-md-6"></div>
+
       <div id="start-ts" class="form-group col-md-3">
         <label for="timeStamp" data-i18n="traces.stime">Start time</label>
         <div>

--- a/zipkin-ui/test/component_data/default.test.js
+++ b/zipkin-ui/test/component_data/default.test.js
@@ -15,7 +15,7 @@ describe('convertToApiQuery', () => {
   });
 
   it('should not require startTs', () => {
-    const parsed = convertToApiQuery('?endTs=1459169770000');
+    const parsed = convertToApiQuery('?lookback=custom&endTs=1459169770000');
 
     parsed.endTs.should.equal('1459169770000');
     should.not.exist(parsed.lookback);
@@ -23,7 +23,7 @@ describe('convertToApiQuery', () => {
   });
 
   it('should replace startTs with lookback', () => {
-    const parsed = convertToApiQuery('?startTs=1459169760000&endTs=1459169770000');
+    const parsed = convertToApiQuery('?lookback=custom&startTs=1459169760000&endTs=1459169770000');
 
     parsed.endTs.should.equal('1459169770000');
     parsed.lookback.should.equal('10000');
@@ -31,7 +31,7 @@ describe('convertToApiQuery', () => {
   });
 
   it('should not add negative lookback', () => {
-    const parsed = convertToApiQuery('?endTs=1459169760000&startTs=1459169770000');
+    const parsed = convertToApiQuery('?lookback=custom&endTs=1459169760000&startTs=1459169770000');
 
     should.not.exist(parsed.lookback);
     should.not.exist(parsed.startTs);


### PR DESCRIPTION
the default start-ts and end-ts elements in the form are imo a little difficult to use. commonly i am usually interested in some sort of relative interval, or lookback.

this patch replaces the start-ts and end-ts fields with a pre-configured dropdown of "1 hour", "3 hours", "6 hours", "12 hours", "1 day", "2 days", and "7 days".

![screen shot 2018-01-06 at 21 46 48](https://user-images.githubusercontent.com/11158255/34643859-f8e99e1c-f32b-11e7-86d4-ebff941b2323.png)
![screen shot 2018-01-06 at 21 47 11](https://user-images.githubusercontent.com/11158255/34643861-fdd148c6-f32b-11e7-89fa-08aefb25de32.png)

there is also a "custom" option which reveals the start-ts and end-ts fields.

![screen shot 2018-01-06 at 21 47 00](https://user-images.githubusercontent.com/11158255/34643863-0247e748-f32c-11e7-8b52-a89c3671e704.png)

a nice side-effect from this is that refreshing the page will now show the latest traces, which can be nice when you are trying to reproduce an issue and "waiting" for the trace to show up.