### PR TITLE
Makes zipkin2.Span use json serialization

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -48,6 +48,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.esotericsoftware.kryo</groupId>
+      <artifactId>kryo</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
       <version>${libthrift.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,13 @@
         <version>1.5.3</version>
       </dependency>
 
+      <!-- for testing flink -->
+      <dependency>
+        <groupId>com.esotericsoftware.kryo</groupId>
+        <artifactId>kryo</artifactId>
+        <version>2.24.0</version>
+      </dependency>
+
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>

--- a/zipkin2/pom.xml
+++ b/zipkin2/pom.xml
@@ -79,6 +79,11 @@
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware.kryo</groupId>
+      <artifactId>kryo</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zipkin2/src/main/java/zipkin2/Annotation.java
+++ b/zipkin2/src/main/java/zipkin2/Annotation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,21 +13,22 @@
  */
 package zipkin2;
 
-import com.google.auto.value.AutoValue;
+import java.io.ObjectStreamException;
 import java.io.Serializable;
+import java.io.StreamCorruptedException;
 
 /**
  * Associates an event that explains latency with a timestamp.
  *
  * <p>Unlike log statements, annotations are often codes: Ex. {@code cache.miss}.
  */
-@AutoValue
 //@Immutable
-public abstract class Annotation implements Comparable<Annotation>, Serializable { // for Spark jobs
+public final class Annotation implements Comparable<Annotation>, Serializable { // for Spark jobs
   private static final long serialVersionUID = 0L;
 
   public static Annotation create(long timestamp, String value) {
-    return new AutoValue_Annotation(timestamp, value);
+    if (value == null) throw new NullPointerException("value == null");
+    return new Annotation(timestamp, value);
   }
 
   /**
@@ -36,12 +37,17 @@ public abstract class Annotation implements Comparable<Annotation>, Serializable
    * <p>This value should be set directly by instrumentation, using the most precise value possible.
    * For example, {@code gettimeofday} or multiplying {@link System#currentTimeMillis} by 1000.
    */
-  public abstract long timestamp();
+  public long timestamp() {
+    return timestamp;
+  }
 
   /**
    * Usually a short tag indicating an event, like {@code cache.miss} or {@code error}
    */
-  public abstract String value();
+  public String value() {
+    return value;
+  }
+
 
   /** Compares by {@link #timestamp}, then {@link #value}. */
   @Override public int compareTo(Annotation that) {
@@ -51,6 +57,61 @@ public abstract class Annotation implements Comparable<Annotation>, Serializable
     return value().compareTo(that.value());
   }
 
-  Annotation() {
+  // clutter below mainly due to difficulty working with Kryo which cannot handle AutoValue subclass
+  // See https://github.com/openzipkin/zipkin/issues/1879
+  final long timestamp;
+  final String value;
+
+  Annotation(long timestamp, String value) {
+    this.timestamp = timestamp;
+    this.value = value;
+  }
+
+  @Override public String toString() {
+    return "Annotation{"
+      + "timestamp=" + timestamp + ", "
+      + "value=" + value
+      + "}";
+  }
+
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof Annotation)) return false;
+    Annotation that = (Annotation) o;
+    return (timestamp == that.timestamp()) && (value.equals(that.value()));
+  }
+
+  @Override public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= (int) ((timestamp >>> 32) ^ timestamp);
+    h *= 1000003;
+    h ^= value.hashCode();
+    return h;
+  }
+
+  // As this is an immutable object (no default constructor), defer to a serialization proxy.
+  final Object writeReplace() throws ObjectStreamException {
+    return new SerializedForm(this);
+  }
+
+  private static final class SerializedForm implements Serializable {
+    static final long serialVersionUID = 0L;
+
+    final long timestamp;
+    final String value;
+
+    SerializedForm(Annotation annotation) {
+      timestamp = annotation.timestamp;
+      value = annotation.value;
+    }
+
+    Object readResolve() throws ObjectStreamException {
+      try {
+        return Annotation.create(timestamp, value);
+      } catch (IllegalArgumentException e) {
+        throw new StreamCorruptedException(e.getMessage());
+      }
+    }
   }
 }

--- a/zipkin2/src/main/java/zipkin2/DependencyLink.java
+++ b/zipkin2/src/main/java/zipkin2/DependencyLink.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,60 +13,90 @@
  */
 package zipkin2;
 
-import com.google.auto.value.AutoValue;
+import java.io.ObjectStreamException;
 import java.io.Serializable;
+import java.io.StreamCorruptedException;
 import java.nio.charset.Charset;
 import java.util.Locale;
+import zipkin2.codec.DependencyLinkBytesDecoder;
 import zipkin2.codec.DependencyLinkBytesEncoder;
 
-@AutoValue
 //@Immutable
-public abstract class DependencyLink implements Serializable { // for Spark jobs
+public final class DependencyLink implements Serializable { // for Spark and Flink jobs
   static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private static final long serialVersionUID = 0L;
 
   public static Builder newBuilder() {
-    return new AutoValue_DependencyLink.Builder().errorCount(0);
+    return new Builder();
   }
 
   /** parent service name (caller) */
-  public abstract String parent();
+  public String parent() {
+    return parent;
+  }
 
   /** child service name (callee) */
-  public abstract String child();
+  public String child() {
+    return child;
+  }
 
   /** total traced calls made from {@link #parent} to {@link #child} */
-  public abstract long callCount();
+  public long callCount() {
+    return callCount;
+  }
 
   /** How many {@link #callCount calls} are known to be errors */
-  public abstract long errorCount();
+  public long errorCount() {
+    return errorCount;
+  }
 
-  public abstract Builder toBuilder();
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
 
-  @AutoValue.Builder
-  public static abstract class Builder {
-
-    public abstract Builder parent(String parent);
-
-    public abstract Builder child(String child);
-
-    public abstract Builder callCount(long callCount);
-
-    public abstract Builder errorCount(long errorCount);
-
-    abstract String parent();
-
-    abstract String child();
-
-    abstract DependencyLink autoBuild();
-
-    public final DependencyLink build() {
-      return parent(parent().toLowerCase(Locale.ROOT))
-        .child(child().toLowerCase(Locale.ROOT)).autoBuild();
-    }
+  public static final class Builder {
+    String parent, child;
+    long callCount, errorCount;
 
     Builder() {
+    }
+
+    Builder(DependencyLink source) {
+      this.parent = source.parent;
+      this.child = source.child;
+      this.callCount = source.callCount;
+      this.errorCount = source.errorCount;
+    }
+
+    public Builder parent(String parent) {
+      if (parent == null) throw new NullPointerException("parent == null");
+      this.parent = parent.toLowerCase(Locale.ROOT);
+      return this;
+    }
+
+    public Builder child(String child) {
+      if (child == null) throw new NullPointerException("child == null");
+      this.child = child.toLowerCase(Locale.ROOT);
+      return this;
+    }
+
+    public Builder callCount(long callCount) {
+      this.callCount = callCount;
+      return this;
+    }
+
+    public Builder errorCount(long errorCount) {
+      this.errorCount = errorCount;
+      return this;
+    }
+
+    public DependencyLink build() {
+      String missing = "";
+      if (parent == null) missing += " parent";
+      if (child == null) missing += " child";
+      if (!"".equals(missing)) throw new IllegalStateException("Missing :" + missing);
+      return new DependencyLink(this);
     }
   }
 
@@ -74,6 +104,61 @@ public abstract class DependencyLink implements Serializable { // for Spark jobs
     return new String(DependencyLinkBytesEncoder.JSON_V1.encode(this), UTF_8);
   }
 
-  DependencyLink() {
+  // clutter below mainly due to difficulty working with Kryo which cannot handle AutoValue subclass
+  // See https://github.com/openzipkin/zipkin/issues/1879
+  final String parent, child;
+  final long callCount, errorCount;
+
+  DependencyLink(Builder builder) {
+    parent = builder.parent;
+    child = builder.child;
+    callCount = builder.callCount;
+    errorCount = builder.errorCount;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof DependencyLink)) return false;
+    DependencyLink that = (DependencyLink) o;
+      return (parent.equals(that.parent))
+        && (child.equals(that.child))
+        && (callCount == that.callCount)
+        && (errorCount == that.errorCount);
+  }
+
+  @Override public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= parent.hashCode();
+    h *= 1000003;
+    h ^= child.hashCode();
+    h *= 1000003;
+    h ^= (int) ((callCount >>> 32) ^ callCount);
+    h *= 1000003;
+    h ^= (int) ((errorCount >>> 32) ^ errorCount);
+    return h;
+  }
+
+  // This is an immutable object, and our encoder is faster than java's: use a serialization proxy.
+  final Object writeReplace() throws ObjectStreamException {
+    return new SerializedForm(DependencyLinkBytesEncoder.JSON_V1.encode(this));
+  }
+
+  private static final class SerializedForm implements Serializable {
+    private static final long serialVersionUID = 0L;
+
+    final byte[] bytes;
+
+    SerializedForm(byte[] bytes) {
+      this.bytes = bytes;
+    }
+
+    Object readResolve() throws ObjectStreamException {
+      try {
+        return DependencyLinkBytesDecoder.JSON_V1.decodeOne(bytes);
+      } catch (IllegalArgumentException e) {
+        throw new StreamCorruptedException(e.getMessage());
+      }
+    }
   }
 }

--- a/zipkin2/src/test/java/zipkin2/EndpointTest.java
+++ b/zipkin2/src/test/java/zipkin2/EndpointTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -109,7 +109,7 @@ public class EndpointTest {
       .isNull();
   }
 
-  @Test public void ip_ipv6_compatIpv4() throws UnknownHostException {
+  @Test public void ip_ipv6_compatIpv4() {
     String ipv6 = "::0000:1.2.3.4";
     Endpoint endpoint = Endpoint.newBuilder().ip(ipv6).build();
 
@@ -195,7 +195,7 @@ public class EndpointTest {
   }
 
   @Test public void lowercasesServiceName() {
-    assertThat(Endpoint.newBuilder().serviceName("fFf").ipv4("127.0.0.1").build().serviceName())
+    assertThat(Endpoint.newBuilder().serviceName("fFf").ip("127.0.0.1").build().serviceName())
       .isEqualTo("fff");
   }
 }

--- a/zipkin2/src/test/java/zipkin2/codec/KryoTest.java
+++ b/zipkin2/src/test/java/zipkin2/codec/KryoTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.codec;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.JavaSerializer;
+import org.junit.Test;
+import zipkin2.Annotation;
+import zipkin2.DependencyLink;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.TestObjects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KryoTest {
+
+  @Test public void kryoJavaSerialization_annotation() {
+    Kryo kryo = new Kryo();
+    kryo.register(Annotation.class, new JavaSerializer());
+
+    Output output = new Output(4096);
+    kryo.writeObject(output, Annotation.create(1L, "foo"));
+    output.flush();
+    byte[] serialized = output.getBuffer();
+
+    assertThat(kryo.readObject(new Input(serialized), Annotation.class))
+      .isEqualTo(Annotation.create(1L, "foo"));
+  }
+
+  @Test public void kryoJavaSerialization_endpoint() {
+    Kryo kryo = new Kryo();
+    kryo.register(Endpoint.class, new JavaSerializer());
+
+    Output output = new Output(4096);
+    kryo.writeObject(output, TestObjects.BACKEND);
+    output.flush();
+    byte[] serialized = output.getBuffer();
+
+    assertThat(kryo.readObject(new Input(serialized), Endpoint.class))
+      .isEqualTo(TestObjects.BACKEND);
+  }
+
+  @Test public void kryoJavaSerialization_span() {
+    Kryo kryo = new Kryo();
+    kryo.register(Span.class, new JavaSerializer());
+
+    Output output = new Output(4096);
+    kryo.writeObject(output, TestObjects.CLIENT_SPAN);
+    output.flush();
+    byte[] serialized = output.getBuffer();
+
+    assertThat(kryo.readObject(new Input(serialized), Span.class))
+      .isEqualTo(TestObjects.CLIENT_SPAN);
+  }
+
+  @Test public void kryoJavaSerialization_dependencyLink() {
+    Kryo kryo = new Kryo();
+    kryo.register(DependencyLink.class, new JavaSerializer());
+
+    DependencyLink link = DependencyLink.newBuilder().parent("client").child("server").callCount(2L)
+      .errorCount(23L).build();
+
+    Output output = new Output(4096);
+    kryo.writeObject(output, link);
+    output.flush();
+    byte[] serialized = output.getBuffer();
+
+    assertThat(kryo.readObject(new Input(serialized), DependencyLink.class))
+      .isEqualTo(link);
+  }
+
+  /** Example test for how to use Kryo and reuse our encoders */
+  public class JsonV2SpanSerializer extends Serializer<Span> {
+    @Override public void write(Kryo kryo, Output output, Span span) {
+      byte[] json = SpanBytesEncoder.JSON_V2.encode(span);
+      output.writeInt(json.length);
+      output.write(json);
+    }
+
+    @Override public Span read(Kryo kryo, Input input, Class<Span> type) {
+      int length = input.readInt();
+      byte[] json = input.readBytes(length);
+      return SpanBytesDecoder.JSON_V2.decodeOne(json);
+    }
+  }
+
+  @Test public void kryoJson2() {
+    Kryo kryo = new Kryo();
+    kryo.register(Span.class, new JsonV2SpanSerializer());
+
+    Output output = new Output(4096);
+    kryo.writeObject(output, TestObjects.CLIENT_SPAN);
+    output.flush();
+    byte[] serialized = output.getBuffer();
+
+    assertThat(kryo.readObject(new Input(serialized), Span.class))
+      .isEqualTo(TestObjects.CLIENT_SPAN);
+  }
+}


### PR DESCRIPTION
Kryo doesn't work with auto-value. This makes a default implementation
of serialization using the json code (which is efficient).

Fixes #1879