### PR TITLE
Adding the ability to import traces from JSON into zipkin-ui

### DIFF
--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -129,7 +129,7 @@ public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
   // If the path is a a file w/an extension, treat normally.
   // Otherwise instead of returning 404, forward to the index.
   // See https://github.com/twitter/finatra/blob/458c6b639c3afb4e29873d123125eeeb2b02e2cd/http/src/main/scala/com/twitter/finatra/http/response/ResponseBuilder.scala#L321
-  @RequestMapping(value = {"/zipkin/", "/zipkin/traces/{id}", "/zipkin/dependency"}, method = GET)
+  @RequestMapping(value = {"/zipkin/", "/zipkin/traces/{id}", "/zipkin/dependency", "/zipkin/traceViewer"}, method = GET)
   public ModelAndView forwardUiEndpoints() {
     return new ModelAndView("forward:/zipkin/index.html");
   }

--- a/zipkin-ui/js/component_ui/uploadTrace.js
+++ b/zipkin-ui/js/component_ui/uploadTrace.js
@@ -1,0 +1,62 @@
+import {component} from 'flightjs';
+import FullPageSpinnerUI from '../component_ui/fullPageSpinner';
+import traceToMustache from '../../js/component_ui/traceToMustache';
+import {SPAN_V1} from '../spanConverter';
+
+function ensureV1(trace) {
+  if (trace == null || trace.length === 0
+          || (trace[0].localEndpoint === undefined && trace[0].remoteEndpoint === undefined)) {
+    return trace;
+  }
+
+  const newTrace = [];
+  for (let i = 0; i < trace.length; i++) {
+    newTrace.push(SPAN_V1.convert(trace[i]));
+  }
+
+  return newTrace;
+}
+
+export default component(function uploadTrace() {
+  this.doUpload = function() {
+    const files = this.node.files;
+    if (files.length === 0) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = evt => {
+      let model;
+      try {
+        let trace = JSON.parse(evt.target.result);
+        trace = ensureV1(trace);
+
+        const modelview = traceToMustache(trace);
+        model = {modelview, trace};
+      } catch (e) {
+        this.trigger('uiServerError',
+              {desc: 'Cannot parse file', message: e});
+        throw e;
+      } finally {
+        this.trigger(document, 'uiHideFullPageSpinner');
+      }
+
+      this.trigger(document, 'traceViewerPageModelView', model);
+    };
+
+    reader.onerror = evt => {
+      this.trigger(document, 'uiHideFullPageSpinner');
+      this.trigger('uiServerError',
+            {desc: 'Cannot load file', message: `${evt.target.error.name}`});
+    };
+
+    this.trigger(document, 'uiShowFullPageSpinner');
+    setTimeout(() => reader.readAsText(files[0]), 0);
+  };
+
+  this.after('initialize', function() {
+    this.on('change', this.doUpload);
+    FullPageSpinnerUI.teardownAll();
+    FullPageSpinnerUI.attachTo('#fullPageSpinner');
+  });
+});

--- a/zipkin-ui/js/component_ui/uploadTrace.js
+++ b/zipkin-ui/js/component_ui/uploadTrace.js
@@ -3,6 +3,16 @@ import FullPageSpinnerUI from '../component_ui/fullPageSpinner';
 import traceToMustache from '../../js/component_ui/traceToMustache';
 import {SPAN_V1} from '../spanConverter';
 
+function rootToFrontComparator(span1/* , span2*/) {
+  return span1.parentId === undefined ? -1 : 0;
+}
+
+function sort(trace) {
+  if (trace != null) {
+    trace.sort(rootToFrontComparator);
+  }
+}
+
 function ensureV1(trace) {
   if (trace == null || trace.length === 0
           || (trace[0].localEndpoint === undefined && trace[0].remoteEndpoint === undefined)) {
@@ -30,6 +40,7 @@ export default component(function uploadTrace() {
       try {
         let trace = JSON.parse(evt.target.result);
         trace = ensureV1(trace);
+        sort(trace);
 
         const modelview = traceToMustache(trace);
         model = {modelview, trace};

--- a/zipkin-ui/js/main.js
+++ b/zipkin-ui/js/main.js
@@ -8,6 +8,7 @@ import {compose, registry, advice, debug} from 'flightjs';
 import crossroads from 'crossroads';
 import initializeDefault from './page/default';
 import initializeTrace from './page/trace';
+import initializeTraceViewer from './page/traceViewer';
 import initializeDependency from './page/dependency';
 import CommonUI from './page/common';
 import loadConfig from './config';
@@ -21,6 +22,7 @@ loadConfig().then(config => {
 
   crossroads.addRoute(contextRoot, () => initializeDefault(config));
   crossroads.addRoute(`${contextRoot}traces/{id}`, traceId => initializeTrace(traceId, config));
+  crossroads.addRoute(`${contextRoot}traceViewer`, () => initializeTraceViewer(config));
   crossroads.addRoute(`${contextRoot}dependency`, () => initializeDependency(config));
   crossroads.parse(window.location.pathname);
 }, e => {

--- a/zipkin-ui/js/page/traceViewer.js
+++ b/zipkin-ui/js/page/traceViewer.js
@@ -1,0 +1,75 @@
+import {component} from 'flightjs';
+import $ from 'jquery';
+import FilterAllServicesUI from '../component_ui/filterAllServices';
+import JsonPanelUI from '../component_ui/jsonPanel';
+import ServiceFilterSearchUI from '../component_ui/serviceFilterSearch';
+import SpanPanelUI from '../component_ui/spanPanel';
+import TraceUI from '../component_ui/trace';
+import FilterLabelUI from '../component_ui/filterLabel';
+import ZoomOut from '../component_ui/zoomOutSpans';
+import UploadTraceUI from '../component_ui/uploadTrace';
+import {traceViewerTemplate} from '../templates';
+import {contextRoot} from '../publicPath';
+
+const TraceViewerPageComponent = component(function TraceViewerPage() {
+  this.render = function(model) {
+    try {
+      this.$node.html(traceViewerTemplate({
+        contextRoot,
+        ...model
+      }));
+    } catch (e) {
+      this.trigger('uiServerError',
+                {desc: 'Failed to render template', message: e.message});
+    }
+
+    UploadTraceUI.attachTo('#traceFile');
+  };
+
+  this.attach = function() {
+    FilterAllServicesUI.attachTo('#filterAllServices', {
+      totalServices: $('.trace-details.services span').length
+    });
+    JsonPanelUI.attachTo('#jsonPanel');
+    ServiceFilterSearchUI.attachTo('#serviceFilterSearch');
+    SpanPanelUI.attachTo('#spanPanel');
+    TraceUI.attachTo('#trace-container');
+    FilterLabelUI.attachTo('.service-filter-label');
+    ZoomOut.attachTo('#zoomOutSpans');
+  };
+
+  this.teardown = function() {
+    ZoomOut.teardownAll();
+    FilterLabelUI.teardownAll();
+    TraceUI.teardownAll();
+    SpanPanelUI.teardownAll();
+    ServiceFilterSearchUI.teardownAll();
+    JsonPanelUI.teardownAll();
+    FilterAllServicesUI.teardownAll();
+  };
+
+  this.after('initialize', function() {
+    window.document.title = 'Zipkin - Trace Viewer';
+
+    this.render({});
+
+    this.on(document, 'traceViewerPageModelView', function(ev, data) {
+      this.teardown();
+      this.render(data.modelview);
+      this.attach();
+
+      this.$node.find('#traceJsonLink').click(e => {
+        e.preventDefault();
+        this.trigger('uiRequestJsonPanel', {title: `Trace ${data.modelview.traceId}`,
+                                            obj: data.trace,
+                                            link: `${contextRoot}traceViewer`});
+      });
+
+      $('.annotation:not(.core)').tooltip({placement: 'left'});
+    });
+  });
+});
+
+export default function initializeTrace(config) {
+  TraceViewerPageComponent.attachTo('.content', {config});
+}

--- a/zipkin-ui/js/spanConverter.js
+++ b/zipkin-ui/js/spanConverter.js
@@ -1,0 +1,114 @@
+function toV1Endpoint(endpoint) {
+  if (endpoint === undefined) {
+    return undefined;
+  }
+  const res = {
+    serviceName: endpoint.serviceName || '', // undefined is not allowed in v1
+  };
+  if (endpoint.ipv4) {
+    res.ipv4 = endpoint.ipv4;
+  }
+  if (endpoint.port) {
+    res.port = endpoint.port;
+  }
+  return res;
+}
+
+function toV1Annotation(ann, endpoint) {
+  return {
+    value: ann.value,
+    timestamp: ann.timestamp,
+    endpoint
+  };
+}
+
+// Copied from https://github.com/openzipkin/zipkin-js/blob/8018e441d01804b02d0d217f10cd82759e71e02a/packages/zipkin/src/jsonEncoder.js#L25
+// Modified to correct assumption that 'annotations' always exist and ensure
+// that 'beginAnnotation' comes first timestamp/duration should always be copied over
+function convertV1(span) {
+  const res = {
+    traceId: span.traceId
+  };
+  if (span.parentId) { // instead of writing "parentId": NULL
+    res.parentId = span.parentId;
+  }
+  res.id = span.id;
+  res.name = span.name || ''; // undefined is not allowed in v1
+  res.timestamp = span.timestamp;
+  res.duration = span.duration;
+
+  const jsonEndpoint = toV1Endpoint(span.localEndpoint);
+
+  let beginAnnotation;
+  let endAnnotation;
+  let addressKey;
+  switch (span.kind) {
+    case 'CLIENT':
+      beginAnnotation = span.timestamp ? 'cs' : undefined;
+      endAnnotation = 'cr';
+      addressKey = 'sa';
+      break;
+    case 'SERVER':
+      beginAnnotation = span.timestamp ? 'sr' : undefined;
+      endAnnotation = 'ss';
+      addressKey = 'ca';
+      break;
+    default:
+  }
+
+  if (span.annotations !== undefined && span.annotations.length > 0
+          || beginAnnotation) { // don't write empty array
+    res.annotations = [];
+  }
+
+  if (beginAnnotation) {
+    res.annotations.push({
+      value: beginAnnotation,
+      timestamp: span.timestamp,
+      endpoint: jsonEndpoint
+    });
+  }
+
+  if (span.annotations !== undefined && span.annotations.length > 0) {
+    span.annotations.forEach((ann) =>
+      res.annotations.push(toV1Annotation(ann, jsonEndpoint))
+    );
+  }
+
+  if (beginAnnotation && span.duration) {
+    res.annotations.push({
+      value: endAnnotation,
+      timestamp: span.timestamp + span.duration,
+      endpoint: jsonEndpoint
+    });
+  }
+
+  const keys = Object.keys(span.tags || {});
+  if (keys.length > 0 || span.remoteEndpoint) { // don't write empty array
+    res.binaryAnnotations = keys.map(key => ({
+      key,
+      value: span.tags[key],
+      endpoint: jsonEndpoint
+    }));
+  }
+
+  if (span.remoteEndpoint) {
+    const address = {
+      key: addressKey,
+      value: true,
+      endpoint: toV1Endpoint(span.remoteEndpoint)
+    };
+    res.binaryAnnotations.push(address);
+  }
+
+  if (span.debug) { // instead of writing "debug": false
+    res.debug = true;
+  }
+  return res;
+}
+
+module.exports.SPAN_V1 = {
+  convert(span) {
+    return convertV1(span);
+  }
+};

--- a/zipkin-ui/js/templates.js
+++ b/zipkin-ui/js/templates.js
@@ -3,3 +3,4 @@ export const searchDisabled = require('../templates/searchDisabled.mustache');
 export const layoutTemplate = require('../templates/layout.mustache');
 export const dependenciesTemplate = require('../templates/dependency.mustache');
 export const traceTemplate = require('../templates/trace.mustache');
+export const traceViewerTemplate = require('../templates/traceViewer.mustache');

--- a/zipkin-ui/static/nav.properties
+++ b/zipkin-ui/static/nav.properties
@@ -2,3 +2,4 @@ nav.inves = Investigate system behavior
 nav.find = Find a trace
 nav.dep = Dependencies
 nav.search = Go to trace
+nav.viewSaved = View Saved Trace

--- a/zipkin-ui/static/trace.properties
+++ b/zipkin-ui/static/trace.properties
@@ -1,4 +1,5 @@
 trace.duration = Duration:
+trace.file = Trace JSON:
 trace.service = Services:
 trace.depth = Depth:
 trace.spans = Total Spans:

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -8,17 +8,18 @@
         <div class="navbar-left">
           <ul class="nav navbar-nav">
             <li data-route="index"><a href="{{contextRoot}}" data-i18n="nav.find">Find a trace</a></li>
+            <li data-route="traceViewer"><a href="{{contextRoot}}traceViewer" data-i18n="nav.viewSaved">View Saved Trace</a></li>
             <li data-route="dependency"><a href="{{contextRoot}}dependency/" data-i18n="nav.dep">Dependencies</a></li>
           </ul>
         </div>
-        <div class="navbar-right" style="width: 50%">
+        <div class="navbar-right" style="width: 30%">
           <div class="navbar-right" style='padding-left: 15px'>
             <p class="navbar-text muted" id="environment"></p>
           </div>
           <form id="traceIdQueryForm" class="form-inline" role="form">
-            <div class="navbar-right" style="width: 25%; float: right">
+            <div class="navbar-right" style="float: right">
               <div class="row well-sm clearfix">
-                  <input type="text" class="form-control input-sm" id="traceIdQuery" name="traceIdQuery" style="width: 100%" placeholder='Go to trace' data-i18n='nav.search'>
+                  <input type="text" class="form-control input-sm" id="traceIdQuery" name="traceIdQuery" placeholder='Go to trace' data-i18n='nav.search'>
               </div>
             </div>
           </form>

--- a/zipkin-ui/templates/traceViewer.mustache
+++ b/zipkin-ui/templates/traceViewer.mustache
@@ -1,0 +1,250 @@
+<div id='trace-controls' class='row well well-sm'>
+
+  <form class="form-inline" role="form">
+    <div class="form-group">
+      <label for="traceFile" data-i18n="trace.file">Trace JSON:</label>
+      <input type="file" accept=".json,application/json" id="traceFile" class="form-control">
+    </div>
+  </form>
+
+  {{#traceId}}
+  <ul class='nav nav-pills'>
+    <li class=''><a href='#'><strong data-i18n="trace.duration">Duration:</strong> <span class='badge'>{{duration}}</span></a></li>
+    <li class=''><a href='#'><strong data-i18n="trace.service">Services:</strong> <span class='badge'>{{services}}</span></a></li>
+    <li class=''><a href='#'><strong data-i18n="trace.depth">Depth:</strong> <span class='badge'>{{depth}}</span></a></li>
+    <li class=''><a href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge'>{{totalSpans}}</span></a></li>
+    {{#logsUrl}}
+    <li class='navbar-right'><a href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-primary btn-xs badge'>Logs</span></a></li>
+    {{/logsUrl}}
+    <li class='navbar-right'><a href='{{ contextRoot }}api/v1/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
+  </ul>
+
+  <form class='form-inline' role='form'>
+    <div class='btn-group btn-group-sm' id='filterAllServices'>
+      <button type='button' class='btn btn-default active' value='uiExpandAllSpans' data-i18n="trace.expand">Expand All</button>
+      <button type='button' class='btn btn-default' value='uiCollapseAllSpans' data-i18n="trace.coollapse">Collapse All</button>
+    </div>
+    <select data-placeholder='Filter Service Search' class='form-control input-sm' name='serviceFilterSearch' id='serviceFilterSearch'>
+      <option value=''></option>
+      {{#serviceCounts}}
+      <option value='{{name}}'>{{name}}</option>
+      {{/serviceCounts}}
+    </select>
+  </form>
+
+  <div class='trace-details services'>
+  {{#serviceCounts}}
+    <span class='label label-default service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
+  {{/serviceCounts}}
+  </div>
+  {{/traceId}}
+</div>
+
+{{#traceId}}
+<div class='row' id='trace-container'>
+  <div id='timeLabel' class='span'>
+    <div class='handle'>Services</div>
+    <div class='duration-container'>
+      {{#timeMarkers}}
+      <div class='time-marker time-marker-{{index}}'>{{time}}</div>
+      {{/timeMarkers}}
+    </div>
+  </div>
+
+  {{#spans}}
+  <div
+    id='{{spanId}}'
+    class='span service-span depth-{{depthClass}}'
+    data-keys='id,traceId,parentId,spanName,serviceNames,serviceName,durationStr,duration'
+    data-id='{{spanId}}'
+    data-trace-id='{{traceId}}'
+    data-parent-id='{{parentId}}'
+    data-span-name='{{spanName}}'
+    data-service-name='{{serviceName}}'
+    data-service-names='{{serviceNames}}'
+    data-duration-str='{{durationStr}}'
+    data-duration='{{duration}}'
+    data-children='{{children}}'
+    data-error-type='{{errorType}}'
+  >
+    <div class='handle'>
+      <div class='service-name' style='margin-left: {{depth}}px'>
+        <span class='expander'>+</span>
+        {{serviceName}}
+      </div>
+    </div>
+
+    <div class='duration-container'>
+      {{#timeMarkers}}
+      <div class='time-marker time-marker-{{index}}'>.</div>
+      {{/timeMarkers}}
+
+      <div class='duration' style='left: {{left}}%; width: {{width}}%'>
+        {{durationStr}} : {{spanName}}
+        {{#annotations}}
+        <div class='annotation{{#isCore}} core{{/isCore}}'
+          style='left: {{left}}%; width: {{width}}px'
+          title='{{value}}'
+          data-keys='endpoint,value,timestamp,relativeTime,serviceName'
+          data-endpoint='{{endpoint}}'
+          data-value='{{value}}'
+          data-timestamp='{{timestamp}}'
+          data-relative-time='{{relativeTime}}'
+          data-service-name='{{serviceName}}'
+        ></div>
+        {{/annotations}}
+      </div>
+    </div>
+
+    {{#binaryAnnotations}}
+    <div class='binary-annotation'
+      data-keys='key,value,type'
+      data-key='{{key}}'
+      data-value='{{value}}'
+      data-type='{{annotationType}}'
+    ></div>
+    {{/binaryAnnotations}}
+  </div>
+  {{/spans}}
+</div>
+{{/traceId}}
+
+<div class='modal fade' id='spanPanel' tabindex='-1'>
+  <div class='modal-dialog modal-lg'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&times;</button>
+        <h4 class='modal-title'></h4>
+        <h5>AKA: <span class='service-names'></span></h5>
+      </div>
+      <div class='modal-body'>
+        <table id='annotations' class='table table-striped'>
+          <thead><tr>
+            <th>Date Time</th>
+            <th>Relative Time</th>
+            <th>Annotation</th>
+            <th>Address</th>
+          </tr></thead>
+          <tbody>
+            <tr>
+              <td data-key='timestamp' class="local-datetime"></td>
+              <td data-key='relativeTime'></td>
+              <td data-key='value'></td>
+              <td data-key='endpoint'></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table id='binaryAnnotations' class='table table-striped'>
+          <thead><tr>
+            <th>Key</th>
+            <th>Value</th>
+          </tr></thead>
+          <tbody>
+            <tr>
+              <td class='key' data-key='key'></td>
+              <td class='value' data-key='value'></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <button class="btn btn-info btn-xs pull-right" type="button" data-toggle="collapse"
+                data-target="#moreInfo" aria-expanded="false" aria-controls="moreInfo" data-i18n="trace.more">More Info</button>
+        <hr/>
+        <div class='clearfix'></div>
+        <div id='moreInfo' class='collapse'>
+          <table class='table table-striped'>
+            <tbody>
+              <tr>
+                <td class='key' data-key='key'></td>
+                <td class='value' data-key='value'></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class='row  hidden' id='trace-container-backup'>
+  <div id='timeLabel-backup' class='span'>
+    <div class='handle'>Services</div>
+    <div class='duration-container'>
+      {{#timeMarkersBackup}}
+      <div class='time-marker time-marker-{{index}}'>{{time}}</div>
+      {{/timeMarkersBackup}}
+    </div>
+  </div>
+
+  {{#spansBackup}}
+  <div
+    id='{{spanId}}'
+    class='span service-span depth-{{depthClass}}'
+    data-keys='id,traceId,parentId,spanName,serviceNames,serviceName,durationStr,duration'
+    data-id='{{spanId}}'
+    data-trace-id='{{traceId}}'
+    data-parent-id='{{parentId}}'
+    data-span-name='{{spanName}}'
+    data-service-name='{{serviceName}}'
+    data-service-names='{{serviceNames}}'
+    data-duration-str='{{durationStr}}'
+    data-duration='{{duration}}'
+    data-children='{{children}}'
+  >
+    <div class='handle'>
+      <div class='service-name' style='margin-left: {{depth}}px'>
+        <span class='expander'>+</span>
+        {{serviceName}}
+      </div>
+    </div>
+
+    <div class='duration-container'>
+      {{#timeMarkersBackup}}
+      <div class='time-marker time-marker-{{index}}'>.</div>
+      {{/timeMarkersBackup}}
+
+      <div class='duration' style='left: {{left}}%; width: {{width}}%'>
+        {{durationStr}} : {{spanName}}
+        {{#annotations}}
+        <div class='annotation{{#isCore}} core{{/isCore}}'
+          style='left: {{left}}%; width: {{width}}px'
+          title='{{value}}'
+          data-keys='endpoint,value,timestamp,relativeTime,serviceName'
+          data-endpoint='{{endpoint}}'
+          data-value='{{value}}'
+          data-timestamp='{{timestamp}}'
+          data-relative-time='{{relativeTime}}'
+          data-service-name='{{serviceName}}'
+        ></div>
+        {{/annotations}}
+      </div>
+    </div>
+
+    {{#binaryAnnotations}}
+    <div class='binary-annotation'
+      data-keys='key,value,type'
+      data-key='{{key}}'
+      data-value='{{value}}'
+      data-type='{{annotationType}}'
+    ></div>
+    {{/binaryAnnotations}}
+  </div>
+  {{/spansBackup}}
+</div>
+
+<div class='modal fade' id='jsonPanel' tabindex='-1'>
+  <div class='modal-dialog modal-lg'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&times;</button>
+        <a href='#' class='save'><span class='glyphicon glyphicon-save' aria-hidden='true' aria-label='save'></span></a>
+        <h4 class='modal-title'></h4>
+      </div>
+      <div class='modal-body'>
+        <pre></pre>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/zipkin-ui/test/spanConverter.test.js
+++ b/zipkin-ui/test/spanConverter.test.js
@@ -1,0 +1,269 @@
+const {SPAN_V1} = require('../js/spanConverter');
+
+describe('SPAN v1 Conversion', () => {
+  it('should transform correctly from v2 to v1', () => {
+    const spanV2 = {
+      traceId: 'a',
+      name: 'get',
+      id: 'c',
+      parentId: 'b',
+      kind: 'SERVER',
+      timestamp: 1,
+      duration: 1,
+      localEndpoint: {
+        serviceName: 'portalservice',
+        ipv4: '10.57.50.83',
+        port: 8080
+      },
+      tags: {
+        warning: 'The cake is a lie'
+      }
+    };
+
+    const expected = {
+      traceId: 'a',
+      name: 'get',
+      id: 'c',
+      parentId: 'b',
+      annotations: [
+        {
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080
+          },
+          timestamp: 1,
+          value: 'sr'
+        },
+        {
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080,
+          },
+          timestamp: 2,
+          value: 'ss'
+        }
+      ],
+      binaryAnnotations: [
+        {
+          key: 'warning',
+          value: 'The cake is a lie',
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080
+          }
+        }
+      ]
+    };
+
+    const spanV1 = SPAN_V1.convert(spanV2);
+    expect(spanV1.traceId).to.equal(expected.traceId);
+    expect(spanV1.name).to.equal(expected.name);
+    expect(spanV1.id).to.equal(expected.id);
+    expect(spanV1.parentId).to.equal(expected.parentId);
+    expect(spanV1.annotations).to.deep.equal(expected.annotations);
+    expect(spanV1.binaryAnnotations).to.deep.equal(expected.binaryAnnotations);
+  });
+
+  it('should write CS/CR when no annotations exist', () => {
+    const spanV2 = {
+      traceId: 'a',
+      name: 'get',
+      id: 'a',
+      kind: 'CLIENT',
+      timestamp: 1,
+      duration: 2,
+      localEndpoint: {
+        serviceName: 'portalservice',
+        ipv4: '10.57.50.83',
+        port: 8080
+      }
+    };
+
+    const expected = {
+      traceId: 'a',
+      name: 'get',
+      id: 'a',
+      timestamp: 1,
+      duration: 2,
+      annotations: [
+        {
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080
+          },
+          timestamp: 1,
+          value: 'cs'
+        },
+        {
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080,
+          },
+          timestamp: 3,
+          value: 'cr'
+        }
+      ]
+    };
+
+    const spanV1 = SPAN_V1.convert(spanV2);
+    expect(spanV1.annotations).to.deep.equal(expected.annotations);
+  });
+
+  it('should maintain CS/CR annotation order', () => {
+    const spanV2 = {
+      traceId: 'a',
+      name: 'get',
+      id: 'a',
+      kind: 'CLIENT',
+      timestamp: 1,
+      duration: 2,
+      localEndpoint: {
+        serviceName: 'portalservice',
+        ipv4: '10.57.50.83',
+        port: 8080
+      },
+      annotations: [
+        {
+          timestamp: 2,
+          value: 'middle'
+        }
+      ]
+    };
+
+    const expected = {
+      traceId: 'a',
+      name: 'get',
+      id: 'a',
+      timestamp: 1,
+      duration: 2,
+      annotations: [
+        {
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080
+          },
+          timestamp: 1,
+          value: 'cs'
+        },
+        {
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080,
+          },
+          timestamp: 2,
+          value: 'middle'
+        },
+        {
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080,
+          },
+          timestamp: 3,
+          value: 'cr'
+        }
+      ]
+    };
+
+    const spanV1 = SPAN_V1.convert(spanV2);
+    expect(spanV1.annotations).to.deep.equal(expected.annotations);
+  });
+
+  it('should set SA annotation on client span', () => {
+    const spanV2 = {
+      traceId: 'a',
+      name: 'get',
+      id: 'a',
+      kind: 'CLIENT',
+      timestamp: 1,
+      duration: 1,
+      localEndpoint: {
+        serviceName: 'portalservice',
+        ipv4: '10.57.50.83',
+        port: 8080
+      },
+      remoteEndpoint: {
+        serviceName: 'there',
+        ipv4: '10.57.50.84',
+        port: 80
+      }
+    };
+
+    const expected = {
+      traceId: 'a',
+      name: 'get',
+      id: 'a',
+      annotations: [
+        {
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080
+          },
+          timestamp: 1,
+          value: 'cs'
+        },
+        {
+          endpoint: {
+            serviceName: 'portalservice',
+            ipv4: '10.57.50.83',
+            port: 8080,
+          },
+          timestamp: 2,
+          value: 'cr'
+        }
+      ],
+      binaryAnnotations: [
+        {
+          key: 'sa',
+          value: true,
+          endpoint: {
+            serviceName: 'there',
+            ipv4: '10.57.50.84',
+            port: 80
+          }
+        }
+      ]
+    };
+
+    const spanV1 = SPAN_V1.convert(spanV2);
+    expect(spanV1.annotations).to.deep.equal(expected.annotations);
+    expect(spanV1.binaryAnnotations).to.deep.equal(expected.binaryAnnotations);
+  });
+
+  it('should write timestamps for shared span', () => {
+    const spanV2 = {
+      traceId: 'a',
+      name: 'get',
+      id: 'a',
+      kind: 'SERVER',
+      shared: true,
+      timestamp: 1,
+      duration: 2,
+      localEndpoint: {
+        serviceName: 'portalservice',
+        ipv4: '10.57.50.83',
+        port: 8080
+      }
+    };
+
+    const expected = {
+      traceId: 'a',
+      name: 'get',
+      id: 'a',
+      timestamp: 1,
+      duration: 2
+    };
+
+    const spanV1 = SPAN_V1.convert(spanV2);
+    expect(spanV1.timestamp).to.deep.equal(expected.timestamp);
+    expect(spanV1.duration).to.deep.equal(expected.duration);
+  });
+});


### PR DESCRIPTION
I got tired of having no way to view previous traces in Zipkin.  Since it provides a way to download the trace JSON I figured there should be a way to add it back.  This adds a new link with the ability to select a JSON file for upload (as opposed to copy/paste due to the potential size of traces, ref: https://github.com/openzipkin/zipkin/issues/1460) and view it just like any other trace.

Relates to: #1747.