### PR TITLE
Optimizes reference count of Span and squashes an errorprone warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 
     <!-- Catch common Java mistakes as compile-time errors -->
     <plexus-compiler-javac-errorprone.version>2.8.2</plexus-compiler-javac-errorprone.version>
-    <errorprone.version>2.1.3</errorprone.version>
+    <errorprone.version>2.2.0</errorprone.version>
   </properties>
 
   <name>Zipkin (Parent)</name>

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchSpanConsumerTest.java
@@ -81,7 +81,7 @@ public class ElasticsearchSpanConsumerTest {
       .kind(Kind.CLIENT)
       .build();
 
-    byte[] result = prefixWithTimestampMillisAndQuery(span, span.timestamp());
+    byte[] result = prefixWithTimestampMillisAndQuery(span, span.timestampAsLong());
 
     assertThat(new String(result, "UTF-8"))
       .startsWith("{\"traceId\":\"");
@@ -93,7 +93,7 @@ public class ElasticsearchSpanConsumerTest {
       .kind(Kind.CLIENT)
       .build();
 
-    byte[] result = prefixWithTimestampMillisAndQuery(span, span.timestamp());
+    byte[] result = prefixWithTimestampMillisAndQuery(span, span.timestampAsLong());
 
     assertThat(new String(result, "UTF-8"))
       .startsWith("{\"timestamp_millis\":1,\"traceId\":");
@@ -105,7 +105,7 @@ public class ElasticsearchSpanConsumerTest {
       .addAnnotation(1L, "\"foo")
       .build();
 
-    byte[] result = prefixWithTimestampMillisAndQuery(span, span.timestamp());
+    byte[] result = prefixWithTimestampMillisAndQuery(span, span.timestampAsLong());
 
     assertThat(new String(result, "UTF-8"))
       .startsWith("{\"_q\":[\"\\\"foo\"],\"traceId");
@@ -117,7 +117,7 @@ public class ElasticsearchSpanConsumerTest {
       .putTag("\"foo", "\"bar")
       .build();
 
-    byte[] result = prefixWithTimestampMillisAndQuery(span, span.timestamp());
+    byte[] result = prefixWithTimestampMillisAndQuery(span, span.timestampAsLong());
 
     assertThat(new String(result, "UTF-8"))
       .startsWith("{\"_q\":[\"\\\"foo\",\"\\\"foo=\\\"bar\"],\"traceId");

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/InsertSpan.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/InsertSpan.java
@@ -49,9 +49,9 @@ final class InsertSpan extends ResultSetFutureCall {
 
     @Nullable abstract String span();
 
-    @Nullable abstract long ts();
+    abstract long ts();
 
-    @Nullable abstract long duration();
+    abstract long duration();
 
     @Nullable abstract EndpointUDT l_ep();
 

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/InsertSpan.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/InsertSpan.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -49,9 +49,9 @@ final class InsertSpan extends ResultSetFutureCall {
 
     @Nullable abstract String span();
 
-    @Nullable abstract Long ts();
+    @Nullable abstract long ts();
 
-    @Nullable abstract Long duration();
+    @Nullable abstract long duration();
 
     @Nullable abstract EndpointUDT l_ep();
 
@@ -115,8 +115,8 @@ final class InsertSpan extends ResultSetFutureCall {
         span.id(),
         span.kind() != null ? span.kind().name() : null,
         span.name(),
-        span.timestamp(),
-        span.duration(),
+        span.timestampAsLong(),
+        span.durationAsLong(),
         span.localEndpoint() != null ? new EndpointUDT(span.localEndpoint()) : null,
         span.remoteEndpoint() != null ? new EndpointUDT(span.remoteEndpoint()) : null,
         annotations,
@@ -175,8 +175,8 @@ final class InsertSpan extends ResultSetFutureCall {
     if (null != input.parent_id()) bound.setString("parent_id", input.parent_id());
     if (null != input.kind()) bound.setString("kind", input.kind());
     if (null != input.span()) bound.setString("span", input.span());
-    if (null != input.ts()) bound.setLong("ts", input.ts());
-    if (null != input.duration()) bound.setLong("duration", input.duration());
+    if (0L != input.ts()) bound.setLong("ts", input.ts());
+    if (0L != input.duration()) bound.setLong("duration", input.duration());
     if (null != input.l_ep()) bound.set("l_ep", input.l_ep(), EndpointUDT.class);
     if (null != input.l_ep()) bound.setString("l_service", input.l_ep().getService());
     if (null != input.r_ep()) bound.set("r_ep", input.r_ep(), EndpointUDT.class);

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/InsertTraceByServiceSpan.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/InsertTraceByServiceSpan.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,7 +41,7 @@ final class InsertTraceByServiceSpan extends ResultSetFutureCall {
 
     abstract String trace_id();
 
-    @Nullable abstract Long duration();
+    abstract long duration();
   }
 
   static class Factory {
@@ -71,7 +71,7 @@ final class InsertTraceByServiceSpan extends ResultSetFutureCall {
       int bucket,
       UUID ts,
       String trace_id,
-      @Nullable Long durationMillis
+      long durationMillis
     ) {
       return new AutoValue_InsertTraceByServiceSpan_Input(
         service,
@@ -104,7 +104,7 @@ final class InsertTraceByServiceSpan extends ResultSetFutureCall {
       .setUUID("ts", input.ts())
       .setString("trace_id", input.trace_id());
 
-    if (null != input.duration()) {
+    if (0L != input.duration()) {
       bound.setLong("duration", input.duration());
     }
     return factory.session.executeAsync(bound);

--- a/zipkin/src/main/java/zipkin/internal/V2SpanConverter.java
+++ b/zipkin/src/main/java/zipkin/internal/V2SpanConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -347,11 +347,11 @@ public final class V2SpanConverter {
       result.traceIdHigh(lowerHexToUnsignedLong(traceId, 0));
     }
 
-    long startTs = in.timestamp() == null ? 0L : in.timestamp();
-    Long endTs = in.duration() == null ? 0L : in.timestamp() + in.duration();
+    long startTs = in.timestampAsLong(), duration = in.durationAsLong();
+    long endTs = startTs != 0L && duration != 0L ? startTs + duration : 0L;
     if (startTs != 0L) {
       result.timestamp(startTs);
-      result.duration(in.duration());
+      result.duration(duration);
     }
 
     zipkin.Endpoint local = in.localEndpoint() != null ? toEndpoint(in.localEndpoint()) : null;

--- a/zipkin2/src/main/java/zipkin2/Span.java
+++ b/zipkin2/src/main/java/zipkin2/Span.java
@@ -148,9 +148,19 @@ public final class Span implements Serializable { // for Spark and Flink jobs
    * <p>Note: timestamps at or before epoch (0L == 1970) are invalid
    *
    * @see #duration()
+   * @see #timestampAsLong()
    */
   @Nullable public Long timestamp() {
     return timestamp > 0 ? timestamp : null;
+  }
+
+  /**
+   * Like {@link #timestamp()} except returns a primitive where zero implies absent.
+   *
+   * <p>Using this method will avoid allocation, so is encouraged when copying data.
+   */
+  public long timestampAsLong() {
+    return timestamp;
   }
 
   /**
@@ -166,9 +176,20 @@ public final class Span implements Serializable { // for Spark and Flink jobs
    * implementation-specific.
    *
    * <p>This field is i64 vs i32 to support spans longer than 35 minutes.
+   *
+   * @see #durationAsLong()
    */
   @Nullable public Long duration() {
     return duration > 0 ? duration : null;
+  }
+
+  /**
+   * Like {@link #duration()} except returns a primitive where zero implies absent.
+   *
+   * <p>Using this method will avoid allocation, so is encouraged when copying data.
+   */
+  public long durationAsLong() {
+    return duration;
   }
 
   /**
@@ -376,26 +397,28 @@ public final class Span implements Serializable { // for Spark and Flink jobs
       return this;
     }
 
-    /** @see Span#timestamp */
+    /** @see Span#timestampAsLong() */
     public Builder timestamp(long timestamp) {
+      if (timestamp < 0L) timestamp = 0L;
       this.timestamp = timestamp;
       return this;
     }
 
-    /** @see Span#timestamp */
+    /** @see Span#timestamp() */
     public Builder timestamp(@Nullable Long timestamp) {
       if (timestamp == null || timestamp == 0L) timestamp = 0L;
       this.timestamp = timestamp;
       return this;
     }
 
-    /** @see Span#duration */
+    /** @see Span#durationAsLong() */
     public Builder duration(long duration) {
+      if (duration < 0L) duration = 0L;
       this.duration = duration;
       return this;
     }
 
-    /** @see Span#duration */
+    /** @see Span#duration() */
     public Builder duration(@Nullable Long duration) {
       if (duration == null || duration == 0L) duration = 0L;
       this.duration = duration;

--- a/zipkin2/src/main/java/zipkin2/Span.java
+++ b/zipkin2/src/main/java/zipkin2/Span.java
@@ -53,6 +53,11 @@ import zipkin2.internal.Nullable;
 public final class Span implements Serializable { // for Spark and Flink jobs
   static final Charset UTF_8 = Charset.forName("UTF-8");
 
+  static final int FLAG_DEBUG = 1 << 1;
+  static final int FLAG_DEBUG_SET = 1 << 2;
+  static final int FLAG_SHARED = 1 << 3;
+  static final int FLAG_SHARED_SET = 1 << 4;
+
   private static final long serialVersionUID = 0L;
 
   /**
@@ -140,10 +145,12 @@ public final class Span implements Serializable { // for Spark and Flink jobs
    * <li>Data about a completed span (ex tags) were sent after the fact</li>
    * </pre><ul>
    *
+   * <p>Note: timestamps at or before epoch (0L == 1970) are invalid
+   *
    * @see #duration()
    */
   @Nullable public Long timestamp() {
-    return timestamp;
+    return timestamp > 0 ? timestamp : null;
   }
 
   /**
@@ -161,7 +168,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
    * <p>This field is i64 vs i32 to support spans longer than 35 minutes.
    */
   @Nullable public Long duration() {
-    return duration;
+    return duration > 0 ? duration : null;
   }
 
   /**
@@ -205,8 +212,10 @@ public final class Span implements Serializable { // for Spark and Flink jobs
   }
 
   /** True is a request to store this span even if it overrides sampling policy. */
-  @Nullable public Boolean debug(){
-    return debug;
+  @Nullable public Boolean debug() {
+    return (flags & FLAG_DEBUG_SET) == FLAG_DEBUG_SET
+      ? (flags & FLAG_DEBUG) == FLAG_DEBUG
+      : null;
   }
 
   /**
@@ -218,7 +227,9 @@ public final class Span implements Serializable { // for Spark and Flink jobs
    * start the span.
    */
   @Nullable public Boolean shared() {
-    return shared;
+    return (flags & FLAG_SHARED_SET) == FLAG_SHARED_SET
+      ? (flags & FLAG_SHARED) == FLAG_SHARED
+      : null;
   }
 
   @Nullable public String localServiceName() {
@@ -243,11 +254,11 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     String traceId, parentId, id;
     Kind kind;
     String name;
-    Long timestamp, duration;
+    long timestamp, duration; // zero means null
     Endpoint localEndpoint, remoteEndpoint;
     ArrayList<Annotation> annotations;
     TreeMap<String, String> tags;
-    Boolean debug, shared;
+    int flags = 0; // bit field for timestamp and duration
 
     public Builder clear() {
       traceId = null;
@@ -255,14 +266,13 @@ public final class Span implements Serializable { // for Spark and Flink jobs
       id = null;
       kind = null;
       name = null;
-      timestamp = null;
-      duration = null;
+      timestamp = 0L;
+      duration = 0L;
       localEndpoint = null;
       remoteEndpoint = null;
       if (annotations != null) annotations.clear();
       if (tags != null) tags.clear();
-      debug = null;
-      shared = null;
+      flags = 0;
       return this;
     }
 
@@ -283,8 +293,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
       if (tags != null) {
         result.tags = (TreeMap) tags.clone();
       }
-      result.debug = debug;
-      result.shared = shared;
+      result.flags = flags;
       return result;
     }
 
@@ -306,8 +315,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
         tags = new TreeMap<>();
         tags.putAll(source.tags);
       }
-      debug = source.debug;
-      shared = source.shared;
+      flags = source.flags;
     }
 
     @Nullable public Kind kind() {
@@ -369,15 +377,27 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     }
 
     /** @see Span#timestamp */
+    public Builder timestamp(long timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    /** @see Span#timestamp */
     public Builder timestamp(@Nullable Long timestamp) {
-      if (timestamp != null && timestamp == 0L) timestamp = null;
+      if (timestamp == null || timestamp == 0L) timestamp = 0L;
       this.timestamp = timestamp;
       return this;
     }
 
     /** @see Span#duration */
+    public Builder duration(long duration) {
+      this.duration = duration;
+      return this;
+    }
+
+    /** @see Span#duration */
     public Builder duration(@Nullable Long duration) {
-      if (duration != null && duration == 0L) duration = null;
+      if (duration == null || duration == 0L) duration = 0L;
       this.duration = duration;
       return this;
     }
@@ -411,14 +431,38 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     }
 
     /** @see Span#debug */
+    public Builder debug(boolean debug) {
+      flags |= FLAG_DEBUG_SET;
+      if (debug) {
+        flags |= FLAG_DEBUG;
+      } else {
+        flags &= ~FLAG_DEBUG;
+      }
+      return this;
+    }
+
+    /** @see Span#debug */
     public Builder debug(@Nullable Boolean debug) {
-      this.debug = debug;
+      if (debug != null) return debug(debug);
+      flags &= ~FLAG_DEBUG_SET;
+      return this;
+    }
+
+    /** @see Span#shared */
+    public Builder shared(boolean shared) {
+      flags |= FLAG_SHARED_SET;
+      if (shared) {
+        flags |= FLAG_SHARED;
+      } else {
+        flags &= ~FLAG_SHARED;
+      }
       return this;
     }
 
     /** @see Span#shared */
     public Builder shared(@Nullable Boolean shared) {
-      this.shared = shared;
+      if (shared != null) return shared(shared);
+      flags &= ~FLAG_SHARED_SET;
       return this;
     }
 
@@ -484,16 +528,16 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     return Collections.unmodifiableList(result);
   }
 
-  // clutter below mainly due to difficulty working with Kryo which cannot handle AutoValue subclass
+  // Custom impl to reduce GC churn and Kryo which cannot handle AutoValue subclass
   // See https://github.com/openzipkin/zipkin/issues/1879
   final String traceId, parentId, id;
   final Kind kind;
   final String name;
-  final Long timestamp, duration;
+  final long timestamp, duration; // zero means null, saving 2 object references
   final Endpoint localEndpoint, remoteEndpoint;
   final List<Annotation> annotations;
   final Map<String, String> tags;
-  final Boolean debug, shared;
+  final int flags; // bit field for timestamp and duration, saving 2 object references
 
   Span(Builder builder) {
     traceId = builder.traceId;
@@ -507,8 +551,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     remoteEndpoint = builder.remoteEndpoint;
     annotations = sortedList(builder.annotations);
     tags = builder.tags == null ? Collections.emptyMap() : new LinkedHashMap<>(builder.tags);
-    debug = builder.debug;
-    shared = builder.shared;
+    flags = builder.flags;
   }
 
   @Override public boolean equals(Object o) {
@@ -520,16 +563,15 @@ public final class Span implements Serializable { // for Spark and Flink jobs
       && (id.equals(that.id))
       && ((kind == null) ? (that.kind == null) : kind.equals(that.kind))
       && ((name == null) ? (that.name == null) : name.equals(that.name))
-      && ((timestamp == null) ? (that.timestamp == null) : timestamp.equals(that.timestamp))
-      && ((duration == null) ? (that.duration == null) : duration.equals(that.duration))
+      && (timestamp == that.timestamp)
+      && (duration == that.duration)
       && ((localEndpoint == null)
       ? (that.localEndpoint == null) : localEndpoint.equals(that.localEndpoint))
       && ((remoteEndpoint == null)
       ? (that.remoteEndpoint == null) : remoteEndpoint.equals(that.remoteEndpoint))
       && (annotations.equals(that.annotations))
       && (tags.equals(that.tags))
-      && ((debug == null) ? (that.debug == null) : debug.equals(that.debug))
-      && ((shared == null) ? (that.shared == null) : shared.equals(that.shared));
+      && (flags == that.flags);
   }
 
   @Override public int hashCode() {
@@ -545,9 +587,9 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     h *= 1000003;
     h ^= (name == null) ? 0 : name.hashCode();
     h *= 1000003;
-    h ^= (timestamp == null) ? 0 : timestamp.hashCode();
+    h ^= (int) (h ^ ((timestamp >>> 32) ^ timestamp));
     h *= 1000003;
-    h ^= (duration == null) ? 0 : duration.hashCode();
+    h ^= (int) (h ^ ((duration >>> 32) ^ duration));
     h *= 1000003;
     h ^= (localEndpoint == null) ? 0 : localEndpoint.hashCode();
     h *= 1000003;
@@ -557,9 +599,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     h *= 1000003;
     h ^= tags.hashCode();
     h *= 1000003;
-    h ^= (debug == null) ? 0 : debug.hashCode();
-    h *= 1000003;
-    h ^= (shared == null) ? 0 : shared.hashCode();
+    h ^= flags;
     return h;
   }
 

--- a/zipkin2/src/main/java/zipkin2/internal/DependencyLinker.java
+++ b/zipkin2/src/main/java/zipkin2/internal/DependencyLinker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -61,7 +61,7 @@ public final class DependencyLinker {
         return copyError(right, left);
       }
       Span server = left.kind() == Kind.SERVER ? left : right;
-      Span client = left == server ? right : left;
+      Span client = left.equals(server) ? right : left;
       if (server.remoteServiceName() != null) {
         return copyError(client, server);
       }

--- a/zipkin2/src/main/java/zipkin2/internal/V2SpanWriter.java
+++ b/zipkin2/src/main/java/zipkin2/internal/V2SpanWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -40,13 +40,13 @@ public final class V2SpanWriter implements Buffer.Writer<Span> {
       sizeInBytes += 10; // ,"name":""
       sizeInBytes += jsonEscapedSizeInBytes(value.name());
     }
-    if (value.timestamp() != null) {
+    if (value.timestampAsLong() != 0L) {
       sizeInBytes += 13; // ,"timestamp":
-      sizeInBytes += asciiSizeInBytes(value.timestamp());
+      sizeInBytes += asciiSizeInBytes(value.timestampAsLong());
     }
-    if (value.duration() != null) {
+    if (value.durationAsLong() != 0L) {
       sizeInBytes += 12; // ,"duration":
-      sizeInBytes += asciiSizeInBytes(value.duration());
+      sizeInBytes += asciiSizeInBytes(value.durationAsLong());
     }
     if (value.localEndpoint() != null) {
       sizeInBytes += 17; // ,"localEndpoint":
@@ -95,11 +95,11 @@ public final class V2SpanWriter implements Buffer.Writer<Span> {
     if (value.name() != null) {
       b.writeAscii(",\"name\":\"").writeUtf8(jsonEscape(value.name())).writeByte('"');
     }
-    if (value.timestamp() != null) {
-      b.writeAscii(",\"timestamp\":").writeAscii(value.timestamp());
+    if (value.timestampAsLong() != 0L) {
+      b.writeAscii(",\"timestamp\":").writeAscii(value.timestampAsLong());
     }
-    if (value.duration() != null) {
-      b.writeAscii(",\"duration\":").writeAscii(value.duration());
+    if (value.durationAsLong() != 0L) {
+      b.writeAscii(",\"duration\":").writeAscii(value.durationAsLong());
     }
     if (value.localEndpoint() != null) {
       b.writeAscii(",\"localEndpoint\":");

--- a/zipkin2/src/main/java/zipkin2/storage/InMemoryStorage.java
+++ b/zipkin2/src/main/java/zipkin2/storage/InMemoryStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -144,7 +144,7 @@ public final class InMemoryStorage extends StorageComponent implements SpanStore
     int spansToRecover = (spansByTraceIdTimeStamp.size() + delta) - maxSpanCount;
     evictToRecoverSpans(spansToRecover);
     for (Span span : spans) {
-      Long timestamp = span.timestamp() != null ? span.timestamp() : Long.MIN_VALUE;
+      long timestamp = span.timestampAsLong();
       String lowTraceId = lowTraceId(span.traceId());
       TraceIdTimestamp traceIdTimeStamp = TraceIdTimestamp.create(lowTraceId, timestamp);
       spansByTraceIdTimeStamp.put(traceIdTimeStamp, span);

--- a/zipkin2/src/main/java/zipkin2/storage/QueryRequest.java
+++ b/zipkin2/src/main/java/zipkin2/storage/QueryRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -212,18 +212,18 @@ public abstract class QueryRequest {
    */
   public boolean test(List<Span> spans) {
     // v2 returns raw spans in any order, get the root's timestamp or the first timestamp
-    Long timestamp = null;
+    long timestamp = 0L;
     for (Span span : spans) {
-      if (span.timestamp() == null) continue;
+      if (span.timestampAsLong() == 0L) continue;
       if (span.parentId() == null) {
-        timestamp = span.timestamp();
+        timestamp = span.timestampAsLong();
         break;
       }
-      if (timestamp == null || timestamp > span.timestamp()) {
-        timestamp = span.timestamp();
+      if (timestamp == 0L || timestamp > span.timestampAsLong()) {
+        timestamp = span.timestampAsLong();
       }
     }
-    if (timestamp == null ||
+    if (timestamp == 0L ||
       timestamp < (endTs() - lookback()) * 1000 ||
       timestamp > endTs() * 1000) {
       return false;
@@ -259,9 +259,9 @@ public abstract class QueryRequest {
 
       if ((serviceName() == null || serviceName().equals(localServiceName)) && !testedDuration) {
         if (minDuration() != null && maxDuration() != null) {
-          testedDuration = span.duration() >= minDuration() && span.duration() <= maxDuration();
+          testedDuration = span.durationAsLong() >= minDuration() && span.durationAsLong() <= maxDuration();
         } else if (minDuration() != null) {
-          testedDuration = span.duration() >= minDuration();
+          testedDuration = span.durationAsLong() >= minDuration();
         }
       }
     }


### PR DESCRIPTION
Based on https://www.youtube.com/watch?time_continue=2118&v=YLTD1GBEfwo
we were a bit noisy for no good reason. Thanks @raphw for noticing

This also squashes an error-prone warning, which while wasn't a bug
wasn't worth explaining in a suppression why it wasn't.