### PR TITLE
Removes UDT workaround using new Datastax driver

### DIFF
--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -126,7 +126,7 @@ final class Schema {
     }
   }
 
-  @UDT(keyspace = DEFAULT_KEYSPACE + "_udts", name = "endpoint")
+  @UDT(name = "endpoint")
   static final class EndpointUDT implements Serializable { // for Spark jobs
     private static final long serialVersionUID = 0L;
 
@@ -189,7 +189,7 @@ final class Schema {
     }
   }
 
-  @UDT(keyspace = DEFAULT_KEYSPACE + "_udts", name = "annotation")
+  @UDT(name = "annotation")
   static final class AnnotationUDT implements Serializable { // for Spark jobs
     private static final long serialVersionUID = 0L;
 


### PR DESCRIPTION
The ideal is to get rid of the dependency on the zipkin_udts keyspace and prevent below

```
Caused by: java.lang.IllegalArgumentException: Keyspace zipkin2_udts does not exist
    at com.datastax.driver.mapping.AnnotationParser.parseUDT(AnnotationParser.java:150) ~[cassandra-driver-mapping-3.4.0.jar!/:na]
    at com.datastax.driver.mapping.MappingManager.getUDTCodec(MappingManager.java:320) ~[cassandra-driver-mapping-3.4.0.jar!/:na]
    at com.datastax.driver.mapping.MappingManager.udtCodec(MappingManager.java:270) ~[cassandra-driver-mapping-3.4.0.jar!/:na]
    at com.datastax.driver.mapping.MappingManager.udtCodec(MappingManager.java:282) ~[cassandra-driver-mapping-3.4.0.jar!/:na]
    at zipkin2.storage.cassandra.DefaultSessionFactory.initializeUDTs(DefaultSessionFactory.java:89) ~[io.zipkin.zipkin2-zipkin-storage-cassandra-2.4.7.jar!/:na]
    at zipkin2.storage.cassandra.DefaultSessionFactory.create(DefaultSessionFactory.java:72) ~[io.zipkin.zipkin2-zipkin-storage-cassandra-2.4.7.jar!/:na]
    at zipkin2.storage.cassandra.CassandraStorage.session(CassandraStorage.java:161) ~[io.zipkin.zipkin2-zipkin-storage-cassandra-2.4.7.jar!/:na]
    at zipkin2.storage.cassandra.AutoValue_CassandraStorage.session(AutoValue_CassandraStorage.java:32) ~[io.zipkin.zipkin2-zipkin-storage-cassandra-2.4.7.jar
```