### PR TITLE
Keep Cassandra storage working even if the annotations query is dropped

### DIFF
--- a/zipkin2/src/test/java/zipkin2/SpanTest.java
+++ b/zipkin2/src/test/java/zipkin2/SpanTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
It should be possible to drop just the CONTAINS SASI and have Zipkin continue to start up.

(Trying to search by annotation will still ofcourse throw an exception, here a NPE)