### PR TITLE
Update MySQL header copyright date.

### DIFF
--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanStore.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLSpanStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
`./mvnw -DskipTests --also-make -pl zipkin-server clean install` 

fails with

[ERROR] Failed to execute goal com.mycila:license-maven-plugin:3.0:check (default) on project zipkin-storage-mysql: Some files do not have the expected license header -> [Help 1]