### PR TITLE
validate hasNext() on itrerator

### DIFF
--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/DependencyLinkV2SpanIterator.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/DependencyLinkV2SpanIterator.java
@@ -14,6 +14,8 @@
 package zipkin.storage.mysql;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
+
 import org.jooq.Record;
 import org.jooq.TableField;
 import zipkin.BinaryAnnotation.Type;
@@ -61,6 +63,9 @@ final class DependencyLinkV2SpanIterator implements Iterator<Span> {
     }
 
     @Override public Iterator<Span> next() {
+      if(!hasNext()) {
+        throw new NoSuchElementException();
+      }
       currentTraceIdHi = hasTraceIdHigh ? traceIdHigh(delegate) : null;
       currentTraceIdLo = delegate.peek().getValue(ZipkinSpans.ZIPKIN_SPANS.TRACE_ID);
       return new DependencyLinkV2SpanIterator(delegate, currentTraceIdHi, currentTraceIdLo);
@@ -92,6 +97,9 @@ final class DependencyLinkV2SpanIterator implements Iterator<Span> {
 
   @Override
   public Span next() {
+    if(!hasNext()) {
+      throw new NoSuchElementException();
+    }
     Record row = delegate.peek();
 
     long spanId = row.getValue(ZipkinSpans.ZIPKIN_SPANS.ID);

--- a/zipkin2/src/main/java/zipkin2/internal/Node.java
+++ b/zipkin2/src/main/java/zipkin2/internal/Node.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.logging.Logger;
 
@@ -96,6 +97,9 @@ public final class Node<V> {
 
     @Override
     public Node<V> next() {
+      if(!hasNext()) {
+        throw new NoSuchElementException();
+      }
       Node<V> result = queue.remove();
       queue.addAll(result.children);
       return result;


### PR DESCRIPTION
By contract, any implementation of the java.util.Iterator.next() method should throw a NoSuchElementException exception when the iteration has no more elements.