### PR TITLE
Installs Cassandra UDT keyspace only when allowed

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -149,10 +149,10 @@ The following are tuning parameters which may not concern all users:
     * `CASSANDRA_INDEX_CACHE_TTL`: How many seconds to cache index metadata about a trace. Defaults to 60.
     * `CASSANDRA_INDEX_FETCH_MULTIPLIER`: How many more index rows to fetch than the user-supplied query limit. Defaults to 3.
 
-Example usage:
+Example usage with logging:
 
 ```bash
-$ STORAGE_TYPE=cassandra3 java -jar zipkin.jar --logging.level.com.datastax.driver.core.QueryLogger=trace
+$ STORAGE_TYPE=cassandra3 java -jar zipkin.jar --logging.level.zipkin=trace --logging.level.zipkin2=trace --logging.level.com.datastax.driver.core=debug
 ```
 
 ### MySQL Storage

--- a/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/zipkin2_cassandra/README.md
+++ b/zipkin-storage/zipkin2_cassandra/README.md
@@ -9,8 +9,18 @@ The implementation uses the [Datastax Java Driver 3.1.x](https://github.com/data
 `zipkin2.storage.cassandra.CassandraStorage.Builder` includes defaults that will operate against a local Cassandra installation.
 
 ## Logging
-Queries are logged to the category "com.datastax.driver.core.QueryLogger" when debug or trace is
-enabled via SLF4J. Trace level includes bound values.
+Since the underlying driver uses SLF4J, Zipkin's storage layer also uses
+this (note SLF4J is supported out-of-the-box with no configuration in
+zipkin-server).
+
+Zipkin's storage layer logs to the category "zipkin2.storage.cassandra",
+but you may wish to see the entire "zipkin2" when troubleshooting.
+Depending on details desired, the underlying driver's category
+"com.datastax.driver.core" at debug level may help.
+
+If you just want to see queries and latency, set the category
+"com.datastax.driver.core.QueryLogger" to debug or trace. Trace level
+includes bound values.
 
 See [Logging Query Latencies](http://docs.datastax.com/en/developer/java-driver/3.0/supplemental/manual/logging/#logging-query-latencies) for more details.
 

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
@@ -58,6 +58,7 @@ final class DefaultSessionFactory implements CassandraStorage.SessionFactory {
       if (cassandra.ensureSchema()) {
         session = closer.register(cluster.connect());
         Schema.ensureExists(cassandra.keyspace(), cassandra.searchEnabled(), session);
+        Schema.ensureExists(DEFAULT_KEYSPACE + "_udts", false, session);
         session.execute("USE " + cassandra.keyspace());
       } else {
         session = cluster.connect(cassandra.keyspace());
@@ -76,10 +77,9 @@ final class DefaultSessionFactory implements CassandraStorage.SessionFactory {
   }
 
   private static void initializeUDTs(Session session) {
-    Schema.ensureExists(DEFAULT_KEYSPACE + "_udts", false, session);
     MappingManager mapping = new MappingManager(session);
 
-    // The UDTs are hardcoded against the zipkin keyspace.
+    // The UDTs are hardcoded against the zipkin2_udts keyspace.
     // If a different keyspace is being used the codecs must be re-applied to this different keyspace
     TypeCodec<EndpointUDT> endpointCodec = mapping.udtCodec(EndpointUDT.class);
     TypeCodec<AnnotationUDT> annoCodec = mapping.udtCodec(AnnotationUDT.class);

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -101,10 +101,10 @@ final class Schema {
   static KeyspaceMetadata ensureExists(String keyspace, boolean searchEnabled, Session session) {
     KeyspaceMetadata result = session.getCluster().getMetadata().getKeyspace(keyspace);
     if (result == null || result.getTable(Schema.TABLE_SPAN) == null) {
-      LOG.info("Installing schema {}", SCHEMA_RESOURCE);
+      LOG.info("Installing schema {} for keyspace {}", SCHEMA_RESOURCE, keyspace);
       applyCqlFile(keyspace, session, SCHEMA_RESOURCE);
       if (searchEnabled) {
-        LOG.info("Installing indexes {}", INDEX_RESOURCE);
+        LOG.info("Installing indexes {} for keyspace {}", INDEX_RESOURCE, keyspace);
         applyCqlFile(keyspace, session, INDEX_RESOURCE);
       }
       // refresh metadata since we've installed the schema


### PR DESCRIPTION
Tested this locally to make sure we're all good. also re-pushed the docker test image to make sure it always installs the UDT keyspace

 cc @mvallebr @llinder @michaelsembwever