### PR TITLE
Prevents overlapping calls to health check

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinHealthIndicator.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinHealthIndicator.java
@@ -41,7 +41,8 @@ final class ZipkinHealthIndicator extends CompositeHealthIndicator {
       this.component = component;
     }
 
-    @Override public Health health() {
+    /** synchronized to prevent overlapping requests to a storage backend */
+    @Override public synchronized Health health() {
       Component.CheckResult result = component.check();
       return result.ok ? Health.up().build() : Health.down(result.exception).build();
     }


### PR DESCRIPTION
Health checks can be expensive, so this ensures only one at a time.

Note: this is different than deduping health checks (ex sharing a
response from concurrent requests). That's more complicated and can be
done later if needed.

Fixes #1907