### PR TITLE
Allow the RabbitMQ collector to be configured via URI

### DIFF
--- a/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.collector.rabbitmq;
+package zipkin.autoconfigure.collector.rabbitmq;
 
 import org.junit.After;
 import org.junit.Ignore;
@@ -23,9 +23,9 @@ import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoCon
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import zipkin.autoconfigure.collector.rabbitmq.ZipkinRabbitMQCollectorAutoConfiguration;
 import zipkin.collector.CollectorMetrics;
 import zipkin.collector.CollectorSampler;
+import zipkin.collector.rabbitmq.RabbitMQCollector;
 import zipkin.storage.InMemoryStorage;
 import zipkin.storage.StorageComponent;
 
@@ -47,7 +47,7 @@ public class ZipkinRabbitMQCollectorAutoConfigurationTest {
   }
 
   @Test
-  public void doesNotProvideCollectorComponent_whenAddressNotSet() {
+  public void doesNotProvideCollectorComponent_whenAddressAndUriNotSet() {
     context = new AnnotationConfigApplicationContext();
     context.register(PropertyPlaceholderAutoConfiguration.class,
         ZipkinRabbitMQCollectorAutoConfiguration.class, InMemoryConfiguration.class);
@@ -58,9 +58,9 @@ public class ZipkinRabbitMQCollectorAutoConfigurationTest {
   }
 
   @Test
-  public void doesNotProvideCollectorComponent_whenAddressesIsEmptyString() {
+  public void doesNotProvideCollectorComponent_whenAddressesAndUriIsEmptyString() {
     context = new AnnotationConfigApplicationContext();
-    addEnvironment(context, "zipkin.collector.rabbitmq.addresses:");
+    addEnvironment(context, "zipkin.collector.rabbitmq.addresses:", "zipkin.collector.rabbitmq.uri:");
     context.register(PropertyPlaceholderAutoConfiguration.class,
         ZipkinRabbitMQCollectorAutoConfiguration.class, InMemoryConfiguration.class);
     context.refresh();

--- a/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
+++ b/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,6 +13,8 @@
  */
 package zipkin.collector.rabbitmq;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -74,8 +76,11 @@ public class ZipkinRabbitMQCollectorPropertiesOverrideTest {
             ZipkinRabbitMQCollectorProperties::getVirtualHost,
             builder -> builder.connectionFactory.getVirtualHost()),
         parameters("useSsl", true,
-          ZipkinRabbitMQCollectorProperties::getUseSsl,
-          builder -> builder.connectionFactory.isSSL())
+            ZipkinRabbitMQCollectorProperties::getUseSsl,
+            builder -> builder.connectionFactory.isSSL()),
+        parameters("uri", URI.create("amqp://localhost"),
+            ZipkinRabbitMQCollectorProperties::getUri,
+            builder -> URI.create("amqp://" + builder.connectionFactory.getHost()))
     );
   }
 
@@ -104,7 +109,7 @@ public class ZipkinRabbitMQCollectorPropertiesOverrideTest {
 
   @Test
   public void propertyTransferredToCollectorBuilder()
-    throws NoSuchAlgorithmException, KeyManagementException {
+    throws NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
     addEnvironment(context, property + ":" + value);
 
     context.register(

--- a/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesTest.java
+++ b/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.collector.rabbitmq;
+
+import com.rabbitmq.client.ConnectionFactory;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import org.junit.Test;
+import zipkin.autoconfigure.collector.rabbitmq.ZipkinRabbitMQCollectorProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZipkinRabbitMQCollectorPropertiesTest {
+
+  @Test
+  public void uriProperlyParsedAndIgnoresOtherProperties_whenUriSet() throws NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
+    ZipkinRabbitMQCollectorProperties properties = new ZipkinRabbitMQCollectorProperties();
+    properties.setUri(URI.create("amqp://admin:admin@localhost:5678/myv"));
+    properties.setAddresses(Collections.singletonList("will_not^work!"));
+    properties.setUsername("bob");
+    properties.setPassword("letmein");
+    properties.setVirtualHost("drwho");
+
+    ConnectionFactory connFactory = properties.toBuilder().connectionFactory;
+    assertThat(connFactory.getHost()).isEqualTo("localhost");
+    assertThat(connFactory.getPort()).isEqualTo(5678);
+    assertThat(connFactory.getUsername()).isEqualTo("admin");
+    assertThat(connFactory.getPassword()).isEqualTo("admin");
+    assertThat(connFactory.getVirtualHost()).isEqualTo("myv");
+  }
+}

--- a/zipkin-collector/rabbitmq/README.md
+++ b/zipkin-collector/rabbitmq/README.md
@@ -10,11 +10,17 @@ The following configuration can be set for the RabbitMQ Collector.
 
 Property | Environment Variable | Description
 --- | --- | ---
-`zipkin.collector.rabbitmq.addresses` | `RABBIT_ADDRESSES` | Comma-separated list of RabbitMQ addresses, ex. `localhost:5672,localhost:5673`
 `zipkin.collector.rabbitmq.concurrency` | `RABBIT_CONCURRENCY` | Number of concurrent consumers. Defaults to `1`
 `zipkin.collector.rabbitmq.connection-timeout` | `RABBIT_CONNECTION_TIMEOUT` | Milliseconds to wait establishing a connection. Defaults to `60000` (1 minute)
-`zipkin.collector.rabbitmq.password` | `RABBIT_PASSWORD`| Password to use when connecting to RabbitMQ. Defaults to `guest`
 `zipkin.collector.rabbitmq.queue` | `RABBIT_QUEUE` | Queue from which to collect span messages. Defaults to `zipkin`
+`zipkin.collector.rabbitmq.uri` | `RABBIT_URI` | [RabbitMQ URI spec](https://www.rabbitmq.com/uri-spec.html)-compliant URI, ex. `amqp://user:pass@host:10000/vhost`
+
+If the URI is set, the following properties will be ignored.
+
+Property | Environment Variable | Description
+--- | --- | ---
+`zipkin.collector.rabbitmq.addresses` | `RABBIT_ADDRESSES` | Comma-separated list of RabbitMQ addresses, ex. `localhost:5672,localhost:5673`
+`zipkin.collector.rabbitmq.password` | `RABBIT_PASSWORD`| Password to use when connecting to RabbitMQ. Defaults to `guest`
 `zipkin.collector.rabbitmq.username` | `RABBIT_USER` | Username to use when connecting to RabbitMQ. Defaults to `guest`
 `zipkin.collector.rabbitmq.virtual-host` | `RABBIT_VIRTUAL_HOST` | RabbitMQ virtual host to use. Defaults to `/`
 `zipkin.collector.rabbitmq.use-ssl` | `RABBIT_USE_SSL` | Set to `true` to use SSL when connecting to RabbitMQ

--- a/zipkin-collector/rabbitmq/src/main/java/zipkin/collector/rabbitmq/RabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/main/java/zipkin/collector/rabbitmq/RabbitMQCollector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -137,7 +137,7 @@ public final class RabbitMQCollector implements CollectorComponent {
     protected Connection compute() {
       Connection connection;
       try {
-        connection = builder.connectionFactory.newConnection(builder.addresses);
+        connection = (builder.addresses == null) ? builder.connectionFactory.newConnection() : builder.connectionFactory.newConnection(builder.addresses);
         connection.createChannel().queueDeclare(builder.queue, true, false, false, null);
       } catch (IOException | TimeoutException e) {
         throw new IllegalStateException("Unable to establish connection to RabbitMQ server", e);

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin/collector/rabbitmq/ITRabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin/collector/rabbitmq/ITRabbitMQCollector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -47,7 +47,7 @@ public class ITRabbitMQCollector {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
-  @Test public void checkPasses() throws Exception {
+  @Test public void checkPasses() {
     assertThat(rabbit.collector.check().ok).isTrue();
   }
 

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -310,7 +310,7 @@ $ KAFKA_ZOOKEEPER=127.0.0.1:2181 java -Dzipkin.collector.kafka.overrides.auto.of
 ```
 
 ### RabbitMQ collector
-The [RabbitMQ collector](../zipkin-collector/rabbitmq) will be enabled when the `addresses` for the RabbitMQ server(s) is set.
+The [RabbitMQ collector](../zipkin-collector/rabbitmq) will be enabled when the `addresses` or `uri` for the RabbitMQ server(s) is set.
 
 Example usage:
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -38,6 +38,7 @@ zipkin:
       username: ${RABBIT_USER:guest}
       virtual-host: ${RABBIT_VIRTUAL_HOST:/}
       useSsl: ${RABBIT_USE_SSL:false}
+      uri: ${RABBIT_URI:}
   query:
     enabled: ${QUERY_ENABLED:true}
     # 1 day in millis


### PR DESCRIPTION
In addition to the existing methods for configuration, this adds the ability to configure the RabbitMQ server to connect to via a RabbitMQ URI spec-compliant URI. When the URI is used, the other connection properties will be ignored, since they should be set via the URI.

Resolves #1901 