### PR TITLE
Adds Java 9 module names with manifest entries

### DIFF
--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -125,6 +125,13 @@
                   <shadedPattern>zipkin.internal.gson</shadedPattern>
                 </relocation>
               </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Automatic-Module-Name>zipkin</Automatic-Module-Name>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
             </configuration>
           </execution>
         </executions>

--- a/zipkin2/pom.xml
+++ b/zipkin2/pom.xml
@@ -127,6 +127,13 @@
                   <shadedPattern>zipkin2.internal.gson</shadedPattern>
                 </relocation>
               </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Automatic-Module-Name>zipkin2</Automatic-Module-Name>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This is the easy way out of getting module names stable and mapped to
our entrypoint packages. I've only done this for the highly re-used
jars.

See https://github.com/square/okhttp/pull/3743
thx @yschimke