### PR TITLE
Allows no date separator in Elasticsearch

### DIFF
--- a/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch-http/src/main/java/zipkin/autoconfigure/storage/elasticsearch/http/ZipkinElasticsearchHttpStorageProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -37,7 +37,7 @@ public class ZipkinElasticsearchHttpStorageProperties implements Serializable { 
   /** The index prefix to use when generating daily index names. Defaults to zipkin. */
   private String index = "zipkin";
   /** The date separator used to create the index name. Default to -. */
-  private char dateSeparator = '-';
+  private String dateSeparator = "-";
   /** Sets maximum in-flight requests from this process to any Elasticsearch host. Defaults to 64 */
   private int maxRequests = 64;
   /** Number of shards (horizontal scaling factor) per index. Defaults to 5. */
@@ -118,11 +118,15 @@ public class ZipkinElasticsearchHttpStorageProperties implements Serializable { 
     this.indexShards = indexShards;
   }
 
-  public char getDateSeparator() {
+  public String getDateSeparator() {
     return dateSeparator;
   }
 
-  public void setDateSeparator(char dateSeparator) {
+  public void setDateSeparator(String dateSeparator) {
+    String trimmed = dateSeparator.trim();
+    if (trimmed.length() > 1) {
+      throw new IllegalArgumentException("dateSeparator must be empty or a single character");
+    }
     this.dateSeparator = dateSeparator;
   }
 
@@ -179,7 +183,7 @@ public class ZipkinElasticsearchHttpStorageProperties implements Serializable { 
     if (hosts != null) builder.hosts(hosts);
     return builder
         .index(index)
-        .dateSeparator(dateSeparator)
+        .dateSeparator(dateSeparator.isEmpty() ? 0 : dateSeparator.charAt(0))
         .pipeline(pipeline)
         .maxRequests(maxRequests)
         .indexShards(indexShards)

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -148,7 +148,8 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
      *
      * <p>By default, spans with a timestamp falling on 2016/03/19 end up in the index
      * 'zipkin:span-2016-03-19'. When the date separator is '.', the index would be
-     * 'zipkin:span-2016.03.19'.
+     * 'zipkin:span-2016.03.19'. If the date separator is 0, there is no delimiter. Ex the
+     * index would be 'zipkin:span-20160319'
      */
     public final Builder dateSeparator(char dateSeparator) {
       indexNameFormatterBuilder().dateSeparator(dateSeparator);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/IndexNameFormatter.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/IndexNameFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -33,7 +33,6 @@ public abstract class IndexNameFormatter {
 
   public abstract Builder toBuilder();
 
-  private static final String DAILY_INDEX_FORMAT = "yyyy-MM-dd";
   private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
   public abstract String index();
@@ -54,8 +53,9 @@ public abstract class IndexNameFormatter {
     public final IndexNameFormatter build() {
       return dateFormat(new ThreadLocal<SimpleDateFormat>() {
         @Override protected SimpleDateFormat initialValue() {
-          SimpleDateFormat result =
-            new SimpleDateFormat(DAILY_INDEX_FORMAT.replace('-', dateSeparator()));
+          char separator = dateSeparator();
+          SimpleDateFormat result = new SimpleDateFormat(separator == 0 ?
+            "yyyyMMdd" : "yyyy-MM-dd".replace('-', separator));
           result.setTimeZone(TimeZone.getTimeZone("UTC"));
           return result;
         }


### PR DESCRIPTION
Before, you couldn't opt-out of a date separator in ES indexes. Now,
you can. Just export ES_DATE_SEPARATOR=    (leave it empty)

Fixes #1925