### PR TITLE
Injects configurable <base> tag to support reverse proxies

### DIFF
--- a/zipkin-autoconfigure/ui/pom.xml
+++ b/zipkin-autoconfigure/ui/pom.xml
@@ -52,5 +52,11 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-ui</artifactId>
     </dependency>
+    <dependency>
+      <!-- HTML library for injecting configurable <base> tag -->
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.11.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.Resource;
@@ -80,17 +81,25 @@ public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
   Resource indexHtml;
 
   @Bean
+  @Lazy
   String processedIndexHtml() throws IOException {
-    InputStream is = indexHtml.getInputStream();
-    Document soup = Jsoup.parse(is, null, ui.getBasePath());
-    is.close();
-    if (soup.head().getElementsByTag("base").isEmpty()) {
-      soup.head().appendChild(
-        soup.createElement("base")
-      );
+    InputStream is = null;
+    try {
+      is = indexHtml.getInputStream();
+      Document soup = Jsoup.parse(is, null, ui.getBasePath());
+      is.close();
+      if (soup.head().getElementsByTag("base").isEmpty()) {
+        soup.head().appendChild(
+          soup.createElement("base")
+        );
+      }
+      soup.head().getElementsByTag("base").html(ui.getBasePath());
+      return soup.html();
+    } finally {
+      if (is != null) {
+        is.close();
+      }
     }
-    soup.head().getElementsByTag("base").html(ui.getBasePath());
-    return soup.html();
   }
 
   @Override

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -93,7 +93,7 @@ public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
         soup.createElement("base")
       );
     }
-    soup.head().getElementsByTag("base").html(baseTagValue);
+    soup.head().getElementsByTag("base").attr("href", baseTagValue);
     return soup.html();
   }
 

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -44,7 +44,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.servlet.HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE;
-import static zipkin.autoconfigure.ui.ZipkinUiProperties.DEFAULT_BASE_PATH;
+import static zipkin.autoconfigure.ui.ZipkinUiProperties.DEFAULT_BASEPATH;
 
 /**
  * Zipkin-UI is a single-page application mounted at /zipkin. For simplicity, assume paths mentioned
@@ -83,16 +83,17 @@ public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
   @Bean
   @Lazy
   String processedIndexHtml() throws IOException {
+    String baseTagValue = "/".equals(ui.getBasepath()) ? "/" : ui.getBasepath() + "/";
     Document soup;
     try (InputStream is = indexHtml.getInputStream()) {
-      soup = Jsoup.parse(is, null, ui.getBasePath());
+      soup = Jsoup.parse(is, null, baseTagValue);
     }
     if (soup.head().getElementsByTag("base").isEmpty()) {
       soup.head().appendChild(
         soup.createElement("base")
       );
     }
-    soup.head().getElementsByTag("base").html(ui.getBasePath());
+    soup.head().getElementsByTag("base").html(baseTagValue);
     return soup.html();
   }
 
@@ -140,7 +141,7 @@ public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
     ResponseEntity.BodyBuilder result = ResponseEntity.ok()
       .cacheControl(CacheControl.maxAge(1, TimeUnit.MINUTES))
       .contentType(MediaType.TEXT_HTML);
-    return DEFAULT_BASE_PATH.equals(ui.getBasePath())
+    return DEFAULT_BASEPATH.equals(ui.getBasepath())
       ? result.body(indexHtml)
       : result.body(processedIndexHtml());
   }

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
@@ -19,12 +19,14 @@ import org.springframework.util.StringUtils;
 
 @ConfigurationProperties("zipkin.ui")
 public class ZipkinUiProperties {
+  static final String DEFAULT_BASE_PATH = "/zipkin/";
+
   private String environment;
   private int queryLimit = 10;
   private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);
   private String instrumented = ".*";
   private String logsUrl = null;
-  private String basePath = "/zipkin/";
+  private String basePath = DEFAULT_BASE_PATH;
   private boolean searchEnabled = true;
   private Dependency dependency = new Dependency();
 

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
@@ -19,14 +19,14 @@ import org.springframework.util.StringUtils;
 
 @ConfigurationProperties("zipkin.ui")
 public class ZipkinUiProperties {
-  static final String DEFAULT_BASE_PATH = "/zipkin/";
+  static final String DEFAULT_BASEPATH = "/zipkin";
 
   private String environment;
   private int queryLimit = 10;
   private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);
   private String instrumented = ".*";
   private String logsUrl = null;
-  private String basePath = DEFAULT_BASE_PATH;
+  private String basepath = DEFAULT_BASEPATH;
   private boolean searchEnabled = true;
   private Dependency dependency = new Dependency();
 
@@ -88,12 +88,12 @@ public class ZipkinUiProperties {
     this.dependency = dependency;
   }
 
-  public String getBasePath() {
-    return basePath;
+  public String getBasepath() {
+    return basepath;
   }
 
-  public void setBasePath(String basePath) {
-    this.basePath = basePath;
+  public void setBasepath(String basepath) {
+    this.basepath = basepath;
   }
 
   public static class Dependency {

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiProperties.java
@@ -24,6 +24,7 @@ public class ZipkinUiProperties {
   private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);
   private String instrumented = ".*";
   private String logsUrl = null;
+  private String basePath = "/zipkin/";
   private boolean searchEnabled = true;
   private Dependency dependency = new Dependency();
 
@@ -83,6 +84,14 @@ public class ZipkinUiProperties {
 
   public void setDependency(Dependency dependency) {
     this.dependency = dependency;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+
+  public void setBasePath(String basePath) {
+    this.basePath = basePath;
   }
 
   public static class Dependency {

--- a/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
@@ -151,7 +151,7 @@ public class ZipkinUiAutoConfigurationTest {
     context = createContextWithOverridenProperty("zipkin.ui.basepath:/foo/bar");
 
     assertThat(context.getBean(ZipkinUiAutoConfiguration.class).serveIndex().getBody().toString())
-      .contains("<base>/foo/bar/</base>");
+      .contains("<base href=\"/foo/bar/\">");
   }
 
   @Test
@@ -159,7 +159,7 @@ public class ZipkinUiAutoConfigurationTest {
     context = createContextWithOverridenProperty("zipkin.ui.basepath:/");
 
     assertThat(context.getBean(ZipkinUiAutoConfiguration.class).serveIndex().getBody().toString())
-      .contains("<base>/</base>");
+      .contains("<base href=\"/\">");
   }
 
   private static AnnotationConfigApplicationContext createContext() {

--- a/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
@@ -18,6 +18,9 @@ import org.junit.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
@@ -39,6 +42,13 @@ public class ZipkinUiAutoConfigurationTest {
 
     assertThat(context.getBean(ZipkinUiAutoConfiguration.class).indexHtml)
         .isNotNull();
+  }
+
+  @Test
+  public void indexContentType() throws IOException {
+    context = createContext();
+    assertThat(context.getBean(ZipkinUiAutoConfiguration.class).serveIndex().getHeaders().getContentType())
+      .isEqualTo(MediaType.TEXT_HTML);
   }
 
   @Test
@@ -100,6 +110,22 @@ public class ZipkinUiAutoConfigurationTest {
 
     assertThat(context.getBean(ZipkinUiProperties.class).getDependency().getHighErrorRate())
       .isEqualTo(0.1f);
+  }
+
+  @Test
+  public void defaultBaseUrl() throws IOException {
+    context = createContext();
+
+    assertThat(context.getBean(ZipkinUiAutoConfiguration.class).serveIndex().getBody())
+      .contains("<base>/zipkin/</base>");
+  }
+
+  @Test
+  public void canOverideProperty_basePath() throws IOException {
+    context = createContextWithOverridenProperty("zipkin.ui.base-path:/foo/bar/");
+
+    assertThat(context.getBean(ZipkinUiAutoConfiguration.class).serveIndex().getBody())
+      .contains("<base>/foo/bar/</base>");
   }
 
   private static AnnotationConfigApplicationContext createContext() {

--- a/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
@@ -65,7 +65,7 @@ public class ZipkinUiAutoConfigurationTest {
   public void invalidIndexHtml() throws IOException {
     // I failed to make Jsoup barf, even on nonsense like: "<head wait no I changed my mind this HTML is totally invalid <<<<<<<<<<<"
     // So let's just run with a case where the file doesn't exist
-    context = createContextWithOverridenProperty("zipkin.ui.base-path:/foo/bar/");
+    context = createContextWithOverridenProperty("zipkin.ui.basepath:/foo/bar");
     ZipkinUiAutoConfiguration ui = context.getBean(ZipkinUiAutoConfiguration.class);
     ui.indexHtml = new ClassPathResource("does-not-exist.html");
 
@@ -148,10 +148,18 @@ public class ZipkinUiAutoConfigurationTest {
 
   @Test
   public void canOverideProperty_basePath() throws IOException {
-    context = createContextWithOverridenProperty("zipkin.ui.base-path:/foo/bar/");
+    context = createContextWithOverridenProperty("zipkin.ui.basepath:/foo/bar");
 
     assertThat(context.getBean(ZipkinUiAutoConfiguration.class).serveIndex().getBody().toString())
       .contains("<base>/foo/bar/</base>");
+  }
+
+  @Test
+  public void canOverideProperty_specialCaseRoot() throws IOException {
+    context = createContextWithOverridenProperty("zipkin.ui.basepath:/");
+
+    assertThat(context.getBean(ZipkinUiAutoConfiguration.class).serveIndex().getBody().toString())
+      .contains("<base>/</base>");
   }
 
   private static AnnotationConfigApplicationContext createContext() {

--- a/zipkin-autoconfigure/ui/src/test/resources/zipkin-ui/index.html
+++ b/zipkin-autoconfigure/ui/src/test/resources/zipkin-ui/index.html
@@ -1,0 +1,4 @@
+<html>
+  <head></head>
+  <body></body>
+</html>

--- a/zipkin-autoconfigure/ui/src/test/resources/zipkin-ui/index.html
+++ b/zipkin-autoconfigure/ui/src/test/resources/zipkin-ui/index.html
@@ -1,4 +1,4 @@
 <html>
   <head></head>
-  <body></body>
+  <body>index.html</body>
 </html>

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -108,6 +108,7 @@ instrumented | zipkin.ui.instrumented | Which sites this Zipkin UI covers. Regex
 logsUrl | zipkin.ui.logs-url | Logs query service url pattern. If specified, a button will appear on the trace page and will replace {traceId} in the url by the traceId. Not required.
 dependency.lowErrorRate | zipkin.ui.dependency.low-error-rate | The rate of error calls on a dependency link that turns it yellow. Defaults to 0.5 (50%) set to >1 to disable.
 dependency.highErrorRate | zipkin.ui.dependency.high-error-rate | The rate of error calls on a dependency link that turns it red. Defaults to 0.75 (75%) set to >1 to disable.
+basePath | zipkin.ui.base-path | URL placed into the <base> tag in the UI HTML; useful when running behind a reverse proxy.
 
 For example, if using docker you can set `ZIPKIN_UI_QUERY_LIMIT=100` to affect `$.queryLimit` in `/config.json`.
 

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -108,7 +108,7 @@ instrumented | zipkin.ui.instrumented | Which sites this Zipkin UI covers. Regex
 logsUrl | zipkin.ui.logs-url | Logs query service url pattern. If specified, a button will appear on the trace page and will replace {traceId} in the url by the traceId. Not required.
 dependency.lowErrorRate | zipkin.ui.dependency.low-error-rate | The rate of error calls on a dependency link that turns it yellow. Defaults to 0.5 (50%) set to >1 to disable.
 dependency.highErrorRate | zipkin.ui.dependency.high-error-rate | The rate of error calls on a dependency link that turns it red. Defaults to 0.75 (75%) set to >1 to disable.
-basePath | zipkin.ui.base-path | URL placed into the <base> tag in the UI HTML; useful when running behind a reverse proxy.
+basePath | zipkin.ui.basepath | path prefix placed into the <base> tag in the UI HTML; useful when running behind a reverse proxy. Default "/zipkin"
 
 For example, if using docker you can set `ZIPKIN_UI_QUERY_LIMIT=100` to affect `$.queryLimit` in `/config.json`.
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -143,6 +143,8 @@ zipkin:
     # - .*example2.com
     # Default is "match all websites"
     instrumented: .*
+    # URL placed into the <base> tag in the HTML
+    base-path: /zipkin/
 
 server:
   port: ${QUERY_PORT:9411}

--- a/zipkin-ui/README.md
+++ b/zipkin-ui/README.md
@@ -112,12 +112,12 @@ To disable coloring of lines, set both rates to a number higher than 1.
 
 ## Running behind a reverse proxy
 Starting with Zipkin `1.31.2`, Zipkin UI supports running under an arbitrary _context root_. As a result, it can be proxied
-under a different path than `/zipkin/` such as `/proxy/foo/bar/zipkin/`. 
+under a different path than `/zipkin/` such as `/proxy/foo/bar/zipkin/`.
 
 > Note that Zipkin requires the last path segment to be `zipkin`.
 
-> Also note that due to `html-webpack-plugin` limitations, Zipkin UI relies on a 
-[`base` tag](https://www.w3schools.com/TAgs/tag_base.asp) and its `href` attribute to be set in the `index.html` file. 
+> Also note that due to `html-webpack-plugin` limitations, Zipkin UI relies on a
+[`base` tag](https://www.w3schools.com/TAgs/tag_base.asp) and its `href` attribute to be set in the `index.html` file.
 By default its value is `/zipkin/` and as such the reverse proxy must rewrite the value to an alternate _context root_.
 
 ### Apache HTTP as a Zipkin reverse proxy
@@ -132,7 +132,7 @@ ProxyPass /proxy/foo/bar/ http://localhost:9411/
 SetOutputFilter proxy-html
 ProxyHTMLURLMap /zipkin/ /proxy/foo/bar/zipkin/
 ProxyHTMLLinks  base        href
-``` 
+```
 
 To access Zipkin UI behind the reverse proxy, execute:
 ```bash
@@ -143,7 +143,7 @@ $ curl http://localhost/proxy/foo/bar/zipkin/
     --><base href="/proxy/foo/bar/zipkin/"><link rel="icon" type="image/x-icon" href="favicon.ico"><meta charset="UTF-8"><title>Webpack App</title><link href="app-94a6ee84dc608c5f9e66.min.css" rel="stylesheet"></head><body>
   <script type="text/javascript" src="app-94a6ee84dc608c5f9e66.min.js"></script></body></html>
 ```
-As you would see, the attribute `href` of the `base` tag is rewritten which is the way to get around the 
+As you would see, the attribute `href` of the `base` tag is rewritten which is the way to get around the
 `html-webpack-plugin` limitations.
 
 Uploading the span is easy as
@@ -153,5 +153,5 @@ $ curl -H "Content-Type: application/json" --data-binary "[$(cat ../benchmarks/s
 
 And then it's observable in the UI:
 ```bash
-$ open http://localhost/proxy/foo/bar/zipkin/?serviceName=zipkin-server&startTs=1378193040000&endTs=1505463856013 
+$ open http://localhost/proxy/foo/bar/zipkin/?serviceName=zipkin-server&startTs=1378193040000&endTs=1505463856013
 ```


### PR DESCRIPTION
Previously: #1930 

Unlike agreed there, this PR does _not_ change the ENV var (`proxy`) used in development mode, because based on the documentation, that seems to be a different animal: documentation for `proxy` says that `http(s)` and the port are required, while here we're preferably using relative paths. I'll be happy if someone who understands exactly what that ENV var does says "nope, that doc string is misleading, they do the same thing".

Full disclosure: I got `org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:testCompile (default-testCompile) on project zipkin: Compilation failure` when trying to compile the whole project for an end-to-end test, so I didn't do that. This is most likely a problem in my env, but I'm hoping I can get away with not tracking it down (at least not today). The newly introduced unit tests _do_ pass.

Fixes #1930