### PR TITLE
Switch to use Cassandra-3.11.3's DelimiterAnalyzer and PREFIX mode SASI for the annotations index in the Zipkin2 Cassandra storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ database needed.
 
 ### Cassandra
 The [Cassandra](zipkin-storage/cassandra) component is tested against
-Cassandra 3.11+. It stores spans using UDTs, such that they appear like
+Cassandra 3.11.3+. It stores spans using UDTs, such that they appear like
 the v2 Zipkin model in cqlsh. It is designed for scale. For example, it
 uses a combination of SASI and manually implemented indexes to make
 querying larger data more performant.

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromSpan.java
@@ -104,8 +104,7 @@ final class SelectTraceIdsFromSpan extends ResultSetFutureCall {
       Input input =
           new AutoValue_SelectTraceIdsFromSpan_Input(
               serviceName,
-              // % for like, bracing with ░ to ensure no accidental substring match
-              "%░" + annotationKey + "░%",
+              annotationKey,
               timestampRange.startUUID,
               timestampRange.endUUID,
               limit);

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
@@ -33,13 +33,14 @@ CREATE TABLE IF NOT EXISTS zipkin2.span_by_service (
     AND speculative_retry = '95percentile'
     AND comment = 'Secondary table for looking up span names by a service name.';
 
+DROP INDEX IF EXISTS zipkin2.span_annotation_query_idx;
+
 CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.span (annotation_query) USING 'org.apache.cassandra.index.sasi.SASIIndex'
    WITH OPTIONS = {
-    'mode': 'CONTAINS',
+    'mode': 'PREFIX',
     'analyzed': 'true',
-    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.NonTokenizingAnalyzer',
-    'case_sensitive': 'false'
-   };
+    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.DelimiterAnalyzer',
+    'delimiter': '░'};
 
 CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.span (l_service) USING 'org.apache.cassandra.index.sasi.SASIIndex'
    WITH OPTIONS = {'mode': 'PREFIX'};

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -47,7 +47,7 @@ import static zipkin2.storage.cassandra.InternalForTests.writeDependencyLinks;
 public class ITCassandraStorage {
 
   static CassandraStorageRule classRule() {
-    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.10.1", "test_cassandra3");
+    return new CassandraStorageRule("openzipkin/zipkin-cassandra:-2.10.4", "test_cassandra3");
   }
 
   public static class ITSpanStore extends zipkin2.storage.ITSpanStore {

--- a/zipkin-storage/cassandra/src/test/resources/zipkin2-test-schema.cql
+++ b/zipkin-storage/cassandra/src/test/resources/zipkin2-test-schema.cql
@@ -1,4 +1,4 @@
-CREATE KEYSPACE IF NOT EXISTS stress_zipkin2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
+CREATE KEYSPACE IF NOT EXISTS stress_zipkin2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'} AND durable_writes = false;
 
 //-- same schema but remove all UDTs and collections (as cassandra-stress doesn't support them)
 
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS stress_zipkin2.span (
     PRIMARY KEY (trace_id, ts_uuid, id)
 )
     WITH CLUSTERING ORDER BY (ts_uuid DESC)
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy', 'compaction_window_size': 10, 'compaction_window_unit': 'MINUTES'}
     AND default_time_to_live =  604800;
 
 
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS stress_zipkin2.trace_by_service_span (
     PRIMARY KEY ((service, span, bucket), ts)
 )
    WITH CLUSTERING ORDER BY (ts DESC)
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy', 'compaction_window_size': 10, 'compaction_window_unit': 'MINUTES'}
     AND default_time_to_live =  259200;
 
 CREATE TABLE IF NOT EXISTS stress_zipkin2.span_by_service (
@@ -43,11 +43,10 @@ CREATE TABLE IF NOT EXISTS stress_zipkin2.span_by_service (
 
 CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin2.span (annotation_query) USING 'org.apache.cassandra.index.sasi.SASIIndex'
    WITH OPTIONS = {
-    'mode': 'CONTAINS',
+    'mode': 'PREFIX',
     'analyzed': 'true',
-    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.NonTokenizingAnalyzer',
-    'case_sensitive': 'false'
-   };
+    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.DelimiterAnalyzer',
+    'delimiter': 'a'};
 
 CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin2.span (l_service) USING 'org.apache.cassandra.index.sasi.SASIIndex'
    WITH OPTIONS = {'mode': 'PREFIX'};


### PR DESCRIPTION
This PR is waiting for Cassandra-3.11.3 to first be released.

It switches the SASI used for the annotation_query from the expensive (cpu, latency and disk space) `CONTAINS NonTokenizingAnalyzer` to the fast efficient `DelimiterAnalyzer` that was provided by @zuochangan and made available via [CASSANDRA-14247](https://issues.apache.org/jira/browse/CASSANDRA-14247).

ref: https://github.com/openzipkin/zipkin/issues/1861

To test Zipkin with the new Delimiter Tokenizer, which will be available in Cassandra-3.11.3, do the following steps:

    # clone and build Cassandra (3.11.2-SNAPSHOT)
    git clone https://github.com/apache/cassandra.git
    cd cassandra
    git checkout cassandra-3.11
    ant artifacts
    # start Cassandra
    build/dist/bin/cassandra -f

    # clone Zipkin
    git clone https://github.com/openzipkin/zipkin.git
    cd zipkin
    git checkout mck/zipkin2-cassandra-delimiter-indexer-for-annotations 
    # Build the server and also make its dependencies
    ./mvnw -DskipTests --also-make -pl zipkin-server clean install
    # start Zipkin
    cd <ZIPKIN_SRC>
    java -jar ./zipkin-server/target/zipkin-server-*exec.jar

    # open http://localhost:8080/


To stress-test the Zipkin schema that uses the new Delimiter Tokenizer

    # start Cassandra (as above)
    …
    # create stress friendly zipkin keyspace and schema
    cd zipkin-storage/zipkin2_cassandra/src/test/resources/
    cqlsh -f zipkin2-test-schema.cql
    
    # warmup, and create initial writes
    cassandra-stress  user profile=span-stress.yaml ops\(insert=1\)  duration=1m  -rate threads=4 throttle=50/s
    # stress
    cassandra-stress  user profile=span-stress.yaml ops\(insert=10,by_trace=1,by_trace_ts_id=1,by_annotation=1\)  duration=1m  -rate threads=4 throttle=50/s  -errors retries=10 ignore
    # repeat, increasing throttle, threads, and duration. and graph to html if desired.
    cassandra-stress  user profile=span-stress.yaml ops\(insert=10,by_trace=1,by_trace_ts_id=1,by_annotation=1\)  duration=1h  -rate threads=16 throttle=10000/s -errors retries=10 ignore -graph file=zipkin_1948.html title=Zipkin revision=with_delimiter_idx



