### PR TITLE
Fixes endpoint formatting, notably undefined references

### DIFF
--- a/zipkin-ui/js/component_ui/traceToMustache.js
+++ b/zipkin-ui/js/component_ui/traceToMustache.js
@@ -79,17 +79,15 @@ function toSpanDepths(spans) {
   return treeDepths(entry, 1);
 }
 
-export function formatEndpoint({ipv4, ipv6, port = 0, serviceName = ''}) {
-  if (serviceName) {
-    if (ipv6) {
-      return `[${ipv6}]:${port} (${serviceName})`;
-    }
-    return `${ipv4}:${port} (${serviceName})`;
+export function formatEndpoint({ipv4, ipv6, port, serviceName}) {
+  if (ipv4 || ipv6) {
+    const ip = ipv6 ? `[${ipv6}]` : ipv4; // arbitrarily prefer ipv6
+    const portString = port ? `:${port}` : '';
+    const serviceNameString = serviceName ? ` (${serviceName})` : '';
+    return ip + portString + serviceNameString;
+  } else {
+    return serviceName || '';
   }
-  if (ipv6) {
-    return `[${ipv6}]:${port}`;
-  }
-  return `${ipv4}:${port}`;
 }
 
 export default function traceToMustache(trace, logsUrl = undefined) {

--- a/zipkin-ui/test/component_ui/traceToMustache.test.js
+++ b/zipkin-ui/test/component_ui/traceToMustache.test.js
@@ -198,13 +198,17 @@ describe('formatEndpoint', () => {
     formatEndpoint({ipv4: '150.151.152.153', port: 5000}).should.equal('150.151.152.153:5000');
   });
 
-  it('should use 0 as default port', () => {
-    formatEndpoint({ipv4: '150.151.152.153'}).should.equal('150.151.152.153:0');
+  it('should not use port when missing or zero', () => {
+    formatEndpoint({ipv4: '150.151.152.153'}).should.equal('150.151.152.153');
+    formatEndpoint({ipv4: '150.151.152.153', port: 0}).should.equal('150.151.152.153');
   });
 
   it('should put service name in parenthesis', () => {
     formatEndpoint({ipv4: '150.151.152.153', port: 9042, serviceName: 'cassandra'}).should.equal(
       '150.151.152.153:9042 (cassandra)'
+    );
+    formatEndpoint({ipv4: '150.151.152.153', serviceName: 'cassandra'}).should.equal(
+      '150.151.152.153 (cassandra)'
     );
   });
 
@@ -212,6 +216,19 @@ describe('formatEndpoint', () => {
     formatEndpoint({ipv4: '150.151.152.153', port: 9042, serviceName: ''}).should.equal(
       '150.151.152.153:9042'
     );
+    formatEndpoint({ipv4: '150.151.152.153', serviceName: ''}).should.equal(
+      '150.151.152.153'
+    );
+  });
+
+  it('should show service name missing IP', () => {
+    formatEndpoint({serviceName: 'rabbit'}).should.equal(
+      'rabbit'
+    );
+  });
+
+  it('should not crash on no data', () => {
+    formatEndpoint({}).should.equal('');
   });
 
   it('should put ipv6 in brackets', () => {
@@ -221,6 +238,10 @@ describe('formatEndpoint', () => {
 
     formatEndpoint({ipv6: '2001:db8::c001', port: 9042}).should.equal(
       '[2001:db8::c001]:9042'
+    );
+
+    formatEndpoint({ipv6: '2001:db8::c001'}).should.equal(
+      '[2001:db8::c001]'
     );
   });
 });


### PR DESCRIPTION
This omits dummy port zero and undefined IPs when viewing span details

Before:
<img width="676" alt="screen shot 2018-03-16 at 5 42 31 pm" src="https://user-images.githubusercontent.com/64215/37514128-00e8d3f2-2942-11e8-91ff-a9d104044560.png">
<img width="673" alt="screen shot 2018-03-16 at 5 42 22 pm" src="https://user-images.githubusercontent.com/64215/37514129-0139c33e-2942-11e8-93bb-9b720d4da4f9.png">
<img width="672" alt="screen shot 2018-03-16 at 5 42 14 pm" src="https://user-images.githubusercontent.com/64215/37514131-02548b1e-2942-11e8-97bf-809afedbbdea.png">


After:

<img width="673" alt="screen shot 2018-03-16 at 5 41 19 pm" src="https://user-images.githubusercontent.com/64215/37514093-f0c08466-2941-11e8-9ec6-7d408e3133c4.png">
<img width="672" alt="screen shot 2018-03-16 at 5 41 04 pm" src="https://user-images.githubusercontent.com/64215/37514094-f0fbac12-2941-11e8-8b5a-91969e39e8bc.png">
<img width="675" alt="screen shot 2018-03-16 at 5 40 55 pm" src="https://user-images.githubusercontent.com/64215/37514095-f12a887a-2941-11e8-8bf3-703acdd11e50.png">
