### PR TITLE
Inlines actuate metrics buffer code to dodge conflicts on Spring Boot 2

### DIFF
--- a/benchmarks/src/main/java/zipkin/benchmarks/MetricsBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/MetricsBenchmarks.java
@@ -13,7 +13,6 @@
  */
 package zipkin.benchmarks;
 
-import com.google.common.io.ByteStreams;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -28,13 +27,10 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import org.springframework.boot.actuate.metrics.buffer.CounterBuffers;
-import org.springframework.boot.actuate.metrics.buffer.GaugeBuffers;
 import zipkin.collector.CollectorMetrics;
 import zipkin.collector.InMemoryCollectorMetrics;
 import zipkin.server.internal.ActuateCollectorMetrics;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 @Measurement(iterations = 80, time = 1)
@@ -51,7 +47,7 @@ public class MetricsBenchmarks
   static final int SHORT_SPAN = 500;
 
   private InMemoryCollectorMetrics inMemoryCollectorMetrics = new InMemoryCollectorMetrics();
-  private ActuateCollectorMetrics actuateCollectorMetrics = new ActuateCollectorMetrics(new CounterBuffers(), new GaugeBuffers());
+  private ActuateCollectorMetrics actuateCollectorMetrics = new ActuateCollectorMetrics();
 
   @Benchmark
   public int incrementBytes_longSpans_inMemory() {
@@ -98,14 +94,5 @@ public class MetricsBenchmarks
         .build();
 
     new Runner(opt).run();
-  }
-
-
-  static byte[] read(String resource) {
-    try {
-      return ByteStreams.toByteArray(CodecBenchmarks.class.getResourceAsStream(resource));
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/internal/ZipkinServerConfiguration.java
@@ -14,14 +14,11 @@
 package zipkin.server.internal;
 
 import brave.Tracing;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.health.HealthAggregator;
-import org.springframework.boot.actuate.metrics.buffer.CounterBuffers;
-import org.springframework.boot.actuate.metrics.buffer.GaugeBuffers;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.embedded.undertow.UndertowDeploymentInfoCustomizer;
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
@@ -84,15 +81,10 @@ public class ZipkinServerConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(CollectorMetrics.class)
-  CollectorMetrics metrics(Optional<CounterBuffers> counterBuffers,
-    Optional<GaugeBuffers> gaugeBuffers) {
-    // it is not guaranteed that BufferCounterService/CounterBuffers will be used,
-    // for ex., com.datastax.cassandra:cassandra-driver-core brings com.codahale.metrics.MetricRegistry
-    // and as result DropwizardMetricServices is getting instantiated instead of standard Java8 BufferCounterService.
-    // On top of it Cassandra driver heavily relies on Dropwizard metrics and manually excluding it from pom.xml is not an option.
-    // MetricsDropwizardAutoConfiguration can be manually excluded either, as Cassandra metrics won't be recorded.
-    return new ActuateCollectorMetrics(counterBuffers.orElse(new CounterBuffers()),
-      gaugeBuffers.orElse(new GaugeBuffers()));
+  CollectorMetrics metrics() {
+    // org.springframework.boot.actuate.metrics.buffer package is removed in boot v2. Temporarily,
+    // this inlines the important code. Later we will switch to micrometer.
+    return new ActuateCollectorMetrics();
   }
 
   @Configuration

--- a/zipkin-server/src/test/java/zipkin/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin/server/internal/ITZipkinServer.java
@@ -65,7 +65,7 @@ public class ITZipkinServer {
   @Before public void init() {
     storage.clear();
     duration.clear();
-    metrics.forTransport("http").reset();
+    metrics.forTransport("http").clear();
   }
 
   @Test public void writeSpans_noContentTypeIsJson() throws Exception {


### PR DESCRIPTION
Spring Boot 2 removes the buffers package we used. This inlines the
essential work going on.