### PR TITLE
Removes scribe from the default jar, as an optional module

### DIFF
--- a/zipkin-autoconfigure/collector-kafka10/pom.xml
+++ b/zipkin-autoconfigure/collector-kafka10/pom.xml
@@ -47,6 +47,7 @@
           <layoutFactory implementation="zipkin.layout.ZipkinLayoutFactory">
             <name>custom</name>
           </layoutFactory>
+          <classifier>module</classifier>
           <!-- exclude dependencies already packaged in zipkin-server -->
           <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
           <excludeGroupIds>org.springframework.boot,org.springframework,org.slf4j,commons-logging,com.google.code.gson</excludeGroupIds>
@@ -57,7 +58,7 @@
           <dependency>
             <groupId>io.zipkin.layout</groupId>
             <artifactId>zipkin-layout-factory</artifactId>
-            <version>0.0.1</version>
+            <version>0.0.2</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/zipkin-autoconfigure/collector-scribe/README.md
+++ b/zipkin-autoconfigure/collector-scribe/README.md
@@ -1,0 +1,76 @@
+# Scribe Collector Auto-configure Module
+
+This module provides support for running the legacy Scribe collector as
+a component of Zipkin server. To activate this collector, reference the
+module jar when running the Zipkin server and configure one or more
+bootstrap brokers via the `SCRIBE_ENABLED=true` environment variable or
+the property `zipkin.collector.scribe.enabled=true`.
+
+## Quick start
+
+JRE 8 is required to run Zipkin server.
+
+Fetch the latest released
+[executable jar for Zipkin server](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec)
+and
+[autoconfigure module jar for the scribe collector](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-autoconfigure-collector-scribe&v=LATEST&c=module).
+Run Zipkin server with the Scribe collector enabled.
+
+For example:
+
+```bash
+$ curl -sSL https://zipkin.io/quickstart.sh | bash -s
+$ curl -sSL https://zipkin.io/quickstart.sh | bash -s io.zipkin.java:zipkin-autoconfigure-collector-scribe:LATEST:module scribe.jar
+$ SCRIBE_ENABLED=true \
+    java \
+    -Dloader.path='scribe.jar,scribe.jar!/lib' \
+    -Dspring.profiles.active=scribe \
+    -cp zipkin.jar \
+    org.springframework.boot.loader.PropertiesLauncher
+```
+
+After executing these steps, the Zipkin UI will be available
+[http://localhost:9411](http://localhost:9411) or port 9411 of the remote
+host the Zipkin server was started on. Scribe will be listening on port
+9410.
+
+The Zipkin server can be further configured as described in the
+[Zipkin server documentation](../../zipkin-server/README.md).
+
+## How this works
+
+The Zipkin server executable jar and the autoconfigure module jar for the
+scribe collector are required. The module jar contains the code for
+loading and configuring the scribe collector, and any dependencies that
+are not already packaged in the Zipkin server jar.
+
+Using PropertiesLauncher as the main class runs the Zipkin server
+executable jar the same as it would be if executed using `java -jar zipkin.jar`,
+except it provides the option to load resources from outside the
+executable jar into the classpath. Those external resources are specified
+using the `loader.path` system property. In this case, it is configured
+to load the scribe collector module jar (`zipkin-autoconfigure-collector-scribe-module.jar`)
+and the jar files contained in the `lib/` directory within that module
+jar (`zipkin-autoconfigure-collector-scribe-module.jar!/lib`).
+
+The `spring.profiles=scribe` system property causes configuration from
+[zipkin-server-scribe.yml](src/main/resources/zipkin-server-scribe.yml)
+to be loaded.
+
+For more information on how this works, see [Spring Boot's documentation on the executable jar
+format](https://docs.spring.io/spring-boot/docs/current/reference/html/executable-jar.html). The
+[section on PropertiesLauncher](https://docs.spring.io/spring-boot/docs/current/reference/html/executable-jar.html#executable-jar-property-launcher-features)
+has more detail on how the external module jar and the libraries it contains are loaded.
+
+## Configuration
+
+The following configuration points apply apply when `SCRIBE_ENABLED=true`
+environment variable or the property `zipkin.collector.scribe.enabled=true`.
+They can be configured by setting an environment variable or by setting
+a java system property using the `-Dproperty.name=value` command line
+argument.
+
+Environment Variable | Property |Description
+--- | --- | --- | ---
+`COLLECTOR_PORT` | `zipkin.collector.scribe.port` | The port to listen for thrift RPC scribe requests. Defaults to 9410
+`SCRIBE_CATEGORY` | `zipkin.collector.scribe.category` | Category zipkin spans will be consumed from. Defaults to `zipkin`

--- a/zipkin-autoconfigure/collector-scribe/pom.xml
+++ b/zipkin-autoconfigure/collector-scribe/pom.xml
@@ -43,6 +43,35 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <configuration>
+          <layoutFactory implementation="zipkin.layout.ZipkinLayoutFactory">
+            <name>custom</name>
+          </layoutFactory>
+          <classifier>module</classifier>
+          <!-- exclude dependencies already packaged in zipkin-server -->
+          <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
+          <excludeGroupIds>org.springframework.boot,org.springframework,org.slf4j,commons-logging,com.google.code.gson</excludeGroupIds>
+          <!-- excludes direct dependency instead of the group id, as otherwise we'd exclude ourselves -->
+          <excludeArtifactIds>zipkin</excludeArtifactIds>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>io.zipkin.layout</groupId>
+            <artifactId>zipkin-layout-factory</artifactId>
+            <version>0.0.2</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>jigsaw</id>

--- a/zipkin-autoconfigure/collector-scribe/src/main/resources/zipkin-server-scribe.yml
+++ b/zipkin-autoconfigure/collector-scribe/src/main/resources/zipkin-server-scribe.yml
@@ -1,0 +1,6 @@
+zipkin:
+  collector:
+    scribe:
+      enabled: ${SCRIBE_ENABLED:false}
+      category: ${SCRIBE_CATEGORY:zipkin}
+      port: ${COLLECTOR_PORT:9410}

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -254,10 +254,8 @@ Property | Environment Variable | Description
 `zipkin.collector.http.enabled` | `HTTP_COLLECTOR_ENABLED` | `false` disables the HTTP collector. Defaults to `true`.
 
 ### Scribe Collector
-The Scribe collector is disabled by default, configured by the following:
-
-    * `SCRIBE_ENABLED`: Set to true to listen for scribe (thrift RPC); Defaults to false
-    * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410
+A collector supporting Scribe is available as an external module. See
+[zipkin-autoconfigure/collector-scribe](../zipkin-autoconfigure/collector-scribe/).
 
 ### Kafka Collector
 This collector remains a Kafka 0.8.x consumer, while Zipkin systems update to 0.9+.

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -185,13 +185,6 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- Scribe Collector -->
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-autoconfigure-collector-scribe</artifactId>
-      <optional>true</optional>
-    </dependency>
-
     <!-- Prometheus metrics -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -23,10 +23,6 @@ zipkin:
       streams: ${KAFKA_STREAMS:1}
       # Maximum size of a message containing spans in bytes
       max-message-size: ${KAFKA_MAX_MESSAGE_SIZE:1048576}
-    scribe:
-      enabled: ${SCRIBE_ENABLED:false}
-      category: zipkin
-      port: ${COLLECTOR_PORT:9410}
     rabbitmq:
       # RabbitMQ server address list (comma-separated list of host:port)
       addresses: ${RABBIT_ADDRESSES:}


### PR DESCRIPTION
This removes scribe and the 2 year abandoned library it uses from the
default server jar. A follow-up change will integrate it conditionally
in the docker image similar to how we integrate kafka10.

See #1192
See https://github.com/openzipkin/zipkin-reporter-java/issues/95