### PR TITLE
Ignores empty rabbit URI property

### DIFF
--- a/zipkin-autoconfigure/collector-rabbitmq/src/main/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorProperties.java
+++ b/zipkin-autoconfigure/collector-rabbitmq/src/main/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorProperties.java
@@ -27,6 +27,7 @@ import zipkin.collector.rabbitmq.RabbitMQCollector;
  */
 @ConfigurationProperties("zipkin.collector.rabbitmq")
 class ZipkinRabbitMQCollectorProperties {
+  static final URI EMPTY_URI = URI.create("");
 
   /** RabbitMQ server addresses in the form of a (comma-separated) list of host:port pairs */
   private List<String> addresses;
@@ -44,8 +45,10 @@ class ZipkinRabbitMQCollectorProperties {
   private String virtualHost;
   /** Flag to use SSL */
   private Boolean useSsl;
-  /** RabbitMQ URI spec-compliant URI to connect to the RabbitMQ server.
-   * When used, other connection properties will be ignored. */
+  /**
+   * RabbitMQ URI spec-compliant URI to connect to the RabbitMQ server.
+   * When used, other connection properties will be ignored.
+   */
   private URI uri;
 
   public List<String> getAddresses() {
@@ -117,6 +120,7 @@ class ZipkinRabbitMQCollectorProperties {
   }
 
   public void setUri(URI uri) {
+    if (EMPTY_URI.equals(uri)) return;
     this.uri = uri;
   }
 

--- a/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesTest.java
+++ b/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin/autoconfigure/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesTest.java
@@ -21,10 +21,9 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZipkinRabbitMQCollectorPropertiesTest {
+  ZipkinRabbitMQCollectorProperties properties = new ZipkinRabbitMQCollectorProperties();
 
-  @Test
-  public void uriProperlyParsedAndIgnoresOtherProperties_whenUriSet() throws Exception {
-    ZipkinRabbitMQCollectorProperties properties = new ZipkinRabbitMQCollectorProperties();
+  @Test public void uriProperlyParsedAndIgnoresOtherProperties_whenUriSet() throws Exception {
     properties.setUri(URI.create("amqp://admin:admin@localhost:5678/myv"));
     properties.setAddresses(Collections.singletonList("will_not^work!"));
     properties.setUsername("bob");
@@ -40,5 +39,12 @@ public class ZipkinRabbitMQCollectorPropertiesTest {
         assertThat(connFactory.getPassword()).isEqualTo("admin");
         assertThat(connFactory.getVirtualHost()).isEqualTo("myv");
       });
+  }
+
+  /** This prevents an empty RABBIT_URI variable from being mistaken as a real one */
+  @Test public void ignoresEmptyURI() {
+    properties.setUri(URI.create(""));
+
+    assertThat(properties.getUri()).isNull();
   }
 }


### PR DESCRIPTION
The default is empty and we accidentally interpreted that as a real URI.

Ex: `uri: ${RABBIT_URI:}`

Caused:
```
| Caused by: java.lang.NullPointerException: null
query_1     |     at com.rabbitmq.client.ConnectionFactory.setUri(ConnectionFactory.java:277) ~[amqp-client-4.5.0.jar!/:4.5.0]
query_1     |     at zipkin.autoconfigure.collector.rabbitmq.ZipkinRabbitMQCollectorProperties.toBuilder(ZipkinRabbitMQCollectorProperties.java:132) ~[zipkin-autoconfigure-collector-rabbitmq-2.7.0.jar!/:na]
query_1     |     at zipkin.autoconfigure.collector.rabbitmq.ZipkinRabbitMQCollectorAutoConfiguration.rabbitMq(ZipkinRabbitMQCollectorAutoConfiguration.java:43) ~[zipkin-autoconfigure-collector-rabbitmq-2.7.0.jar!/:na]
query_1     |
```

Thanks @marcingrzejszczak for pointing this out