### PR TITLE
Adds direct transcoding of UTF-8 strings via code most similar to Netty

### DIFF
--- a/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
@@ -218,6 +218,19 @@ public class CodecBenchmarks {
     return SpanBytesEncoder.JSON_V1.encodeList(tenSpan2s);
   }
 
+  static final byte[] zipkin2JsonChinese = read("/zipkin2-chinese.json");
+  static final Span zipkin2Chinese = SpanBytesDecoder.JSON_V2.decodeOne(zipkin2JsonChinese);
+
+  @Benchmark
+  public Span readChineseSpan_json_zipkin2() {
+    return SpanBytesDecoder.JSON_V2.decodeOne(zipkin2JsonChinese);
+  }
+
+  @Benchmark
+  public byte[] writeChineseSpan_json_zipkin2() {
+    return SpanBytesEncoder.JSON_V2.encode(zipkin2Chinese);
+  }
+
   static final byte[] rpcSpanJson = read("/span-rpc.json");
   static final zipkin.Span rpcSpan = Codec.JSON.readSpan(rpcSpanJson);
   static final byte[] rpcSpanThrift = Codec.THRIFT.writeSpan(rpcSpan);
@@ -291,7 +304,7 @@ public class CodecBenchmarks {
   // Convenience main entry-point
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-        .include(".*" + CodecBenchmarks.class.getSimpleName() + ".*kryo_zipkin2")
+        .include(".*" + CodecBenchmarks.class.getSimpleName())
         .build();
 
     new Runner(opt).run();

--- a/benchmarks/src/main/java/zipkin2/internal/BufferBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/internal/BufferBenchmarks.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Threads(1)
+public class BufferBenchmarks {
+  static final Charset UTF_8 = Charset.forName("UTF-8");
+  // Order id = d07c4daa-0fa9-4c03-90b1-e06c4edae250 doesn't exist
+  static final String CHINESE_UTF8 = "订单d07c4daa-0fa9-4c03-90b1-e06c4edae250不存在";
+  static final int CHINESE_UTF8_SIZE = CHINESE_UTF8.getBytes(UTF_8).length;
+
+  @Benchmark public int utf8SizeInBytes_chinese() {
+    return Buffer.utf8SizeInBytes(CHINESE_UTF8);
+  }
+
+  @Benchmark public byte[] writeUtf8_chinese() {
+    Buffer bufferUtf8 = new Buffer(CHINESE_UTF8_SIZE);
+    bufferUtf8.writeUtf8(CHINESE_UTF8);
+    return bufferUtf8.toByteArray();
+  }
+
+  @Benchmark public byte[] writeUtf8_chinese_jdk() {
+    return CHINESE_UTF8.getBytes(UTF_8);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+      .include(".*" + BufferBenchmarks.class.getSimpleName() + ".*")
+      .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/main/resources/zipkin2-chinese.json
+++ b/benchmarks/src/main/resources/zipkin2-chinese.json
@@ -1,0 +1,23 @@
+{
+  "traceId": "4d1e00c0db9010db86154a4ba6e91385",
+  "parentId": "86154a4ba6e91385",
+  "id": "4d1e00c0db9010db",
+  "kind": "CLIENT",
+  "name": "个人信息查询",
+  "timestamp": 1472470996199000,
+  "duration": 207000,
+  "localEndpoint": {
+    "serviceName": "订单维护服务",
+    "ipv6": "7::0.128.128.127"
+  },
+  "remoteEndpoint": {
+    "serviceName": "个人信息服务",
+    "ipv4": "192.168.99.101",
+    "port": 9000
+  },
+  "tags": {
+    "http.path": "/person/profile/query",
+    "http.status_code": "403",
+    "error": "此用户没有操作权限"
+  }
+}

--- a/zipkin2/src/main/java/zipkin2/internal/Buffer.java
+++ b/zipkin2/src/main/java/zipkin2/internal/Buffer.java
@@ -13,11 +13,7 @@
  */
 package zipkin2.internal;
 
-import java.nio.charset.Charset;
-
 public final class Buffer {
-  static final Charset UTF_8 = Charset.forName("UTF-8");
-
   public interface Writer<T> {
     int sizeInBytes(T value);
 
@@ -47,19 +43,30 @@ public final class Buffer {
     return this;
   }
 
+  /**
+   * This returns the bytes needed to transcode a UTF-16 Java String to UTF-8 bytes.
+   *
+   * <p>Originally based on http://stackoverflow.com/questions/8511490/calculating-length-in-utf-8-of-java-string-without-actually-encoding-it
+   * <p>Later, ASCII run and malformed surrogate logic borrowed from okio.Utf8
+   */
   static int utf8SizeInBytes(String string) {
-    // Adapted from http://stackoverflow.com/questions/8511490/calculating-length-in-utf-8-of-java-string-without-actually-encoding-it
     int sizeInBytes = 0;
     for (int i = 0, len = string.length(); i < len; i++) {
       char ch = string.charAt(i);
       if (ch < 0x80) {
-        sizeInBytes++; // 7-bit character
+        sizeInBytes++; // 7-bit ASCII character
+        // This could be an ASCII run, or possibly entirely ASCII
+        while (i < len - 1) {
+          ch = string.charAt(i + 1);
+          if (ch >= 0x80) break;
+          i++;
+          sizeInBytes++; // another 7-bit ASCII character
+        }
       } else if (ch < 0x800) {
         sizeInBytes += 2; // 11-bit character
       } else if (ch < 0xd800 || ch > 0xdfff) {
         sizeInBytes += 3; // 16-bit character
       } else {
-        // malformed surrogate logic borrowed from okio.Utf8
         int low = i + 1 < len ? string.charAt(i + 1) : 0;
         if (ch > 0xdbff || low < 0xdc00 || low > 0xdfff) {
           sizeInBytes++; // A malformed surrogate, which yields '?'.
@@ -74,26 +81,61 @@ public final class Buffer {
   }
 
   public Buffer writeAscii(String v) {
-    int length = v.length();
-    for (int i = 0; i < length; i++) {
+    for (int i = 0, len = v.length(); i < len; i++) {
       buf[pos++] = (byte) v.charAt(i);
     }
     return this;
   }
 
-  static boolean isAscii(String v) {
-    for (int i = 0, length = v.length(); i < length; i++) {
-      if (v.charAt(i) >= 0x80) {
-        return false;
+  /**
+   * This transcodes a UTF-16 Java String to UTF-8 bytes.
+   *
+   * <p>This looks most similar to {@code io.netty.buffer.ByteBufUtil.writeUtf8(AbstractByteBuf, int, CharSequence, int)}
+   * v4.1, modified including features to address ASCII runs of text.
+   */
+  public Buffer writeUtf8(String string) {
+    for (int i = 0, len = string.length(); i < len; i++) {
+      char ch = string.charAt(i);
+      if (ch < 0x80) { // 7-bit ASCII character
+        buf[pos++] = (byte) ch;
+        // This could be an ASCII run, or possibly entirely ASCII
+        while (i < len - 1) {
+          ch = string.charAt(i + 1);
+          if (ch >= 0x80) break;
+          i++;
+          buf[pos++] = (byte) ch; // another 7-bit ASCII character
+        }
+      } else if (ch < 0x800) {  // 11-bit character
+        buf[pos++] = (byte) (0xc0 | (ch >> 6));
+        buf[pos++] = (byte) (0x80 | (ch & 0x3f));
+      } else if (ch < 0xd800 || ch > 0xdfff) { // 16-bit character
+        buf[pos++] = (byte) (0xe0 | (ch >> 12));
+        buf[pos++] = (byte) (0x80 | ((ch >> 6) & 0x3f));
+        buf[pos++] = (byte) (0x80 | (ch & 0x3f));
+      } else { // Possibly a 21-bit character
+        if (!Character.isHighSurrogate(ch)) { // Malformed or not UTF-8
+          buf[pos++] = '?';
+          continue;
+        }
+        if (i == len - 1) { // Truncated or not UTF-8
+          buf[pos++] = '?';
+          break;
+        }
+        char low = string.charAt(++i);
+        if (!Character.isLowSurrogate(low)) { // Malformed or not UTF-8
+          buf[pos++] = '?';
+          buf[pos++] = (byte) (Character.isHighSurrogate(low) ? '?' : low);
+          continue;
+        }
+        // Write the 21-bit character using 4 bytes
+        // See http://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G2630
+        int codePoint = Character.toCodePoint(ch, low);
+        buf[pos++] = (byte) (0xf0 | (codePoint >> 18));
+        buf[pos++] = (byte) (0x80 | ((codePoint >> 12) & 0x3f));
+        buf[pos++] = (byte) (0x80 | ((codePoint >> 6) & 0x3f));
+        buf[pos++] = (byte) (0x80 | (codePoint & 0x3f));
       }
     }
-    return true;
-  }
-
-  public Buffer writeUtf8(String v) {
-    if (isAscii(v)) return writeAscii(v);
-    byte[] temp = v.getBytes(UTF_8);
-    write(temp);
     return this;
   }
 


### PR DESCRIPTION
Before, we kicked out to `String.getBytes(UTF_8)` when encoding found
characters outside the normal ASCII range. This redundantly allocates
arrays and is generally less efficient than directly encoding.

This directly encodes UTF-8 using code most similar to Netty

https://github.com/netty/netty/blob/4.1/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java#L518

Thanks @wu-sheng for the sample data used in benchmarks

```
Benchmark                                      Mode  Cnt  Score   Error  Units
BEFORE:
CodecBenchmarks.writeChineseSpan_json_zipkin2  avgt   15  1.103 ± 0.006  us/op
AFTER:
CodecBenchmarks.writeChineseSpan_json_zipkin2  avgt   15  0.953 ± 0.008  us/op

Benchmark                                 Mode  Cnt  Score    Error  Units
BEFORE:
BufferBenchmarks.writeUtf8_chinese        avgt   15  0.098 ±  0.005  us/op
AFTER:
BufferBenchmarks.writeUtf8_chinese        avgt   15  0.061 ±  0.001  us/op
```