### PR TITLE
Adds numeric encodings needed by proto3

### DIFF
--- a/benchmarks/src/main/java/zipkin2/internal/BufferBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/internal/BufferBenchmarks.java
@@ -42,6 +42,11 @@ public class BufferBenchmarks {
   // Order id = d07c4daa-0fa9-4c03-90b1-e06c4edae250 doesn't exist
   static final String CHINESE_UTF8 = "订单d07c4daa-0fa9-4c03-90b1-e06c4edae250不存在";
   static final int CHINESE_UTF8_SIZE = CHINESE_UTF8.getBytes(UTF_8).length;
+  /* length-prefixing a 1 KiB span */
+  static final int TEST_INT = 1024;
+  /* epoch micros timestamp */
+  static final long TEST_LONG = 1472470996199000L;
+  Buffer buffer = new Buffer(8);
 
   @Benchmark public int utf8SizeInBytes_chinese() {
     return Buffer.utf8SizeInBytes(CHINESE_UTF8);
@@ -55,6 +60,32 @@ public class BufferBenchmarks {
 
   @Benchmark public byte[] writeUtf8_chinese_jdk() {
     return CHINESE_UTF8.getBytes(UTF_8);
+  }
+
+  @Benchmark public int varIntSizeInBytes_32() {
+    return Buffer.varintSizeInBytes(TEST_INT);
+  }
+
+  @Benchmark public int varIntSizeInBytes_64() {
+    return Buffer.varintSizeInBytes(TEST_LONG);
+  }
+
+  @Benchmark public int writeVarint_32() {
+    buffer.pos = 0;
+    buffer.writeVarint(TEST_INT);
+    return buffer.pos;
+  }
+
+  @Benchmark public int writeVarint_64() {
+    buffer.pos = 0;
+    buffer.writeVarint(TEST_LONG);
+    return buffer.pos;
+  }
+
+  @Benchmark public int writeLongLe() {
+    buffer.pos = 0;
+    buffer.writeLongLe(TEST_LONG);
+    return buffer.pos;
   }
 
   // Convenience main entry-point

--- a/zipkin2/src/main/java/zipkin2/internal/Buffer.java
+++ b/zipkin2/src/main/java/zipkin2/internal/Buffer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -197,6 +197,66 @@ public final class Buffer {
   }
 
   static final byte[] DIGITS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
+
+  /**
+   * A base 128 varint encodes 7 bits at a time, this checks how many bytes are needed to
+   * represent the value.
+   *
+   * <p>See https://developers.google.com/protocol-buffers/docs/encoding#varints
+   *
+   * <p>This logic is the same as {@code com.squareup.wire.ProtoWriter.varint32Size} v2.3.0
+   * which benchmarked faster than loop variants of the frequently copy/pasted VarInt.varIntSize
+   */
+  public static int varintSizeInBytes(int value) {
+    if ((value & (0xffffffff << 7)) == 0) return 1;
+    if ((value & (0xffffffff << 14)) == 0) return 2;
+    if ((value & (0xffffffff << 21)) == 0) return 3;
+    if ((value & (0xffffffff << 28)) == 0) return 4;
+    return 5;
+  }
+
+  // com.squareup.wire.ProtoWriter.writeVarint v2.3.0
+  void writeVarint(int v) {
+    while ((v & ~0x7f) != 0) {
+      buf[pos++] = (byte) ((v & 0x7f) | 0x80);
+      v >>>= 7;
+    }
+    buf[pos++] = (byte) v;
+  }
+
+  /** Like {@link #varintSizeInBytes(int)}, except for uint64. */
+  public static int varintSizeInBytes(long v) {
+    if ((v & (0xffffffffffffffffL << 7)) == 0) return 1;
+    if ((v & (0xffffffffffffffffL << 14)) == 0) return 2;
+    if ((v & (0xffffffffffffffffL << 21)) == 0) return 3;
+    if ((v & (0xffffffffffffffffL << 28)) == 0) return 4;
+    if ((v & (0xffffffffffffffffL << 35)) == 0) return 5;
+    if ((v & (0xffffffffffffffffL << 42)) == 0) return 6;
+    if ((v & (0xffffffffffffffffL << 49)) == 0) return 7;
+    if ((v & (0xffffffffffffffffL << 56)) == 0) return 8;
+    if ((v & (0xffffffffffffffffL << 63)) == 0) return 9;
+    return 10;
+  }
+
+  // com.squareup.wire.ProtoWriter.writeVarint v2.3.0
+  void writeVarint(long v) {
+    while ((v & ~0x7fL) != 0) {
+      buf[pos++] = (byte) ((v & 0x7f) | 0x80);
+      v >>>= 7;
+    }
+    buf[pos++] = (byte) v;
+  }
+
+  void writeLongLe(long v) {
+    buf[pos++] = (byte) (v & 0xff);
+    buf[pos++] = (byte) ((v >> 8 & 0xff));
+    buf[pos++] = (byte) ((v >> 16 & 0xff));
+    buf[pos++] = (byte) ((v >> 24 & 0xff));
+    buf[pos++] = (byte) ((v >> 32) & 0xff);
+    buf[pos++] = (byte) ((v >> 40) & 0xff);
+    buf[pos++] = (byte) ((v >> 48) & 0xff);
+    buf[pos++] = (byte) ((v >> 56) & 0xff);
+  }
 
   public byte[] toByteArray() {
     //assert pos == buf.length;

--- a/zipkin2/src/main/java/zipkin2/internal/JsonCodec.java
+++ b/zipkin2/src/main/java/zipkin2/internal/JsonCodec.java
@@ -29,10 +29,10 @@ import static java.lang.String.format;
  * reasons.
  *
  * <ul>
- *   <li>Eliminates the need to keep separate model classes for thrift vs json</li>
+ *   <li>Eliminates the need to keep separate model classes for proto3 vs json</li>
  *   <li>Avoids magic field initialization which, can miss constructor guards</li>
  *   <li>Allows us to safely re-use the json form in toString methods</li>
- *   <li>Encourages logic to be based on the thrift shape of objects</li>
+ *   <li>Encourages logic to be based on the json shape of objects</li>
  *   <li>Ensures the order and naming of the fields in json is stable</li>
  * </ul>
  *

--- a/zipkin2/src/test/java/zipkin2/internal/BufferTest.java
+++ b/zipkin2/src/test/java/zipkin2/internal/BufferTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,8 @@ package zipkin2.internal;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -143,5 +145,53 @@ public class BufferTest {
     String string = stringBuffer.toString();
     byte[] buffered = new Buffer(string.length()).writeAscii(string).toByteArray();
     assertThat(new String(buffered, "US-ASCII")).isEqualTo(string);
+  }
+
+  @Test public void unsignedVarintSize_32_largest() {
+    // largest to encode is a negative number
+    assertThat(Buffer.varintSizeInBytes(Integer.MIN_VALUE))
+      .isEqualTo(5);
+  }
+
+  @Test public void unsignedVarintSize_64_largest() {
+    // largest to encode is a negative number
+    assertThat(Buffer.varintSizeInBytes(Long.MIN_VALUE))
+      .isEqualTo(10);
+  }
+
+  @Test public void writeLongLe_matchesByteBuffer() {
+    for (long number : Arrays.asList(Long.MIN_VALUE, 0L, Long.MAX_VALUE)) {
+      Buffer buffer = new Buffer(8);
+      buffer.writeLongLe(number);
+
+      ByteBuffer byteBuffer = ByteBuffer.allocate(8);
+      byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+      byteBuffer.putLong(number);
+
+      assertThat(buffer.toByteArray())
+        .containsExactly(byteBuffer.array());
+    }
+  }
+
+  // https://developers.google.com/protocol-buffers/docs/encoding#varints
+  @Test public void writeVarint_32() {
+    int number = 300;
+
+    Buffer buffer = new Buffer(Buffer.varintSizeInBytes(number));
+    buffer.writeVarint(number);
+
+    assertThat(buffer.toByteArray())
+      .containsExactly(0b1010_1100, 0b0000_0010);
+  }
+
+  // https://developers.google.com/protocol-buffers/docs/encoding#varints
+  @Test public void writeVarint_64() {
+    long number = 300;
+
+    Buffer buffer = new Buffer(Buffer.varintSizeInBytes(300));
+    buffer.writeVarint(number);
+
+    assertThat(buffer.toByteArray())
+      .containsExactly(0b1010_1100, 0b0000_0010);
   }
 }


### PR DESCRIPTION
```
Benchmark                                 Mode  Cnt  Score    Error  Units
BufferBenchmarks.varIntSizeInBytes_32     avgt   15  0.002 ±  0.001  us/op
BufferBenchmarks.varIntSizeInBytes_64     avgt   15  0.002 ±  0.001  us/op
BufferBenchmarks.writeLongLe              avgt   15  0.004 ±  0.001  us/op
BufferBenchmarks.writeVarint_32           avgt   15  0.003 ±  0.001  us/op
BufferBenchmarks.writeVarint_64           avgt   15  0.010 ±  0.001  us/op
```

See https://github.com/openzipkin/zipkin-api/pull/47