### PR TITLE
Adds Endpoint IP address bytes accessors

### DIFF
--- a/benchmarks/src/main/java/zipkin2/EndpointBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/EndpointBenchmarks.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Threads(1)
+public class EndpointBenchmarks {
+  static final String IPV4 = "43.0.192.2", IPV6 = "2001:db8::c001";
+  static final InetAddress IPV4_ADDR, IPV6_ADDR;
+
+  static {
+    try {
+      IPV4_ADDR = Inet4Address.getByName(IPV4);
+      IPV6_ADDR = Inet6Address.getByName(IPV6);
+    } catch (UnknownHostException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  Endpoint.Builder builder = Endpoint.newBuilder();
+
+  @Benchmark public boolean parseIpv4_literal() {
+    return builder.parseIp(IPV4);
+  }
+
+  @Benchmark public boolean parseIpv4_addr() {
+    return builder.parseIp(IPV4_ADDR);
+  }
+
+  @Benchmark public boolean parseIpv6_literal() {
+    return builder.parseIp(IPV6);
+  }
+
+  @Benchmark public boolean parseIpv6_addr() {
+    return builder.parseIp(IPV6_ADDR);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+      .include(".*" + EndpointBenchmarks.class.getSimpleName())
+      .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/zipkin2/src/main/java/zipkin2/Endpoint.java
+++ b/zipkin2/src/main/java/zipkin2/Endpoint.java
@@ -48,13 +48,34 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
   }
 
   /**
+   * IPv4 endpoint address packed into 4 bytes or null if unknown.
+   *
+   * @see #ipv6()
+   * @see java.net.Inet4Address#getAddress()
+   */
+  @Nullable public byte[] ipv4Bytes() {
+    return ipv4Bytes;
+  }
+
+  /**
    * The text representation of the primary IPv6 address associated with this a connection. Ex.
    * 2001:db8::c001 Absent if unknown.
    *
-   * <p>Prefer using the {@link #ipv4()} field for mapped addresses.
+   * @see #ipv4() for mapped addresses
+   * @see #ipv6Bytes()
    */
   @Nullable public String ipv6() {
     return ipv6;
+  }
+
+  /**
+   * IPv6 endpoint address packed into 16 bytes or null if unknown.
+   *
+   * @see #ipv6()
+   * @see java.net.Inet6Address#getAddress()
+   */
+  @Nullable public byte[] ipv6Bytes() {
+    return ipv6Bytes;
   }
 
   /**
@@ -76,12 +97,15 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
 
   public static final class Builder {
     String serviceName, ipv4, ipv6;
+    byte[] ipv4Bytes, ipv6Bytes;
     Integer port;
 
     Builder(Endpoint source) {
       serviceName = source.serviceName;
       ipv4 = source.ipv4;
       ipv6 = source.ipv6;
+      ipv4Bytes = source.ipv4Bytes;
+      ipv6Bytes = source.ipv6Bytes;
       port = source.port;
     }
 
@@ -115,13 +139,12 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
       if (addr == null) return false;
       if (addr instanceof Inet4Address) {
         ipv4 = addr.getHostAddress();
+        ipv4Bytes = addr.getAddress();
       } else if (addr instanceof Inet6Address) {
         byte[] addressBytes = addr.getAddress();
-        String ipv4 = parseEmbeddedIPv4(addressBytes);
-        if (ipv4 != null) {
-          this.ipv4 = ipv4;
-        } else {
+        if (!parseEmbeddedIPv4(addressBytes)) {
           ipv6 = writeIpV6(addressBytes);
+          ipv6Bytes = addressBytes;
         }
       } else {
         return false;
@@ -153,12 +176,15 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
       IpFamily format = detectFamily(ipString);
       if (format == IpFamily.IPv4) {
         ipv4 = ipString;
+        ipv4Bytes = getIpv4Bytes(ipv4);
       } else if (format == IpFamily.IPv4Embedded) {
         ipv4 = ipString.substring(ipString.lastIndexOf(':') + 1);
+        ipv4Bytes = getIpv4Bytes(ipv4);
       } else if (format == IpFamily.IPv6) {
         byte[] addressBytes = textToNumericFormatV6(ipString);
         if (addressBytes == null) return false;
         ipv6 = writeIpV6(addressBytes); // ensures consistent format
+        ipv6Bytes = addressBytes;
       } else {
         return false;
       }
@@ -186,22 +212,24 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
 
     Builder() {
     }
-  }
 
-  static @Nullable String parseEmbeddedIPv4(byte[] ipv6) {
-    for (int i = 0; i < 10; i++) { // Embedded IPv4 addresses start with unset 80 bits
-      if (ipv6[i] != 0) return null;
+    boolean parseEmbeddedIPv4(byte[] ipv6) {
+      for (int i = 0; i < 10; i++) { // Embedded IPv4 addresses start with unset 80 bits
+        if (ipv6[i] != 0) return false;
+      }
+
+      int flag = (ipv6[10] & 0xff) << 8 | (ipv6[11] & 0xff);
+      if (flag != 0 && flag != -1) return false; // IPv4-Compatible or IPv4-Mapped
+
+      byte o1 = ipv6[12], o2 = ipv6[13], o3 = ipv6[14], o4 = ipv6[15];
+      if (flag == 0 && o1 == 0 && o2 == 0 && o3 == 0 && o4 == 1) {
+        return false; // ::1 is localhost, not an embedded compat address
+      }
+
+      ipv4 = String.valueOf(o1 & 0xff) + '.' + (o2 & 0xff) + '.' + (o3 & 0xff) + '.' + (o4 & 0xff);
+      ipv4Bytes = new byte[] {o1, o2, o3, o4};
+      return true;
     }
-
-    int flag = (ipv6[10] & 0xff) << 8 | (ipv6[11] & 0xff);
-    if (flag != 0 && flag != -1) return null; // IPv4-Compatible or IPv4-Mapped
-
-    int o1 = ipv6[12] & 0xff, o2 = ipv6[13] & 0xff, o3 = ipv6[14] & 0xff, o4 = ipv6[15] & 0xff;
-    if (flag == 0 && o1 == 0 && o2 == 0 && o3 == 0 && o4 == 1) {
-      return null; // ::1 is localhost, not an embedded compat address
-    }
-
-    return String.valueOf(o1) + '.' + o2 + '.' + o3 + '.' + o4;
   }
 
   enum IpFamily {
@@ -440,19 +468,24 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
   // clutter below mainly due to difficulty working with Kryo which cannot handle AutoValue subclass
   // See https://github.com/openzipkin/zipkin/issues/1879
   final String serviceName, ipv4, ipv6;
+  final byte[] ipv4Bytes, ipv6Bytes;
   final Integer port;
 
   Endpoint(Builder builder) {
     serviceName = builder.serviceName;
     ipv4 = builder.ipv4;
+    ipv4Bytes = builder.ipv4Bytes;
     ipv6 = builder.ipv6;
+    ipv6Bytes = builder.ipv6Bytes;
     port = builder.port;
   }
 
   Endpoint(SerializedForm serializedForm) {
     serviceName = serializedForm.serviceName;
     ipv4 = serializedForm.ipv4;
+    ipv4Bytes = serializedForm.ipv4Bytes;
     ipv6 = serializedForm.ipv6;
+    ipv6Bytes = serializedForm.ipv6Bytes;
     port = serializedForm.port;
   }
 
@@ -494,16 +527,20 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
     return new SerializedForm(this);
   }
 
+  // TODO: replace this with native proto3 encoding
   private static final class SerializedForm implements Serializable {
     static final long serialVersionUID = 0L;
 
     final String serviceName, ipv4, ipv6;
+    final byte[] ipv4Bytes, ipv6Bytes;
     final Integer port;
 
     SerializedForm(Endpoint endpoint) {
       serviceName = endpoint.serviceName;
       ipv4 = endpoint.ipv4;
+      ipv4Bytes = endpoint.ipv4Bytes;
       ipv6 = endpoint.ipv6;
+      ipv6Bytes = endpoint.ipv6Bytes;
       port = endpoint.port;
     }
 
@@ -514,5 +551,31 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
         throw new StreamCorruptedException(e.getMessage());
       }
     }
+  }
+
+  static byte[] getIpv4Bytes(String ipv4) {
+    byte[] result = new byte[4];
+    int pos = 0;
+    for (int i = 0, len = ipv4.length(); i < len; ) {
+      char ch = ipv4.charAt(i++);
+      int octet = ch - '0';
+      if (i == len || (ch = ipv4.charAt(i++)) == '.') {
+        // then we have a single digit octet
+        result[pos++] = (byte) octet;
+        continue;
+      }
+      // push the decimal
+      octet = (octet * 10) + (ch - '0');
+      if (i == len || (ch = ipv4.charAt(i++)) == '.') {
+        // then we have a two digit octet
+        result[pos++] = (byte) octet;
+        continue;
+      }
+      // otherwise, we have a three digit octet
+      octet = (octet * 10) + (ch - '0');
+      result[pos++] = (byte) octet;
+      i++; // skip the dot
+    }
+    return result;
   }
 }

--- a/zipkin2/src/test/java/zipkin2/EndpointTest.java
+++ b/zipkin2/src/test/java/zipkin2/EndpointTest.java
@@ -15,7 +15,6 @@ package zipkin2;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.net.UnknownHostException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -46,129 +45,124 @@ public class EndpointTest {
       .isEqualTo(65535);
   }
 
-  @Test public void ip_addr_ipv4() throws UnknownHostException {
+  @Test public void ip_addr_ipv4() throws Exception {
     Endpoint.Builder newBuilder = Endpoint.newBuilder();
-    assertThat(newBuilder.parseIp(Inet4Address.getByName("1.2.3.4"))).isTrue();
+    assertThat(newBuilder.parseIp(Inet4Address.getByName("43.0.192.2"))).isTrue();
     Endpoint endpoint = newBuilder.build();
 
-    assertThat(endpoint.ipv4())
-      .isEqualTo("1.2.3.4");
-    assertThat(endpoint.ipv6())
-      .isNull();
+    assertExpectedIpv4(endpoint);
   }
 
   @Test
-  public void ip_string_ipv4() throws UnknownHostException {
+  public void ip_string_ipv4() {
     Endpoint.Builder newBuilder = Endpoint.newBuilder();
-    assertThat(newBuilder.parseIp("1.2.3.4")).isTrue();
+    assertThat(newBuilder.parseIp("43.0.192.2")).isTrue();
     Endpoint endpoint = newBuilder.build();
 
-    assertThat(endpoint.ipv4())
-      .isEqualTo("1.2.3.4");
-    assertThat(endpoint.ipv6())
-      .isNull();
+    assertExpectedIpv4(endpoint);
   }
 
-  @Test public void ip_ipv6() throws UnknownHostException {
+  @Test public void ip_ipv6() throws Exception {
     String ipv6 = "2001:db8::c001";
     Endpoint endpoint = Endpoint.newBuilder().ip(ipv6).build();
 
     assertThat(endpoint.ipv4())
       .isNull();
+    assertThat(endpoint.ipv4Bytes())
+      .isNull();
     assertThat(endpoint.ipv6())
       .isEqualTo(ipv6);
+    assertThat(endpoint.ipv6Bytes())
+      .containsExactly(Inet6Address.getByName(ipv6).getAddress());
   }
 
-  @Test public void ip_ipv6_addr() throws UnknownHostException {
+  @Test public void ip_ipv6_addr() throws Exception {
     String ipv6 = "2001:db8::c001";
     Endpoint endpoint = Endpoint.newBuilder().ip(Inet6Address.getByName(ipv6)).build();
 
     assertThat(endpoint.ipv4())
       .isNull();
+    assertThat(endpoint.ipv4Bytes())
+      .isNull();
     assertThat(endpoint.ipv6())
       .isEqualTo(ipv6);
+    assertThat(endpoint.ipv6Bytes())
+      .containsExactly(Inet6Address.getByName(ipv6).getAddress());
   }
 
-  @Test public void ip_ipv6_mappedIpv4() throws UnknownHostException {
-    String ipv6 = "::FFFF:1.2.3.4";
+  @Test public void ip_ipv6_mappedIpv4() {
+    String ipv6 = "::FFFF:43.0.192.2";
     Endpoint endpoint = Endpoint.newBuilder().ip(ipv6).build();
 
-    assertThat(endpoint.ipv4())
-      .isEqualTo("1.2.3.4");
-    assertThat(endpoint.ipv6())
-      .isNull();
+    assertExpectedIpv4(endpoint);
   }
 
-  @Test public void ip_ipv6_addr_mappedIpv4() throws UnknownHostException {
-    String ipv6 = "::FFFF:1.2.3.4";
+  @Test public void ip_ipv6_addr_mappedIpv4() throws Exception {
+    String ipv6 = "::FFFF:43.0.192.2";
     Endpoint endpoint = Endpoint.newBuilder().ip(Inet6Address.getByName(ipv6)).build();
 
-    assertThat(endpoint.ipv4())
-      .isEqualTo("1.2.3.4");
-    assertThat(endpoint.ipv6())
-      .isNull();
+    assertExpectedIpv4(endpoint);
   }
 
   @Test public void ip_ipv6_compatIpv4() {
-    String ipv6 = "::0000:1.2.3.4";
+    String ipv6 = "::0000:43.0.192.2";
     Endpoint endpoint = Endpoint.newBuilder().ip(ipv6).build();
 
-    assertThat(endpoint.ipv4())
-      .isEqualTo("1.2.3.4");
-    assertThat(endpoint.ipv6())
-      .isNull();
+    assertExpectedIpv4(endpoint);
   }
 
-  @Test public void ip_ipv6_addr_compatIpv4() throws UnknownHostException {
-    String ipv6 = "::0000:1.2.3.4";
+  @Test public void ip_ipv6_addr_compatIpv4() throws Exception {
+    String ipv6 = "::0000:43.0.192.2";
     Endpoint endpoint = Endpoint.newBuilder().ip(Inet6Address.getByName(ipv6)).build();
 
-    assertThat(endpoint.ipv4())
-      .isEqualTo("1.2.3.4");
-    assertThat(endpoint.ipv6())
-      .isNull();
+    assertExpectedIpv4(endpoint);
   }
 
-  @Test public void ipv6_notMappedIpv4() throws UnknownHostException {
-    String ipv6 = "::ffef:1.2.3.4";
+  @Test public void ipv6_notMappedIpv4() {
+    String ipv6 = "::ffef:43.0.192.2";
     Endpoint endpoint = Endpoint.newBuilder().ip(ipv6).build();
 
     assertThat(endpoint.ipv4())
       .isNull();
+    assertThat(endpoint.ipv4Bytes())
+      .isNull();
     assertThat(endpoint.ipv6())
+      .isNull();
+    assertThat(endpoint.ipv6Bytes())
       .isNull();
   }
 
-  @Test public void ipv6_downcases() throws UnknownHostException {
+  @Test public void ipv6_downcases() {
     Endpoint endpoint = Endpoint.newBuilder().ip("2001:DB8::C001").build();
 
     assertThat(endpoint.ipv6())
       .isEqualTo("2001:db8::c001");
   }
 
-  @Test public void ip_ipv6_compatIpv4_compressed() throws UnknownHostException {
-    String ipv6 = "::1.2.3.4";
+  @Test public void ip_ipv6_compatIpv4_compressed() {
+    String ipv6 = "::43.0.192.2";
     Endpoint endpoint = Endpoint.newBuilder().ip(ipv6).build();
 
-    assertThat(endpoint.ipv4())
-      .isEqualTo("1.2.3.4");
-    assertThat(endpoint.ipv6())
-      .isNull();
+    assertExpectedIpv4(endpoint);
   }
 
   /** This ensures we don't mistake IPv6 localhost for a mapped IPv4 0.0.0.1 */
-  @Test public void ipv6_localhost() throws UnknownHostException {
+  @Test public void ipv6_localhost() {
     String ipv6 = "::1";
     Endpoint endpoint = Endpoint.newBuilder().ip(ipv6).build();
 
     assertThat(endpoint.ipv4())
       .isNull();
+    assertThat(endpoint.ipv4Bytes())
+      .isNull();
     assertThat(endpoint.ipv6())
       .isEqualTo(ipv6);
+    assertThat(endpoint.ipv6Bytes())
+      .containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
   }
 
   /** This is an unusable compat Ipv4 of 0.0.0.2. This makes sure it isn't mistaken for localhost */
-  @Test public void ipv6_notLocalhost() throws UnknownHostException {
+  @Test public void ipv6_notLocalhost() {
     String ipv6 = "::2";
     Endpoint endpoint = Endpoint.newBuilder().ip(ipv6).build();
 
@@ -197,5 +191,16 @@ public class EndpointTest {
   @Test public void lowercasesServiceName() {
     assertThat(Endpoint.newBuilder().serviceName("fFf").ip("127.0.0.1").build().serviceName())
       .isEqualTo("fff");
+  }
+
+  static void assertExpectedIpv4(Endpoint endpoint) {
+    assertThat(endpoint.ipv4())
+      .isEqualTo("43.0.192.2");
+    assertThat(endpoint.ipv4Bytes())
+      .containsExactly(43, 0, 192, 2);
+    assertThat(endpoint.ipv6())
+      .isNull();
+    assertThat(endpoint.ipv6Bytes())
+      .isNull();
   }
 }


### PR DESCRIPTION
This adds `Endpoint.ipv4Bytes()` and `Endpoint.ipv6Bytes()` needed to
prevent excess overhead marshaling into byte arrays. It is efficient to
do this once, as endpoint IPs are most often shared (local endpoint) for
all spans. Even in the case of remote endpoint, these are often parsed
from `Inet6Address` objects who already have a byte array reference.

This will be used in proto3 and possibly in a future retrofitted v1
thrift encoder.

See #1998