### PR TITLE
Implements proto3 encoding

### DIFF
--- a/zipkin2/src/main/java/zipkin2/codec/Encoding.java
+++ b/zipkin2/src/main/java/zipkin2/codec/Encoding.java
@@ -14,7 +14,6 @@
 package zipkin2.codec;
 
 import java.util.List;
-import zipkin2.internal.Buffer;
 
 // ZIPKIN3 make this not an enum as it prevents non-standard encoding, for example reporting to
 // DataDog which has a message pack encoding.
@@ -36,24 +35,22 @@ public enum Encoding {
     }
   },
   /**
-   * Repeated (type 2) fields are length-prefixed, the value is a concatenation with no additional
-   * overhead.
+   * Repeated (type 2) fields are length-prefixed. A list is a concatenation of fields with no
+   * additional overhead.
    *
    * <p>See https://developers.google.com/protocol-buffers/docs/encoding#optional
    */
   PROTO3 {
-    /** Returns the size of a length-prefixed field in a protobuf message */
+    /** Returns the input as it is assumed to be length-prefixed field from a protobuf message */
     @Override public int listSizeInBytes(int encodedSizeInBytes) {
-      return 1 // assumes field number <= 15
-        + Buffer.varintSizeInBytes(encodedSizeInBytes) // bytes to encode the length
-        + encodedSizeInBytes; // the actual length
+      return encodedSizeInBytes;
     }
 
-    /** Returns a concatenation of length-prefixed size for each value */
+    /** Returns a concatenation of sizes */
     @Override public int listSizeInBytes(List<byte[]> values) {
       int sizeInBytes = 0;
       for (int i = 0, length = values.size(); i < length; ) {
-        sizeInBytes += listSizeInBytes(values.get(i++).length);
+        sizeInBytes += values.get(i++).length;
       }
       return sizeInBytes;
     }

--- a/zipkin2/src/main/java/zipkin2/codec/SpanBytesDecoder.java
+++ b/zipkin2/src/main/java/zipkin2/codec/SpanBytesDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin2/src/main/java/zipkin2/codec/SpanBytesEncoder.java
+++ b/zipkin2/src/main/java/zipkin2/codec/SpanBytesEncoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ import java.util.List;
 import zipkin2.Span;
 import zipkin2.internal.Buffer;
 import zipkin2.internal.JsonCodec;
+import zipkin2.internal.Proto3Codec;
 import zipkin2.internal.V1SpanWriter;
 import zipkin2.internal.V2SpanWriter;
 
@@ -69,6 +70,29 @@ public enum SpanBytesEncoder implements BytesEncoder<Span> {
 
     @Override public int encodeList(List<Span> spans, byte[] out, int pos) {
       return JsonCodec.writeList(writer, spans, out, pos);
+    }
+  },
+  PROTO3 {
+    final Proto3Codec codec = new Proto3Codec();
+
+    @Override public Encoding encoding() {
+      return Encoding.PROTO3;
+    }
+
+    @Override public int sizeInBytes(Span input) {
+      return codec.sizeInBytes(input);
+    }
+
+    @Override public byte[] encode(Span span) {
+      return codec.write(span);
+    }
+
+    @Override public byte[] encodeList(List<Span> spans) {
+      return codec.writeList(spans);
+    }
+
+    @Override public int encodeList(List<Span> spans, byte[] out, int pos) {
+      return codec.writeList(spans, out, pos);
     }
   };
 

--- a/zipkin2/src/main/java/zipkin2/internal/Proto3Codec.java
+++ b/zipkin2/src/main/java/zipkin2/internal/Proto3Codec.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import java.util.List;
+import zipkin2.Span;
+
+//@Immutable
+public final class Proto3Codec {
+
+  final Proto3SpanWriter writer = new Proto3SpanWriter();
+
+  public int sizeInBytes(Span input) {
+    return writer.sizeInBytes(input);
+  }
+
+  public byte[] write(Span span) {
+    return writer.write(span);
+  }
+
+  public byte[] writeList(List<Span> spans) {
+    return writer.writeList(spans);
+  }
+
+  public int writeList(List<Span> spans, byte[] out, int pos) {
+    return writer.writeList(spans, out, pos);
+  }
+}

--- a/zipkin2/src/main/java/zipkin2/internal/Proto3Fields.java
+++ b/zipkin2/src/main/java/zipkin2/internal/Proto3Fields.java
@@ -1,0 +1,334 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import java.util.Map;
+
+import static zipkin2.internal.JsonCodec.UTF_8;
+
+/**
+ * Everything here assumes the field numbers are less than 16, implying a 1 byte tag.
+ */
+//@Immutable
+final class Proto3Fields {
+  /**
+   * Define the wire types, except the deprecated ones (groups)
+   *
+   * <p>See https://developers.google.com/protocol-buffers/docs/encoding#structure
+   */
+  static final int
+    WIRETYPE_VARINT = 0,
+    WIRETYPE_FIXED64 = 1,
+    WIRETYPE_LENGTH_DELIMITED = 2,
+    WIRETYPE_FIXED32 = 5;
+
+  static class Field {
+    final int fieldNumber;
+    final int wireType;
+    /**
+     * "Each key in the streamed message is a varint with the value {@code (field_number << 3) | wire_type}"
+     *
+     * <p>See https://developers.google.com/protocol-buffers/docs/encoding#structure
+     */
+    final int key;
+
+    Field(int fieldNumber, int wireType) {
+      this(fieldNumber, wireType, (fieldNumber << 3) | wireType);
+    }
+
+    Field(int fieldNumber, int wireType, int key) {
+      this.fieldNumber = fieldNumber;
+      this.wireType = wireType;
+      this.key = key;
+    }
+
+    void readThisKey(Buffer buffer) {
+      int readKey = buffer.readVarint32();
+      if (key != readKey) {
+        int lastPositionRead = buffer.pos - 1;
+        int readWireType = Proto3Fields.Field.wireType(readKey, lastPositionRead);
+        if (readWireType != wireType) {
+          throw new IllegalArgumentException(
+            "Expected wire type " + wireType + " but was " + readWireType);
+        }
+        int readFieldNumber = Proto3Fields.Field.fieldNumber(readKey, lastPositionRead);
+        if (readFieldNumber != fieldNumber) {
+          throw new IllegalArgumentException(
+            "Expected field number " + fieldNumber + " but was " + readFieldNumber);
+        }
+      }
+    }
+
+    static int fieldNumber(int key, int pos) {
+      int fieldNumber = key >>> 3;
+      if (fieldNumber != 0) return fieldNumber;
+      throw new IllegalArgumentException("fieldNumber was zero at position: " + pos);
+    }
+
+    static int wireType(int key, int pos) {
+      int wireType = key & (1 << 3) - 1;
+      if (wireType != 0 && wireType != 1 && wireType != 2 && wireType != 5) {
+        throw new IllegalArgumentException("invalid wireType " + wireType + " at position: " + pos);
+      }
+      return wireType;
+    }
+
+    static boolean skipValue(Buffer buffer, int wireType) {
+      int remaining = buffer.remaining();
+      switch (wireType) {
+        case WIRETYPE_VARINT:
+          for (int i = 0; i < remaining; i++) {
+            if (buffer.readByte() >= 0) return true;
+          }
+          return false;
+        case WIRETYPE_FIXED64:
+          return buffer.skip(8);
+        case WIRETYPE_LENGTH_DELIMITED:
+          int length = buffer.readVarint32();
+          return buffer.skip(length);
+        case WIRETYPE_FIXED32:
+          return buffer.skip(4);
+        default:
+          throw new IllegalArgumentException(
+            "invalid wireType " + wireType + " at position: " + (buffer.pos - 1));
+      }
+    }
+  }
+
+  static abstract class LengthDelimitedField<T> extends Field {
+    LengthDelimitedField(int fieldNumber) {
+      super(fieldNumber, WIRETYPE_LENGTH_DELIMITED);
+    }
+
+    final int sizeInBytes(T value) {
+      if (value == null) return 0;
+      int sizeOfValue = sizeOfValue(value);
+      return sizeOfLengthDelimitedField(sizeOfValue);
+    }
+
+    final void write(Buffer b, T value) {
+      if (value == null) return;
+      int sizeOfValue = sizeOfValue(value);
+      if (sizeOfValue == 0) return;
+      b.writeByte(key);
+      b.writeVarint(sizeOfValue); // length prefix
+      writeValue(b, value);
+    }
+
+    abstract int sizeOfValue(T value);
+
+    abstract void writeValue(Buffer b, T value);
+
+    /** Call this after consuming the field key to ensure there's enough space for the data */
+    int ensureLength(Buffer buffer) {
+      int length = buffer.readVarint32();
+      Proto3Fields.ensureLength(buffer, length);
+      return length;
+    }
+  }
+
+  static class BytesField extends LengthDelimitedField<byte[]> {
+    BytesField(int fieldNumber) {
+      super(fieldNumber);
+    }
+
+    @Override int sizeOfValue(byte[] bytes) {
+      return bytes.length;
+    }
+
+    @Override void writeValue(Buffer b, byte[] bytes) {
+      b.write(bytes);
+    }
+  }
+
+  static class HexField extends LengthDelimitedField<String> {
+    static final char[] HEX_DIGITS =
+      {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+    HexField(int fieldNumber) {
+      super(fieldNumber);
+    }
+
+    @Override int sizeOfValue(String hex) {
+      if (hex == null) return 0;
+      return hex.length() / 2;
+    }
+
+    @Override void writeValue(Buffer b, String hex) {
+      // similar logic to okio.ByteString.decodeHex
+      for (int i = 0, length = hex.length(); i < length; i++) {
+        int d1 = decodeLowerHex(hex.charAt(i++)) << 4;
+        int d2 = decodeLowerHex(hex.charAt(i));
+        b.writeByte((byte) (d1 + d2));
+      }
+    }
+
+    static int decodeLowerHex(char c) {
+      if (c >= '0' && c <= '9') return c - '0';
+      if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+      throw new AssertionError("not lowerHex " + c); // bug
+    }
+
+    String readValue(Buffer buffer) {
+      int length = ensureLength(buffer) * 2;
+      if (length == 0) return null;
+
+      char[] result = new char[length];
+
+      for (int i = 0; i < length; i += 2) {
+        byte b = buffer.readByte();
+        result[i + 0] = HEX_DIGITS[(b >> 4) & 0xf];
+        result[i + 1] = HEX_DIGITS[b & 0xf];
+      }
+
+      return new String(result);
+    }
+  }
+
+  static class Utf8Field extends LengthDelimitedField<String> {
+    Utf8Field(int fieldNumber) {
+      super(fieldNumber);
+    }
+
+    @Override int sizeOfValue(String utf8) {
+      return utf8 != null ? Buffer.utf8SizeInBytes(utf8) : 0;
+    }
+
+    @Override void writeValue(Buffer b, String utf8) {
+      b.writeUtf8(utf8);
+    }
+
+    String readValue(Buffer buffer) {
+      int lengthOfString = ensureLength(buffer);
+      if (lengthOfString == 0) return null;
+      return new String(buffer.toByteArray(), buffer.pos, lengthOfString, UTF_8);
+    }
+  }
+
+  static final class Fixed64Field extends Field {
+    Fixed64Field(int fieldNumber) {
+      super(fieldNumber, WIRETYPE_FIXED64);
+    }
+
+    void write(Buffer b, long number) {
+      if (number == 0) return;
+      b.writeByte(key);
+      b.writeLongLe(number);
+    }
+
+    int sizeInBytes(long number) {
+      if (number == 0) return 0;
+      return 1 + 8; // tag + 8 byte number
+    }
+
+    long readValue(Buffer buffer) {
+      ensureLength(buffer, 8);
+      return buffer.readLongLe();
+    }
+  }
+
+  static class VarintField extends Field {
+    VarintField(int fieldNumber) {
+      super(fieldNumber, WIRETYPE_VARINT);
+    }
+
+    int sizeInBytes(int number) {
+      return number != 0 ? 1 + Buffer.varintSizeInBytes(number) : 0; // tag + varint
+    }
+
+    void write(Buffer b, int number) {
+      if (number == 0) return;
+      b.writeByte(key);
+      b.writeVarint(number);
+    }
+
+    int sizeInBytes(long number) {
+      return number != 0 ? 1 + Buffer.varintSizeInBytes(number) : 0; // tag + varint
+    }
+
+    void write(Buffer b, long number) {
+      if (number == 0) return;
+      b.writeByte(key);
+      b.writeVarint(number);
+    }
+  }
+
+  static final class BooleanField extends Field {
+    BooleanField(int fieldNumber) {
+      super(fieldNumber, WIRETYPE_VARINT);
+    }
+
+    int sizeInBytes(boolean bool) {
+      return bool ? 2 : 0; // tag + varint
+    }
+
+    void write(Buffer b, boolean bool) {
+      if (!bool) return;
+      b.writeByte(key);
+      b.writeByte(1);
+    }
+
+    boolean read(Buffer b) {
+      byte bool = b.readByte();
+      if (bool < 0 || bool > 1) {
+        throw new IllegalArgumentException("invalid boolean value at position " + (b.pos - 1));
+      }
+      return bool == 1;
+    }
+  }
+
+  static class MapEntryField extends LengthDelimitedField<Map.Entry<String, String>> {
+    static final int KEY_FIELD = 1;
+    static final int VALUE_FIELD = 1;
+
+    static final Utf8Field KEY = new Utf8Field(KEY_FIELD);
+    static final Utf8Field VALUE = new Utf8Field(VALUE_FIELD);
+
+    MapEntryField(int fieldNumber) {
+      super(fieldNumber);
+    }
+
+    @Override int sizeOfValue(Map.Entry<String, String> value) {
+      return KEY.sizeInBytes(value.getKey()) + VALUE.sizeInBytes(value.getValue());
+    }
+
+    @Override void writeValue(Buffer b, Map.Entry<String, String> value) {
+      KEY.write(b, value.getKey());
+      VALUE.write(b, value.getValue());
+    }
+  }
+
+  // added for completion as later we will skip fields we don't use
+  static final class Fixed32Field extends Field {
+    Fixed32Field(int fieldNumber) {
+      super(fieldNumber, WIRETYPE_FIXED32);
+    }
+
+    int sizeInBytes(int number) {
+      if (number == 0) return 0;
+      return 1 + 4; // tag + 4 byte number
+    }
+  }
+
+  static int sizeOfLengthDelimitedField(int sizeInBytes) {
+    return 1 + Buffer.varintSizeInBytes(sizeInBytes) + sizeInBytes; // tag + len + bytes
+  }
+
+  static void ensureLength(Buffer buffer, int length) {
+    if (length > buffer.remaining()) {
+      throw new IllegalArgumentException(
+        "truncated: length " + length + " > bytes remaining " + buffer.remaining());
+    }
+  }
+}

--- a/zipkin2/src/main/java/zipkin2/internal/Proto3SpanWriter.java
+++ b/zipkin2/src/main/java/zipkin2/internal/Proto3SpanWriter.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import java.util.List;
+import zipkin2.Span;
+
+import static zipkin2.internal.Proto3Fields.sizeOfLengthDelimitedField;
+import static zipkin2.internal.Proto3ZipkinFields.SPAN;
+
+//@Immutable
+final class Proto3SpanWriter implements Buffer.Writer<Span> {
+
+  static final byte[] EMPTY_ARRAY = new byte[0];
+
+  @Override public int sizeInBytes(Span span) {
+    return SPAN.sizeInBytes(span);
+  }
+
+  @Override public void write(Span value, Buffer b) {
+    SPAN.write(b, value);
+  }
+
+  @Override public String toString() {
+    return "Span";
+  }
+
+  /** Encodes per ListOfSpans data wireType, where field one is repeated spans */
+  public byte[] writeList(List<Span> spans) {
+    int lengthOfSpans = spans.size();
+    if (lengthOfSpans == 0) return EMPTY_ARRAY;
+    if (lengthOfSpans == 1) return write(spans.get(0));
+
+    int sizeInBytes = 0;
+    int[] sizeOfValues = new int[lengthOfSpans];
+    for (int i = 0; i < lengthOfSpans; i++) {
+      int sizeOfValue = sizeOfValues[i] = SPAN.sizeOfValue(spans.get(i));
+      sizeInBytes += sizeOfLengthDelimitedField(sizeOfValue);
+    }
+    Buffer result = new Buffer(sizeInBytes);
+    for (int i = 0; i < lengthOfSpans; i++) {
+      writeSpan(spans.get(i), sizeOfValues[i], result);
+    }
+    return result.toByteArray();
+  }
+
+  byte[] write(Span onlySpan) {
+    int sizeOfValue = SPAN.sizeOfValue(onlySpan);
+    Buffer result = new Buffer(sizeOfLengthDelimitedField(sizeOfValue));
+    writeSpan(onlySpan, sizeOfValue, result);
+    return result.toByteArray();
+  }
+
+  // prevents resizing twice
+  void writeSpan(Span span, int sizeOfSpan, Buffer result) {
+    result.writeByte(SPAN.key);
+    result.writeVarint(sizeOfSpan); // length prefix
+    SPAN.writeValue(result, span);
+  }
+
+  int writeList(List<Span> spans, byte[] out, int pos) {
+    int lengthOfSpans = spans.size();
+    if (lengthOfSpans == 0) return 0;
+
+    Buffer result = new Buffer(out, pos);
+    for (int i = 0; i < lengthOfSpans; i++) {
+      SPAN.write(result, spans.get(i));
+    }
+    return result.pos - pos;
+  }
+}

--- a/zipkin2/src/main/java/zipkin2/internal/Proto3ZipkinFields.java
+++ b/zipkin2/src/main/java/zipkin2/internal/Proto3ZipkinFields.java
@@ -1,0 +1,270 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import java.util.List;
+import java.util.Map;
+import zipkin2.Annotation;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.internal.Proto3Fields.BooleanField;
+import zipkin2.internal.Proto3Fields.Field;
+import zipkin2.internal.Proto3Fields.MapEntryField;
+import zipkin2.internal.Proto3Fields.Utf8Field;
+
+import static zipkin2.internal.Proto3Fields.BytesField;
+import static zipkin2.internal.Proto3Fields.Fixed64Field;
+import static zipkin2.internal.Proto3Fields.HexField;
+import static zipkin2.internal.Proto3Fields.LengthDelimitedField;
+import static zipkin2.internal.Proto3Fields.VarintField;
+
+//@Immutable
+final class Proto3ZipkinFields {
+  /** This is the only field in the ListOfSpans type */
+  static final SpanField SPAN = new SpanField();
+  static final Endpoint EMPTY_ENDPOINT = Endpoint.newBuilder().build();
+
+  static class EndpointField extends LengthDelimitedField<Endpoint> {
+    static final int SERVICE_NAME_FIELD = 1;
+    static final int IPV4_FIELD = 2;
+    static final int IPV6_FIELD = 3;
+    static final int PORT_FIELD = 4;
+
+    static final Utf8Field SERVICE_NAME = new Utf8Field(SERVICE_NAME_FIELD);
+    static final BytesField IPV4 = new BytesField(IPV4_FIELD);
+    static final BytesField IPV6 = new BytesField(IPV6_FIELD);
+    static final VarintField PORT = new VarintField(PORT_FIELD);
+
+    EndpointField(int fieldNumber) {
+      super(fieldNumber);
+    }
+
+    @Override int sizeOfValue(Endpoint value) {
+      if (EMPTY_ENDPOINT.equals(value)) return 0;
+      int result = 0;
+      result += SERVICE_NAME.sizeInBytes(value.serviceName());
+      result += IPV4.sizeInBytes(value.ipv4Bytes());
+      result += IPV6.sizeInBytes(value.ipv6Bytes());
+      result += PORT.sizeInBytes(value.portAsInt());
+      return result;
+    }
+
+    @Override void writeValue(Buffer b, Endpoint value) {
+      SERVICE_NAME.write(b, value.serviceName());
+      IPV4.write(b, value.ipv4Bytes());
+      IPV6.write(b, value.ipv6Bytes());
+      PORT.write(b, value.portAsInt());
+    }
+  }
+
+  static class AnnotationField extends LengthDelimitedField<Annotation> {
+    static final int TIMESTAMP_FIELD = 1;
+    static final int VALUE_FIELD = 2;
+
+    static final Fixed64Field TIMESTAMP = new Fixed64Field(TIMESTAMP_FIELD);
+    static final Utf8Field VALUE = new Utf8Field(VALUE_FIELD);
+
+    AnnotationField(int fieldNumber) {
+      super(fieldNumber);
+    }
+
+    @Override int sizeOfValue(Annotation value) {
+      return TIMESTAMP.sizeInBytes(value.timestamp()) + VALUE.sizeInBytes(value.value());
+    }
+
+    @Override void writeValue(Buffer b, Annotation value) {
+      TIMESTAMP.write(b, value.timestamp());
+      VALUE.write(b, value.value());
+    }
+  }
+
+  static class SpanField extends LengthDelimitedField<Span> {
+    static final int TRACE_ID_FIELD = 1;
+    static final int PARENT_ID_FIELD = 2;
+    static final int ID_FIELD = 3;
+    static final int KIND_FIELD = 4;
+    static final int NAME_FIELD = 5;
+    static final int TIMESTAMP_FIELD = 6;
+    static final int DURATION_FIELD = 7;
+    static final int LOCAL_ENDPOINT_FIELD = 8;
+    static final int REMOTE_ENDPOINT_FIELD = 9;
+    static final int ANNOTATION_FIELD = 10;
+    static final int TAG_FIELD = 11;
+    static final int DEBUG_FIELD = 12;
+    static final int SHARED_FIELD = 13;
+
+    static final HexField TRACE_ID = new HexField(TRACE_ID_FIELD);
+    static final HexField PARENT_ID = new HexField(PARENT_ID_FIELD);
+    static final HexField ID = new HexField(ID_FIELD);
+    static final VarintField KIND = new VarintField(KIND_FIELD);
+    static final Utf8Field NAME = new Utf8Field(NAME_FIELD);
+    static final Fixed64Field TIMESTAMP = new Fixed64Field(TIMESTAMP_FIELD);
+    static final VarintField DURATION = new VarintField(DURATION_FIELD);
+    static final EndpointField LOCAL_ENDPOINT = new EndpointField(LOCAL_ENDPOINT_FIELD);
+    static final EndpointField REMOTE_ENDPOINT = new EndpointField(REMOTE_ENDPOINT_FIELD);
+    static final AnnotationField ANNOTATION = new AnnotationField(ANNOTATION_FIELD);
+    static final MapEntryField TAG = new MapEntryField(TAG_FIELD);
+    static final BooleanField DEBUG = new BooleanField(DEBUG_FIELD);
+    static final BooleanField SHARED = new BooleanField(SHARED_FIELD);
+
+    SpanField() {
+      super(1);
+    }
+
+    @Override int sizeOfValue(Span span) {
+      int sizeOfSpan = TRACE_ID.sizeInBytes(span.traceId());
+      sizeOfSpan += PARENT_ID.sizeInBytes(span.parentId());
+      sizeOfSpan += ID.sizeInBytes(span.id());
+      sizeOfSpan += KIND.sizeInBytes(span.kind() != null ? 1 : 0);
+      sizeOfSpan += NAME.sizeInBytes(span.name());
+      sizeOfSpan += TIMESTAMP.sizeInBytes(span.timestampAsLong());
+      sizeOfSpan += DURATION.sizeInBytes(span.durationAsLong());
+      sizeOfSpan += LOCAL_ENDPOINT.sizeInBytes(span.localEndpoint());
+      sizeOfSpan += REMOTE_ENDPOINT.sizeInBytes(span.remoteEndpoint());
+
+      List<Annotation> annotations = span.annotations();
+      int annotationCount = annotations.size();
+      for (int i = 0; i < annotationCount; i++) {
+        sizeOfSpan += ANNOTATION.sizeInBytes(annotations.get(i));
+      }
+
+      Map<String, String> tags = span.tags();
+      int tagCount = tags.size();
+      if (tagCount > 0) { // avoid allocating an iterator when empty
+        for (Map.Entry<String, String> entry : tags.entrySet()) {
+          sizeOfSpan += TAG.sizeInBytes(entry);
+        }
+      }
+
+      sizeOfSpan += DEBUG.sizeInBytes(Boolean.TRUE.equals(span.debug()));
+      sizeOfSpan += SHARED.sizeInBytes(Boolean.TRUE.equals(span.shared()));
+      return sizeOfSpan;
+    }
+
+    @Override void writeValue(Buffer b, Span value) {
+      TRACE_ID.write(b, value.traceId());
+      PARENT_ID.write(b, value.parentId());
+      ID.write(b, value.id());
+      KIND.write(b, toByte(value.kind()));
+      NAME.write(b, value.name());
+      TIMESTAMP.write(b, value.timestampAsLong());
+      DURATION.write(b, value.durationAsLong());
+      LOCAL_ENDPOINT.write(b, value.localEndpoint());
+      REMOTE_ENDPOINT.write(b, value.remoteEndpoint());
+
+      List<Annotation> annotations = value.annotations();
+      int annotationLength = annotations.size();
+      for (int i = 0; i < annotationLength; i++) {
+        ANNOTATION.write(b, annotations.get(i));
+      }
+
+      Map<String, String> tags = value.tags();
+      if (!tags.isEmpty()) { // avoid allocating an iterator when empty
+        for (Map.Entry<String, String> entry : tags.entrySet()) {
+          TAG.write(b, entry);
+        }
+      }
+
+      SpanField.DEBUG.write(b, Boolean.TRUE.equals(value.debug()));
+      SpanField.SHARED.write(b, Boolean.TRUE.equals(value.shared()));
+    }
+
+    // in java, there's no zero index for unknown
+    int toByte(Span.Kind kind) {
+      return kind != null ? kind.ordinal() + 1 : 0;
+    }
+
+    public Span read(Buffer buffer) {
+      readThisKey(buffer);
+      return readValue(buffer);
+    }
+
+    Span readValue(Buffer buffer) {
+      int length = ensureLength(buffer);
+      if (length == 0) return null;
+      int endPos = buffer.pos + length;
+
+      // now, we are in the span fields
+      Span.Builder builder = Span.newBuilder();
+      while (buffer.pos < endPos) {
+        int nextKey = buffer.readVarint32();
+        int lastPos = buffer.pos - 1;
+        int nextWireType = wireType(nextKey, lastPos);
+        int nextFieldNumber = fieldNumber(nextKey, lastPos);
+        switch (nextFieldNumber) {
+          case TRACE_ID_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.traceId", TRACE_ID);
+            builder.traceId(TRACE_ID.readValue(buffer));
+            break;
+          case PARENT_ID_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.parentId", PARENT_ID);
+            builder.parentId(PARENT_ID.readValue(buffer));
+            break;
+          case ID_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.id", ID);
+            builder.id(ID.readValue(buffer));
+            break;
+          case KIND_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.kind", KIND);
+            int kind = buffer.readVarint32();
+            builder.kind(Span.Kind.values()[kind]);
+            break;
+          case NAME_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.name", NAME);
+            builder.name(NAME.readValue(buffer));
+            break;
+          case TIMESTAMP_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.timestamp", TIMESTAMP);
+            builder.timestamp(TIMESTAMP.readValue(buffer));
+            break;
+          case DURATION_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.duration", DURATION);
+            builder.duration(buffer.readVarint64());
+            break;
+          case LOCAL_ENDPOINT_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.localEndpoint", LOCAL_ENDPOINT);
+            break;
+          case REMOTE_ENDPOINT_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.remoteEndpoint", REMOTE_ENDPOINT);
+            break;
+          case ANNOTATION_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.annotations", ANNOTATION);
+            break;
+          case TAG_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.tags", TAG);
+            break;
+          case DEBUG_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.debug", DEBUG);
+            if (DEBUG.read(buffer)) builder.debug(true);
+            break;
+          case SHARED_FIELD:
+            checkWireType(lastPos, nextWireType, "Span.shared", SHARED);
+            if (SHARED.read(buffer)) builder.shared(true);
+            break;
+          default:
+            skipValue(buffer, nextWireType);
+        }
+      }
+      return builder.build();
+    }
+  }
+
+  static void checkWireType(int pos, int wireType, String fieldName, Field field) {
+    if (wireType == field.wireType) return;
+    throw new IllegalArgumentException(
+      "wireType " + wireType + " at position " + pos + " was not " + fieldName + "'s wireType "
+        + field.wireType
+    );
+  }
+}

--- a/zipkin2/src/test/java/zipkin2/codec/EncodingTest.java
+++ b/zipkin2/src/test/java/zipkin2/codec/EncodingTest.java
@@ -48,35 +48,20 @@ public class EncodingTest {
       .isEqualTo(0);
   }
 
+  // an entry in a list is a repeated field
   @Test public void singletonList_proto3() {
     List<byte[]> encoded = Arrays.asList(new byte[10]);
 
     assertThat(Encoding.PROTO3.listSizeInBytes(encoded.get(0).length))
-      .isEqualTo(1 + 1 /* tag, length */ + 10);
+      .isEqualTo(10);
     assertThat(Encoding.PROTO3.listSizeInBytes(encoded))
-      .isEqualTo(1 + 1 /* tag, length */ + 10);
+      .isEqualTo(10);
   }
 
   // per ListOfSpans in zipkin2.proto
   @Test public void multiItemList_proto3() {
     List<byte[]> encoded = Arrays.asList(new byte[3], new byte[4], new byte[128]);
     assertThat(Encoding.PROTO3.listSizeInBytes(encoded))
-      .isEqualTo(0
-        + (1 + 1 /* tag, length */ + 3)
-        + (1 + 1 /* tag, length */ + 4)
-        + (1 + 2 /* tag, length */ + 128)
-      );
-  }
-
-  @Test public void singletonList_proto3_big() {
-    // Not good to have a 5MiB span, but lets test the length prefix
-    int bigSpan = 5 * 1024 * 1024;
-    assertThat(Encoding.PROTO3.listSizeInBytes(bigSpan))
-      .isEqualTo(1 + 4 /* tag, length */ + bigSpan);
-
-    // Terrible value in real life as this would be a 536 meg span!
-    int twentyNineBitNumber = 536870911;
-    assertThat(Encoding.PROTO3.listSizeInBytes(twentyNineBitNumber))
-      .isEqualTo(1 + 5 /* tag, length */ + twentyNineBitNumber);
+      .isEqualTo(3 + 4 + 128);
   }
 }

--- a/zipkin2/src/test/java/zipkin2/internal/BufferTest.java
+++ b/zipkin2/src/test/java/zipkin2/internal/BufferTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static zipkin2.TestObjects.UTF_8;
 
 public class BufferTest {
@@ -188,10 +189,100 @@ public class BufferTest {
   @Test public void writeVarint_64() {
     long number = 300;
 
-    Buffer buffer = new Buffer(Buffer.varintSizeInBytes(300));
+    Buffer buffer = new Buffer(Buffer.varintSizeInBytes(number));
     buffer.writeVarint(number);
 
     assertThat(buffer.toByteArray())
       .containsExactly(0b1010_1100, 0b0000_0010);
+  }
+
+  @Test public void writeVarint_ports() {
+    // normal case
+    Buffer buffer = new Buffer(Buffer.varintSizeInBytes(80));
+    buffer.writeVarint(80);
+
+    assertThat(buffer.toByteArray())
+      .containsExactly(0b0101_0000);
+
+    // largest value to not require more than 2 bytes (14 bits set)
+    buffer = new Buffer(Buffer.varintSizeInBytes(16383));
+    buffer.writeVarint(16383);
+
+    assertThat(buffer.toByteArray())
+      .containsExactly(0b1111_1111, 0b0111_1111);
+
+    // worst case is a byte longer than fixed 16
+    buffer = new Buffer(Buffer.varintSizeInBytes(65535));
+    buffer.writeVarint(65535);
+
+    assertThat(buffer.toByteArray())
+      .containsExactly(0b1111_1111, 0b1111_1111, 0b0000_0011);
+
+    // most bits
+    buffer = new Buffer(Buffer.varintSizeInBytes(0xFFFFFFFF));
+    buffer.writeVarint(0xFFFFFFFF);
+
+    // we have a total of 32 bits encoded
+    assertThat(buffer.toByteArray())
+      .containsExactly(0b1111_1111, 0b1111_1111, 0b1111_1111, 0b1111_1111, 0b0000_1111);
+  }
+
+  @Test public void readVarint32() {
+    assertReadVarint32(0);
+    assertReadVarint32(0b0011_1111_1111_1111);
+    assertReadVarint32(0xFFFFFFFF);
+  }
+
+  static void assertReadVarint32(int value) {
+    Buffer buffer = new Buffer(Buffer.varintSizeInBytes(value));
+    buffer.writeVarint(value);
+    buffer.pos = 0; // reset
+
+    assertThat(buffer.readVarint32())
+      .isEqualTo(value);
+  }
+
+  @Test public void readVarint32_malformedTooBig() {
+    Buffer buffer = new Buffer(8);
+    buffer.writeLongLe(0xffffffffffffL);
+    buffer.pos = 0; // reset
+
+    try {
+      buffer.readVarint32();
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertThat(e)
+        .hasMessage("Greater than 32-bit varint at position 4");
+    }
+  }
+
+  @Test public void readVarint64() {
+    assertReadVarint64(0L);
+    assertReadVarint64(0b0011_1111_1111_1111L);
+    assertReadVarint64(0xffffffffffffffffL);
+  }
+
+  static void assertReadVarint64(long value) {
+    Buffer buffer = new Buffer(Buffer.varintSizeInBytes(value));
+    buffer.writeVarint(value);
+    buffer.pos = 0; // reset
+
+    assertThat(buffer.readVarint64())
+      .isEqualTo(value);
+  }
+
+  @Test public void readVarint64_malformedTooBig() {
+    Buffer buffer = new Buffer(16);
+    buffer.writeLongLe(0xffffffffffffffffL);
+    buffer.writeLongLe(0xffffffffffffffffL);
+    buffer.pos = 0; // reset
+
+    try {
+      buffer.readVarint64();
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertThat(e)
+        .hasMessage("Greater than 64-bit varint at position 9");
+    }
   }
 }

--- a/zipkin2/src/test/java/zipkin2/internal/Proto3FieldsTest.java
+++ b/zipkin2/src/test/java/zipkin2/internal/Proto3FieldsTest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import org.junit.Test;
+import zipkin2.internal.Proto3Fields.BooleanField;
+import zipkin2.internal.Proto3Fields.BytesField;
+import zipkin2.internal.Proto3Fields.Fixed64Field;
+import zipkin2.internal.Proto3Fields.MapEntryField;
+import zipkin2.internal.Proto3Fields.Utf8Field;
+import zipkin2.internal.Proto3Fields.VarintField;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.data.MapEntry.entry;
+import static zipkin2.internal.Proto3Fields.Field;
+import static zipkin2.internal.Proto3Fields.Fixed32Field;
+import static zipkin2.internal.Proto3Fields.HexField;
+import static zipkin2.internal.Proto3Fields.WIRETYPE_FIXED32;
+import static zipkin2.internal.Proto3Fields.WIRETYPE_FIXED64;
+import static zipkin2.internal.Proto3Fields.WIRETYPE_LENGTH_DELIMITED;
+import static zipkin2.internal.Proto3Fields.WIRETYPE_VARINT;
+
+public class Proto3FieldsTest {
+  Buffer buf = new Buffer(2048); // bigger than needed to test sizeOf
+
+  /** Shows we can reliably look at a byte zero to tell if we are decoding proto3 repeated fields. */
+  @Test public void field_key_fieldOneLengthDelimited() {
+    Field field = new Field(1, WIRETYPE_LENGTH_DELIMITED);
+    assertThat(field.key)
+      .isEqualTo(0b00001010) // (field_number << 3) | wire_type = 1 << 3 | 2
+      .isEqualTo(10); // for sanity of those looking at debugger, 4th bit + 2nd bit = 10
+  }
+
+  @Test public void varint_sizeInBytes() {
+    VarintField field = new VarintField(1);
+
+    assertThat(field.sizeInBytes(0))
+      .isZero();
+    assertThat(field.sizeInBytes(0xffffffff))
+      .isEqualTo(0
+        + 1 /* tag of varint field */ + 5 // max size of varint32
+      );
+
+    assertThat(field.sizeInBytes(0L))
+      .isZero();
+    assertThat(field.sizeInBytes(0xffffffffffffffffL))
+      .isEqualTo(0
+        + 1 /* tag of varint field */ + 10 // max size of varint64
+      );
+  }
+
+  @Test public void boolean_sizeInBytes() {
+    BooleanField field = new BooleanField(1);
+
+    assertThat(field.sizeInBytes(false))
+      .isZero();
+    assertThat(field.sizeInBytes(true))
+      .isEqualTo(0
+        + 1 /* tag of varint field */ + 1 // size of 1
+      );
+  }
+
+  @Test public void utf8_sizeInBytes() {
+    Utf8Field field = new Utf8Field(1);
+    assertThat(field.sizeInBytes("12345678"))
+      .isEqualTo(0
+        + 1 /* tag of string field */ + 1 /* len */ + 8 // 12345678
+      );
+  }
+
+  /** A map entry is an embedded messages: one for field the key and one for the value */
+  @Test public void mapEntry_sizeInBytes() {
+    MapEntryField field = new MapEntryField(1);
+    assertThat(field.sizeInBytes(entry("123", "56789")))
+      .isEqualTo(0
+        + 1 /* tag of embedded key field */ + 1 /* len */ + 3
+        + 1 /* tag of embedded value field  */ + 1 /* len */ + 5
+        + 1 /* tag of map entry field */ + 1 /* len */
+      );
+  }
+
+  @Test public void fixed64_sizeInBytes() {
+    Fixed64Field field = new Fixed64Field(1);
+    assertThat(field.sizeInBytes(Long.MIN_VALUE))
+      .isEqualTo(9);
+  }
+
+  @Test public void fixed32_sizeInBytes() {
+    Fixed32Field field = new Fixed32Field(1);
+    assertThat(field.sizeInBytes(Integer.MIN_VALUE))
+      .isEqualTo(5);
+  }
+
+  @Test public void supportedFields() {
+    for (Field field : asList(
+      new VarintField(128),
+      new BooleanField(128),
+      new HexField(128),
+      new Utf8Field(128),
+      new BytesField(128),
+      new Fixed32Field(128),
+      new Fixed64Field(128),
+      new MapEntryField(128)
+    )) {
+      assertThat(Field.fieldNumber(field.key, 0))
+        .isEqualTo(field.fieldNumber);
+      assertThat(Field.wireType(field.key, 0))
+        .isEqualTo(field.wireType);
+    }
+  }
+
+  @Test public void fieldNumber_malformed() {
+    try {
+      Field.fieldNumber(0, 2);
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertThat(e)
+        .hasMessage("fieldNumber was zero at position: 2");
+    }
+  }
+
+  @Test public void wireType_unsupported() {
+    for (int unsupported : asList(3, 4, 6)) {
+      try {
+        Field.wireType(1 << 3 | unsupported, 2);
+        failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+      } catch (IllegalArgumentException e) {
+        assertThat(e)
+          .hasMessage("invalid wireType " + unsupported + " at position: 2");
+      }
+    }
+  }
+
+  @Test public void field_skipValue_VARINT() {
+    VarintField field = new VarintField(128);
+    field.write(buf, 0xffffffffffffffffL);
+
+    buf.pos = 1; // skip the key
+    skipValue(WIRETYPE_VARINT);
+  }
+
+  @Test public void field_skipValue_LENGTH_DELIMITED() {
+    Utf8Field field = new Utf8Field(128);
+    field.write(buf, "订单维护服务");
+
+    buf.pos = 1; // skip the key
+    skipValue(WIRETYPE_LENGTH_DELIMITED);
+  }
+
+  @Test public void field_skipValue_FIXED64() {
+    Fixed64Field field = new Fixed64Field(128);
+    field.write(buf, 0xffffffffffffffffL);
+
+    buf.pos = 1; // skip the key
+    skipValue(WIRETYPE_FIXED64);
+  }
+
+  @Test public void field_skipValue_FIXED32() {
+    Fixed32Field field = new Fixed32Field(128);
+    buf.writeByte(field.key);
+    buf.writeByte(0xff).writeByte(0xff).writeByte(0xff).writeByte(0xff);
+
+    buf.pos = 1; // skip the key
+    skipValue(WIRETYPE_FIXED32);
+  }
+
+  @Test public void field_ensureLength_LENGTH_DELIMITED() {
+    BytesField field = new BytesField(128);
+    field.write(buf, new byte[10]);
+    buf.pos = 1; // skip the key
+
+    assertThat(field.ensureLength(buf))
+      .isEqualTo(10);
+  }
+
+  @Test public void field_ensureLength_LENGTH_DELIMITED_truncated() {
+    BytesField field = new BytesField(128);
+    buf = new Buffer(10);
+    buf.writeVarint(100); // much larger than the buffer size
+    buf.pos = 0; // reset
+
+    try {
+      field.ensureLength(buf);
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("truncated: length 100 > bytes remaining 9");
+    }
+  }
+
+  @Test public void field_read_FIXED64() {
+    Fixed64Field field = new Fixed64Field(128);
+    field.write(buf, 0xffffffffffffffffL);
+
+    buf.pos = 1; // skip the key
+    assertThat(field.readValue(buf))
+      .isEqualTo(0xffffffffffffffffL);
+  }
+
+  void skipValue(int wireType) {
+    assertThat(Field.skipValue(buf, wireType))
+      .isTrue();
+  }
+}

--- a/zipkin2/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
+++ b/zipkin2/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+import static zipkin2.internal.Proto3ZipkinFields.SPAN;
+
+public class Proto3SpanWriterTest {
+  Buffer buf = new Buffer(2048); // bigger than needed to test sizeOf
+
+  Proto3SpanWriter writer = new Proto3SpanWriter();
+
+  @Test public void writeList_startsWithSpanKeyAndLengthPrefix() {
+    byte[] buff = writer.writeList(asList(CLIENT_SPAN));
+
+    assertThat(buff)
+      .hasSize(writer.sizeInBytes(CLIENT_SPAN))
+      .startsWith((byte) 10, SPAN.sizeOfValue(CLIENT_SPAN));
+  }
+
+  @Test public void writeList_multiple() {
+    byte[] buff = writer.writeList(asList(CLIENT_SPAN, CLIENT_SPAN));
+
+    assertThat(buff)
+      .hasSize(writer.sizeInBytes(CLIENT_SPAN) * 2)
+      .startsWith((byte) 10, SPAN.sizeOfValue(CLIENT_SPAN));
+  }
+
+  @Test public void writeList_empty() {
+    assertThat(writer.writeList(asList()))
+      .isEmpty();
+  }
+
+  @Test public void writeList_offset_startsWithSpanKeyAndLengthPrefix() {
+    writer.writeList(asList(CLIENT_SPAN, CLIENT_SPAN), buf.toByteArray(), 0);
+
+    assertThat(buf.toByteArray())
+      .startsWith((byte) 10, SPAN.sizeOfValue(CLIENT_SPAN));
+  }
+}

--- a/zipkin2/src/test/java/zipkin2/internal/Proto3ZipkinFieldsTest.java
+++ b/zipkin2/src/test/java/zipkin2/internal/Proto3ZipkinFieldsTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import org.junit.Test;
+import zipkin2.Annotation;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.internal.Proto3ZipkinFields.AnnotationField;
+import zipkin2.internal.Proto3ZipkinFields.EndpointField;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.atIndex;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+import static zipkin2.internal.Proto3ZipkinFields.SPAN;
+
+public class Proto3ZipkinFieldsTest {
+  Buffer buf = new Buffer(2048); // bigger than needed to test sizeInBytes
+
+  @Test public void annotation_sizeInBytes() {
+    AnnotationField field = new AnnotationField(1);
+    assertThat(field.sizeInBytes(Annotation.create(1L, "12345678")))
+      .isEqualTo(0
+        + 1 /* tag of timestamp field */ + 8 /* 8 byte number */
+        + 1 /* tag of value field */ + 1 /* len */ + 8 // 12345678
+        + 1 /* tag of annotation field */ + 1 /* len */
+      );
+  }
+
+  @Test public void endpoint_sizeInBytes() {
+    EndpointField field = new EndpointField(1);
+
+    assertThat(field.sizeInBytes(Endpoint.newBuilder()
+      .serviceName("12345678")
+      .ip("192.168.99.101")
+      .ip("2001:db8::c001")
+      .port(80)
+      .build()))
+      .isEqualTo(0
+        + 1 /* tag of servicename field */ + 1 /* len */ + 8 // 12345678
+        + 1 /* tag of ipv4 field */ + 1 /* len */ + 4 // octets in ipv4
+        + 1 /* tag of ipv6 field */ + 1 /* len */ + 16 // octets in ipv6
+        + 1 /* tag of port field */ + 1 /* small varint */
+        + 1 /* tag of endpoint field */ + 1 /* len */
+      );
+  }
+
+  @Test public void span_write_startsWithFieldInListOfSpans() {
+    SPAN.write(buf, Span.newBuilder().traceId("1").id("2").build());
+
+    assertThat(buf.toByteArray()).startsWith(
+      0b00001010 /* span key */, 20 /* bytes for length of the span */
+    );
+  }
+
+  @Test public void span_write_writesIds() {
+    SPAN.write(buf, Span.newBuilder().traceId("1").id("2").build());
+    assertThat(buf.toByteArray()).startsWith(
+      0b00001010 /* span key */, 20 /* bytes for length of the span */,
+      0b00001010 /* trace ID key */, 8 /* bytes for 64-bit trace ID */,
+      0, 0, 0, 0, 0, 0, 0, 1, // hex trace ID
+      0b00011010 /* span ID key */, 8 /* bytes for 64-bit span ID */,
+      0, 0, 0, 0, 0, 0, 0, 2 // hex span ID
+    );
+    assertThat(buf.pos)
+      .isEqualTo(3 * 2 /* overhead of three fields */ + 2 * 8 /* 64-bit fields */)
+      .isEqualTo(22); // easier math on the next test
+  }
+
+  @Test public void span_write_omitsEmptyEndpoints() {
+    SPAN.write(buf, Span.newBuilder().traceId("1").id("2")
+      .localEndpoint(Endpoint.newBuilder().build())
+      .remoteEndpoint(Endpoint.newBuilder().build())
+      .build());
+
+    assertThat(buf.pos)
+      .isEqualTo(22);
+  }
+
+  @Test public void span_write_kind() {
+    SPAN.write(buf, Span.newBuilder().traceId("1").id("2").kind(Span.Kind.PRODUCER).build());
+    assertThat(buf.toByteArray())
+      .contains(0b0100000, atIndex(22)); // (field_number << 3) | wire_type = 4 << 3 | 0
+  }
+
+  @Test public void span_write_debug() {
+    SPAN.write(buf, CLIENT_SPAN.toBuilder().debug(true).build());
+
+    assertThat(buf.toByteArray())
+      .contains(0b01100000, atIndex(buf.pos - 2)) // (field_number << 3) | wire_type = 12 << 3 | 0
+      .contains(1, atIndex(buf.pos - 1)); // true
+  }
+
+  @Test public void span_write_shared() {
+    SPAN.write(buf, CLIENT_SPAN.toBuilder().shared(true).build());
+
+    assertThat(buf.toByteArray())
+      .contains(0b01101000, atIndex(buf.pos - 2)) // (field_number << 3) | wire_type = 13 << 3 | 0
+      .contains(1, atIndex(buf.pos - 1)); // true
+  }
+}


### PR DESCRIPTION
This is the first part of proto3 implementation, raised separately to
keep things readable.

See #1998

Fun fact. Our `TestObjects.CLIENT_SPAN`
 * in json v1 is 798 bytes
 * in json v2 is 438 bytes
 * in proto3 is 163 bytes
