### PR TITLE
Adds Endpoint.portAsInt to avoid allocations

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/JsonAdapters.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/JsonAdapters.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -135,7 +135,7 @@ final class JsonAdapters {
     @Override public Endpoint fromJson(JsonReader reader) throws IOException {
       reader.beginObject();
       String serviceName = null, ipv4 = null, ipv6 = null;
-      Integer port = null;
+      int port = 0;
       while (reader.hasNext()) {
         String nextName = reader.nextName();
         if (reader.peek() == JsonReader.Token.NULL) {
@@ -160,9 +160,7 @@ final class JsonAdapters {
         }
       }
       reader.endObject();
-      if (serviceName == null && ipv4 == null && ipv6 == null && port == null) {
-        throw new IllegalStateException("Incomplete endpoint at " + reader.getPath());
-      }
+      if (serviceName == null && ipv4 == null && ipv6 == null && port == 0) return null;
       return Endpoint.newBuilder().serviceName(serviceName).ip(ipv4).ip(ipv6).port(port).build();
     }
 

--- a/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/zipkin2_cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -133,20 +133,20 @@ final class Schema {
     private String service;
     private InetAddress ipv4;
     private InetAddress ipv6;
-    private Integer port;
+    private int port;
 
     EndpointUDT() {
       this.service = null;
       this.ipv4 = null;
       this.ipv6 = null;
-      this.port = null;
+      this.port = 0;
     }
 
     EndpointUDT(Endpoint endpoint) {
       this.service = endpoint.serviceName();
       this.ipv4 = endpoint.ipv4() == null ? null : InetAddresses.forString(endpoint.ipv4());
       this.ipv6 = endpoint.ipv6() == null ? null : InetAddresses.forString(endpoint.ipv6());
-      this.port = endpoint.port();
+      this.port = endpoint.portAsInt();
     }
 
     public String getService() {
@@ -161,7 +161,7 @@ final class Schema {
       return ipv6;
     }
 
-    public Integer getPort() {
+    public int getPort() {
       return port;
     }
 

--- a/zipkin/src/main/java/zipkin/Endpoint.java
+++ b/zipkin/src/main/java/zipkin/Endpoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -266,7 +266,7 @@ public final class Endpoint implements Serializable { // for Spark jobs
   public zipkin2.Endpoint toV2() {
     zipkin2.Endpoint.Builder result = zipkin2.Endpoint.newBuilder()
       .serviceName(serviceName)
-      .port(port != null ? port & 0xffff : null);
+      .port(port != null ? port & 0xffff : 0);
     if (ipv4 != 0) {
       result.parseIp(new StringBuilder()
         .append(ipv4 >> 24 & 0xff).append('.')

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -102,10 +102,11 @@ public final class JsonCodec implements Codec {
         sizeInBytes += 9; // "ipv6":""
         sizeInBytes += value.ipv6().length();
       }
-      if (value.port() != null) {
+      int port = value.portAsInt();
+      if (port != 0) {
         if (sizeInBytes != 1) sizeInBytes++; // ,
         sizeInBytes += 7; // "port":
-        sizeInBytes += asciiSizeInBytes(value.port());
+        sizeInBytes += asciiSizeInBytes(port);
       }
       return ++sizeInBytes; // }
     }
@@ -125,8 +126,9 @@ public final class JsonCodec implements Codec {
         b.writeAscii(",\"ipv6\":\"");
         b.writeAscii(value.ipv6()).writeByte('"');
       }
-      if (value.port() != null) {
-        b.writeAscii(",\"port\":").writeAscii(value.port());
+      int port = value.portAsInt();
+      if (port != 0) {
+        b.writeAscii(",\"port\":").writeAscii(port);
       }
       b.writeByte('}');
     }

--- a/zipkin/src/main/java/zipkin/internal/V2SpanConverter.java
+++ b/zipkin/src/main/java/zipkin/internal/V2SpanConverter.java
@@ -478,7 +478,7 @@ public final class V2SpanConverter {
   public static zipkin.Endpoint toEndpoint(Endpoint input) {
     zipkin.Endpoint.Builder result = zipkin.Endpoint.builder()
       .serviceName(input.serviceName() != null ? input.serviceName() : "")
-      .port(input.port() != null ? input.port() : 0);
+      .port(input.portAsInt());
     if (input.ipv6() != null) {
       result.parseIp(input.ipv6()); // parse first in case there's a mapped IP
     }

--- a/zipkin2/src/main/java/zipkin2/Endpoint.java
+++ b/zipkin2/src/main/java/zipkin2/Endpoint.java
@@ -84,6 +84,15 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
    * @see java.net.InetSocketAddress#getPort()
    */
   @Nullable public Integer port() {
+    return port != 0 ? port : null;
+  }
+
+  /**
+   * Like {@link #port()} except returns a primitive where zero implies absent.
+   *
+   * <p>Using this method will avoid allocation, so is encouraged when copying data.
+   */
+  public int portAsInt() {
     return port;
   }
 
@@ -98,7 +107,7 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
   public static final class Builder {
     String serviceName, ipv4, ipv6;
     byte[] ipv4Bytes, ipv6Bytes;
-    Integer port;
+    int port; // zero means null
 
     Builder(Endpoint source) {
       serviceName = source.serviceName;
@@ -200,8 +209,16 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
     public Builder port(@Nullable Integer port) {
       if (port != null) {
         if (port > 0xffff) throw new IllegalArgumentException("invalid port " + port);
-        if (port <= 0) port = null;
+        if (port <= 0) port = 0;
       }
+      this.port = port != null ? port : 0;
+      return this;
+    }
+
+    /** @see Endpoint#portAsInt() */
+    public Builder port(int port) {
+      if (port > 0xffff) throw new IllegalArgumentException("invalid port " + port);
+      if (port < 0) port = 0;
       this.port = port;
       return this;
     }
@@ -469,7 +486,7 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
   // See https://github.com/openzipkin/zipkin/issues/1879
   final String serviceName, ipv4, ipv6;
   final byte[] ipv4Bytes, ipv6Bytes;
-  final Integer port;
+  final int port;
 
   Endpoint(Builder builder) {
     serviceName = builder.serviceName;
@@ -506,7 +523,7 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
       ? (that.serviceName == null) : serviceName.equals(that.serviceName))
       && ((ipv4 == null) ? (that.ipv4 == null) : ipv4.equals(that.ipv4))
       && ((ipv6 == null) ? (that.ipv6 == null) : ipv6.equals(that.ipv6))
-      && ((port == null) ? (that.port == null) : port.equals(that.port));
+      && port == that.port;
   }
 
   @Override public int hashCode() {
@@ -518,7 +535,7 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
     h *= 1000003;
     h ^= (ipv6 == null) ? 0 : ipv6.hashCode();
     h *= 1000003;
-    h ^= (port == null) ? 0 : port.hashCode();
+    h ^= port;
     return h;
   }
 
@@ -533,7 +550,7 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
 
     final String serviceName, ipv4, ipv6;
     final byte[] ipv4Bytes, ipv6Bytes;
-    final Integer port;
+    final int port;
 
     SerializedForm(Endpoint endpoint) {
       serviceName = endpoint.serviceName;

--- a/zipkin2/src/main/java/zipkin2/Span.java
+++ b/zipkin2/src/main/java/zipkin2/Span.java
@@ -406,7 +406,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
 
     /** @see Span#timestamp() */
     public Builder timestamp(@Nullable Long timestamp) {
-      if (timestamp == null || timestamp == 0L) timestamp = 0L;
+      if (timestamp == null || timestamp < 0L) timestamp = 0L;
       this.timestamp = timestamp;
       return this;
     }
@@ -420,7 +420,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
 
     /** @see Span#duration() */
     public Builder duration(@Nullable Long duration) {
-      if (duration == null || duration == 0L) duration = 0L;
+      if (duration == null || duration < 0L) duration = 0L;
       this.duration = duration;
       return this;
     }

--- a/zipkin2/src/main/java/zipkin2/internal/JsonCodec.java
+++ b/zipkin2/src/main/java/zipkin2/internal/JsonCodec.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin2/src/main/java/zipkin2/internal/V2SpanWriter.java
+++ b/zipkin2/src/main/java/zipkin2/internal/V2SpanWriter.java
@@ -158,10 +158,11 @@ public final class V2SpanWriter implements Buffer.Writer<Span> {
       sizeInBytes += 9; // "ipv6":""
       sizeInBytes += value.ipv6().length();
     }
-    if (value.port() != null) {
+    int port = value.portAsInt();
+    if (port != 0) {
       if (sizeInBytes != 1) sizeInBytes++; // ,
       sizeInBytes += 7; // "port":
-      sizeInBytes += asciiSizeInBytes(value.port());
+      sizeInBytes += asciiSizeInBytes(port);
     }
     return ++sizeInBytes; // }
   }
@@ -186,9 +187,10 @@ public final class V2SpanWriter implements Buffer.Writer<Span> {
       b.writeAscii(value.ipv6()).writeByte('"');
       wroteField = true;
     }
-    if (value.port() != null) {
+    int port = value.portAsInt();
+    if (port != 0) {
       if (wroteField) b.writeByte(',');
-      b.writeAscii("\"port\":").writeAscii(value.port());
+      b.writeAscii("\"port\":").writeAscii(port);
     }
     b.writeByte('}');
   }

--- a/zipkin2/src/test/java/zipkin2/EndpointTest.java
+++ b/zipkin2/src/test/java/zipkin2/EndpointTest.java
@@ -188,6 +188,14 @@ public class EndpointTest {
     Endpoint.newBuilder().port(65536).build();
   }
 
+  /** Catches common error when zero is passed instead of null for a port */
+  @Test public void coercesZeroPortToNull() {
+    Endpoint endpoint = Endpoint.newBuilder().port(0).build();
+
+    assertThat(endpoint.port())
+      .isNull();
+  }
+
   @Test public void lowercasesServiceName() {
     assertThat(Endpoint.newBuilder().serviceName("fFf").ip("127.0.0.1").build().serviceName())
       .isEqualTo("fff");


### PR DESCRIPTION
This adds and uses Endpoint.portAsInt accessors to prevent routine
object allocation.