### PR TITLE
Clarifies Span text for the purpose of synchronizing code with api

### DIFF
--- a/zipkin2/src/main/java/zipkin2/Span.java
+++ b/zipkin2/src/main/java/zipkin2/Span.java
@@ -30,17 +30,22 @@ import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.internal.Nullable;
 
 /**
- * A trace is a series of spans (often RPC calls) which form a latency tree.
+ * A span is a single-host view of an operation. A trace is a series of spans (often RPC calls)
+ * which nest to form a latency tree. Spans are in the same trace when they share the same trace ID.
+ * The {@link #parentId} field establishes the position of one span in the tree.
  *
- * <p>Spans are usually created by instrumentation in RPC clients or servers, but can also represent
- * in-process activity. Annotations in spans are similar to log statements, and are sometimes
- * created directly by application developers to indicate events of interest, such as a cache miss.
+ * The root span is where {@link #parentId} is null and usually has the longest {@link #duration}
+ * in the trace. However, nested asynchronous work can materialize as child spans whose duration
+ * exceed the root span.
  *
- * <p>The root span is where {@link #parentId} is null; it usually has the longest {@link #duration}
- * in the trace.
+ * <p>Spans usually represent remote activity such as RPC calls, or messaging producers and
+ * consumers. However, they can also represent in-process activity in any position of the trace. For
+ * example, a root span could represent a server receiving an initial client request. A root span
+ * could also represent a scheduled job that has no remote context. At any place in the trace tree,
+ * intermediate in-process activities such as message processors, could be also be spans.
  *
- * <p>Span identifiers are packed into longs, but should be treated opaquely. ID encoding is 16 or
- * 32 character lower-hex, to avoid signed interpretation.
+ * <p>While span identifiers are packed into longs, they should be treated opaquely. ID encoding is
+ * 16 or 32 character lower-hex, to avoid signed interpretation.
  *
  * <h3>Relationship to {@code zipkin.Span}</h3>
  *

--- a/zipkin2/src/main/java/zipkin2/Span.java
+++ b/zipkin2/src/main/java/zipkin2/Span.java
@@ -34,15 +34,14 @@ import zipkin2.internal.Nullable;
  * which nest to form a latency tree. Spans are in the same trace when they share the same trace ID.
  * The {@link #parentId} field establishes the position of one span in the tree.
  *
- * The root span is where {@link #parentId} is null and usually has the longest {@link #duration}
+ * <p>The root span is where {@link #parentId} is null and usually has the longest {@link #duration}
  * in the trace. However, nested asynchronous work can materialize as child spans whose duration
  * exceed the root span.
  *
  * <p>Spans usually represent remote activity such as RPC calls, or messaging producers and
  * consumers. However, they can also represent in-process activity in any position of the trace. For
  * example, a root span could represent a server receiving an initial client request. A root span
- * could also represent a scheduled job that has no remote context. At any place in the trace tree,
- * intermediate in-process activities such as message processors, could be also be spans.
+ * could also represent a scheduled job that has no remote context.
  *
  * <p>While span identifiers are packed into longs, they should be treated opaquely. ID encoding is
  * 16 or 32 character lower-hex, to avoid signed interpretation.


### PR DESCRIPTION
The zipkin-api project has no text to define what a span is. This
clarifies text so we can use it consistently.

See https://github.com/openzipkin/zipkin-api/pull/47