### PR TITLE
Bumps to latest releases of things we can, except Kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,12 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <brave.version>4.18.2</brave.version>
-    <cassandra-driver-core.version>3.4.0</cassandra-driver-core.version>
+    <cassandra-driver-core.version>3.5.0</cassandra-driver-core.version>
     <okhttp.version>3.10.0</okhttp.version>
     <okio.version>1.14.0</okio.version>
     <!-- important to keep this in sync with spring-boot-dependencies -->
     <jooq.version>3.9.6</jooq.version>
-    <spring-boot.version>1.5.10.RELEASE</spring-boot.version>
+    <spring-boot.version>1.5.12.RELEASE</spring-boot.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
 
@@ -61,7 +61,7 @@
     <!-- Version 2.x might conflict w/ Spring Boot's version -->
     <mariadb-java-client.version>1.7.3</mariadb-java-client.version>
     <!-- Java 8 dep, which is ok as zipkin-mysql is Java 8 anyway -->
-    <HikariCP.version>2.7.6</HikariCP.version>
+    <HikariCP.version>2.7.9</HikariCP.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
     <!-- Be careful to set this as a provided dep, so that it doesn't interfere with dependencies
@@ -73,7 +73,7 @@
     <powermock.version>2.0.0-beta.5</powermock.version>
     <assertj.version>3.9.1</assertj.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <testcontainers.version>1.6.0</testcontainers.version>
+    <testcontainers.version>1.7.1</testcontainers.version>
 
     <animal-sniffer-maven-plugin.version>1.16</animal-sniffer-maven-plugin.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/zipkin-autoconfigure/metrics-prometheus/pom.xml
+++ b/zipkin-autoconfigure/metrics-prometheus/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <prometheus_simpleclient.version>0.2.0</prometheus_simpleclient.version>
+    <prometheus_simpleclient.version>0.3.0</prometheus_simpleclient.version>
   </properties>
 
   <dependencies>

--- a/zipkin-autoconfigure/storage-elasticsearch-aws/pom.xml
+++ b/zipkin-autoconfigure/storage-elasticsearch-aws/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <aws.sdk.version>1.11.273</aws.sdk.version>
+    <aws.sdk.version>1.11.315</aws.sdk.version>
   </properties>
 
   <dependencies>

--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -30,7 +30,7 @@
 	<properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
 
-    <amqp-client.version>4.5.0</amqp-client.version>
+    <amqp-client.version>4.6.0</amqp-client.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Kafka 1.1.0 we can't change to without kafka-junit (not without ripping
it out or updating to junit 5).

See https://github.com/charithe/kafka-junit/pull/37