### PR TITLE
Fixes naming convention and removes empty prometheus metrics and fixes skips

### DIFF
--- a/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
@@ -18,6 +18,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -30,9 +31,9 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 class ZipkinPrometheusMetricsAutoConfiguration {
-  private MeterRegistry registry;
+  final PrometheusMeterRegistry registry;
 
-  ZipkinPrometheusMetricsAutoConfiguration(MeterRegistry registry) {
+  ZipkinPrometheusMetricsAutoConfiguration(PrometheusMeterRegistry registry) {
     this.registry = registry;
   }
 

--- a/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
@@ -18,6 +18,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
@@ -29,12 +30,18 @@ import org.springframework.boot.web.embedded.undertow.UndertowDeploymentInfoCust
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration
-class ZipkinPrometheusMetricsAutoConfiguration {
+@Configuration class ZipkinPrometheusMetricsAutoConfiguration {
   final PrometheusMeterRegistry registry;
 
   ZipkinPrometheusMetricsAutoConfiguration(PrometheusMeterRegistry registry) {
     this.registry = registry;
+    NamingConvention delegate = registry.config().namingConvention();
+    registry.config().namingConvention((name, type, baseUnit) -> {
+      if (name.contains("zipkin_collector")) {
+        return NamingConvention.snakeCase.name(name, type, baseUnit);
+      }
+      return delegate.name(name, type, baseUnit);
+    });
   }
 
   @Bean @Qualifier("httpRequestDurationCustomizer")

--- a/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfigurationTest.java
@@ -13,6 +13,8 @@
  */
 package zipkin.autoconfigure.prometheus;
 
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,6 +23,9 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.web.embedded.undertow.UndertowDeploymentInfoCustomizer;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static io.micrometer.core.instrument.Meter.Type.COUNTER;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZipkinPrometheusMetricsAutoConfigurationTest {
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
@@ -41,5 +46,13 @@ public class ZipkinPrometheusMetricsAutoConfigurationTest {
 
   @Test public void providesHttpRequestDurationCustomizer() {
     context.getBean(UndertowDeploymentInfoCustomizer.class);
+  }
+
+  /** old naming convention didn't end in _total */
+  @Test public void usesOldNamingConvention() {
+    NamingConvention prometheusNamingConvention =
+      context.getBean(PrometheusMeterRegistry.class).config().namingConvention();
+    assertThat(prometheusNamingConvention.name("counter.zipkin_collector.messages.http", COUNTER))
+      .doesNotEndWith("_total");
   }
 }

--- a/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfigurationTest.java
@@ -13,39 +13,33 @@
  */
 package zipkin.autoconfigure.prometheus;
 
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.web.embedded.undertow.UndertowDeploymentInfoCustomizer;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 public class ZipkinPrometheusMetricsAutoConfigurationTest {
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+  @Before public void refresh() {
+    context.register(
+      PropertyPlaceholderAutoConfiguration.class,
+      MetricsAutoConfiguration.class,
+      PrometheusMetricsExportAutoConfiguration.class,
+      ZipkinPrometheusMetricsAutoConfiguration.class
+    );
+    context.refresh();
+  }
 
   @After public void close() {
     context.close();
   }
 
   @Test public void providesHttpRequestDurationCustomizer() {
-    context.register(
-      PropertyPlaceholderAutoConfiguration.class,
-      ZipkinPrometheusMetricsAutoConfiguration.class,
-      TestConfig.class
-    );
-    context.refresh();
-
     context.getBean(UndertowDeploymentInfoCustomizer.class);
-  }
-
-  @Configuration
-  static class TestConfig {
-    @Bean
-    MeterRegistry registry() {
-      return new SimpleMeterRegistry();
-    }
   }
 }

--- a/zipkin-server/src/test/java/zipkin/server/internal/ITZipkinMetricsHealth.java
+++ b/zipkin-server/src/test/java/zipkin/server/internal/ITZipkinMetricsHealth.java
@@ -106,6 +106,9 @@ public class ITZipkinMetricsHealth {
     assertThat(response.isSuccessful()).isTrue();
     String prometheus = response.body().string();
 
+    // ensure unscoped counter does not exist
+    assertThat(prometheus)
+      .doesNotContain("counter_zipkin_collector_spans_total " + messagesCount);
     assertThat(prometheus)
       .contains("counter_zipkin_collector_spans_http_total " + messagesCount);
     assertThat(prometheus)


### PR DESCRIPTION
When we switched to micrometer's prometheus in 2.7.3, we accidentally
broke the naming convention used before.

Notably, in prometheus.yml, we had this:

```yaml
      - source_labels: [__name__]
        regex: '(?:gauge|counter)_zipkin_collector_(.*)_([^_]*)'
        replacement: '${2}'
        target_label: transport

```

As the default naming convention adds "_total", this causes dashboards
to end up with a transport literally named "_total".

This also removes empty metrics eagerly initialized and patterns that should have been skipped.