### PR TITLE
Reverts old naming convention as so many metrics changed

### DIFF
--- a/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
@@ -18,7 +18,6 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
@@ -35,13 +34,6 @@ import org.springframework.context.annotation.Configuration;
 
   ZipkinPrometheusMetricsAutoConfiguration(PrometheusMeterRegistry registry) {
     this.registry = registry;
-    NamingConvention delegate = registry.config().namingConvention();
-    registry.config().namingConvention((name, type, baseUnit) -> {
-      if (name.contains("zipkin_collector")) {
-        return NamingConvention.snakeCase.name(name, type, baseUnit);
-      }
-      return delegate.name(name, type, baseUnit);
-    });
   }
 
   @Bean @Qualifier("httpRequestDurationCustomizer")

--- a/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/test/java/zipkin/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfigurationTest.java
@@ -13,8 +13,6 @@
  */
 package zipkin.autoconfigure.prometheus;
 
-import io.micrometer.core.instrument.config.NamingConvention;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,9 +21,6 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.web.embedded.undertow.UndertowDeploymentInfoCustomizer;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-
-import static io.micrometer.core.instrument.Meter.Type.COUNTER;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZipkinPrometheusMetricsAutoConfigurationTest {
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
@@ -46,13 +41,5 @@ public class ZipkinPrometheusMetricsAutoConfigurationTest {
 
   @Test public void providesHttpRequestDurationCustomizer() {
     context.getBean(UndertowDeploymentInfoCustomizer.class);
-  }
-
-  /** old naming convention didn't end in _total */
-  @Test public void usesOldNamingConvention() {
-    NamingConvention prometheusNamingConvention =
-      context.getBean(PrometheusMeterRegistry.class).config().namingConvention();
-    assertThat(prometheusNamingConvention.name("counter.zipkin_collector.messages.http", COUNTER))
-      .doesNotEndWith("_total");
   }
 }

--- a/zipkin-server/src/test/java/zipkin/server/internal/ITZipkinMetricsHealth.java
+++ b/zipkin-server/src/test/java/zipkin/server/internal/ITZipkinMetricsHealth.java
@@ -131,10 +131,9 @@ public class ITZipkinMetricsHealth {
 
     // ensure unscoped counter does not exist
     assertThat(prometheus)
-      .doesNotContain("counter_zipkin_collector_spans " + messagesCount);
-    // has the old name, which does not have a _total suffix
+      .doesNotContain("counter_zipkin_collector_spans_total " + messagesCount);
     assertThat(prometheus)
-      .contains("counter_zipkin_collector_spans_http " + messagesCount);
+      .contains("counter_zipkin_collector_spans_http_total " + messagesCount);
     assertThat(prometheus)
       .contains(
         "http_request_duration_seconds_count{method=\"POST\",path=\"/api/v1/spans\",status=\"200\",} "


### PR DESCRIPTION
This reverts part of b5402bf481866463fead10764b84e323176cd6bb

Basically almost all metrics changed in the last version. We'll announce
and take a one-time hit to ensure the metrics used are standard moving
forward.