### PR TITLE
Support for setting  the json field names (filebeat).

### DIFF
--- a/zipkin-autoconfigure/collector-kafka10/src/main/java/zipkin/autoconfigure/collector/kafka10/ZipkinKafkaCollectorProperties.java
+++ b/zipkin-autoconfigure/collector-kafka10/src/main/java/zipkin/autoconfigure/collector/kafka10/ZipkinKafkaCollectorProperties.java
@@ -26,6 +26,8 @@ class ZipkinKafkaCollectorProperties {
   private String groupId;
   /** Kafka topic span data will be retrieved from. */
   private String topic;
+  /** Kafka topic span data field (if it's json). */
+  private String field;
   /** Number of Kafka consumer threads to run. */
   private Integer streams;
   /** Additional Kafka consumer configuration. */
@@ -55,6 +57,14 @@ class ZipkinKafkaCollectorProperties {
     this.topic = emptyToNull(topic);
   }
 
+  public String getField() {
+    return field;
+  }
+
+  public void setField(String field) {
+    this.field = emptyToNull(field);
+  }
+
   public Integer getStreams() {
     return streams;
   }
@@ -76,6 +86,7 @@ class ZipkinKafkaCollectorProperties {
     if (bootstrapServers != null) result.bootstrapServers(bootstrapServers);
     if (groupId != null) result.groupId(groupId);
     if (topic != null) result.topic(topic);
+    if (field != null) result.field(field);
     if (streams != null) result.streams(streams);
     if (overrides != null) result.overrides(overrides);
     return result;

--- a/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollector.java
+++ b/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollector.java
@@ -58,6 +58,7 @@ public final class KafkaCollector implements CollectorComponent {
     Collector.Builder delegate = Collector.builder(KafkaCollector.class);
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
     String topic = "zipkin";
+    String field = "message";
     int streams = 1;
 
     @Override public Builder storage(StorageComponent storage) {
@@ -82,6 +83,14 @@ public final class KafkaCollector implements CollectorComponent {
      */
     public Builder topic(String topic) {
       this.topic = checkNotNull(topic, "topic");
+      return this;
+    }
+
+    /**
+     * The field of the span json data will be parsed. Defaults to "message"
+     */
+    public Builder field(String field) {
+      this.field = checkNotNull(field, "message");
       return this;
     }
 

--- a/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollectorWorker.java
+++ b/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollectorWorker.java
@@ -13,6 +13,8 @@
  */
 package zipkin.collector.kafka10;
 
+import com.google.gson.Gson;
+import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -86,6 +88,20 @@ final class KafkaCollectorWorker implements Runnable {
               } catch (RuntimeException e) {
                 metrics.incrementMessagesDropped();
               }
+            } else if (bytes[0] == 123) {
+              // If the string start with "{", we parse the Json Object, then get specified field
+              Gson gson;
+              String str, newStr;
+              byte[] newBytes;
+              HashMap<String, String> map;
+
+              gson = new Gson();
+              str = new String(bytes);
+              map = gson.fromJson(str, map.getClass());
+              newStr = map.get("message");
+              newBytes = newStr.getBytes();
+
+              collector.acceptSpans(newBytes, DETECTING_DECODER, NOOP);
             } else {
               collector.acceptSpans(bytes, DETECTING_DECODER, NOOP);
             }

--- a/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollectorWorker.java
+++ b/zipkin-collector/kafka10/src/main/java/zipkin/collector/kafka10/KafkaCollectorWorker.java
@@ -93,16 +93,19 @@ final class KafkaCollectorWorker implements Runnable {
               }
             } else if (bytes[0] == 123) {
               // If the string start with "{", we parse the Json Object, then get specified field
+              String newStr;
               byte[] newBytes;
               Gson gson = new Gson();
               String str = new String(bytes);
               HashMap<String, String> map = new HashMap<>();
               map = gson.fromJson(str, map.getClass());
-              // str = map.get("message");
-			  LOG.debug(field);
-              str = map.get(field);
-              newBytes = str.getBytes();
-              collector.acceptSpans(newBytes, DETECTING_DECODER, NOOP);
+              newStr = map.get(field);
+              if (newStr != null) {
+                newBytes = newStr.getBytes();
+                collector.acceptSpans(newBytes, DETECTING_DECODER, NOOP);
+              } else {
+                LOG.warn("Unexpected json formate, not included field: {}, data: {}", field, str);
+              }
             } else {
               collector.acceptSpans(bytes, DETECTING_DECODER, NOOP);
             }


### PR DESCRIPTION
When the application architecture as follow:
`application -> filebeat -> kafka -> zipkin`
The kafka10 collector would print error  , because of it can't parse the packaged json string. 

The origin kafka topic data :
```
{"@timestamp":"2019-04-11T03:28:20.985Z","beat":{"hostname":"vm-10-112-33-39","name":"vm-10-112-33-39","version":"5.1.2"},"fields":{"topic":"lefan_tracing_log"},"input_type":"log","message":"[{\"traceId\":\"7e93c1680995fcdc\",\"name\":\"GET\",\"version\":\"php-4\",\"id\":\"79fcb72dfaf3a691\",\"timestamp\":1554953300670084,\"duration\":10517,\"annotations\":[{\"value\":\"sr\",\"timestamp\":1554953300670084,\"endpoint\":{\"serviceName\":\"odp\",\"ipv4\":\"10.112.33.39\",\"port\":80}},{\"value\":\"ss\",\"timestamp\":1554953300680601,\"endpoint\":{\"serviceName\":\"odp\",\"ipv4\":\"10.112.33.39\",\"port\":80}}],\"binaryAnnotations\":[{\"key\":\"http.url\",\"value\":\"http:\\/\\/odp.my.le.com\\/tv\\/growth?uid=238737344\u0026times=1554953300\u0026channel=0\u0026saltkey=7f76101bb7e0027bad315ee0b7f103c9\",\"endpoint\":{\"serviceName\":\"odp\",\"ipv4\":\"10.112.33.39\",\"port\":80}},{\"key\":\"path\",\"value\":\"\\/letv\\/www\\/odp.my.le.com\\/index.php\",\"endpoint\":{\"serviceName\":\"odp\",\"ipv4\":\"10.112.33.39\",\"port\":80}}]}]","offset":18446626,"source":"/letv/logs/phpzipkin/tracing-20190411.log","tags":["service-lefan","web-tier"],"type":"log"}
```
But zipkin-collector only need the `message` data，and can't handle other format.
```
[{"traceId":"b018df0c8d465265","name":"GET","version":"php-4","id":"8abd9e83ed3f9af5","timestamp":1524900779537352,"duration":12561,"annotations":[{"value":"sr","timestamp":1524900779537352,"endpoint":{"serviceName":"growth","ipv4":"10.112.156.88","port":80}},{"value":"ss","timestamp":1524900779549913,"endpoint":{"serviceName":"growth","ipv4":"10.112.156.88","port":80}}],"binaryAnnotations":[{"key":"http.url","value":"http:\/\/le.com\/growth\/v2\/values\/get?app=1&uid=125614239","endpoint":{"serviceName":"growth","ipv4":"10.112.156.88","port":80}},{"key":"path","value":"\/letv\/www\/usergrowth-lwf\/public\/index.php","endpoint":{"serviceName":"growth","ipv4":"10.112.156.88","port":80}}]}]
```
 So it does't work.


This version supports for setting the json filed name. Default value is `message`, it's for filebeat friendly. 
```
    java \
    -Dloader.path='kafka10.jar,kafka10.jar!/lib' \
    -Dspring.profiles.active=kafka \
    -Dzipkin.collector.kafka.bootstrap-servers=10.183.1.1:9092,10.183.1.2:9092,10.183.1.3:9092 \
    -Dzipkin.collector.kafka.topic=tracing_log \
    -Dzipkin.collector.kafka.field=message \
    -cp zipkin.jar \
    org.springframework.boot.loader.PropertiesLauncher \
    --logging.level.zipkin=DEBUG 2>&1 >>/tmp/zipkin2.log &
```