### PR TITLE
Redirect /info endpoint for Boot 2 Actuator

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/internal/ZipkinServerConfiguration.java
@@ -31,6 +31,8 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import zipkin.collector.CollectorMetrics;
 import zipkin.collector.CollectorSampler;
 import zipkin.internal.V2StorageComponent;
@@ -40,7 +42,7 @@ import zipkin.storage.StorageComponent;
 import zipkin2.storage.InMemoryStorage;
 
 @Configuration
-public class ZipkinServerConfiguration {
+public class ZipkinServerConfiguration implements WebMvcConfigurer {
 
   @Autowired(required = false) @Qualifier("httpTracingCustomizer")
   UndertowDeploymentInfoCustomizer httpTracingCustomizer;
@@ -52,6 +54,11 @@ public class ZipkinServerConfiguration {
   /** Registers health for any components, even those not in this jar. */
   @Bean ZipkinHealthIndicator zipkinHealthIndicator(HealthAggregator healthAggregator) {
     return new ZipkinHealthIndicator(healthAggregator);
+  }
+
+  @Override
+  public void addViewControllers(ViewControllerRegistry registry) {
+    registry.addRedirectViewController("/info", "/actuator/info");
   }
 
   @Bean public UndertowServletWebServerFactory embeddedServletContainerFactory(

--- a/zipkin-server/src/test/java/zipkin/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin/server/internal/ITZipkinServer.java
@@ -55,7 +55,7 @@ public class ITZipkinServer {
   @Autowired InMemoryStorage storage;
   @Value("${local.server.port}") int zipkinPort;
 
-  OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
+  OkHttpClient client = new OkHttpClient.Builder().followRedirects(true).build();
 
   @Before public void init() {
     storage.clear();
@@ -293,6 +293,10 @@ public class ITZipkinServer {
     // Redirect header should be the proxy, not the backed IP/port
     assertThat(response.header("Location"))
       .isEqualTo("./zipkin/");
+  }
+
+  @Test public void infoEndpointIsAvailable() throws IOException {
+    assertThat(get("/info").isSuccessful()).isTrue();
   }
 
   private Response get(String path) throws IOException {


### PR DESCRIPTION
Similar to the other endpoints we mention in the Server README, the /info endpoint should be redirected since it was moved along with other Actuator endpoints during the Spring Boot 2 upgrade. Adds a test to ensure this is checked going forward.

I didn't put this config with the redirect for the prometheus endpoint since the info endpoint isn't exactly related to metrics or health. Actually, I was tempted to move the prometheus redirect configuration to where I made this to keep the redirect config in one place, but for now I submit these changes for review.