### PR TITLE
[WIP] Fix for Log4J and trailing double slash in the URL of UI

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -56,7 +56,16 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-tomcat</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
     </dependency>
 
     <!-- reduces http transport latency -->
@@ -176,6 +185,16 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-autoconfigure-collector-kafka</artifactId>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- RabbitMQ Collector -->

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -140,7 +140,7 @@ zipkin:
     # Default is "match all websites"
     instrumented: .*
     # URL placed into the <base> tag in the HTML
-    base-path: /zipkin/
+    base-path: /zipkin
 
 server:
   port: ${QUERY_PORT:9411}


### PR DESCRIPTION
This should fix the logging issue and the tests did not fail in Kafka collector. And has the fix for #2037 as well.