### PR TITLE
Fixes Kafka by using log4j2 instead of slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,34 @@
         <artifactId>jooq</artifactId>
         <version>${jooq.version}</version>
       </dependency>
+
+      <!-- Makes sure spring doesn't eagerly bind tomcat or slf4j -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>${spring-boot.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-actuator</artifactId>
+        <version>${spring-boot.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
       <!-- End spring-boot-dependencies overrides -->
 
       <dependency>

--- a/zipkin-autoconfigure/collector-kafka/pom.xml
+++ b/zipkin-autoconfigure/collector-kafka/pom.xml
@@ -34,6 +34,18 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-collector-kafka</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- com.101tec:zkclient has a log4j dep, re-route it with the bridge
+         https://logging.apache.org/log4j/2.x/manual/migration.html -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/zipkin-autoconfigure/metrics-prometheus/pom.xml
+++ b/zipkin-autoconfigure/metrics-prometheus/pom.xml
@@ -33,19 +33,24 @@
   <dependencies>
     <!-- Micrometer and Prometheus Registry-->
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${spring-boot.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
       <version>${micrometer.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
       <version>${spring-boot.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-undertow</artifactId>
-      <version>${spring-boot.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/zipkin-autoconfigure/metrics-prometheus/src/test/resources/log4j2.properties
+++ b/zipkin-autoconfigure/metrics-prometheus/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/zipkin-autoconfigure/ui/pom.xml
+++ b/zipkin-autoconfigure/ui/pom.xml
@@ -48,6 +48,14 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+    <!-- In excluding tomcat, we exclude its indirect dep on servlet-api. This one is
+         from spring-boot-starter-undertow -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-ui</artifactId>
@@ -62,6 +70,12 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
+      <version>${spring-boot.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -43,20 +43,13 @@
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.11</artifactId>
       <version>${kafka.version}</version>
-      <!-- don't eagerly bind slf4j -->
       <exclusions>
+        <!-- don't eagerly bind slf4j -->
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/zipkin-collector/kafka10/pom.xml
+++ b/zipkin-collector/kafka10/pom.xml
@@ -65,6 +65,12 @@
        https://github.com/charithe/kafka-junit -->
       <version>4.1.1</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>log4j-over-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -51,12 +51,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-tomcat</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+
+    <!-- Use log4j 2 instead of SLF4J to allow log4j 1.2 used by Kafka 0.8 to still work -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
     </dependency>
 
     <!-- reduces http transport latency -->
@@ -204,10 +204,9 @@
       <version>${brave.version}</version>
       <optional>true</optional>
     </dependency>
-    <!-- Spring Boot uses SLF4J -->
     <dependency>
       <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave-context-slf4j</artifactId>
+      <artifactId>brave-context-log4j2</artifactId>
       <version>${brave.version}</version>
       <optional>true</optional>
     </dependency>
@@ -286,6 +285,7 @@
         <configuration>
           <classifier>exec</classifier>
           <executable>true</executable>
+          <excludeArtifactIds>logback-classic</excludeArtifactIds>
         </configuration>
       </plugin>
       <!-- disable retrolambda since this module uses java 8 types -->

--- a/zipkin-server/src/it/execjar/pom.xml
+++ b/zipkin-server/src/it/execjar/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin</artifactId>
-      <version>@project.version@</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin-server</artifactId>
-      <version>@project.version@</version>
+      <version>${project.version}</version>
       <classifier>exec</classifier>
       <exclusions>
         <!-- TODO: should the exec jar declare dependencies it bundles? -->

--- a/zipkin-server/src/it/minimal-dependencies/pom.xml
+++ b/zipkin-server/src/it/minimal-dependencies/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2017 The OpenZipkin Authors
+    Copyright 2015-2018 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -62,13 +62,24 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.9.0</version>
+      <version>3.10.0</version>
       <scope>test</scope>
     </dependency>
+    <!-- Use log4j 2 instead of SLF4J to allow log4j 1.2 used by Kafka 0.8 to still work -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
     </dependency>
   </dependencies>
 
@@ -93,13 +104,6 @@
         <configuration>
           <!-- It's just an integration test -->
           <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <classifier>exec</classifier>
         </configuration>
       </plugin>
     </plugins>

--- a/zipkin-server/src/main/java/zipkin/server/internal/brave/TracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/internal/brave/TracingConfiguration.java
@@ -14,7 +14,7 @@
 package zipkin.server.internal.brave;
 
 import brave.Tracing;
-import brave.context.slf4j.MDCCurrentTraceContext;
+import brave.context.log4j2.ThreadContextCurrentTraceContext;
 import brave.http.HttpAdapter;
 import brave.http.HttpSampler;
 import brave.http.HttpTracing;
@@ -66,9 +66,8 @@ public class TracingConfiguration {
       .metrics(new ReporterMetricsAdapter(metrics.forTransport("local"))).build();
   }
 
-  // Spring Boot uses SLF4J
   @Bean CurrentTraceContext currentTraceContext() {
-    return MDCCurrentTraceContext.create(); // puts trace IDs into logs
+    return ThreadContextCurrentTraceContext.create(); // puts trace IDs into logs
   }
 
   /** Controls aspects of tracing such as the name that shows up in the UI */


### PR DESCRIPTION
log4j has a means to support log4j 1.2, which is used by our Kafka 0.8
component.

Fixes #2035