### PR TITLE
To distinguish from the zipkin module.

### DIFF
--- a/zipkin2/pom.xml
+++ b/zipkin2/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>
-  <artifactId>zipkin</artifactId>
+  <artifactId>zipkin2</artifactId>
   <name>Zipkin v2</name>
 
   <properties>


### PR DESCRIPTION
This will cause a error in Eclipse when importing the project due to that there are two same artifacts in the maven project.