### PR TITLE
Removes auto-value dependency and maven metadata from core jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,12 @@
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>${maven-jar-plugin.version}</version>
+          <configuration>
+            <archive>
+              <!-- prevents huge pom file from also being added to the jar under META-INF/maven -->
+              <addMavenDescriptor>false</addMavenDescriptor>
+            </archive>
+          </configuration>
         </plugin>
 
         <plugin>

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -143,6 +143,8 @@
             <id>default-jar</id>
             <configuration>
               <archive>
+                <!-- prevents huge pom file from also being added to the jar under META-INF/maven -->
+                <addMavenDescriptor>false</addMavenDescriptor>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
               </archive>
             </configuration>

--- a/zipkin/src/test/java/zipkin/internal/V2SpanStoreAdapterTest.java
+++ b/zipkin/src/test/java/zipkin/internal/V2SpanStoreAdapterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -436,7 +436,7 @@ public class V2SpanStoreAdapterTest {
       .lookback(60L)
       .limit(100)
       .build()))
-      .isEqualTo(zipkin2.storage.QueryRequest.newBuilder()
+      .isEqualToComparingFieldByField(zipkin2.storage.QueryRequest.newBuilder()
         .serviceName("service")
         .spanName("span")
         .parseAnnotationQuery("annotation and tag=value")

--- a/zipkin/src/test/java/zipkin/internal/V2SpanStoreAdapterTest.java
+++ b/zipkin/src/test/java/zipkin/internal/V2SpanStoreAdapterTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static zipkin.TestObjects.DAY;
 import static zipkin.TestObjects.TODAY;
 
 public class V2SpanStoreAdapterTest {
@@ -446,6 +447,19 @@ public class V2SpanStoreAdapterTest {
         .lookback(60L)
         .limit(100)
         .build());
+  }
+
+  @Test public void convert_queryRequest_less() {
+    // from CassandraSpanStoreTest.overFetchesToCompensateForDuplicateIndexData
+    QueryRequest input = QueryRequest.builder()
+      .serviceName("web")
+      .lookback(DAY).limit(2000).build();
+    zipkin2.storage.QueryRequest converted = V2SpanStoreAdapter.convertRequest(input);
+
+    assertThat(converted.serviceName()).isEqualTo(input.serviceName);
+    assertThat(converted.endTs()).isEqualTo(input.endTs);
+    assertThat(converted.lookback()).isEqualTo(input.lookback);
+    assertThat(converted.limit()).isEqualTo(input.limit);
   }
 
   void doEnqueue(Consumer<zipkin2.Callback> answer) {

--- a/zipkin2/pom.xml
+++ b/zipkin2/pom.xml
@@ -35,18 +35,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <!-- generated code includes Generated annotations! -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jvnet</groupId>
       <artifactId>animal-sniffer-annotation</artifactId>
       <version>1.0</version>
@@ -145,6 +133,8 @@
             <id>default-jar</id>
             <configuration>
               <archive>
+                <!-- prevents huge pom file from also being added to the jar under META-INF/maven -->
+                <addMavenDescriptor>false</addMavenDescriptor>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
               </archive>
             </configuration>

--- a/zipkin2/src/main/java/zipkin2/Call.java
+++ b/zipkin2/src/main/java/zipkin2/Call.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -228,8 +228,8 @@ public abstract class Call<V> implements Cloneable {
     final Mapper<V, R> mapper;
     final Call<V> delegate;
 
-    Mapping(Mapper<V, R> Mapper, Call<V> delegate) {
-      this.mapper = Mapper;
+    Mapping(Mapper<V, R> mapper, Call<V> delegate) {
+      this.mapper = mapper;
       this.delegate = delegate;
     }
 
@@ -320,7 +320,7 @@ public abstract class Call<V> implements Cloneable {
       try {
         return delegate.execute();
       } catch (IOException | RuntimeException | Error e) {
-        final AtomicReference ref = new AtomicReference(SENTINEL);
+        final AtomicReference ref = new AtomicReference<>(SENTINEL);
         errorHandler.onErrorReturn(e, new Callback<V>() {
           @Override public void onSuccess(V value) {
             ref.set(value);

--- a/zipkin2/src/main/java/zipkin2/CheckResult.java
+++ b/zipkin2/src/main/java/zipkin2/CheckResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 The OpenZipkin Authors
+ * Copyright 2015-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
  */
 package zipkin2;
 
-import com.google.auto.value.AutoValue;
 import zipkin2.internal.Nullable;
 
 /**
@@ -25,20 +24,34 @@ import zipkin2.internal.Nullable;
  *
  * @see CheckResult#OK
  */
-@AutoValue
-//@Immutable
-public abstract class CheckResult {
-  public static final CheckResult OK = new AutoValue_CheckResult(true, null);
+// @Immutable
+public final class CheckResult {
+  public static final CheckResult OK = new CheckResult(true, null);
 
   public static CheckResult failed(Throwable error) {
-    return new AutoValue_CheckResult(false, error);
+    return new CheckResult(false, error);
   }
 
-  public abstract boolean ok();
+  public boolean ok() {
+    return ok;
+  }
 
   /** Present when not ok */
-  @Nullable public abstract Throwable error();
+  @Nullable
+  public Throwable error() {
+    return error;
+  }
 
-  CheckResult() {
+  final boolean ok;
+  final Throwable error;
+
+  CheckResult(boolean ok, @Nullable Throwable error) {
+    this.ok = ok;
+    this.error = error;
+  }
+
+  @Override
+  public String toString() {
+    return "CheckResult{ok=" + ok + ", " + "error=" + error + "}";
   }
 }

--- a/zipkin2/src/main/java/zipkin2/internal/Buffer.java
+++ b/zipkin2/src/main/java/zipkin2/internal/Buffer.java
@@ -341,7 +341,7 @@ public final class Buffer {
       if (i == 9 && (b & 0xf0) != 0) {
         throw new IllegalArgumentException("Greater than 64-bit varint at position " + (pos - 1));
       }
-      result |= (long) (b & 0x7f) << i * 7;
+      result |= (long) (b & 0x7f) << (i * 7);
     }
     return result;
   }

--- a/zipkin2/src/main/java/zipkin2/storage/QueryRequest.java
+++ b/zipkin2/src/main/java/zipkin2/storage/QueryRequest.java
@@ -13,7 +13,6 @@
  */
 package zipkin2.storage;
 
-import com.google.auto.value.AutoValue;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -37,16 +36,19 @@ import zipkin2.internal.Nullable;
  * microseconds, the grain of {@link Span#timestamp()}. Milliseconds is a more familiar and
  * supported granularity for query, index and windowing functions.
  */
-@AutoValue
-public abstract class QueryRequest {
+public final class QueryRequest {
   /**
    * When present, corresponds to {@link zipkin2.Endpoint#serviceName} and constrains all other
    * parameters.
    */
-  @Nullable public abstract String serviceName();
+  @Nullable public String serviceName() {
+    return serviceName;
+  }
 
   /** When present, only include traces with this {@link Span#name} */
-  @Nullable public abstract String spanName();
+  @Nullable public String spanName() {
+    return spanName;
+  }
 
   /**
    * When an input value is the empty string, include traces whose {@link Span#annotations()}
@@ -55,34 +57,46 @@ public abstract class QueryRequest {
    *
    * <p>Multiple entries are combined with AND, and AND against other conditions.
    */
-  public abstract Map<String, String> annotationQuery();
+  public Map<String, String> annotationQuery(){
+    return annotationQuery;
+  }
 
   /**
    * Only return traces whose {@link Span#duration()} is greater than or equal to minDuration
    * microseconds.
    */
-  @Nullable public abstract Long minDuration();
+  @Nullable public Long minDuration() {
+    return minDuration;
+  }
 
   /**
    * Only return traces whose {@link Span#duration()} is less than or equal to maxDuration
    * microseconds. Only valid with {@link #minDuration}.
    */
-  @Nullable public abstract Long maxDuration();
+  @Nullable public Long maxDuration() {
+    return maxDuration;
+  }
 
   /**
    * Only return traces where all {@link Span#timestamp()} are at or before this time in epoch
    * milliseconds. Defaults to current time.
    */
-  public abstract long endTs();
+  public long endTs() {
+    return endTs;
+  }
 
   /**
    * Only return traces where all {@link Span#timestamp()} are at or after (endTs - lookback) in
    * milliseconds. Defaults to endTs.
    */
-  public abstract long lookback();
+  public long lookback() {
+    return lookback;
+  }
 
   /** Maximum number of traces to return. Defaults to 10 */
-  public abstract int limit();
+  public int limit() {
+    return limit;
+  }
 
   /**
    * Corresponds to query parameter "annotationQuery". Ex. "http.method=GET and error"
@@ -103,24 +117,47 @@ public abstract class QueryRequest {
     return result.length() > 0 ? result.toString() : null;
   }
 
-  public abstract Builder toBuilder();
-
-  public static Builder newBuilder() {
-    return new AutoValue_QueryRequest.Builder().annotationQuery(Collections.emptyMap());
+  public Builder toBuilder() {
+    return new Builder(this);
   }
 
-  @AutoValue.Builder
-  public abstract static class Builder {
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    String serviceName, spanName;
+    Map<String, String> annotationQuery = Collections.emptyMap();
+    Long minDuration, maxDuration;
+    long endTs, lookback;
+    int limit;
+
+    Builder(QueryRequest source) {
+      serviceName = source.serviceName;
+      spanName = source.spanName;
+      annotationQuery = source.annotationQuery;
+      minDuration = source.minDuration;
+      maxDuration = source.maxDuration;
+      endTs = source.endTs;
+      lookback = source.lookback;
+      limit = source.limit;
+    }
 
     /** @see QueryRequest#serviceName() */
-    public abstract Builder serviceName(@Nullable String serviceName);
+    public Builder serviceName(@Nullable String serviceName) {
+      this.serviceName = serviceName;
+      return this;
+    }
 
     /**
      * This ignores the reserved span name "all".
      *
      * @see QueryRequest#spanName()
      */
-    public abstract Builder spanName(@Nullable String spanName);
+    public Builder spanName(@Nullable String spanName) {
+      this.spanName = spanName;
+      return this;
+    }
 
     /**
      * Corresponds to query parameter "annotationQuery". Ex. "http.method=GET and error"
@@ -143,61 +180,73 @@ public abstract class QueryRequest {
     }
 
     /** @see QueryRequest#annotationQuery() */
-    public abstract Builder annotationQuery(Map<String, String> annotationQuery);
+    public Builder annotationQuery(Map<String, String> annotationQuery) {
+      if (annotationQuery == null) throw new NullPointerException("annotationQuery == null");
+      this.annotationQuery = annotationQuery;
+      return this;
+    }
 
     /** @see QueryRequest#minDuration() */
-    public abstract Builder minDuration(@Nullable Long minDuration);
+    public Builder minDuration(@Nullable Long minDuration) {
+      this.minDuration = minDuration;
+      return this;
+    }
 
     /** @see QueryRequest#maxDuration() */
-    public abstract Builder maxDuration(@Nullable Long maxDuration);
+    public Builder maxDuration(@Nullable Long maxDuration) {
+      this.maxDuration = maxDuration;
+      return this;
+    }
 
     /** @see QueryRequest#endTs() */
-    public abstract Builder endTs(long endTs);
+    public Builder endTs(long endTs) {
+      this.endTs = endTs;
+      return this;
+    }
 
     /** @see QueryRequest#lookback() */
-    public abstract Builder lookback(long lookback);
+    public Builder lookback(long lookback) {
+      this.lookback = lookback;
+      return this;
+    }
 
     /** @see QueryRequest#limit() */
-    public abstract Builder limit(int limit);
-
-    // getters for validation
-    @Nullable abstract String serviceName();
-
-    @Nullable abstract String spanName();
-
-    abstract Map<String, String> annotationQuery();
-
-    @Nullable abstract Long minDuration();
-
-    @Nullable abstract Long maxDuration();
-
-    abstract long endTs();
-
-    abstract int limit();
-
-    abstract QueryRequest autoBuild();
+    public Builder limit(int limit) {
+      this.limit = limit;
+      return this;
+    }
 
     public final QueryRequest build() {
       // coerce service and span names to lowercase
-      if (serviceName() != null) serviceName(serviceName().toLowerCase(Locale.ROOT));
-      if (spanName() != null) spanName(spanName().toLowerCase(Locale.ROOT));
+      if (serviceName != null) serviceName = serviceName.toLowerCase(Locale.ROOT);
+      if (spanName != null) spanName = spanName.toLowerCase(Locale.ROOT);
 
       // remove any accidental empty strings
-      annotationQuery().remove("");
-      if ("".equals(serviceName())) serviceName(null);
-      if ("".equals(spanName()) || "all".equals(spanName())) spanName(null);
+      annotationQuery.remove("");
+      if ("".equals(serviceName)) serviceName = null ;
+      if ("".equals(spanName) || "all".equals(spanName)) spanName = null;
 
-      if (endTs() <= 0) throw new IllegalArgumentException("endTs <= 0");
-      if (limit() <= 0) throw new IllegalArgumentException("limit <= 0");
-      if (minDuration() != null) {
-        if (minDuration() <= 0) throw new IllegalArgumentException("minDuration <= 0");
-        if (maxDuration() != null && maxDuration() < minDuration()) {
+      if (endTs <= 0) throw new IllegalArgumentException("endTs <= 0");
+      if (limit <= 0) throw new IllegalArgumentException("limit <= 0");
+      if (minDuration != null) {
+        if (minDuration <= 0) throw new IllegalArgumentException("minDuration <= 0");
+        if (maxDuration != null && maxDuration < minDuration) {
           throw new IllegalArgumentException("maxDuration < minDuration");
         }
-      } else if (maxDuration() != null) {
+      } else if (maxDuration != null) {
         throw new IllegalArgumentException("maxDuration is only valid with minDuration");
       }
-      return autoBuild();
+
+      return new QueryRequest(
+        serviceName,
+        spanName,
+        annotationQuery,
+        minDuration,
+        maxDuration,
+        endTs,
+        lookback,
+        limit
+      );
     }
 
     Builder() {
@@ -270,6 +319,43 @@ public abstract class QueryRequest {
       && testedDuration;
   }
 
-  QueryRequest() {
+
+  final String serviceName, spanName;
+  final Map<String, String> annotationQuery;
+  final Long minDuration, maxDuration;
+  final long endTs, lookback;
+  final int limit;
+
+  QueryRequest(
+    @Nullable String serviceName,
+    @Nullable String spanName,
+    Map<String, String> annotationQuery,
+    @Nullable Long minDuration,
+    @Nullable Long maxDuration,
+    long endTs,
+    long lookback,
+    int limit) {
+    this.serviceName = serviceName;
+    this.spanName = spanName;
+    this.annotationQuery = annotationQuery;
+    this.minDuration = minDuration;
+    this.maxDuration = maxDuration;
+    this.endTs = endTs;
+    this.lookback = lookback;
+    this.limit = limit;
+  }
+
+  @Override
+  public String toString() {
+    return "QueryRequest{"
+      + "serviceName=" + serviceName + ", "
+      + "spanName=" + spanName + ", "
+      + "annotationQuery=" + annotationQuery + ", "
+      + "minDuration=" + minDuration + ", "
+      + "maxDuration=" + maxDuration + ", "
+      + "endTs=" + endTs + ", "
+      + "lookback=" + lookback + ", "
+      + "limit=" + limit
+      + "}";
   }
 }

--- a/zipkin2/src/main/java/zipkin2/storage/QueryRequest.java
+++ b/zipkin2/src/main/java/zipkin2/storage/QueryRequest.java
@@ -228,6 +228,7 @@ public final class QueryRequest {
 
       if (endTs <= 0) throw new IllegalArgumentException("endTs <= 0");
       if (limit <= 0) throw new IllegalArgumentException("limit <= 0");
+      if (lookback <= 0) throw new IllegalArgumentException("lookback <= 0");
       if (minDuration != null) {
         if (minDuration <= 0) throw new IllegalArgumentException("minDuration <= 0");
         if (maxDuration != null && maxDuration < minDuration) {


### PR DESCRIPTION
This removes the auto-value dependency from the zipkin2 core jar as
we only use it in a couple places now. This prevents a version problem
where new versions require a hard dependency. It also reduces the
number of classes and the size (orders of tens of kilobytes
uncompressed).

By default, the maven plugin includes a copy of the pom file, which can
be a kilobyte or more of text. This excludes it in favor of normal
download location.