### PR TITLE
Support for plugin span filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,27 @@ $ ./mvnw -DskipTests --also-make -pl zipkin-server clean install
 $ java -jar ./zipkin-server/target/zipkin-server-*exec.jar
 ```
 
+## Zipkin Filters
+
+Zipkin supports a plugin model for filters. You can take filters off the shelf or create your own. Right now you can 
+filter incoming Spans. This can be useful if you want to block certain Spans from being stored for capacity 
+ reasons, edit contents of Spans for prevent PII data from getting stored, or enrich Spans with additional information.     
+ Please follow the examples mentioned into the links below to find out how to create filters. 
+
+### Zipkin Span Filters
+
+Here is an example enrichment filter that allows you to inject a tag to your spans from environment passed to Zipkin:
+[zipkin-generic-enrichment-filter](https://github.com/afalko/zipkin-generic-enrichment-filter) 
+
+### Configuring Filters
+
+You are responsible for placing any filters onto Spring's loader.path and using `PropertiesLancher` to run Zipkin:
+```
+java -Dloader.path=/path/to/my/filters/ExampleSpanFilter-1.0.0.jar \
+  -cp zipkin-server-*exec.jar \
+  org.springframework.boot.loader.PropertiesLauncher
+```
+
 ## Artifacts
 ### Library Releases
 Releases are uploaded to [Bintray](https://bintray.com/openzipkin/maven/zipkin).

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorComponent.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorComponent.java
@@ -15,6 +15,7 @@ package zipkin2.collector;
 
 import java.util.List;
 import zipkin2.Component;
+import zipkin2.collector.filter.SpanFilter;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.StorageComponent;
 
@@ -51,6 +52,13 @@ public abstract class CollectorComponent extends Component {
      * system. Defaults to always sample.
      */
     public abstract Builder sampler(CollectorSampler sampler);
+
+    /**
+     * {@link SpanFilter allows administrators to add filters to their spans. Defaults to no filters}
+     * @param filters
+     * @return
+     */
+    public abstract Builder filters(List<SpanFilter> filters);
 
     public abstract CollectorComponent build();
   }

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/filter/SpanFilter.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/filter/SpanFilter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.collector.filter;
+
+import zipkin2.Callback;
+import zipkin2.Span;
+import zipkin2.collector.CollectorMetrics;
+
+import java.util.List;
+
+public interface SpanFilter {
+  /**
+   * Process filters given a set of v1 spans. The callback should return a FilterActivatedException if filter
+   * implementor wants to produce custom return codes back to the user.
+   * @param spans
+   * @param metrics
+   * @param callback
+   */
+  List<Span> process(List<Span> spans, CollectorMetrics metrics, Callback<Void> callback);
+}

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.collector.kafka;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -31,6 +32,7 @@ import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
+import zipkin2.collector.filter.SpanFilter;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.StorageComponent;
 
@@ -70,6 +72,12 @@ public final class KafkaCollector extends CollectorComponent {
     @Override
     public Builder sampler(CollectorSampler sampler) {
       delegate.sampler(sampler);
+      return this;
+    }
+
+    @Override
+    public CollectorComponent.Builder filters(List<SpanFilter> filters) {
+      delegate.filters(filters);
       return this;
     }
 

--- a/zipkin-collector/kafka08/src/main/java/zipkin2/collector/kafka08/KafkaCollector.java
+++ b/zipkin-collector/kafka08/src/main/java/zipkin2/collector/kafka08/KafkaCollector.java
@@ -14,6 +14,7 @@
 package zipkin2.collector.kafka08;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
@@ -28,6 +29,7 @@ import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
+import zipkin2.collector.filter.SpanFilter;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.StorageComponent;
 
@@ -64,6 +66,12 @@ public final class KafkaCollector extends CollectorComponent {
     @Override
     public Builder sampler(CollectorSampler sampler) {
       delegate.sampler(sampler);
+      return this;
+    }
+
+    @Override
+    public CollectorComponent.Builder filters(List<SpanFilter> filters) {
+      delegate.filters(filters);
       return this;
     }
 

--- a/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
@@ -30,6 +30,7 @@ import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
+import zipkin2.collector.filter.SpanFilter;
 import zipkin2.storage.StorageComponent;
 
 /** This collector consumes encoded binary messages from a RabbitMQ queue. */
@@ -65,6 +66,12 @@ public final class RabbitMQCollector extends CollectorComponent {
     @Override
     public Builder sampler(CollectorSampler sampler) {
       this.delegate.sampler(sampler);
+      return this;
+    }
+
+    @Override
+    public CollectorComponent.Builder filters(List<SpanFilter> filters) {
+      delegate.filters(filters);
       return this;
     }
 

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
@@ -22,8 +22,11 @@ import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
+import zipkin2.collector.filter.SpanFilter;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.StorageComponent;
+
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.emptyList;
@@ -63,6 +66,12 @@ public final class ScribeCollector extends CollectorComponent {
     @Override
     public Builder sampler(CollectorSampler sampler) {
       delegate.sampler(sampler);
+      return this;
+    }
+
+    @Override
+    public CollectorComponent.Builder filters(List<SpanFilter> filters) {
+      delegate.filters(filters);
       return this;
     }
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -286,6 +286,8 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
+          <!-- This forces Spring Boot to use the PropertiesLauncher for startup, enabling loader.path -->
+          <layout>ZIP</layout>
           <classifier>exec</classifier>
           <executable>true</executable>
           <excludeArtifactIds>logback-classic</excludeArtifactIds>


### PR DESCRIPTION
This is one of the requirements for the architecture described here: https://docs.google.com/document/d/11_MB69A6d_9_N5ClxVcUhKJRMvVI18voV5cGv1Ji5oc/edit?usp=sharing

In addition to SpanFilters we'd like to introduce HttpFilters so that we can respond to things found in HttpHeaders. That would be a follow up PR. 

This is an enrichment filter we plan to deploy to production as our first filter: https://github.com/afalko/zipkin-generic-enrichment-filter . I'm happy to move this filter to openzipkin project if requested. 

Additional filters that we plan to implement:

> ServiceTagMappingFilter
	This filter would take in a static configuration where services claim tag and annotation identifiers. If another service comes in and tries to use a reserved tag, it will get a 409 (conflict) error from our server. An alternative scheme can be developed whereby annotations and tags are namespaced, the drawback of that would be an increase in storage requirements.
	Another way to implement this filter is to remove conflicting tags, but not drop the message. In that case, the regular 202 http message is sent back to the caller. 

> GDPRFilters
	These filters depend on the company and the nature of the data processed by the apps of that company.  There might be cases where the implementer might want to enrich spans or replace the data within the spans. These would likely never have any use if they are open sourced. They are not in the minimum viable change path.


An additional example filter that does blocking can be found here: https://github.com/afalko/ExampleSpanFilter

- [] Utests for failure cases