### PR TITLE
Renames Kafka autoconfig types for easier conditions checks

### DIFF
--- a/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka10/ZipkinKafkaCollectorAutoConfiguration.java
+++ b/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka10/ZipkinKafkaCollectorAutoConfiguration.java
@@ -31,8 +31,8 @@ import zipkin2.storage.StorageComponent;
  */
 @Configuration
 @EnableConfigurationProperties(ZipkinKafkaCollectorProperties.class)
-@Conditional(ZipkinKafka10CollectorAutoConfiguration.KafkaBootstrapServersSet.class)
-class ZipkinKafka10CollectorAutoConfiguration { // makes simple type name unique for /autoconfig
+@Conditional(ZipkinKafkaCollectorAutoConfiguration.KafkaBootstrapServersSet.class)
+class ZipkinKafkaCollectorAutoConfiguration { // makes simple type name unique for /autoconfig
 
   @Bean(initMethod = "start")
   KafkaCollector kafka(

--- a/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka10/ZipkinKafkaCollectorAutoConfiguration.java
+++ b/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka10/ZipkinKafkaCollectorAutoConfiguration.java
@@ -32,7 +32,7 @@ import zipkin2.storage.StorageComponent;
 @Configuration
 @EnableConfigurationProperties(ZipkinKafkaCollectorProperties.class)
 @Conditional(ZipkinKafkaCollectorAutoConfiguration.KafkaBootstrapServersSet.class)
-class ZipkinKafkaCollectorAutoConfiguration { // makes simple type name unique for /autoconfig
+class ZipkinKafkaCollectorAutoConfiguration { // makes simple type name unique for /actuator/conditions
 
   @Bean(initMethod = "start")
   KafkaCollector kafka(

--- a/zipkin-autoconfigure/collector-kafka/src/main/resources/META-INF/spring.factories
+++ b/zipkin-autoconfigure/collector-kafka/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-zipkin.autoconfigure.collector.kafka10.ZipkinKafka10CollectorAutoConfiguration
+zipkin.autoconfigure.collector.kafka10.ZipkinKafkaCollectorAutoConfiguration

--- a/zipkin-autoconfigure/collector-kafka08/src/main/java/zipkin/autoconfigure/collector/kafka/ZipkinKafka08CollectorAutoConfiguration.java
+++ b/zipkin-autoconfigure/collector-kafka08/src/main/java/zipkin/autoconfigure/collector/kafka/ZipkinKafka08CollectorAutoConfiguration.java
@@ -29,7 +29,7 @@ import zipkin2.storage.StorageComponent;
 @Configuration
 @EnableConfigurationProperties(ZipkinKafkaCollectorProperties.class)
 @Conditional(KafkaZooKeeperSetCondition.class)
-class ZipkinKafkaCollectorAutoConfiguration {
+class ZipkinKafka08CollectorAutoConfiguration {
 
   /**
    * This launches a thread to run start. This prevents a several second hang, or worse crash if

--- a/zipkin-autoconfigure/collector-kafka08/src/main/resources/META-INF/spring.factories
+++ b/zipkin-autoconfigure/collector-kafka08/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-zipkin.autoconfigure.collector.kafka.ZipkinKafkaCollectorAutoConfiguration
+zipkin.autoconfigure.collector.kafka.ZipkinKafka08CollectorAutoConfiguration


### PR DESCRIPTION
endpoints like http://192.168.99.100:9411/actuator/conditions are easier to read with this in