### PR TITLE
Attempts to compile with JDK 10

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,8 @@
 # NOTE: Travis tests Elasticsearch and MySQL using Docker, and Kafka manually. We don't redundantly test them here
 machine:
   environment:
-    # Use java 9 here and 1.8 in travis (so that we test both)
-    JAVA_HOME: /usr/lib/jvm/zulu-9-amd64
+    # Use java 10 here and 1.8 in travis (so that we test both)
+    JAVA_HOME: /usr/lib/jvm/zulu-10-amd64
     # Quiet Maven invoker logs (Downloading... when running zipkin-server/src/it)
     MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
@@ -25,7 +25,7 @@ dependencies:
     - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
     - sudo apt-add-repository -y "deb http://repos.azulsystems.com/ubuntu stable main"
     - sudo apt-get -y update
-    - sudo apt-get -y install zulu-9
+    - sudo apt-get -y install zulu-10
     - sudo apt-get install xsltproc
     - ./circleci/go-offline.sh
     - ./mvnw frontend:install-node-and-npm frontend:npm -pl zipkin-ui

--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
         <plugin>
           <groupId>net.orfjackal.retrolambda</groupId>
           <artifactId>retrolambda-maven-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>2.5.4</version>
           <executions>
             <execution>
               <goals>
@@ -780,7 +780,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,10)</version>
+                  <version>[1.8,11)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.zipkin.java</groupId>
@@ -66,9 +68,9 @@
     <guava.version>19.0</guava.version>
     <junit.version>4.12</junit.version>
     <!-- to match powermock and spring testing -->
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>2.18.3</mockito.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
-    <assertj.version>3.9.1</assertj.version>
+    <assertj.version>3.10.0</assertj.version>
     <hamcrest.version>1.3</hamcrest.version>
     <testcontainers.version>1.7.3</testcontainers.version>
 
@@ -599,39 +601,7 @@
           <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
           <source>1.8</source>
           <target>1.8</target>
-          <!-- or die! com.sun.tools.javac.api.JavacTool -->
-          <fork>true</fork>
         </configuration>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <!-- only use errorprone on main source tree -->
-            <configuration>
-              <compilerId>javac-with-errorprone</compilerId>
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
-              <showWarnings>true</showWarnings>
-              <compilerArgs>
-                <arg>-XepDisableWarningsInGeneratedCode</arg>
-              </compilerArgs>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>${plexus-compiler-javac-errorprone.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>${errorprone.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
 
       <!-- Explicitly disable when using java version 1.8+ or not using java -->
@@ -792,6 +762,50 @@
 
   <profiles>
     <profile>
+      <id>errorprone-not-java10</id>
+      <activation>
+        <!-- errorprone doesn't yet support java 10 https://github.com/google/error-prone/issues/860 -->
+        <jdk>[1.8,10)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <!-- only use errorprone on main source tree -->
+                <configuration>
+                  <compilerId>javac-with-errorprone</compilerId>
+                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                  <showWarnings>true</showWarnings>
+                  <compilerArgs>
+                    <arg>-XepDisableWarningsInGeneratedCode</arg>
+                  </compilerArgs>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                <version>${plexus-compiler-javac-errorprone.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>${errorprone.version}</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>release</id>
       <build>
         <plugins>
@@ -846,16 +860,22 @@
     <profile>
       <id>netbeans</id>
       <activation>
-          <activeByDefault>true</activeByDefault>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
         <!-- NetBeans -->
-        <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>2</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>2</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>2</org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>110</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>true</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project
+        </org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>2
+        </org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>2
+        </org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>2
+        </org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>110
+        </org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>true
+        </org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Note: there are some warnings like this using JDK 10.0.1 on osx

```
[WARNING] /Users/acole/oss/zipkin/zipkin-autoconfigure/collector-scribe/src/main/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorAutoConfiguration.java:[-1,-1] /modules/java.base/java/io/InputStream.class: major version 54 is newer than 53, the highest major version supported by this compiler.
  It is recommended that the compiler be upgraded.

```