### PR TITLE
Ensures cassandra self-tracing libraries exist and bumps micrometer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <okio.version>1.14.1</okio.version>
     <!-- important to keep this in sync with spring-boot-dependencies -->
     <jooq.version>3.10.7</jooq.version>
+    <micrometer.version>1.0.4</micrometer.version>
     <spring-boot.version>2.0.2.RELEASE</spring-boot.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
@@ -457,6 +458,11 @@
             <artifactId>zipkin</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.zipkin.brave.cassandra</groupId>
+        <artifactId>brave-instrumentation-cassandra-driver</artifactId>
+        <version>0.7.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/zipkin-autoconfigure/metrics-prometheus/pom.xml
+++ b/zipkin-autoconfigure/metrics-prometheus/pom.xml
@@ -27,7 +27,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <micrometer.version>1.0.3</micrometer.version>
   </properties>
 
   <dependencies>

--- a/zipkin-autoconfigure/storage-cassandra/pom.xml
+++ b/zipkin-autoconfigure/storage-cassandra/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>io.zipkin.brave.cassandra</groupId>
       <artifactId>brave-instrumentation-cassandra-driver</artifactId>
-      <version>0.7.0</version>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/zipkin-autoconfigure/storage-cassandra3/pom.xml
+++ b/zipkin-autoconfigure/storage-cassandra3/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -36,14 +38,13 @@
       <artifactId>zipkin-storage-cassandra</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.zipkin.brave.cassandra</groupId>
-      <artifactId>brave-instrumentation-cassandra-driver</artifactId>
-      <version>0.7.0</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>io.zipkin.zipkin2</groupId>
       <artifactId>zipkin-storage-cassandra-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave.cassandra</groupId>
+      <artifactId>brave-instrumentation-cassandra-driver</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -208,6 +208,11 @@
       <version>${brave.version}</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave.cassandra</groupId>
+      <artifactId>brave-instrumentation-cassandra-driver</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This removes a NCDFE when self-tracing is enabled on cassandra as
reported by @llinder.

```
java.lang.NoClassDefFoundError: brave/cassandra/driver/TracingSession
        at zipkin.autoconfigure.storage.cassandra3.TracingZipkinCassandra3StorageAutoConfiguration.lambda$tracingSessionFactory$0(TracingZipkinCassandra3StorageAutoConfiguration.java:42) ~[zipkin-autoconfigure-storage-cassandra3-2.9.1.jar!/:?]
        at zipkin2.storage.cassandra.CassandraStorage.session(CassandraStorage.java:179) ~[zipkin-storage-cassandra-2.9.1.jar!/:?]
        at zipkin2.storage.cassandra.AutoValue_CassandraStorage.session(AutoValue_CassandraStorage.java:32) ~[zipkin-storage-cassandra-2.9.1.jar!/:?]
        at zipkin2.storage.cassandra.CassandraSpanConsumer.<init>(CassandraSpanConsumer.java:45) ~[zipkin-storage-cassandra-2.9.1.jar!/:?]
        at zipkin2.storage.cassandra.CassandraStorage.spanConsumer(CassandraStorage.java:195) ~[zipkin-storage-cassandra-2.9.1.jar!/:?]
        at zipkin2.storage.cassandra.AutoValue_CassandraStorage.spanConsumer(AutoValue_CassandraStorage.java:62) ~[zipkin-storage-cassandra-2.9.1.jar!/:?]
        at zipkin.server.internal.brave.TracingStorageComponent.spanConsumer(TracingStorageComponent.java:46) ~[classes/:?]
        at zipkin2.collector.Collector.record(Collector.java:150) ~[zipkin-collector-2.9.1.jar!/:?]
```