### PR TITLE
Completes javascript port of v2 -> v1 span conversion

### DIFF
--- a/zipkin2/src/main/java/zipkin2/v1/V2SpanConverter.java
+++ b/zipkin2/src/main/java/zipkin2/v1/V2SpanConverter.java
@@ -170,6 +170,7 @@ public final class V2SpanConverter {
           throw new AssertionError("update kind mapping");
       }
 
+      // If we didn't find a span kind, directly or indirectly, unset the addr
       if (in.remoteEndpoint() == null) addr = null;
     }
   }


### PR DESCRIPTION
There are a number of edge cases that our Java code handles which the
Javascript does not. This will complete the port as a part of migrating
the UI to use v2 endpoints.

See #2047