### PR TITLE
Adds trace IDs to dependency links

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/internal/ZipkinQueryApiV2.java
+++ b/zipkin-server/src/main/java/zipkin/server/internal/ZipkinQueryApiV2.java
@@ -103,7 +103,10 @@ public class ZipkinQueryApiV2 {
       @Nullable @RequestParam(value = "maxDuration", required = false) Long maxDuration,
       @Nullable @RequestParam(value = "endTs", required = false) Long endTs,
       @Nullable @RequestParam(value = "lookback", required = false) Long lookback,
-      @RequestParam(value = "limit", defaultValue = "10") int limit)
+      @RequestParam(value = "limit", defaultValue = "10") int limit,
+      @Nullable @RequestParam(value = "parentService", required = false) String parentServiceName,
+      @Nullable @RequestParam(value = "childService", required = false) String childServiceName,
+      @RequestParam(value = "fetchErrors", required = false) boolean fetchErrors)
       throws IOException {
     QueryRequest queryRequest =
         QueryRequest.newBuilder()
@@ -115,6 +118,9 @@ public class ZipkinQueryApiV2 {
             .endTs(endTs != null ? endTs : System.currentTimeMillis())
             .lookback(lookback != null ? lookback : defaultLookback)
             .limit(limit)
+            .parentServiceName(parentServiceName)
+            .childServiceName(childServiceName)
+            .fetchErrors(fetchErrors)
             .build();
 
     List<List<Span>> traces = storage.spanStore().getTraces(queryRequest).execute();

--- a/zipkin-server/src/main/java/zipkin/server/internal/brave/TracingStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin/server/internal/brave/TracingStorageComponent.java
@@ -70,6 +70,10 @@ public final class TracingStorageComponent extends StorageComponent {
       return new TracedCall<>(tracer, delegate.getTrace(traceId), "get-trace");
     }
 
+    @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+      return new TracedCall<>(tracer, delegate.getTraces(traceIds), "get-traces");
+    }
+
     @Override
     public Call<List<String>> getServiceNames() {
       return new TracedCall<>(tracer, delegate.getServiceNames(), "get-service-names");

--- a/zipkin-server/src/main/java/zipkin/server/internal/brave/TracingStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin/server/internal/brave/TracingStorageComponent.java
@@ -20,10 +20,7 @@ import java.util.List;
 import zipkin2.Call;
 import zipkin2.DependencyLink;
 import zipkin2.Span;
-import zipkin2.storage.QueryRequest;
-import zipkin2.storage.SpanConsumer;
-import zipkin2.storage.SpanStore;
-import zipkin2.storage.StorageComponent;
+import zipkin2.storage.*;
 
 // public for use in ZipkinServerConfiguration
 public final class TracingStorageComponent extends StorageComponent {
@@ -62,6 +59,11 @@ public final class TracingStorageComponent extends StorageComponent {
 
     @Override
     public Call<List<List<Span>>> getTraces(QueryRequest request) {
+      return new TracedCall<>(tracer, delegate.getTraces(request), "get-traces");
+    }
+
+    @Override
+    public Call<List<List<Span>>> getTraces(DependencyQueryRequest request) {
       return new TracedCall<>(tracer, delegate.getTraces(request), "get-traces");
     }
 

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
@@ -153,6 +153,10 @@ public final class CassandraSpanStore implements SpanStore {
     return spans.newCall(normalizedTraceId);
   }
 
+  @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+    return spans.newCall(traceIds);
+  }
+
   @Override
   public Call<List<String>> getServiceNames() {
     return serviceNames.clone();

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/integration/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/integration/ITCassandraStorage.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra.v1.integration;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import zipkin2.storage.StorageComponent;
+import zipkin2.storage.cassandra.v1.CassandraStorage;
+import zipkin2.storage.cassandra.v1.CassandraStorageRule;
+import zipkin2.storage.cassandra.v1.InternalForTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.storage.cassandra.v1.InternalForTests.dropKeyspace;
+import static zipkin2.storage.cassandra.v1.InternalForTests.keyspace;
+
+@RunWith(Enclosed.class)
+public class ITCassandraStorage {
+
+  static CassandraStorageRule classRule() {
+    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.4.6", "test_cassandra3");
+  }
+
+  public static class ITStrictTraceIdFalse extends zipkin2.storage.ITStrictTraceIdFalse {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    CassandraStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().keyspace(keyspace(testName))
+        .strictTraceId(false).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() {
+      dropKeyspace(backend.session(), keyspace(testName));
+    }
+  }
+
+  public static class ITSpanStore extends zipkin2.storage.ITSpanStore {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    @Override @Test @Ignore("Multiple services unsupported") public void getTraces_tags()
+      throws Exception {
+      super.getTraces_tags();
+    }
+
+    @Override @Test @Ignore("Duration unsupported") public void getTraces_minDuration()
+      throws Exception {
+      super.getTraces_minDuration();
+    }
+
+    @Override @Test @Ignore("Duration unsupported") public void getTraces_maxDuration()
+      throws Exception {
+      super.getTraces_maxDuration();
+    }
+
+    CassandraStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().keyspace(keyspace(testName))
+        .build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() {
+      dropKeyspace(backend.session(), keyspace(testName));
+    }
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
@@ -19,6 +19,7 @@ import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.utils.UUIDs;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -199,6 +200,10 @@ class CassandraSpanStore implements SpanStore { // not final for testing
     // make sure we have a 16 or 32 character trace ID
     String normalizedTraceId = Span.normalizeTraceId(traceId);
     return spans.newCall(normalizedTraceId);
+  }
+
+  @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+    return spans.newCall(traceIds);
   }
 
   @Override

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
@@ -17,19 +17,16 @@ import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.utils.UUIDs;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.Call;
 import zipkin2.DependencyLink;
 import zipkin2.Span;
+import zipkin2.storage.DependencyQueryRequest;
 import zipkin2.storage.QueryRequest;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.cassandra.internal.call.IntersectKeySets;
@@ -141,6 +138,24 @@ class CassandraSpanStore implements SpanStore { // not final for testing
     IntersectKeySets intersectedTraceIds = new IntersectKeySets(callsToIntersect);
     // @xxx the sorting by timestamp desc is broken here^
     return intersectedTraceIds.flatMap(spans.newFlatMapper(request));
+  }
+
+  @Override
+  public Call<List<List<Span>>> getTraces(DependencyQueryRequest request) {
+    // TODO: refactor to share this code between different SpanStore implementations
+    return getDependencies(request.endTs, request.limit).flatMap((links) -> {
+      for (DependencyLink link : links) {
+        if (request.parentServiceName.equals(link.parent()) && request.childServiceName.equals(link.child())) {
+          if (request.errorsOnly) {
+            return getTraces(link.errorTraceIds());
+          } else {
+            return getTraces(link.callTraceIds());
+          }
+        }
+      }
+
+      return Call.create(Collections.emptyList());
+    });
   }
 
   /**

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
@@ -19,6 +19,7 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -92,6 +93,22 @@ final class SelectFromSpan extends ResultSetFutureCall {
 
       Call<List<Span>> result = new SelectFromSpan(this, traceIds, maxTraceCols).flatMap(readSpans);
       return strictTraceId ? result.map(StrictTraceId.filterSpans(hexTraceId)) : result;
+    }
+
+    Call<List<List<Span>>> newCall(List<String> traceIds) {
+      Set<String> normalizedTraceIds = new LinkedHashSet<>();
+      for (String traceId : traceIds) {
+        // make sure we have a 16 or 32 character trace ID
+        traceId = Span.normalizeTraceId(traceId);
+        // Unless we are strict, truncate the trace ID to 64bit (encoded as 16 characters)
+        if (!strictTraceId && traceId.length() == 32) traceId = traceId.substring(16);
+        normalizedTraceIds.add(traceId);
+      }
+      Call<List<List<Span>>> result = new SelectFromSpan(this,
+        normalizedTraceIds,
+        maxTraceCols)
+        .flatMap(readSpans).map(groupByTraceId);
+      return strictTraceId ? result.map(StrictTraceId.filterTraces(normalizedTraceIds)) : result;
     }
 
     FlatMapper<Set<String>, List<List<Span>>> newFlatMapper(QueryRequest request) {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/integration/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/integration/ITCassandraStorage.java
@@ -64,4 +64,44 @@ public class ITCassandraStorage {
       dropKeyspace(backend.session(), keyspace(testName));
     }
   }
+
+  public static class ITStrictTraceIdFalse extends zipkin2.storage.ITStrictTraceIdFalse {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    CassandraStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().keyspace(keyspace(testName))
+        .strictTraceId(false).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() {
+      dropKeyspace(backend.session(), keyspace(testName));
+    }
+  }
+
+  public static class ITSpanStore extends zipkin2.storage.ITSpanStore {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    CassandraStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().keyspace(keyspace(testName))
+        .build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() {
+      dropKeyspace(backend.session(), keyspace(testName));
+    }
+  }
 }

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
@@ -13,9 +13,11 @@
  */
 package zipkin2.elasticsearch;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import zipkin2.Call;
 import zipkin2.DependencyLink;
 import zipkin2.Span;
@@ -119,6 +121,22 @@ final class ElasticsearchSpanStore implements SpanStore {
 
     SearchRequest request = SearchRequest.create(asList(allSpanIndices)).term("traceId", traceId);
     return search.newCall(request, BodyConverters.SPANS);
+  }
+
+  @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+    Set<String> normalizedTraceIds = new LinkedHashSet<>();
+    for (String traceId : traceIds) {
+      // make sure we have a 16 or 32 character trace ID
+      traceId = Span.normalizeTraceId(traceId);
+
+      // Unless we are strict, truncate the trace ID to 64bit (encoded as 16 characters)
+      if (!strictTraceId && traceId.length() == 32) traceId = traceId.substring(16);
+
+      normalizedTraceIds.add(traceId);
+    }
+    SearchRequest request =
+      SearchRequest.create(asList(allSpanIndices)).terms("traceId", normalizedTraceIds);
+    return search.newCall(request, BodyConverters.SPANS).map(groupByTraceId);
   }
 
   @Override

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/SearchRequest.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/SearchRequest.java
@@ -63,42 +63,6 @@ public final class SearchRequest {
       add(new Term(field, value));
       return this;
     }
-
-    public Filters addNestedTerms(Collection<String> nestedFields, String value) {
-      add(_nestedTermsEqual(nestedFields, value));
-      return this;
-    }
-
-    public Filters addNestedTerms(Map<String, String>... nestedTerms) {
-      if (nestedTerms.length == 1) {
-        add(mustMatchAllNestedTerms(nestedTerms[0]));
-        return this;
-      }
-      List<NestedBoolQuery> nestedBoolQueries = new ArrayList<>(nestedTerms.length);
-      for (Map<String, String> next : nestedTerms) {
-        nestedBoolQueries.add(mustMatchAllNestedTerms(next));
-      }
-      add(new SearchRequest.BoolQuery("should", nestedBoolQueries));
-      return this;
-    }
-
-    static SearchRequest.BoolQuery _nestedTermsEqual(Collection<String> nestedFields, String value) {
-      List<SearchRequest.NestedBoolQuery> conditions = new ArrayList<>();
-      for (String nestedField : nestedFields) {
-        conditions.add(new NestedBoolQuery(nestedField.substring(0, nestedField.indexOf('.')), "must",
-          new SearchRequest.Term(nestedField, value)));
-      }
-      return new SearchRequest.BoolQuery("should", conditions);
-    }
-
-    static NestedBoolQuery mustMatchAllNestedTerms(Map<String, String> next) {
-      List<Term> terms = new ArrayList<>();
-      String field = null;
-      for (Map.Entry<String, String> nestedTerm : next.entrySet()) {
-        terms.add(new Term(field = nestedTerm.getKey(), nestedTerm.getValue()));
-      }
-      return new NestedBoolQuery(field.substring(0, field.indexOf('.')), "must", terms);
-    }
   }
 
   public SearchRequest filters(Filters filters) {
@@ -109,7 +73,7 @@ public final class SearchRequest {
     return query(new Term(field, value));
   }
 
-  public SearchRequest terms(String field, List<String> values) {
+  public SearchRequest terms(String field, Collection<String> values) {
     return query(new Terms(field, values));
   }
 
@@ -135,14 +99,6 @@ public final class SearchRequest {
 
     Term(String field, String value) {
       term = Collections.singletonMap(field, value);
-    }
-  }
-
-  static class Exists {
-    final Map<String, String> exists;
-
-    Exists(String field) {
-      exists = Collections.singletonMap("field", field);
     }
   }
 
@@ -179,22 +135,6 @@ public final class SearchRequest {
 
     BoolQuery(String op, Object clause) {
       bool = Collections.singletonMap(op, clause);
-    }
-  }
-
-  static class NestedBoolQuery {
-    final Map<String, Object> nested;
-
-    NestedBoolQuery(String path, String condition, List<Term> terms) {
-      nested = new LinkedHashMap<>(2);
-      nested.put("path", path);
-      nested.put("query", new BoolQuery(condition, terms));
-    }
-
-    NestedBoolQuery(String path, String condition, Term term) {
-      nested = new LinkedHashMap<>(2);
-      nested.put("path", path);
-      nested.put("query", new BoolQuery(condition, term));
     }
   }
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
@@ -52,4 +52,43 @@ public class ITElasticsearchStorageV2 {
       storage.clear();
     }
   }
+
+  public static class ITStrictTraceIdFalse extends zipkin2.storage.ITStrictTraceIdFalse {
+    @ClassRule public static ElasticsearchStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    ElasticsearchStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().index(index(testName))
+        .strictTraceId(false).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
+
+  public static class ITSpanStore extends zipkin2.storage.ITSpanStore {
+    @ClassRule public static ElasticsearchStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    ElasticsearchStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().index(index(testName)).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
@@ -52,4 +52,43 @@ public class ITElasticsearchStorageV5 {
       storage.clear();
     }
   }
+
+  public static class ITStrictTraceIdFalse extends zipkin2.storage.ITStrictTraceIdFalse {
+    @ClassRule public static ElasticsearchStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    ElasticsearchStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().index(index(testName))
+        .strictTraceId(false).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
+
+  public static class ITSpanStore extends zipkin2.storage.ITSpanStore {
+    @ClassRule public static ElasticsearchStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    ElasticsearchStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().index(index(testName)).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -52,4 +52,43 @@ public class ITElasticsearchStorageV6 {
       storage.clear();
     }
   }
+
+  public static class ITStrictTraceIdFalse extends zipkin2.storage.ITStrictTraceIdFalse {
+    @ClassRule public static ElasticsearchStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    ElasticsearchStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().index(index(testName))
+        .strictTraceId(false).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
+
+  public static class ITSpanStore extends zipkin2.storage.ITSpanStore {
+    @ClassRule public static ElasticsearchStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    ElasticsearchStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().index(index(testName)).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
 }

--- a/zipkin-storage/mysql-v1/pom.xml
+++ b/zipkin-storage/mysql-v1/pom.xml
@@ -47,6 +47,14 @@
       <artifactId>jooq</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
     <!-- add v1 dependency for integration tests -->
     <dependency>
       <groupId>io.zipkin.java</groupId>

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/MySQLSpanStore.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/MySQLSpanStore.java
@@ -69,6 +69,16 @@ final class MySQLSpanStore implements SpanStore {
   }
 
   @Override
+  public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+    Call<List<List<Span>>> result =
+      dataSourceCallFactory
+        .create(selectFromSpansAndAnnotationsFactory.create(traceIds))
+        .map(groupByTraceId);
+
+    return strictTraceId ? result.map(StrictTraceId.filterTraces(traceIds)) : result;
+  }
+
+  @Override
   public Call<List<String>> getServiceNames() {
     return getServiceNamesCall.clone();
   }

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/Schema.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/Schema.java
@@ -122,7 +122,18 @@ final class Schema {
         : ZIPKIN_SPANS.TRACE_ID.eq(traceIdLow);
   }
 
+  Condition spanTraceIdCondition(Set<Pair> traceIds) {
+    return traceIdCondition(ZIPKIN_SPANS.TRACE_ID_HIGH, ZIPKIN_SPANS.TRACE_ID, traceIds);
+  }
+
   Condition annotationsTraceIdCondition(Set<Pair> traceIds) {
+    return traceIdCondition(ZIPKIN_ANNOTATIONS.TRACE_ID_HIGH, ZIPKIN_ANNOTATIONS.TRACE_ID, traceIds);
+  }
+
+  Condition traceIdCondition(
+    TableField<Record, Long> TRACE_ID_HIGH,
+    TableField<Record, Long> TRACE_ID, Set<Pair> traceIds
+  ) {
     boolean hasTraceIdHigh = false;
     for (Pair traceId : traceIds) {
       if (traceId.left != 0) {
@@ -136,14 +147,14 @@ final class Schema {
       for (Pair traceId128 : traceIds) {
         result[i++] = row(traceId128.left, traceId128.right);
       }
-      return row(ZIPKIN_ANNOTATIONS.TRACE_ID_HIGH, ZIPKIN_ANNOTATIONS.TRACE_ID).in(result);
+      return row(TRACE_ID_HIGH, TRACE_ID).in(result);
     } else {
       Long[] result = new Long[traceIds.size()];
       int i = 0;
       for (Pair traceId128 : traceIds) {
         result[i++] = traceId128.right;
       }
-      return ZIPKIN_ANNOTATIONS.TRACE_ID.in(result);
+      return TRACE_ID.in(result);
     }
   }
 

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -81,4 +81,34 @@ public class ITMySQLStorage {
       storage.clear();
     }
   }
+
+  public static class ITSpanStore extends zipkin2.storage.ITSpanStore {
+    @ClassRule public static LazyMySQLStorage storage = classRule();
+
+    @Override protected zipkin2.storage.StorageComponent storage() {
+      return storage.get();
+    }
+
+    @Override
+    public void clear() {
+      storage.get().clear();
+    }
+  }
+
+  public static class ITStrictTraceIdFalse extends zipkin2.storage.ITStrictTraceIdFalse {
+    @ClassRule public static LazyMySQLStorage storageRule = classRule();
+
+    MySQLStorage storage;
+
+    @Override protected zipkin2.storage.StorageComponent storage() {
+      return storage;
+    }
+
+    @Override public void clear() {
+      storage = storageRule.computeStorageBuilder()
+        .strictTraceId(false)
+        .build();
+      storage.clear();
+    }
+  }
 }

--- a/zipkin-ui/js/component_data/dependency.js
+++ b/zipkin-ui/js/component_data/dependency.js
@@ -1,6 +1,7 @@
 import {component} from 'flightjs';
 import moment from 'moment';
 import $ from 'jquery';
+import {traceSummary, traceSummariesToMustache} from '../component_ui/traceSummary';
 
 export default component(function dependency() {
   let services = {};
@@ -28,18 +29,34 @@ export default component(function dependency() {
     });
   };
 
+  this.filterDependency = function(parent, child, endTs, lookback, limit, error, serviceName) {
+    const apiURL = `api/v2/traces?parentService=${parent}&childService=${child}&lookback=
+    ${lookback}&endTs=${endTs}&limit=${limit}&error=${error}`;
+    $.ajax(apiURL, {
+      type: 'GET',
+      dataType: 'json'
+    }).done(traces => {
+      const traceView = {
+        traces: traceSummariesToMustache('all', traces.map(traceSummary)),
+        apiURL,
+        rawResponse: traces,
+        serviceName
+      };
+      this.trigger('filterLinkDataRecieved', traceView);
+    }).fail(e => {
+      this.trigger('defaultPageModelView', {traces: 'No traces to show', error: e});
+    });
+  };
+
   this.buildServiceData = function(links) {
     services = {};
     dependencies = {};
     links.forEach(link => {
       const {parent, child} = link;
-
       dependencies[parent] = dependencies[parent] || {};
       dependencies[parent][child] = link;
-
       services[parent] = services[parent] || {serviceName: parent, uses: [], usedBy: []};
       services[child] = services[child] || {serviceName: child, uses: [], usedBy: []};
-
       services[parent].uses.push(child);
       services[child].usedBy.push(parent);
     });
@@ -61,7 +78,6 @@ export default component(function dependency() {
         this.trigger(document, 'parentChildDataReceived', data);
       });
     });
-
     const endTs = document.getElementById('endTs').value || moment().valueOf();
     const startTs = document.getElementById('startTs').value;
     let lookback;
@@ -69,6 +85,11 @@ export default component(function dependency() {
       lookback = endTs - startTs;
     }
     this.getDependency(endTs, lookback);
+    this.on(document, 'filterLinkDataRequested',
+    function(event, {parentService, childService, limit, error, serviceName}) {
+      this.filterDependency(parentService, childService, endTs,
+        lookback, limit, error, serviceName);
+    });
   });
 
   this.getServiceData = function(serviceName, callback) {

--- a/zipkin-ui/js/component_ui/serviceDataModal.js
+++ b/zipkin-ui/js/component_ui/serviceDataModal.js
@@ -1,7 +1,9 @@
 import {component} from 'flightjs';
 import $ from 'jquery';
 import bootstrap // eslint-disable-line no-unused-vars
-    from 'bootstrap-sass/assets/javascripts/bootstrap.js';
+from 'bootstrap-sass/assets/javascripts/bootstrap.js';
+import TracesUI from './traces';
+import {tracesTemplate} from '../templates';
 
 function renderDependencyModal(event, data) {
   const $modal = $('#dependencyModal');
@@ -20,7 +22,6 @@ function renderDependencyModal(event, data) {
       serviceName: data.child
     });
   });
-
   $modal.find('#dependencyModalParent').html($parentElement);
   $modal.find('#dependencyModalChild').html($childElement);
   $modal.find('#dependencyCallCount').text(data.callCount);
@@ -72,8 +73,20 @@ function renderServiceDataModal(event, data) {
 }
 
 export default component(function serviceDataModal() {
+  this.attributes({
+    filterForm: '#filterForm',
+    selectlimit: ':input[name=limit]',
+    selecterorr: '#errorradio :selected'
+  });
+
   this.showServiceDataModal = function(event, data) {
     this.trigger(document, 'serviceDataRequested', {
+      serviceName: data.serviceName
+    });
+  };
+
+  this.showTracesForLinkedServices = function(event, data) {
+    this.trigger(document, 'filterLinkDataRequested', {
       serviceName: data.serviceName
     });
   };
@@ -85,11 +98,35 @@ export default component(function serviceDataModal() {
       callCount: data.callCount
     });
   };
+  this.renderItems = function(event, modelView) {
+    event.preventDefault();
+    event.stopPropagation();
+    $('#traces').html(tracesTemplate({
+      ...modelView
+    }));
+    TracesUI.attachTo('#traces');
+  };
 
+  this.filterLinkDependency = function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    // TODO: Find a better way to get the filter values
+    this.trigger(document, 'filterLinkDataRequested', {
+      limit: document.getElementById('limit').value,
+      error: document.getElementById('erroronly').checked || false,
+      parentService: document.getElementById('dependencyModalParent').children[0].text,
+      childService: document.getElementById('dependencyModalChild').children[0].text,
+      serviceName: document.getElementById('serviceModalTitle').textContent
+    });
+  };
   this.after('initialize', function() {
     this.on(document, 'showServiceDataModal', this.showServiceDataModal);
     this.on(document, 'showDependencyModal', this.showDependencyModal);
     this.on(document, 'serviceDataReceived', renderServiceDataModal);
     this.on(document, 'parentChildDataReceived', renderDependencyModal);
+    this.on('#filterTraceBtn', 'click', {
+      filterForm: this.filterLinkDependency,
+    });
+    this.on(document, 'filterLinkDataRecieved', this.renderItems);
   });
 });

--- a/zipkin-ui/js/page/dependency.js
+++ b/zipkin-ui/js/page/dependency.js
@@ -25,6 +25,7 @@ const DependencyPageComponent = component(function DependencyPage() {
     DependencyData.attachTo('#dependency-container');
     DependencyGraphUI.attachTo('#dependency-container', {config: this.attr.config});
     ServiceDataModal.attachTo('#service-data-modal-container');
+    ServiceDataModal.attachTo('#filterForm');
     TimeStampUI.attachTo('#end-ts');
     TimeStampUI.attachTo('#start-ts');
     GoToDependencyUI.attachTo('#dependency-query-form');

--- a/zipkin-ui/js/templates.js
+++ b/zipkin-ui/js/templates.js
@@ -4,3 +4,5 @@ export const layoutTemplate = require('../templates/layout.mustache');
 export const dependenciesTemplate = require('../templates/dependency.mustache');
 export const traceTemplate = require('../templates/trace.mustache');
 export const traceViewerTemplate = require('../templates/traceViewer.mustache');
+export const tracesTemplate = require('../templates/traces.mustache');
+

--- a/zipkin-ui/templates/dependency.mustache
+++ b/zipkin-ui/templates/dependency.mustache
@@ -23,13 +23,12 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+          <button type="button" id="dependencyclose" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
           <h3 class="modal-title">
             <span id="serviceModalTitle">[title]</span>
           </h3>
         </div>
         <div class="modal-body">
-
           <div class="container">
             <div class="row">
               <div class="col-sm-6">
@@ -48,7 +47,7 @@
   </div>
 
   <div class="modal" id="dependencyModal" tabindex="-1">
-    <div class="modal-dialog">
+    <div class="modal-dialog" style="min-width: 80%">
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
@@ -56,7 +55,6 @@
             <div id="dependencyModalParent">[parent]</div>
             <div class=""><span class="glyphicon glyphicon-arrow-down"></span></div>
             <div id="dependencyModalChild">[child]</div>
-
           </h3>
         </div>
         <div class="modal-body">
@@ -78,6 +76,35 @@
             </tr>
             </tbody>
           </table>
+          <div class="panel panel-default">
+            <div class="panel-heading">          
+              <h4 text-center> Filter Traces </h4>
+            </div>
+            <div class="panel-body">
+              <form role='form' id="filterForm">
+              <div class="form-group">
+                <label for="limit" data-i18n="traces.limit">Limit</label>
+                <input class="form-control input-sm" id="limit" name="limit" type="text" value="{{limit}}">
+              </div>
+              <div class="form-group">
+                {{! <label class="radio-inline">
+                  <input id="alltrace" type="radio" name="alltrace">All Traces
+                </label>
+                <label class="radio-inline">
+                  <input id="erroronly" type="radio" name="erroronly">Errors only
+                </label> }}
+                <div class="custom-control custom-checkbox">
+                  <input id="erroronly" type="checkbox" class="custom-control-input" id="customCheck1">
+                  <label class="custom-control-label" for="customCheck1">Fetch only errors</label>
+                </div>
+              </div>
+              <div class="form-group">
+                <button type="button" id="filterTraceBtn" class="btn btn-primary btn-lg" data-i18n="traces.findBtn">Filter Traces</button>
+              </div>
+              </form>
+              <ul id="traces" />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/zipkin-ui/templates/traces.mustache
+++ b/zipkin-ui/templates/traces.mustache
@@ -1,0 +1,24 @@
+<hr><h6> Filter Results </h6><hr>
+{{#traces}}
+<li class="trace {{infoClass}}" data-traceId="{{traceId}}" data-duration="{{duration}}" data-timestamp="{{timestamp}}" data-service-percentage="{{servicePercentage}}">
+  <a href="{{contextRoot}}traces/{{traceId}}">
+    <div class="bar-block">
+      <span class="bar-graphic" style="width:{{width}}%;"></span>
+      <span class="bar-label">{{durationStr}}</span>
+      <span class="bar-label">{{totalSpans}} spans</span>
+    </div>
+    <div class="bar-block">
+      <span class="bar-graphic" style="width:{{servicePercentage}}%;"></span>
+      <span class="bar-label">{{serviceName}} {{servicePercentage}}%</span>
+    </div>
+  </a>
+  <div class="trace-details services">
+    {{#serviceDurations}}
+    <span class="label label-default service-filter-label" data-service-name="{{name}}">{{name}}
+                          x{{count}} {{max}}ms</span> {{/serviceDurations}}
+  </div>
+  <div class="trace-details timestamp pull-right">
+    <time class="label timeago" datetime="{{startTs}}">{{startTs}}</time>
+  </div>
+</li>
+{{/traces}}

--- a/zipkin2/src/main/java/zipkin2/storage/DependencyQueryRequest.java
+++ b/zipkin2/src/main/java/zipkin2/storage/DependencyQueryRequest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import zipkin2.internal.Nullable;
+
+public final class DependencyQueryRequest {
+
+  public Builder toBuilder() { return new Builder(this); }
+
+  public static Builder newBuilder() { return new Builder(); }
+
+  public static final class Builder {
+
+    private String parentServiceName;
+    private String childServiceName;
+    private long endTs, lookback;
+    private int limit;
+    private boolean errorsOnly;
+
+    Builder() {}
+
+    Builder(DependencyQueryRequest source) {
+      parentServiceName = source.parentServiceName;
+      childServiceName = source.childServiceName;
+      endTs = source.endTs;
+      lookback = source.lookback;
+      limit = source.limit;
+      errorsOnly = source.errorsOnly;
+    }
+
+    public Builder parentServiceName(String parentServiceName) {
+      this.parentServiceName = parentServiceName;
+      return this;
+    }
+
+    public Builder childServiceName(String childServiceName) {
+      this.childServiceName = childServiceName;
+      return this;
+    }
+
+    public Builder endTs(long endTs) {
+      this.endTs = endTs;
+      return this;
+    }
+
+    public Builder lookback(long lookback) {
+      this.lookback = lookback;
+      return this;
+    }
+
+    public Builder limit(int limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder errorsOnly(boolean errorsOnly) {
+      this.errorsOnly = errorsOnly;
+      return this;
+    }
+
+    public final DependencyQueryRequest build() {
+      if ("".equals(parentServiceName)) throw new IllegalArgumentException("parentServiceName == ''");
+      if ("".equals(childServiceName)) throw new IllegalArgumentException("childServiceName == ''");
+      if (parentServiceName == null) throw new IllegalArgumentException("parentServiceName == null");
+      if (childServiceName == null) throw new IllegalArgumentException("childServiceName == null");
+      if (endTs <= 0) throw new IllegalArgumentException("endTs <= 0");
+      if (limit <= 0) throw new IllegalArgumentException("limit <= 0");
+      if (lookback <= 0) throw new IllegalArgumentException("lookback <= 0");
+
+      return new DependencyQueryRequest(
+        parentServiceName,
+        childServiceName,
+        endTs,
+        lookback,
+        limit,
+        errorsOnly
+      );
+    }
+  }
+
+  public final String parentServiceName;
+  public final String childServiceName;
+  public final long endTs, lookback;
+  public final int limit;
+  public final Boolean errorsOnly;
+
+  private DependencyQueryRequest(
+    String parentServiceName,
+    String childServiceName,
+    long endTs,
+    long lookback,
+    int limit,
+    @Nullable Boolean errorsOnly
+  ) {
+    this.parentServiceName = parentServiceName;
+    this.childServiceName = childServiceName;
+    this.endTs = endTs;
+    this.lookback = lookback;
+    this.limit = limit;
+    this.errorsOnly = errorsOnly;
+  }
+
+  @Override
+  public String toString() {
+    return "DependencyQueryRequest{"
+      + "parentServiceName=" + parentServiceName + ", "
+      + "childServiceName=" + childServiceName + ", "
+      + "endTs=" + endTs + ", "
+      + "lookback=" + lookback + ", "
+      + "limit=" + limit + ", "
+      + "errorsOnly=" + errorsOnly
+      + "}";
+  }
+
+}

--- a/zipkin2/src/main/java/zipkin2/storage/QueryRequest.java
+++ b/zipkin2/src/main/java/zipkin2/storage/QueryRequest.java
@@ -98,6 +98,22 @@ public final class QueryRequest {
     return limit;
   }
 
+  /** Parent service name to fetch for the link dependency */
+  @Nullable
+  public String parentServiceName(){
+    return parentServiceName;
+  }
+
+  /** Child service name to fetch for the link dependency */
+  @Nullable
+  public String childServiceName(){
+    return childServiceName;
+  }
+
+  /** Only return {@link Span} which has error */
+  public boolean fetchErrors(){
+    return fetchErrors;
+  }
   /**
    * Corresponds to query parameter "annotationQuery". Ex. "http.method=GET and error"
    *
@@ -126,11 +142,12 @@ public final class QueryRequest {
   }
 
   public static final class Builder {
-    String serviceName, spanName;
+    String serviceName, spanName, parentServiceName, childServiceName;
     Map<String, String> annotationQuery = Collections.emptyMap();
     Long minDuration, maxDuration;
     long endTs, lookback;
     int limit;
+    boolean fetchErrors;
 
     Builder(QueryRequest source) {
       serviceName = source.serviceName;
@@ -141,6 +158,9 @@ public final class QueryRequest {
       endTs = source.endTs;
       lookback = source.lookback;
       limit = source.limit;
+      parentServiceName = source.parentServiceName;
+      childServiceName = source.childServiceName;
+      fetchErrors = source.fetchErrors;
     }
 
     /** @see QueryRequest#serviceName() */
@@ -216,15 +236,34 @@ public final class QueryRequest {
       return this;
     }
 
+    /** @see QueryRequest#parentServiceName */
+    public Builder parentServiceName(String parentServiceName){
+      this.parentServiceName = parentServiceName;
+      return this;
+    }
+
+    /** @see QueryRequest#childServiceName */
+    public Builder childServiceName(String childServiceName){
+      this.childServiceName = childServiceName;
+      return this;
+    }
+    /** @see QueryRequest#fetchErrors */
+    public Builder fetchErrors(boolean fetchErrors){
+      this.fetchErrors = fetchErrors;
+      return this;
+    }
     public final QueryRequest build() {
       // coerce service and span names to lowercase
       if (serviceName != null) serviceName = serviceName.toLowerCase(Locale.ROOT);
       if (spanName != null) spanName = spanName.toLowerCase(Locale.ROOT);
-
+      if (parentServiceName != null) parentServiceName = parentServiceName.toLowerCase(Locale.ROOT);
+      if (childServiceName != null) childServiceName = childServiceName.toLowerCase(Locale.ROOT);
       // remove any accidental empty strings
       annotationQuery.remove("");
       if ("".equals(serviceName)) serviceName = null ;
       if ("".equals(spanName) || "all".equals(spanName)) spanName = null;
+      if ("".equals(parentServiceName)) parentServiceName = null ;
+      if ("".equals(childServiceName)) childServiceName = null ;
 
       if (endTs <= 0) throw new IllegalArgumentException("endTs <= 0");
       if (limit <= 0) throw new IllegalArgumentException("limit <= 0");
@@ -246,7 +285,10 @@ public final class QueryRequest {
         maxDuration,
         endTs,
         lookback,
-        limit
+        limit,
+        parentServiceName,
+        childServiceName,
+        fetchErrors
       );
     }
 
@@ -321,11 +363,12 @@ public final class QueryRequest {
   }
 
 
-  final String serviceName, spanName;
+  final String serviceName, spanName, parentServiceName, childServiceName;
   final Map<String, String> annotationQuery;
   final Long minDuration, maxDuration;
   final long endTs, lookback;
   final int limit;
+  final boolean fetchErrors;
 
   QueryRequest(
     @Nullable String serviceName,
@@ -335,7 +378,10 @@ public final class QueryRequest {
     @Nullable Long maxDuration,
     long endTs,
     long lookback,
-    int limit) {
+    int limit,
+    @Nullable String parentServiceName,
+    @Nullable String childServiceName,
+    boolean fetchErrors) {
     this.serviceName = serviceName;
     this.spanName = spanName;
     this.annotationQuery = annotationQuery;
@@ -344,19 +390,27 @@ public final class QueryRequest {
     this.endTs = endTs;
     this.lookback = lookback;
     this.limit = limit;
+    this.parentServiceName = parentServiceName;
+    this.childServiceName = childServiceName;
+    this.fetchErrors = fetchErrors;
   }
 
-  @Override
-  public String toString() {
-    return "QueryRequest{"
-      + "serviceName=" + serviceName + ", "
-      + "spanName=" + spanName + ", "
-      + "annotationQuery=" + annotationQuery + ", "
-      + "minDuration=" + minDuration + ", "
-      + "maxDuration=" + maxDuration + ", "
-      + "endTs=" + endTs + ", "
-      + "lookback=" + lookback + ", "
-      + "limit=" + limit
-      + "}";
+  @Override public String toString() {
+    return "QueryRequest{" +
+      "parentServiceName='" + parentServiceName + '\'' +
+      ", childServiceName='" + childServiceName + '\'' +
+      ", fetchErrors=" + fetchErrors +
+      ", serviceName='" + serviceName + '\'' +
+      ", spanName='" + spanName + '\'' +
+      ", parentServiceName='" + parentServiceName + '\'' +
+      ", childServiceName='" + childServiceName + '\'' +
+      ", annotationQuery=" + annotationQuery +
+      ", minDuration=" + minDuration +
+      ", maxDuration=" + maxDuration +
+      ", endTs=" + endTs +
+      ", lookback=" + lookback +
+      ", limit=" + limit +
+      ", fetchErrors=" + fetchErrors +
+      '}';
   }
 }

--- a/zipkin2/src/main/java/zipkin2/storage/SpanStore.java
+++ b/zipkin2/src/main/java/zipkin2/storage/SpanStore.java
@@ -37,6 +37,16 @@ public interface SpanStore {
   Call<List<List<Span>>> getTraces(QueryRequest request);
 
   /**
+   * Retrieves spans grouped by trace ID where the trace includes spans between the given dependencies.
+   *
+   * <p>When strict trace ID is disabled, spans are grouped by the right-most 16 characters of the
+   * trace ID.
+   *
+   * @param request a query request
+   */
+  Call<List<List<Span>>> getTraces(DependencyQueryRequest request);
+
+  /**
    * Retrieves spans that share a 128-bit trace id with no ordering expectation or empty if none are
    * found.
    *

--- a/zipkin2/src/main/java/zipkin2/storage/SpanStore.java
+++ b/zipkin2/src/main/java/zipkin2/storage/SpanStore.java
@@ -50,6 +50,19 @@ public interface SpanStore {
   Call<List<Span>> getTrace(String traceId);
 
   /**
+   * Retrieves list of spans that share a 128-bit trace id with no ordering expectation or empty if none are
+   * found.
+   *
+   * <p>When strict trace ID is disabled, spans with the same right-most 16 characters are returned
+   * even if the characters to the left are not.
+   *
+   * <p>Implementations should use {@link Span#normalizeTraceId(String)} to ensure consistency.
+   *
+   * @param traceIds a list of {@link Span#traceId() trace ID}
+   */
+  Call<List<List<Span>>> getTraces(List<String> traceIds);
+
+  /**
    * Retrieves all {@link Span#localEndpoint() local} and {@link Span#remoteEndpoint() remote}
    * {@link Endpoint#serviceName service names}, sorted lexicographically.
    */

--- a/zipkin2/src/test/java/zipkin2/storage/ITInMemoryStorage.java
+++ b/zipkin2/src/test/java/zipkin2/storage/ITInMemoryStorage.java
@@ -43,4 +43,16 @@ public class ITInMemoryStorage {
       // no need.. the test rule does this
     }
   }
+
+  public static class ITStrictTraceIdFalse extends zipkin2.storage.ITStrictTraceIdFalse {
+    InMemoryStorage storage = InMemoryStorage.newBuilder().strictTraceId(false).build();
+
+    @Override protected InMemoryStorage storage() {
+      return storage;
+    }
+
+    @Override public void clear() throws IOException {
+      // no need.. the test rule does this
+    }
+  }
 }

--- a/zipkin2/src/test/java/zipkin2/storage/ITSpanStore.java
+++ b/zipkin2/src/test/java/zipkin2/storage/ITSpanStore.java
@@ -14,7 +14,9 @@
 package zipkin2.storage;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -75,16 +77,16 @@ public abstract class ITSpanStore {
     assertThat(store().getTraces(requestBuilder().build()).execute())
       .hasSize(20);
 
-    assertThat(store().getTraces(requestBuilder()
-      .limit(10).build()).execute())
+    assertThat(sortTraces(store().getTraces(requestBuilder()
+      .limit(10).build()).execute()))
       .containsExactly(lateTraces);
 
-    assertThat(store().getTraces(requestBuilder()
-      .endTs(TODAY + gapBetweenSpans).lookback(gapBetweenSpans).build()).execute())
+    assertThat(sortTraces(store().getTraces(requestBuilder()
+      .endTs(TODAY + gapBetweenSpans).lookback(gapBetweenSpans).build()).execute()))
       .containsExactly(lateTraces);
 
-    assertThat(store().getTraces(requestBuilder()
-      .endTs(TODAY).build()).execute())
+    assertThat(sortTraces(store().getTraces(requestBuilder()
+      .endTs(TODAY).build()).execute()))
       .containsExactly(earlyTraces);
   }
 
@@ -173,11 +175,73 @@ public abstract class ITSpanStore {
       .contains(CLIENT_SPAN.localServiceName());
   }
 
+  Span with128BitId1 = Span.newBuilder()
+    .traceId("baaaaaaaaaaaaaaaa").id("a").timestamp(TODAY * 1000).build();
+  Span with64BitId1 = Span.newBuilder()
+    .traceId("aaaaaaaaaaaaaaaa").id("b").timestamp((TODAY + 1) * 1000).build();
+  Span with128BitId2 = Span.newBuilder()
+    .traceId("21111111111111111").id("1").timestamp(TODAY * 1000).build();
+  Span with64BitId2 = Span.newBuilder()
+    .traceId("1111111111111111").id("2").timestamp((TODAY + 1) * 1000).build();
+  Span with128BitId3 = Span.newBuilder()
+    .traceId("effffffffffffffff").id("1").timestamp(TODAY * 1000).build();
+  Span with64BitId3 = Span.newBuilder()
+    .traceId("ffffffffffffffff").id("2").timestamp(TODAY * 1000).build();
+
+  /** current implementation cannot return exact form reported */
+  @Test
+  public void getTraces_retrievesBy64Or128BitTraceId() throws Exception {
+    accept(with128BitId1, with64BitId1, with128BitId2, with64BitId2, with128BitId3, with64BitId3);
+
+    List<List<Span>> resultsWithBothIdLength = sortTraces(store()
+      .getTraces(asList(
+        with128BitId1.traceId(),
+        with64BitId1.traceId(),
+        with128BitId3.traceId(),
+        with64BitId3.traceId()
+      )).execute());
+
+    assertThat(resultsWithBothIdLength)
+      .containsExactly(
+        asList(with128BitId1),
+        asList(with128BitId3),
+        asList(with64BitId1),
+        asList(with64BitId3)
+      );
+
+    List<List<Span>> resultsWith64BitIdLength = sortTraces(store()
+      .getTraces(asList(
+        with64BitId1.traceId(), with64BitId3.traceId()
+      )).execute());
+
+    assertThat(resultsWith64BitIdLength)
+      .containsExactly(asList(with64BitId1), asList(with64BitId3));
+
+    List<List<Span>> resultsWith128BitIdLength = sortTraces(store()
+      .getTraces(asList(
+        with128BitId1.traceId(), with128BitId3.traceId()
+      )).execute());
+
+    assertThat(resultsWith128BitIdLength)
+      .containsExactly(asList(with128BitId1), asList(with128BitId3));
+  }
+
   protected void accept(Span... spans) throws IOException {
     storage().spanConsumer().accept(asList(spans)).execute();
   }
 
   static QueryRequest.Builder requestBuilder() {
     return QueryRequest.newBuilder().endTs(TODAY + DAY).lookback(DAY * 2).limit(100);
+  }
+
+  static List<List<Span>> sortTraces(List<List<Span>> traces) {
+    List<List<Span>> result = new ArrayList<>();
+    for (List<Span> trace: traces) {
+      ArrayList<Span> sorted = new ArrayList<>(trace);
+      Collections.sort(sorted, Comparator.comparing(Span::traceId));
+      result.add(sorted);
+    }
+    Collections.sort(result, Comparator.comparing(o -> o.get(0).traceId()));
+    return result;
   }
 }

--- a/zipkin2/src/test/java/zipkin2/storage/ITStrictTraceIdFalse.java
+++ b/zipkin2/src/test/java/zipkin2/storage/ITStrictTraceIdFalse.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Span;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.TODAY;
+import static zipkin2.storage.ITSpanStore.sortTraces;
+
+/**
+ * Base test for when {@link StorageComponent.Builder#strictTraceId(boolean) strictTraceId ==
+ * false}.
+ *
+ * <p>Subtypes should create a connection to a real backend, even if that backend is in-process.
+ */
+public abstract class ITStrictTraceIdFalse {
+
+  /** Should maintain state between multiple calls within a test. */
+  protected abstract StorageComponent storage();
+
+  protected SpanStore store() {
+    return storage().spanStore();
+  }
+
+  /** Clears store between tests. */
+  @Before public abstract void clear() throws Exception;
+
+  Span with128BitId1 = Span.newBuilder()
+    .traceId("baaaaaaaaaaaaaaaa").id("a").timestamp(TODAY * 1000).build();
+  Span with64BitId1 = Span.newBuilder()
+    .traceId("aaaaaaaaaaaaaaaa").id("b").timestamp((TODAY + 1) * 1000).build();
+  Span with128BitId2 = Span.newBuilder()
+    .traceId("21111111111111111").id("1").timestamp(TODAY * 1000).build();
+  Span with64BitId2 = Span.newBuilder()
+    .traceId("1111111111111111").id("2").timestamp((TODAY + 1) * 1000).build();
+  Span with128BitId3 = Span.newBuilder()
+    .traceId("effffffffffffffff").id("1").timestamp(TODAY * 1000).build();
+  Span with64BitId3 = Span.newBuilder()
+    .traceId("ffffffffffffffff").id("2").timestamp(TODAY * 1000).build();
+
+  /** current implementation cannot return exact form reported */
+  @Test
+  public void getTraces_retrievesBy64Or128BitTraceId() throws Exception {
+    accept(with128BitId1, with64BitId1, with128BitId2, with64BitId2, with128BitId3, with64BitId3);
+
+    List<List<Span>> trace1And3 = asList(
+      asList(with128BitId1, with64BitId1),
+      asList(with128BitId3, with64BitId3)
+    );
+
+    List<List<Span>> resultsWithBothIdLength = sortTraces(store()
+      .getTraces(asList(
+        with128BitId1.traceId(),
+        with64BitId1.traceId(),
+        with128BitId3.traceId(),
+        with64BitId3.traceId()
+      )).execute());
+
+    assertThat(resultsWithBothIdLength).containsExactlyElementsOf(trace1And3);
+
+    List<List<Span>> resultsWith64BitIdLength = sortTraces(store()
+      .getTraces(asList(
+        with64BitId1.traceId(), with64BitId3.traceId()
+      )).execute());
+
+    assertThat(resultsWith64BitIdLength).containsExactlyElementsOf(trace1And3);
+
+    List<List<Span>> resultsWith128BitIdLength = sortTraces(store()
+      .getTraces(asList(
+        with128BitId1.traceId(), with128BitId3.traceId()
+      )).execute());
+
+    assertThat(resultsWith128BitIdLength).containsExactlyElementsOf(trace1And3);
+  }
+
+  protected void accept(Span... spans) throws IOException {
+    storage().spanConsumer().accept(asList(spans)).execute();
+  }
+}

--- a/zipkin2/src/test/java/zipkin2/storage/InMemoryStorageTest.java
+++ b/zipkin2/src/test/java/zipkin2/storage/InMemoryStorageTest.java
@@ -14,9 +14,7 @@
 package zipkin2.storage;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.Test;
@@ -120,6 +118,34 @@ public class InMemoryStorageTest {
 
     assertThat(storage.getSpanNames("app").execute()).containsOnly(
       "root"
+    );
+  }
+
+  @Test public void getTraces_byTraceIds() throws IOException {
+    Span trace1Span1 = Span.newBuilder().traceId("1").id("1").name("root")
+      .localEndpoint(Endpoint.newBuilder().serviceName("app").build())
+      .timestamp(TODAY * 1000)
+      .build();
+    Span trace1Span2 = Span.newBuilder().traceId("1").parentId("1").id("2")
+      .localEndpoint(Endpoint.newBuilder().serviceName("app").build())
+      .timestamp(TODAY * 1000)
+      .build();
+
+    Span trace2Span1 = Span.newBuilder().traceId("2").id("1").name("root")
+      .localEndpoint(Endpoint.newBuilder().serviceName("app").build())
+      .timestamp(TODAY * 1000)
+      .build();
+    Span trace2Span2 = Span.newBuilder().traceId("2").parentId("1").id("2")
+      .localEndpoint(Endpoint.newBuilder().serviceName("app").build())
+      .timestamp(TODAY * 1000)
+      .build();
+
+    storage.accept(asList(trace1Span1, trace1Span2, trace2Span1, trace2Span2));
+
+
+    assertThat(storage.getTraces(asList("1", "2")).execute()).contains(
+      asList(trace1Span1, trace1Span2),
+      asList(trace2Span1, trace2Span2)
     );
   }
 }


### PR DESCRIPTION
TODO: make this conditional, as existing dependency linker jobs won't
need IDs and keeping them might make spark jobs move more data than
they currently need.

See #1206