### PR TITLE
Completes storage test conversion to v2 model

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
@@ -97,6 +97,7 @@ final class CassandraSpanConsumer implements SpanConsumer {
     }
 
     indexer.index(spansToIndex.build(), calls);
+    if (calls.size() == 1) return calls.get(0).map(r -> null);
     return new StoreSpansCall(calls);
   }
 

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
@@ -160,6 +160,7 @@ public final class CassandraSpanStore implements SpanStore {
 
   @Override
   public Call<List<String>> getSpanNames(String serviceName) {
+    if (serviceName.isEmpty()) return Call.emptyList();
     return spanNames.create(serviceName);
   }
 

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -13,7 +13,14 @@
  */
 package zipkin2.storage.cassandra.v1;
 
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.Session;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -22,9 +29,16 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import zipkin2.Endpoint;
 import zipkin2.Span;
+import zipkin2.TestObjects;
+import zipkin2.storage.QueryRequest;
 import zipkin2.storage.StorageComponent;
 
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.DAY;
+import static zipkin2.TestObjects.TODAY;
 import static zipkin2.storage.cassandra.v1.InternalForTests.dropKeyspace;
 import static zipkin2.storage.cassandra.v1.InternalForTests.keyspace;
 import static zipkin2.storage.cassandra.v1.InternalForTests.writeDependencyLinks;
@@ -33,21 +47,12 @@ import static zipkin2.storage.cassandra.v1.InternalForTests.writeDependencyLinks
 public class ITCassandraStorage {
 
   static CassandraStorageRule classRule() {
-    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.4.6", "test_cassandra3");
+    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.10.1", "test_cassandra3");
   }
 
   public static class ITSpanStore extends zipkin2.storage.ITSpanStore {
     @ClassRule public static CassandraStorageRule backend = classRule();
     @Rule public TestName testName = new TestName();
-
-    @Override @Test @Ignore("Multiple services unsupported") public void getTraces_tags() {
-    }
-
-    @Override @Test @Ignore("Duration unsupported") public void getTraces_minDuration() {
-    }
-
-    @Override @Test @Ignore("Duration unsupported") public void getTraces_maxDuration() {
-    }
 
     CassandraStorage storage;
 
@@ -57,6 +62,89 @@ public class ITCassandraStorage {
 
     @Override protected StorageComponent storage() {
       return storage;
+    }
+
+    @Override @Test @Ignore("Multiple services unsupported") public void getTraces_tags() {
+    }
+
+    @Override @Test @Ignore("Duration unsupported") public void getTraces_duration() {
+    }
+
+    @Override @Test @Ignore("Duration unsupported") public void getTraces_minDuration() {
+    }
+
+    @Override @Test @Ignore("Duration unsupported") public void getTraces_maxDuration() {
+    }
+
+    @Test public void overFetchesToCompensateForDuplicateIndexData() throws IOException {
+      int traceCount = 2000;
+
+      List<Span> spans = new ArrayList<>();
+      for (int i = 0; i < traceCount; i++) {
+        final long delta = i * 1000; // all timestamps happen a millisecond later
+        for (Span s : TestObjects.TRACE) {
+          Span.Builder builder = s.toBuilder()
+            .traceId(Long.toHexString((i + 1) * 10L))
+            .timestamp(s.timestampAsLong() + delta);
+          s.annotations().forEach(a -> builder.addAnnotation(a.timestamp() + delta, a.value()));
+          spans.add(builder.build());
+        }
+      }
+
+      accept(spans.toArray(new Span[0]));
+
+      // Index ends up containing more rows than services * trace count, and cannot be de-duped
+      // in a server-side query.
+      assertThat(storage
+        .session()
+        .execute("SELECT COUNT(*) from service_name_index")
+        .one()
+        .getLong(0))
+        .isGreaterThan(traceCount * store().getServiceNames().execute().size());
+
+      // Implementation over-fetches on the index to allow the user to receive unsurprising results.
+      QueryRequest request = requestBuilder()
+        .serviceName("frontend") // Ensure we use serviceName so that trace_by_service_span is used
+        .lookback(DAY).limit(traceCount).build();
+      assertThat(store().getTraces(request).execute())
+        .hasSize(traceCount);
+    }
+
+    @Test public void searchingByAnnotationShouldFilterBeforeLimiting() throws IOException {
+      int queryLimit = 2;
+      int nbTraceFetched = queryLimit * storage.indexFetchMultiplier;
+
+      for (int i = 0; i < nbTraceFetched; i++) {
+        accept(TestObjects.LOTS_OF_SPANS[i++].toBuilder().timestamp((TODAY - i) * 1000L).build());
+      }
+
+      // Add two traces with the tag we're looking for before the preceding ones
+      Endpoint endpoint = TestObjects.LOTS_OF_SPANS[0].localEndpoint();
+      for (int i = 0; i < 2; i++) {
+        int j = nbTraceFetched + i;
+        accept(TestObjects.LOTS_OF_SPANS[j].toBuilder()
+          .timestamp((TODAY - j) * 1000L)
+          .localEndpoint(endpoint)
+          .putTag("host.name", "host1")
+          .build());
+      }
+      QueryRequest queryRequest =
+        requestBuilder()
+          .parseAnnotationQuery("host.name=host1")
+          .serviceName(endpoint.serviceName())
+          .limit(queryLimit)
+          .build();
+      assertThat(store().getTraces(queryRequest).execute()).hasSize(queryLimit);
+    }
+
+    /** Makes sure the test cluster doesn't fall over on BusyPoolException */
+    @Override protected void accept(Span... spans) throws IOException {
+      // TODO: this avoids overrunning the cluster with BusyPoolException
+      for (List<Span> nextChunk : Lists.partition(asList(spans), 100)) {
+        super.accept(nextChunk.toArray(new Span[0]));
+        // Now, block until writes complete, notably so we can read them.
+        blockWhileInFlight(storage);
+      }
     }
 
     @Before @Override public void clear() {
@@ -109,6 +197,48 @@ public class ITCassandraStorage {
 
     @Before @Override public void clear() {
       dropKeyspace(backend.session(), keyspace(testName));
+    }
+  }
+
+  public static class ITEnsureSchema extends zipkin2.storage.cassandra.v1.ITEnsureSchema {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    @Override protected String keyspace() {
+      return InternalForTests.keyspace(testName);
+    }
+
+    @Override protected Session session() {
+      return backend.session;
+    }
+  }
+
+  public static class ITSpanConsumer extends zipkin2.storage.cassandra.v1.ITSpanConsumer {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    @Override protected String keyspace() {
+      return InternalForTests.keyspace(testName);
+    }
+
+    @Override CassandraStorage.Builder storageBuilder() {
+      return backend.computeStorageBuilder();
+    }
+  }
+
+  static void blockWhileInFlight(CassandraStorage storage) {
+    // Now, block until writes complete, notably so we can read them.
+    Session.State state = storage.session().getState();
+    refresh:
+    while (true) {
+      for (Host host : state.getConnectedHosts()) {
+        if (state.getInFlightQueries(host) > 0) {
+          Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+          state = storage.session().getState();
+          continue refresh;
+        }
+      }
+      break;
     }
   }
 }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra.v1;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Session;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+abstract class ITEnsureSchema {
+
+  protected abstract String keyspace();
+
+  protected abstract Session session();
+
+  @Test public void installsKeyspaceWhenMissing() {
+    Schema.ensureExists(keyspace(), session());
+
+    KeyspaceMetadata metadata = session().getCluster().getMetadata().getKeyspace(keyspace());
+    assertThat(metadata).isNotNull();
+    assertThat(Schema.hasUpgrade1_defaultTtl(metadata)).isTrue();
+  }
+
+  @Test public void installsTablesWhenMissing() {
+    session()
+      .execute(
+        "CREATE KEYSPACE "
+          + keyspace()
+          + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+
+    Schema.ensureExists(keyspace(), session());
+
+    KeyspaceMetadata metadata = session().getCluster().getMetadata().getKeyspace(keyspace());
+    assertThat(metadata).isNotNull();
+    assertThat(Schema.hasUpgrade1_defaultTtl(metadata)).isTrue();
+  }
+
+  @Test public void upgradesOldSchema() {
+    Schema.applyCqlFile(keyspace(), session(), "/cassandra-schema-cql3-original.txt");
+
+    Schema.ensureExists(keyspace(), session());
+
+    KeyspaceMetadata metadata = session().getCluster().getMetadata().getKeyspace(keyspace());
+    assertThat(metadata).isNotNull();
+    assertThat(Schema.hasUpgrade1_defaultTtl(metadata)).isTrue();
+  }
+}

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra.v1;
+
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Span;
+import zipkin2.TestObjects;
+import zipkin2.storage.SpanConsumer;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+abstract class ITSpanConsumer {
+  protected abstract String keyspace();
+
+  private CassandraStorage storage;
+
+  @Before
+  public void connect() {
+    storage = storageBuilder().keyspace(keyspace()).build();
+  }
+
+  abstract CassandraStorage.Builder storageBuilder();
+
+  /**
+   * Core/Boundary annotations like "sr" aren't queryable, and don't add value to users. Address
+   * annotations, like "sa", don't have string values, so are similarly not queryable. Skipping
+   * indexing of such annotations dramatically reduces the load on cassandra and size of indexes.
+   */
+  @Test public void doesntIndexCoreOrNonStringAnnotations() throws IOException {
+    accept(storage.spanConsumer(), TestObjects.CLIENT_SPAN);
+
+    assertThat(
+      InternalForTests.session(storage)
+        .execute("SELECT blobastext(annotation) from annotations_index")
+        .all())
+      .extracting(r -> r.getString(0))
+      .containsExactlyInAnyOrder(
+        "frontend:http.path",
+        "frontend:http.path:/api",
+        "frontend:clnt/finagle.version:6.45.0",
+        "frontend:foo",
+        "frontend:clnt/finagle.version");
+  }
+
+  /**
+   * Simulates a trace with a step pattern, where each span starts a millisecond after the prior
+   * one. The consumer code optimizes index inserts to only represent the interval represented by
+   * the trace as opposed to each individual timestamp.
+   */
+  @Test public void skipsRedundantIndexingInATrace() throws IOException {
+    Span[] trace = new Span[101];
+    trace[0] = TestObjects.CLIENT_SPAN;
+
+    for (int i = 0; i < 100; i++) {
+      trace[i + 1] =
+        Span.newBuilder()
+          .traceId(trace[0].traceId())
+          .parentId(trace[0].id())
+          .id(i + 1)
+          .name(String.valueOf(i + 1))
+          .timestamp(trace[0].timestamp() + i * 1000) // child span timestamps happen 1 ms later
+          .addAnnotation(trace[0].annotations().get(0).timestamp() + i * 1000, "bar")
+          .build();
+    }
+
+    accept(storage.spanConsumer(), trace);
+    assertThat(rowCount("annotations_index")).isEqualTo(5L);
+    assertThat(rowCount("service_span_name_index")).isEqualTo(2L);
+    assertThat(rowCount("service_name_index")).isEqualTo(2L);
+
+    // redundant store doesn't change the indexes
+    accept(storage.spanConsumer(), trace);
+    assertThat(rowCount("annotations_index")).isEqualTo(5L);
+    assertThat(rowCount("service_span_name_index")).isEqualTo(2L);
+    assertThat(rowCount("service_name_index")).isEqualTo(2L);
+  }
+
+  void accept(SpanConsumer consumer, Span... spans) throws IOException {
+    consumer.accept(asList(spans)).execute();
+    // Now, block until writes complete, notably so we can read them.
+    ITCassandraStorage.blockWhileInFlight(storage);
+  }
+
+  long rowCount(String table) {
+    return InternalForTests.session(storage)
+      .execute("SELECT COUNT(*) from " + table)
+      .one()
+      .getLong(0);
+  }
+}

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/integrationV1/ITCassandraStorageV1.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/integrationV1/ITCassandraStorageV1.java
@@ -31,7 +31,7 @@ public class ITCassandraStorageV1 {
 
   static CassandraStorageRule classRule() {
     return new CassandraStorageRule(
-        "openzipkin/zipkin-cassandra:2.4.6", "test_cassandra3_zipkinv1");
+        "openzipkin/zipkin-cassandra:2.10.1", "test_cassandra3_zipkinv1");
   }
 
   public static class DependenciesTest extends CassandraDependenciesTest {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
@@ -122,6 +122,7 @@ class CassandraSpanConsumer implements SpanConsumer { // not final for testing
         calls.add(insertTraceByServiceSpan.create(serviceSpan));
       }
     }
+    if (calls.size() == 1) return calls.get(0).map(r -> null);
     return new StoreSpansCall(calls);
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
@@ -209,7 +209,7 @@ class CassandraSpanStore implements SpanStore { // not final for testing
 
   @Override
   public Call<List<String>> getSpanNames(String serviceName) {
-    if (!searchEnabled) return Call.emptyList();
+    if (serviceName.isEmpty() || !searchEnabled) return Call.emptyList();
     return spanNames.create(serviceName);
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
@@ -89,7 +89,10 @@ final class SelectSpanNames extends ResultSetFutureCall {
 
     @Override
     protected BiConsumer<Row, List<String>> accumulator() {
-      return (row, list) -> list.add(row.getString("span"));
+      return (row, list) -> {
+        String result = row.getString("span");
+        if (!result.isEmpty()) list.add(result);
+      };
     }
 
     @Override

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromServiceSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromServiceSpan.java
@@ -23,6 +23,7 @@ import com.datastax.driver.core.utils.UUIDs;
 import com.google.auto.value.AutoValue;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
@@ -131,6 +132,7 @@ final class SelectTraceIdsFromServiceSpan extends ResultSetFutureCall {
     }
 
     Call<Set<Entry<String, Long>>> newCall(List<Input> inputs) {
+      if (inputs.isEmpty()) return Call.create(Collections.emptySet());
       if (inputs.size() == 1) return newCall(inputs.get(0));
 
       List<Call<Set<Entry<String, Long>>>> bucketedTraceIdCalls = new ArrayList<>();
@@ -174,6 +176,7 @@ final class SelectTraceIdsFromServiceSpan extends ResultSetFutureCall {
           bucketedTraceIdCalls.add(newCall(scopedInputs));
         }
 
+        if (bucketedTraceIdCalls.isEmpty()) return Call.create(Collections.emptySet());
         if (bucketedTraceIdCalls.size() == 1) return bucketedTraceIdCalls.get(0);
         return new AggregateIntoSet<>(bucketedTraceIdCalls);
       }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/AggregateCall.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/AggregateCall.java
@@ -31,7 +31,8 @@ public abstract class AggregateCall<I, O> extends Call.Base<O> {
   final List<Call<I>> calls;
 
   protected AggregateCall(List<Call<I>> calls) {
-    assert !calls.isEmpty() : "do not create single-element aggregates";
+    assert !calls.isEmpty() : "do not create empty aggregate calls";
+    assert calls.size() > 1 : "do not create single-element aggregates";
     this.calls = calls;
   }
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
@@ -37,14 +37,14 @@ public class CassandraSpanConsumerTest {
   CassandraSpanConsumer consumer = spanConsumer(CassandraStorage.newBuilder());
 
   Span spanWithoutAnnotationsOrTags =
-      Span.newBuilder()
-          .traceId("a")
-          .id("1")
-          .name("get")
-          .localEndpoint(FRONTEND)
-          .timestamp(1472470996199000L)
-          .duration(207000L)
-          .build();
+    Span.newBuilder()
+      .traceId("a")
+      .id("1")
+      .name("get")
+      .localEndpoint(FRONTEND)
+      .timestamp(1472470996199000L)
+      .duration(207000L)
+      .build();
 
   @Test
   public void emptyInput_emptyCall() {
@@ -55,16 +55,16 @@ public class CassandraSpanConsumerTest {
   @Test
   public void doesntSetTraceIdHigh_128() {
     Span span =
-        spanWithoutAnnotationsOrTags
-            .toBuilder()
-            .traceId("77fcac3d4c5be8d2a037812820c65f28")
-            .build();
+      spanWithoutAnnotationsOrTags
+        .toBuilder()
+        .traceId("77fcac3d4c5be8d2a037812820c65f28")
+        .build();
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertSpan)
-        .extracting("input.trace_id_high", "input.trace_id")
-        .containsExactly(tuple(null, span.traceId()));
+      .filteredOn(c -> c instanceof InsertSpan)
+      .extracting("input.trace_id_high", "input.trace_id")
+      .containsExactly(tuple(null, span.traceId()));
   }
 
   @Test
@@ -73,9 +73,9 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertSpan)
-        .extracting("input.trace_id_high", "input.trace_id")
-        .containsExactly(tuple(null, span.traceId()));
+      .filteredOn(c -> c instanceof InsertSpan)
+      .extracting("input.trace_id_high", "input.trace_id")
+      .containsExactly(tuple(null, span.traceId()));
   }
 
   @Test
@@ -83,16 +83,16 @@ public class CassandraSpanConsumerTest {
     consumer = spanConsumer(CassandraStorage.newBuilder().strictTraceId(false));
 
     Span span =
-        spanWithoutAnnotationsOrTags
-            .toBuilder()
-            .traceId("77fcac3d4c5be8d2a037812820c65f28")
-            .build();
+      spanWithoutAnnotationsOrTags
+        .toBuilder()
+        .traceId("77fcac3d4c5be8d2a037812820c65f28")
+        .build();
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertSpan)
-        .extracting("input.trace_id_high", "input.trace_id")
-        .containsExactly(tuple("77fcac3d4c5be8d2", "a037812820c65f28"));
+      .filteredOn(c -> c instanceof InsertSpan)
+      .extracting("input.trace_id_high", "input.trace_id")
+      .containsExactly(tuple("77fcac3d4c5be8d2", "a037812820c65f28"));
   }
 
   @Test
@@ -102,9 +102,9 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertServiceSpan)
-        .extracting("input.service", "input.span")
-        .containsExactly(tuple(FRONTEND.serviceName(), span.name()));
+      .filteredOn(c -> c instanceof InsertServiceSpan)
+      .extracting("input.service", "input.span")
+      .containsExactly(tuple(FRONTEND.serviceName(), span.name()));
   }
 
   @Test
@@ -114,10 +114,10 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertServiceSpan)
-        .extracting("input.service", "input.span")
-        .containsExactly(
-            tuple(BACKEND.serviceName(), span.name()), tuple(FRONTEND.serviceName(), span.name()));
+      .filteredOn(c -> c instanceof InsertServiceSpan)
+      .extracting("input.service", "input.span")
+      .containsExactly(
+        tuple(BACKEND.serviceName(), span.name()), tuple(FRONTEND.serviceName(), span.name()));
   }
 
   @Test
@@ -127,18 +127,17 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertServiceSpan)
-        .extracting("input.service", "input.span")
-        .containsExactly(tuple(FRONTEND.serviceName(), ""));
+      .filteredOn(c -> c instanceof InsertServiceSpan)
+      .extracting("input.service", "input.span")
+      .containsExactly(tuple(FRONTEND.serviceName(), ""));
   }
 
   @Test
   public void serviceSpanKeys_emptyWhenNoEndpoints() {
     Span span = spanWithoutAnnotationsOrTags.toBuilder().localEndpoint(null).build();
 
-    StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
-
-    assertEnclosedCalls(call).filteredOn(c -> c instanceof InsertServiceSpan).isEmpty();
+    assertThat(consumer.accept(singletonList(span)))
+      .isNotInstanceOf(StoreSpansCall.class);
   }
 
   /**
@@ -152,10 +151,10 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
-        .extracting("input.service", "input.span")
-        .containsExactly(
-            tuple(FRONTEND.serviceName(), span.name()), tuple(FRONTEND.serviceName(), ""));
+      .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
+      .extracting("input.service", "input.span")
+      .containsExactly(
+        tuple(FRONTEND.serviceName(), span.name()), tuple(FRONTEND.serviceName(), ""));
   }
 
   @Test
@@ -165,9 +164,9 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
-        .extracting("input.duration")
-        .containsOnly(span.duration() / 1000L);
+      .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
+      .extracting("input.duration")
+      .containsOnly(span.duration() / 1000L);
   }
 
   @Test
@@ -177,9 +176,9 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
-        .extracting("input.duration")
-        .containsOnly(0L);
+      .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
+      .extracting("input.duration")
+      .containsOnly(0L);
   }
 
   @Test
@@ -189,9 +188,9 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
-        .extracting("input.service", "input.span")
-        .isEmpty();
+      .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
+      .extracting("input.service", "input.span")
+      .isEmpty();
   }
 
   @Test
@@ -201,10 +200,10 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
-        .hasSize(2)
-        .extracting("input.service")
-        .doesNotContain(BACKEND.serviceName());
+      .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
+      .hasSize(2)
+      .extracting("input.service")
+      .doesNotContain(BACKEND.serviceName());
   }
 
   @Test
@@ -214,18 +213,17 @@ public class CassandraSpanConsumerTest {
     StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-        .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
-        .extracting("input.service", "input.span")
-        .containsExactly(tuple(FRONTEND.serviceName(), ""));
+      .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
+      .extracting("input.service", "input.span")
+      .containsExactly(tuple(FRONTEND.serviceName(), ""));
   }
 
   @Test
   public void traceByServiceSpan_emptyWhenNoEndpoints() {
     Span span = spanWithoutAnnotationsOrTags.toBuilder().localEndpoint(null).build();
 
-    StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
-
-    assertEnclosedCalls(call).filteredOn(c -> c instanceof InsertTraceByServiceSpan).isEmpty();
+    assertThat(consumer.accept(singletonList(span)))
+      .isNotInstanceOf(StoreSpansCall.class);
   }
 
   @Test
@@ -233,34 +231,31 @@ public class CassandraSpanConsumerTest {
     consumer = spanConsumer(CassandraStorage.newBuilder().searchEnabled(false));
 
     Span span =
-        spanWithoutAnnotationsOrTags
-            .toBuilder()
-            .addAnnotation(TODAY, "annotation")
-            .putTag("foo", "bar")
-            .duration(10000L)
-            .build();
+      spanWithoutAnnotationsOrTags
+        .toBuilder()
+        .addAnnotation(TODAY, "annotation")
+        .putTag("foo", "bar")
+        .duration(10000L)
+        .build();
 
-    StoreSpansCall call = (StoreSpansCall) consumer.accept(singletonList(span));
-
-    assertEnclosedCalls(call)
-        .hasSize(1)
-        .filteredOn(c -> c instanceof InsertSpan)
-        .extracting("input.annotation_query")
-        .allSatisfy(q -> assertThat(q).isNull());
+    assertThat(consumer.accept(singletonList(span)))
+      .extracting("delegate.input.annotation_query")
+      .allSatisfy(q -> assertThat(q).isNull());
   }
 
   static AbstractListAssert<
-          ?, List<? extends Call<ResultSet>>, Call<ResultSet>, ObjectAssert<Call<ResultSet>>>
-      assertEnclosedCalls(StoreSpansCall call) {
+    ?, List<? extends Call<ResultSet>>, Call<ResultSet>, ObjectAssert<Call<ResultSet>>>
+  assertEnclosedCalls(StoreSpansCall call) {
     return assertThat(call)
-        .extracting("calls")
-        .flatExtracting(calls -> (Collection<Call<ResultSet>>) calls);
+      .extracting("calls")
+      .flatExtracting(calls -> (Collection<Call<ResultSet>>) calls);
   }
 
   static CassandraSpanConsumer spanConsumer(CassandraStorage.Builder builder) {
     return new CassandraSpanConsumer(
-        builder
-            .sessionFactory(mock(CassandraStorage.SessionFactory.class, Mockito.RETURNS_MOCKS))
-            .build()) {};
+      builder
+        .sessionFactory(mock(CassandraStorage.SessionFactory.class, Mockito.RETURNS_MOCKS))
+        .build()) {
+    };
   }
 }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -13,8 +13,15 @@
  */
 package zipkin2.storage.cassandra;
 
+import com.datastax.driver.core.Host;
 import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Session;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -22,10 +29,16 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import zipkin2.Endpoint;
 import zipkin2.Span;
+import zipkin2.TestObjects;
+import zipkin2.storage.QueryRequest;
 import zipkin2.storage.StorageComponent;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.DAY;
+import static zipkin2.TestObjects.TODAY;
 import static zipkin2.storage.cassandra.InternalForTests.dropKeyspace;
 import static zipkin2.storage.cassandra.InternalForTests.keyspace;
 import static zipkin2.storage.cassandra.InternalForTests.session;
@@ -35,7 +48,7 @@ import static zipkin2.storage.cassandra.InternalForTests.writeDependencyLinks;
 public class ITCassandraStorage {
 
   static CassandraStorageRule classRule() {
-    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.4.6", "test_cassandra3");
+    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.10.1", "test_cassandra3");
   }
 
   public static class ITSpanStore extends zipkin2.storage.ITSpanStore {
@@ -50,6 +63,77 @@ public class ITCassandraStorage {
 
     @Override protected StorageComponent storage() {
       return storage;
+    }
+
+    @Test public void overFetchesToCompensateForDuplicateIndexData() throws IOException {
+      int traceCount = 2000;
+
+      List<Span> spans = new ArrayList<>();
+      for (int i = 0; i < traceCount; i++) {
+        final long delta = i * 1000; // all timestamps happen a millisecond later
+        for (Span s : TestObjects.TRACE) {
+          Span.Builder builder = s.toBuilder()
+            .traceId(Long.toHexString((i + 1) * 10L))
+            .timestamp(s.timestampAsLong() + delta);
+          s.annotations().forEach(a -> builder.addAnnotation(a.timestamp() + delta, a.value()));
+          spans.add(builder.build());
+        }
+      }
+
+      accept(spans.toArray(new Span[0]));
+
+      // Index ends up containing more rows than services * trace count, and cannot be de-duped
+      // in a server-side query.
+      assertThat(storage
+        .session()
+        .execute("SELECT COUNT(*) from trace_by_service_span")
+        .one()
+        .getLong(0))
+        .isGreaterThan(traceCount * store().getServiceNames().execute().size());
+
+      // Implementation over-fetches on the index to allow the user to receive unsurprising results.
+      QueryRequest request = requestBuilder()
+        .serviceName("frontend") // Ensure we use serviceName so that trace_by_service_span is used
+        .lookback(DAY).limit(traceCount).build();
+      assertThat(store().getTraces(request).execute())
+        .hasSize(traceCount);
+    }
+
+    @Test public void searchingByAnnotationShouldFilterBeforeLimiting() throws IOException {
+      int queryLimit = 2;
+      int nbTraceFetched = queryLimit * storage.indexFetchMultiplier();
+
+      for (int i = 0; i < nbTraceFetched; i++) {
+        accept(TestObjects.LOTS_OF_SPANS[i++].toBuilder().timestamp((TODAY - i) * 1000L).build());
+      }
+
+      // Add two traces with the tag we're looking for before the preceding ones
+      Endpoint endpoint = TestObjects.LOTS_OF_SPANS[0].localEndpoint();
+      for (int i = 0; i < 2; i++) {
+        int j = nbTraceFetched + i;
+        accept(TestObjects.LOTS_OF_SPANS[j].toBuilder()
+          .timestamp((TODAY - j) * 1000L)
+          .localEndpoint(endpoint)
+          .putTag("host.name", "host1")
+          .build());
+      }
+      QueryRequest queryRequest =
+        requestBuilder()
+          .parseAnnotationQuery("host.name=host1")
+          .serviceName(endpoint.serviceName())
+          .limit(queryLimit)
+          .build();
+      assertThat(store().getTraces(queryRequest).execute()).hasSize(queryLimit);
+    }
+
+    /** Makes sure the test cluster doesn't fall over on BusyPoolException */
+    @Override protected void accept(Span... spans) throws IOException {
+      // TODO: this avoids overrunning the cluster with BusyPoolException
+      for (List<Span> nextChunk : Lists.partition(asList(spans), 100)) {
+        super.accept(nextChunk.toArray(new Span[0]));
+        // Now, block until writes complete, notably so we can read them.
+        blockWhileInFlight(storage);
+      }
     }
 
     @Before @Override public void clear() {
@@ -89,11 +173,26 @@ public class ITCassandraStorage {
     @ClassRule public static CassandraStorageRule backend = classRule();
     @Rule public TestName testName = new TestName();
 
-    CassandraStorage storage;
+    CassandraStorage storageBeforeSwitch, storage;
 
     @Before public void connect() {
+      storageBeforeSwitch =
+        backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
       storage =
         backend.computeStorageBuilder().keyspace(keyspace(testName)).strictTraceId(false).build();
+    }
+
+    /** Ensures we can still lookup fully 128-bit traces when strict trace ID id disabled */
+    @Test public void getTraces_128BitTraceId() throws IOException {
+      getTraces_128BitTraceId(accept128BitTrace(storageBeforeSwitch));
+    }
+
+    /** Ensures data written before strict trace ID was enabled can be read */
+    @Test public void getTrace_retrievesBy128BitTraceId_afterSwitch() throws IOException {
+      List<Span> trace = accept128BitTrace(storageBeforeSwitch);
+
+      assertThat(store().getTrace(trace.get(0).traceId()).execute())
+        .containsOnlyElementsOf(trace);
     }
 
     @Override protected StorageComponent storage() {
@@ -130,6 +229,48 @@ public class ITCassandraStorage {
 
     @Before @Override public void clear() {
       dropKeyspace(backend.session(), keyspace(testName));
+    }
+  }
+
+  public static class ITEnsureSchema extends zipkin2.storage.cassandra.ITEnsureSchema {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    @Override protected String keyspace() {
+      return InternalForTests.keyspace(testName);
+    }
+
+    @Override protected Session session() {
+      return backend.session;
+    }
+  }
+
+  public static class ITSpanConsumer extends zipkin2.storage.cassandra.ITSpanConsumer {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    @Override protected String keyspace() {
+      return InternalForTests.keyspace(testName);
+    }
+
+    @Override CassandraStorage.Builder storageBuilder() {
+      return backend.computeStorageBuilder();
+    }
+  }
+
+  static void blockWhileInFlight(CassandraStorage storage) {
+    // Now, block until writes complete, notably so we can read them.
+    Session.State state = storage.session().getState();
+    refresh:
+    while (true) {
+      for (Host host : state.getConnectedHosts()) {
+        if (state.getInFlightQueries(host) > 0) {
+          Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+          state = storage.session().getState();
+          continue refresh;
+        }
+      }
+      break;
     }
   }
 }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Session;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+abstract class ITEnsureSchema {
+
+  abstract protected String keyspace();
+
+  abstract protected Session session();
+
+  @Test public void installsKeyspaceWhenMissing() {
+    Schema.ensureExists(keyspace(), false, session());
+
+    KeyspaceMetadata metadata = session().getCluster().getMetadata().getKeyspace(keyspace());
+    assertThat(metadata).isNotNull();
+  }
+
+  @Test public void installsTablesWhenMissing() {
+    session().execute("CREATE KEYSPACE " + keyspace()
+      + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+
+    Schema.ensureExists(keyspace(), false, session());
+
+    KeyspaceMetadata metadata = session().getCluster().getMetadata().getKeyspace(keyspace());
+    assertThat(metadata.getTable("span")).isNotNull();
+  }
+
+  @Test public void installsIndexesWhenMissing() {
+    session().execute("CREATE KEYSPACE " + keyspace()
+      + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+
+    Schema.ensureExists(keyspace(), true, session());
+
+    KeyspaceMetadata metadata = session().getCluster().getMetadata().getKeyspace(keyspace());
+    assertThat(metadata.getTable("trace_by_service_span")).isNotNull();
+  }
+}

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra;
+
+import java.io.IOException;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Span;
+import zipkin2.TestObjects;
+import zipkin2.storage.SpanConsumer;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.FRONTEND;
+
+abstract class ITSpanConsumer {
+  abstract protected String keyspace();
+
+  private CassandraStorage storage;
+
+  @Before public void connect() {
+    storage = storageBuilder().keyspace(keyspace()).build();
+  }
+
+  abstract CassandraStorage.Builder storageBuilder();
+
+  /**
+   * {@link Span#duration} == 0 is likely to be a mistake, and coerces to null. It is not helpful to
+   * index rows who have no duration.
+   */
+  @Test public void doesntIndexSpansMissingDuration() throws IOException {
+    Span span = Span.newBuilder().traceId("1").id("1").name("get").duration(0L).build();
+
+    accept(storage.spanConsumer(), span);
+
+    assertThat(rowCountForTraceByServiceSpan(storage)).isZero();
+  }
+
+  /**
+   * Simulates a trace with a step pattern, where each span starts a millisecond after the prior
+   * one. The consumer code optimizes index inserts to only represent the interval represented by
+   * the trace as opposed to each individual timestamp.
+   */
+  @Test public void skipsRedundantIndexingInATrace() throws IOException {
+    Span[] trace = new Span[101];
+    trace[0] = TestObjects.CLIENT_SPAN.toBuilder().kind(Span.Kind.SERVER).build();
+
+    IntStream.range(0, 100).forEach(i -> trace[i + 1] = Span.newBuilder()
+      .traceId(trace[0].traceId())
+      .parentId(trace[0].id())
+      .id(Long.toHexString(i))
+      .name("get")
+      .kind(Span.Kind.CLIENT)
+      .localEndpoint(FRONTEND)
+      .timestamp(
+        trace[0].timestamp() + i * 1000) // all peer span timestamps happen a millisecond later
+      .duration(10L)
+      .build());
+
+    accept(storage.spanConsumer(), trace);
+    assertThat(rowCountForTraceByServiceSpan(storage))
+      .isGreaterThanOrEqualTo(4L);
+    assertThat(rowCountForTraceByServiceSpan(storage))
+      .isGreaterThanOrEqualTo(4L);
+
+    // sanity check base case
+    accept(storage.toBuilder().strictTraceId(false).build().spanConsumer(), trace);
+
+    assertThat(rowCountForTraceByServiceSpan(storage))
+      .isGreaterThanOrEqualTo(120L); // TODO: magic number
+    assertThat(rowCountForTraceByServiceSpan(storage))
+      .isGreaterThanOrEqualTo(120L);
+  }
+
+  void accept(SpanConsumer consumer, Span... spans) throws IOException {
+    consumer.accept(asList(spans)).execute();
+  }
+
+  static long rowCountForTraceByServiceSpan(CassandraStorage storage) {
+    return storage
+      .session()
+      .execute("SELECT COUNT(*) from " + Schema.TABLE_TRACE_BY_SERVICE_SPAN)
+      .one()
+      .getLong(0);
+  }
+}

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/integrationV1/ITCassandraStorageV1.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/integrationV1/ITCassandraStorageV1.java
@@ -30,7 +30,7 @@ import static zipkin2.storage.cassandra.InternalForTests.dropKeyspace;
 public class ITCassandraStorageV1 {
 
   static CassandraStorageRule classRule() {
-    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.4.6",
+    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.10.1",
       "test_cassandra3_zipkinv1");
   }
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
@@ -145,9 +145,7 @@ final class ElasticsearchSpanStore implements SpanStore {
 
   @Override
   public Call<List<String>> getSpanNames(String serviceName) {
-    if (!searchEnabled) return Call.emptyList();
-
-    if ("".equals(serviceName)) return Call.emptyList();
+    if (serviceName.isEmpty() || !searchEnabled) return Call.emptyList();
 
     long endMillis = System.currentTimeMillis();
     long beginMillis = endMillis - namesLookback;

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
@@ -17,7 +17,9 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
@@ -32,7 +34,7 @@ import static zipkin2.elasticsearch.integration.ElasticsearchStorageRule.index;
 public class ITElasticsearchStorageV2 {
 
   static ElasticsearchStorageRule classRule() {
-    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch:2.4.6",
+    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch:2.10.1",
       "test_elasticsearch3");
   }
 
@@ -48,6 +50,10 @@ public class ITElasticsearchStorageV2 {
 
     @Override protected StorageComponent storage() {
       return storage;
+    }
+
+    // we don't map this in elasticsearch
+    @Test @Ignore @Override public void getSpanNames_mapsNameToRemoteServiceName() {
     }
 
     @Before @Override public void clear() throws IOException {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
@@ -17,7 +17,9 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
@@ -32,7 +34,7 @@ import static zipkin2.elasticsearch.integration.ElasticsearchStorageRule.index;
 public class ITElasticsearchStorageV5 {
 
   static ElasticsearchStorageRule classRule() {
-    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch5:2.4.6",
+    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch5:2.10.1",
       "test_elasticsearch3");
   }
 
@@ -48,6 +50,10 @@ public class ITElasticsearchStorageV5 {
 
     @Override protected StorageComponent storage() {
       return storage;
+    }
+
+    // we don't map this in elasticsearch
+    @Test @Ignore @Override public void getSpanNames_mapsNameToRemoteServiceName() {
     }
 
     @Before @Override public void clear() throws IOException {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -17,7 +17,9 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
@@ -32,7 +34,7 @@ import static zipkin2.elasticsearch.integration.ElasticsearchStorageRule.index;
 public class ITElasticsearchStorageV6 {
 
   static ElasticsearchStorageRule classRule() {
-    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch6:2.4.6",
+    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch6:2.10.1",
       "test_elasticsearch3");
   }
 
@@ -48,6 +50,10 @@ public class ITElasticsearchStorageV6 {
 
     @Override protected StorageComponent storage() {
       return storage;
+    }
+
+    // we don't map this in elasticsearch
+    @Test @Ignore @Override public void getSpanNames_mapsNameToRemoteServiceName() {
     }
 
     @Before @Override public void clear() throws IOException {

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/MySQLSpanStore.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/MySQLSpanStore.java
@@ -75,7 +75,7 @@ final class MySQLSpanStore implements SpanStore {
 
   @Override
   public Call<List<String>> getSpanNames(String serviceName) {
-    if (serviceName == null) return Call.emptyList();
+    if (serviceName.isEmpty()) return Call.emptyList();
 
     return dataSourceCallFactory.create(new SelectSpanNames(schema, serviceName));
   }

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectSpanNames.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectSpanNames.java
@@ -32,13 +32,14 @@ final class SelectSpanNames implements Function<DSLContext, List<String>> {
   @Override
   public List<String> apply(DSLContext context) {
     return context
-        .selectDistinct(ZIPKIN_SPANS.NAME)
-        .from(ZIPKIN_SPANS)
-        .join(ZIPKIN_ANNOTATIONS)
-        .on(schema.joinCondition(ZIPKIN_ANNOTATIONS))
-        .where(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME.eq(serviceName))
-        .orderBy(ZIPKIN_SPANS.NAME)
-        .fetch(ZIPKIN_SPANS.NAME);
+      .selectDistinct(ZIPKIN_SPANS.NAME)
+      .from(ZIPKIN_SPANS)
+      .join(ZIPKIN_ANNOTATIONS)
+      .on(schema.joinCondition(ZIPKIN_ANNOTATIONS))
+      .where(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME.eq(serviceName))
+      .and(ZIPKIN_SPANS.NAME.notEqual(""))
+      .orderBy(ZIPKIN_SPANS.NAME)
+      .fetch(ZIPKIN_SPANS.NAME);
   }
 
   @Override

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -35,7 +35,7 @@ import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinDependenc
 public class ITMySQLStorage {
 
   static LazyMySQLStorage classRule() {
-    return new LazyMySQLStorage("2.4.6");
+    return new LazyMySQLStorage("2.10.1");
   }
 
   public static class SpanStoreTest extends zipkin.storage.SpanStoreTest {

--- a/zipkin2/src/main/java/zipkin2/storage/StrictTraceId.java
+++ b/zipkin2/src/main/java/zipkin2/storage/StrictTraceId.java
@@ -46,9 +46,7 @@ public final class StrictTraceId {
       Iterator<List<Span>> i = input.iterator();
       while (i.hasNext()) { // Not using removeIf as that's java 8+
         List<Span> next = i.next();
-        if (next.get(0).traceId().length() > 16 && !request.test(next)) {
-          i.remove();
-        }
+        if (!request.test(next)) i.remove();
       }
       return input;
     }
@@ -72,9 +70,7 @@ public final class StrictTraceId {
       Iterator<Span> i = input.iterator();
       while (i.hasNext()) { // Not using removeIf as that's java 8+
         Span next = i.next();
-        if (!next.traceId().equals(traceId)) {
-          i.remove();
-        }
+        if (!next.traceId().equals(traceId)) i.remove();
       }
       return input;
     }
@@ -83,5 +79,8 @@ public final class StrictTraceId {
     public String toString() {
       return "FilterSpans{traceId=" + traceId + "}";
     }
+  }
+
+  StrictTraceId() {
   }
 }

--- a/zipkin2/src/test/java/zipkin2/storage/ITSpanStore.java
+++ b/zipkin2/src/test/java/zipkin2/storage/ITSpanStore.java
@@ -15,9 +15,11 @@ package zipkin2.storage;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -28,8 +30,11 @@ import zipkin2.Span;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.BACKEND;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.DAY;
+import static zipkin2.TestObjects.FRONTEND;
+import static zipkin2.TestObjects.LOTS_OF_SPANS;
 import static zipkin2.TestObjects.TODAY;
 import static zipkin2.TestObjects.TRACE;
 import static zipkin2.TestObjects.TRACE_STARTTS;
@@ -51,6 +56,73 @@ public abstract class ITSpanStore {
   /** Clears store between tests. */
   @Before public abstract void clear() throws Exception;
 
+  @Test public void getTrace_considersBitsAbove64bit() throws IOException {
+    // 64-bit trace ID
+    Span span1 = Span.newBuilder().traceId(CLIENT_SPAN.traceId().substring(16)).id("1").build();
+    // 128-bit trace ID prefixed by above
+    Span span2 = Span.newBuilder().traceId(CLIENT_SPAN.traceId()).id("2").build();
+    // Different 128-bit trace ID prefixed by above
+    Span span3 = Span.newBuilder().traceId("1" + span1.traceId()).id("3").build();
+
+    accept(span1, span2, span3);
+
+    for (Span span : Arrays.asList(span1, span2, span3)) {
+      assertThat(store().getTrace(span.traceId()).execute())
+        .containsOnly(span);
+    }
+  }
+
+  @Test public void getTrace_returnsEmptyOnNotFound() throws IOException {
+    assertThat(store().getTrace(CLIENT_SPAN.traceId()).execute())
+      .isEmpty();
+
+    accept(CLIENT_SPAN);
+
+    assertThat(store().getTrace(CLIENT_SPAN.traceId()).execute())
+      .containsExactly(CLIENT_SPAN);
+
+    assertThat(store().getTrace(CLIENT_SPAN.traceId().substring(16)).execute())
+      .isEmpty();
+  }
+
+  /** This would only happen when the store layer is bootstrapping, or has been purged. */
+  @Test public void allShouldWorkWhenEmpty() throws IOException {
+    QueryRequest.Builder q = requestBuilder().serviceName("service");
+    assertThat(store().getTraces(q.build()).execute()).isEmpty();
+    assertThat(store().getTraces(q.spanName("methodcall").build()).execute()).isEmpty();
+    assertThat(store().getTraces(q.parseAnnotationQuery("custom").build()).execute()).isEmpty();
+    assertThat(store().getTraces(q.parseAnnotationQuery("BAH=BEH").build()).execute()).isEmpty();
+  }
+
+  /** This is unlikely and means instrumentation sends empty spans by mistake. */
+  @Test public void allShouldWorkWhenNoIndexableDataYet() throws IOException {
+    accept(Span.newBuilder().traceId("1").id("1").build());
+
+    allShouldWorkWhenEmpty();
+  }
+
+  @Test public void getTraces_considersBitsAbove64bit() throws IOException {
+    // 64-bit trace ID
+    Span span1 = Span.newBuilder().traceId(CLIENT_SPAN.traceId().substring(16)).id("1")
+      .putTag("foo", "1")
+      .timestamp(TODAY * 1000L)
+      .localEndpoint(FRONTEND)
+      .build();
+    // 128-bit trace ID prefixed by above
+    Span span2 = span1.toBuilder().traceId(CLIENT_SPAN.traceId()).putTag("foo", "2").build();
+    // Different 128-bit trace ID prefixed by above
+    Span span3 = span1.toBuilder().traceId("1" + span1.traceId()).putTag("foo", "3").build();
+
+    accept(span1, span2, span3);
+
+    for (Span span : Arrays.asList(span1, span2, span3)) {
+      assertThat(store().getTraces(requestBuilder()
+        .serviceName("frontend")
+        .parseAnnotationQuery("foo=" + span.tags().get("foo")).build()
+      ).execute()).flatExtracting(t -> t).containsExactly(span);
+    }
+  }
+
   @Test public void getTraces_filteringMatchesMostRecentTraces() throws Exception {
     List<Endpoint> endpoints = IntStream.rangeClosed(1, 10)
       .mapToObj(i -> Endpoint.newBuilder().serviceName("service" + i).ip("127.0.0.1").build())
@@ -60,12 +132,12 @@ public abstract class ITSpanStore {
     Span[] earlySpans =
       IntStream.rangeClosed(1, 10).mapToObj(i -> Span.newBuilder().name("early")
         .traceId(Integer.toHexString(i)).id(Integer.toHexString(i))
-        .timestamp((TODAY - i) * 1000).duration(1L)
+        .timestamp((TODAY - i) * 1000L).duration(1L)
         .localEndpoint(endpoints.get(i - 1)).build()).toArray(Span[]::new);
 
     Span[] lateSpans = IntStream.rangeClosed(1, 10).mapToObj(i -> Span.newBuilder().name("late")
       .traceId(Integer.toHexString(i + 10)).id(Integer.toHexString(i + 10))
-      .timestamp((TODAY + gapBetweenSpans - i) * 1000).duration(1L)
+      .timestamp((TODAY + gapBetweenSpans - i) * 1000L).duration(1L)
       .localEndpoint(endpoints.get(i - 1)).build()).toArray(Span[]::new);
 
     accept(earlySpans);
@@ -96,11 +168,11 @@ public abstract class ITSpanStore {
     accept(CLIENT_SPAN);
 
     assertThat(store().getTraces(requestBuilder()
-      .serviceName(CLIENT_SPAN.localServiceName() + 1)
+      .serviceName("frontend" + 1)
       .build()).execute()).isEmpty();
 
     assertThat(store().getTraces(requestBuilder()
-      .serviceName(CLIENT_SPAN.localServiceName())
+      .serviceName("frontend")
       .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
   }
 
@@ -114,6 +186,21 @@ public abstract class ITSpanStore {
     assertThat(store().getTraces(requestBuilder()
       .spanName(CLIENT_SPAN.name())
       .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
+
+    assertThat(store().getTraces(requestBuilder()
+      .spanName("frontend")
+      .spanName(CLIENT_SPAN.name())
+      .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
+  }
+
+  @Test public void getTraces_spanName_128() throws Exception {
+    // add a trace with the same trace ID truncated to 64 bits, except the span name.
+    accept(CLIENT_SPAN.toBuilder()
+      .traceId(CLIENT_SPAN.traceId().substring(16))
+      .name("bar")
+      .build());
+
+    getTraces_spanName();
   }
 
   @Test public void getTraces_tags() throws Exception {
@@ -154,27 +241,430 @@ public abstract class ITSpanStore {
       .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
   }
 
-  @Test public void getSpanNames() throws Exception {
-    assertThat(store().getSpanNames(CLIENT_SPAN.localServiceName()).execute())
-      .isEmpty();
+  /**
+   * While large spans are discouraged, and maybe not indexed, we should be able to read them back.
+   */
+  @Test public void readsBackLargeValues() throws IOException {
+    char[] kilobyteOfText = new char[1024];
+    Arrays.fill(kilobyteOfText, 'a');
 
-    accept(CLIENT_SPAN);
+    // Make a span that's over 1KiB in size
+    Span span = Span.newBuilder().traceId("1").id("1").name("big")
+      .timestamp(TODAY * 1000L + 100L).duration(200L)
+      .localEndpoint(FRONTEND)
+      .putTag("a", new String(kilobyteOfText)).build();
 
-    assertThat(store().getSpanNames(CLIENT_SPAN.localServiceName() + 1).execute())
-      .isEmpty();
+    accept(span);
 
-    assertThat(store().getSpanNames(CLIENT_SPAN.localServiceName()).execute())
-      .contains(CLIENT_SPAN.name());
+    // read back to ensure the data wasn't truncated
+    assertThat(store().getTraces(requestBuilder().build()).execute())
+      .containsExactly(asList(span));
+    assertThat(store().getTrace(span.traceId()).execute())
+      .containsExactly(span);
   }
 
-  /** Ensure complete traces are aggregated, even if they complete after endTs */
-  @Test
-  public void getTraces_endTsInsideTheTrace() throws IOException {
-    accept(TRACE);
+  /** Not a good span name, but better to test it than break mysteriously */
+  @Test public void spanNameIsJson() throws IOException {
+    String json = "{\"foo\":\"bar\"}";
+    Span withJsonSpanName = CLIENT_SPAN.toBuilder().name(json).build();
+
+    accept(withJsonSpanName);
+
+    QueryRequest query = requestBuilder().serviceName("frontend").spanName(json).build();
+    assertThat(store().getTraces(query).execute())
+      .extracting(t -> t.get(0).name())
+      .containsExactly(json);
+  }
+
+  /** Dots in tag names can create problems in storage which tries to make a tree out of them */
+  @Test public void tagsWithNestedDots() throws IOException {
+    Span tagsWithNestedDots = CLIENT_SPAN.toBuilder()
+      .putTag("http.path", "/api")
+      .putTag("http.path.morepath", "/api/api")
+      .build();
+
+    accept(tagsWithNestedDots);
+
+    assertThat(store().getTrace(tagsWithNestedDots.traceId()).execute())
+      .containsExactly(tagsWithNestedDots);
+  }
+
+  /**
+   * Formerly, a bug was present where cassandra didn't index more than bucket count traces per
+   * millisecond. This stores a lot of spans to ensure indexes work under high-traffic scenarios.
+   */
+  @Test public void getTraces_manyTraces() throws IOException {
+    int traceCount = 1000;
+    Span span = LOTS_OF_SPANS[0];
+    Map.Entry<String, String> tag = span.tags().entrySet().iterator().next();
+
+    accept(Arrays.copyOfRange(LOTS_OF_SPANS, 0, traceCount));
+
+    assertThat(store().getTraces(requestBuilder().limit(traceCount).build()).execute())
+      .hasSize(traceCount);
+
+    QueryRequest.Builder builder =
+      requestBuilder().limit(traceCount).serviceName(span.localServiceName());
+
+    assertThat(store().getTraces(builder.build()).execute())
+      .hasSize(traceCount);
+
+    assertThat(store().getTraces(builder.spanName(span.name()).build()).execute())
+      .hasSize(traceCount);
+
+    assertThat(
+      store().getTraces(builder.parseAnnotationQuery(tag.getKey() + "=" + tag.getValue()).build())
+        .execute())
+      .hasSize(traceCount);
+  }
+
+  /** Shows that duration queries go against the root span, not the child */
+  @Test public void getTraces_duration() throws IOException {
+    setupDurationData();
+
+    QueryRequest.Builder q = requestBuilder().endTs(TODAY).lookback(DAY); // instead of since epoch
+    QueryRequest query;
+
+    // Min duration is inclusive and is applied by service.
+    query = q.serviceName("service1").minDuration(200_000L).build();
+    assertThat(store().getTraces(query).execute()).extracting(t -> t.get(0).traceId())
+      .containsExactly("0000000000000001");
+
+    query = q.serviceName("service3").minDuration(200_000L).build();
+    assertThat(store().getTraces(query).execute()).extracting(t -> t.get(0).traceId())
+      .containsExactly("0000000000000002");
+
+    // Duration bounds aren't limited to root spans: they apply to all spans by service in a trace
+    query = q.serviceName("service2").minDuration(50_000L).maxDuration(150_000L).build();
+    assertThat(store().getTraces(query).execute()).extracting(t -> t.get(0).traceId())
+      // service2 root of trace 3, but middle of 1 and 2.
+      .containsExactlyInAnyOrder("0000000000000003", "0000000000000002", "0000000000000001");
+
+    // Span name should apply to the duration filter
+    query = q.serviceName("service2").spanName("zip").maxDuration(50_000L).build();
+    assertThat(store().getTraces(query).execute()).extracting(t -> t.get(0).traceId())
+      .containsExactly("0000000000000003");
+
+    // Max duration should filter our longer spans from the same service
+    query = q.serviceName("service2").minDuration(50_000L).maxDuration(50_000L).build();
+    assertThat(store().getTraces(query).execute()).extracting(t -> t.get(0).traceId())
+      .containsExactly("0000000000000003");
+  }
+
+  /**
+   * Spans and traces are meaningless unless they have a timestamp. While unlikely, this could
+   * happen if a binary annotation is logged before a timestamped one is.
+   */
+  @Test public void getTraces_absentWhenNoTimestamp() throws IOException {
+    // Index the service name but no timestamp of any sort
+    accept(Span.newBuilder()
+      .traceId(CLIENT_SPAN.traceId())
+      .id(CLIENT_SPAN.id())
+      .name(CLIENT_SPAN.name())
+      .localEndpoint(CLIENT_SPAN.localEndpoint())
+      .build()
+    );
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("frontend").build()
+    ).execute()).isEmpty();
+
+    assertThat(store().getTraces(
+      requestBuilder()
+        .serviceName("frontend")
+        .spanName(CLIENT_SPAN.name())
+        .build()
+    ).execute()).isEmpty();
+
+    // now store the timestamped span
+    accept(CLIENT_SPAN);
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("frontend").build()
+    ).execute()).isNotEmpty();
+
+    assertThat(store().getTraces(
+      requestBuilder()
+        .serviceName("frontend")
+        .spanName(CLIENT_SPAN.name())
+        .build()
+    ).execute()).isNotEmpty();
+  }
+
+  @Test public void getTraces_annotation() throws IOException {
+    accept(CLIENT_SPAN);
+
+    // fetch by time based annotation, find trace
+    assertThat(store().getTraces(
+      requestBuilder()
+        .serviceName("frontend")
+        .parseAnnotationQuery(CLIENT_SPAN.annotations().get(0).value())
+        .build()
+    ).execute()).isNotEmpty();
+
+    // should find traces by a tag
+    Map.Entry<String, String> tag = CLIENT_SPAN.tags().entrySet().iterator().next();
+    assertThat(store().getTraces(
+      requestBuilder()
+        .serviceName("frontend")
+        .parseAnnotationQuery(tag.getKey() + "=" + tag.getValue())
+        .build()
+    ).execute()).isNotEmpty();
+  }
+
+  @Test public void getTraces_multipleAnnotationsBecomeAndFilter() throws IOException {
+    Span foo = Span.newBuilder().traceId("1").name("call1").id(1)
+      .timestamp((TODAY + 1) * 1000L)
+      .localEndpoint(FRONTEND)
+      .addAnnotation((TODAY + 1) * 1000L, "foo").build();
+    // would be foo bar, except lexicographically bar precedes foo
+    Span barAndFoo = Span.newBuilder().traceId("2").name("call2").id(2)
+      .timestamp((TODAY + 2) * 1000L)
+      .localEndpoint(FRONTEND)
+      .addAnnotation((TODAY + 2) * 1000L, "bar")
+      .addAnnotation((TODAY + 2) * 1000L, "foo").build();
+    Span fooAndBazAndQux = Span.newBuilder().traceId("3").name("call3").id(3)
+      .timestamp((TODAY + 3) * 1000L)
+      .localEndpoint(FRONTEND)
+      .addAnnotation((TODAY + 3) * 1000L, "foo")
+      .putTag("baz", "qux")
+      .build();
+    Span barAndFooAndBazAndQux = Span.newBuilder().traceId("4").name("call4").id(4)
+      .timestamp((TODAY + 4) * 1000L)
+      .localEndpoint(FRONTEND)
+      .addAnnotation((TODAY + 4) * 1000L, "bar")
+      .addAnnotation((TODAY + 4) * 1000L, "foo")
+      .putTag("baz", "qux")
+      .build();
+
+    accept(foo, barAndFoo, fooAndBazAndQux, barAndFooAndBazAndQux);
 
     assertThat(sortTraces(store().getTraces(
-      requestBuilder().endTs(TRACE_STARTTS + 100).lookback(200).build()
-    ).execute())).containsOnly(TRACE);
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("foo").build()
+    ).execute())).containsExactly(
+      asList(foo), asList(barAndFoo), asList(fooAndBazAndQux), asList(barAndFooAndBazAndQux)
+    );
+
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("foo and bar").build()
+    ).execute())).containsExactly(
+      asList(barAndFoo), asList(barAndFooAndBazAndQux)
+    );
+
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().serviceName("frontend")
+        .parseAnnotationQuery("foo and bar and baz=qux")
+        .build()
+    ).execute())).containsExactly(
+      asList(barAndFooAndBazAndQux)
+    );
+
+    // ensure we can search only by tag key
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("baz").build()
+    ).execute())).containsExactly(
+      asList(fooAndBazAndQux), asList(barAndFooAndBazAndQux)
+    );
+  }
+
+  /** This test makes sure that annotation queries pay attention to which host recorded data */
+  @Test public void getTraces_differentiateOnServiceName() throws IOException {
+    Span trace1 = Span.newBuilder().traceId("1").name("1").id(1)
+      .kind(Span.Kind.CLIENT)
+      .timestamp((TODAY + 1) * 1000L)
+      .duration(3000L)
+      .localEndpoint(FRONTEND)
+      .addAnnotation(((TODAY + 1) * 1000L) + 500, "web")
+      .putTag("local", "web")
+      .putTag("web-b", "web")
+      .build();
+
+    Span trace1Server = Span.newBuilder().traceId("1").name("1").id(1)
+      .kind(Span.Kind.SERVER)
+      .shared(true)
+      .localEndpoint(BACKEND)
+      .timestamp((TODAY + 2) * 1000L)
+      .duration(1000L)
+      .build();
+
+    Span trace2 = Span.newBuilder().traceId("2").name("2").id(2)
+      .timestamp((TODAY + 11) * 1000L)
+      .duration(3000L)
+      .kind(Span.Kind.CLIENT)
+      .localEndpoint(BACKEND)
+      .addAnnotation(((TODAY + 11) * 1000) + 500, "app")
+      .putTag("local", "app")
+      .putTag("app-b", "app")
+      .build();
+
+    Span trace2Server = Span.newBuilder().traceId("2").name("2").id(2)
+      .shared(true)
+      .kind(Span.Kind.SERVER)
+      .localEndpoint(FRONTEND)
+      .timestamp((TODAY + 12) * 1000L)
+      .duration(1000L).build();
+
+    accept(trace1, trace1Server, trace2, trace2Server);
+
+    // Sanity check
+    assertThat(store().getTrace(trace1.traceId()).execute())
+      .containsExactlyInAnyOrder(trace1, trace1Server);
+    assertThat(sortTrace(store().getTrace(trace2.traceId()).execute()))
+      .containsExactly(trace2, trace2Server);
+    assertThat(sortTraces(store().getTraces(requestBuilder().build()).execute()))
+      .containsExactly(asList(trace1, trace1Server), asList(trace2, trace2Server));
+
+    // We only return traces where the service specified caused the data queried.
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("web").build()
+    ).execute())).containsExactly(asList(trace1, trace1Server));
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("backend").parseAnnotationQuery("web").build()
+    ).execute()).isEmpty();
+
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().serviceName("backend").parseAnnotationQuery("app").build()
+    ).execute())).containsExactly(asList(trace2, trace2Server));
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("app").build()
+    ).execute()).isEmpty();
+
+    // tags are returned on annotation queries
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("web-b").build()
+    ).execute())).containsExactly(asList(trace1, trace1Server));
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("backend").parseAnnotationQuery("web-b").build()
+    ).execute()).isEmpty();
+
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().serviceName("backend").parseAnnotationQuery("app-b").build()
+    ).execute())).containsExactly(asList(trace2, trace2Server));
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("app-b").build()
+    ).execute()).isEmpty();
+
+    // We only return traces where the service specified caused the tag queried.
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("local=web").build()
+    ).execute())).containsExactly(asList(trace1, trace1Server));
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("backend").parseAnnotationQuery("local=web").build()
+    ).execute()).isEmpty();
+
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().serviceName("backend").parseAnnotationQuery("local=app").build()
+    ).execute())).containsExactly(asList(trace2, trace2Server));
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("local=app").build()
+    ).execute()).isEmpty();
+  }
+
+  /** Make sure empty binary annotation values don't crash */
+  @Test public void getTraces_tagWithEmptyValue() throws IOException {
+    Span span = Span.newBuilder()
+      .traceId("1")
+      .name("call1")
+      .id(1)
+      .timestamp((TODAY + 1) * 1000)
+      .localEndpoint(FRONTEND)
+      .putTag("empty", "").build();
+
+    accept(span);
+
+    assertThat(store().getTraces(requestBuilder().serviceName("frontend").build()).execute())
+      .containsExactly(asList(span));
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("frontend").parseAnnotationQuery("empty").build()
+    ).execute()).containsExactly(asList(span));
+
+    assertThat(store().getTrace(span.traceId()).execute())
+      .containsExactly(span);
+  }
+
+  /** limit should apply to traces closest to endTs */
+  @Test public void getTraces_limit() throws IOException {
+    Span span1 = Span.newBuilder()
+      .traceId("a")
+      .id("1")
+      .timestamp((TODAY + 1) * 1000L)
+      .localEndpoint(FRONTEND)
+      .build();
+    Span span2 = span1.toBuilder().traceId("b").timestamp((TODAY + 2) * 1000L).build();
+    accept(span1, span2);
+
+    assertThat(
+      store().getTraces(requestBuilder().serviceName("frontend").limit(1).build()).execute())
+      .extracting(t -> t.get(0).id())
+      .containsExactly(span2.id());
+  }
+
+  /** Traces whose root span has timestamps between (endTs - lookback) and endTs are returned */
+  @Test public void getTraces_endTsAndLookback() throws IOException {
+    Span span1 = Span.newBuilder()
+      .traceId("a")
+      .id("1")
+      .timestamp((TODAY + 1) * 1000L)
+      .localEndpoint(FRONTEND)
+      .build();
+    Span span2 = span1.toBuilder().traceId("b").timestamp((TODAY + 2) * 1000L).build();
+    accept(span1, span2);
+
+    assertThat(store().getTraces(requestBuilder().endTs(TODAY).build()).execute())
+      .isEmpty();
+    assertThat(store().getTraces(requestBuilder().endTs(TODAY + 1).build()).execute())
+      .extracting(t -> t.get(0).id())
+      .containsExactly(span1.id());
+    assertThat(store().getTraces(requestBuilder().endTs(TODAY + 2).build()).execute())
+      .extracting(t -> t.get(0).id())
+      .containsExactlyInAnyOrder(span1.id(), span2.id());
+    assertThat(store().getTraces(requestBuilder().endTs(TODAY + 3).build()).execute())
+      .extracting(t -> t.get(0).id())
+      .containsExactlyInAnyOrder(span1.id(), span2.id());
+
+    assertThat(store().getTraces(requestBuilder().endTs(TODAY).build()).execute())
+      .isEmpty();
+    assertThat(store().getTraces(requestBuilder().endTs(TODAY + 1).lookback(1).build()).execute())
+      .extracting(t -> t.get(0).id())
+      .containsExactly(span1.id());
+    assertThat(store().getTraces(requestBuilder().endTs(TODAY + 2).lookback(1).build()).execute())
+      .extracting(t -> t.get(0).id())
+      .containsExactlyInAnyOrder(span1.id(), span2.id());
+    assertThat(store().getTraces(requestBuilder().endTs(TODAY + 3).lookback(1).build()).execute())
+      .extracting(t -> t.get(0).id())
+      .containsExactlyInAnyOrder(span2.id());
+  }
+
+  // Bugs have happened in the past where trace limit was mistaken for span count.
+  @Test public void traceWithManySpans() throws IOException {
+    Span[] trace = new Span[101];
+    trace[0] = Span.newBuilder().traceId("f66529c8cc356aa0").id("93288b4644570496").name("get")
+      .timestamp(TODAY * 1000).duration(350 * 1000L)
+      .kind(Span.Kind.SERVER)
+      .localEndpoint(BACKEND)
+      .build();
+
+    IntStream.range(1, trace.length).forEach(i ->
+      trace[i] = Span.newBuilder().traceId(trace[0].traceId()).parentId(trace[0].id()).id(i)
+        .name("foo")
+        .timestamp((TODAY + i) * 1000).duration(10L)
+        .localEndpoint(BACKEND)
+        .build());
+
+    accept(trace);
+
+    assertThat(store().getTraces(requestBuilder().build()).execute())
+      .flatExtracting(t -> t)
+      .containsExactlyInAnyOrder(trace);
+    assertThat(store().getTrace(trace[0].traceId()).execute())
+      .containsExactlyInAnyOrder(trace);
   }
 
   @Test public void getServiceNames_includesLocalServiceName() throws Exception {
@@ -184,7 +674,86 @@ public abstract class ITSpanStore {
     accept(CLIENT_SPAN);
 
     assertThat(store().getServiceNames().execute())
-      .contains(CLIENT_SPAN.localServiceName());
+      .contains("frontend");
+  }
+
+  @Test public void getServiceNames_includesRemoteServiceName() throws Exception {
+    accept(CLIENT_SPAN);
+
+    assertThat(store().getServiceNames().execute())
+      .contains(CLIENT_SPAN.remoteServiceName());
+  }
+
+  /** Our storage services aren't 100% consistent on this. we should reconsider at some point */
+  @Test public void getSpanNames_mapsNameToRemoteServiceName() throws Exception {
+    accept(CLIENT_SPAN);
+
+    assertThat(store().getSpanNames(CLIENT_SPAN.remoteServiceName()).execute())
+      .contains(CLIENT_SPAN.name());
+  }
+
+  @Test public void getSpanNames() throws Exception {
+    assertThat(store().getSpanNames("frontend").execute())
+      .isEmpty();
+
+    accept(CLIENT_SPAN);
+
+    assertThat(store().getSpanNames("frontend" + 1).execute())
+      .isEmpty();
+
+    assertThat(store().getSpanNames("frontend").execute())
+      .contains(CLIENT_SPAN.name());
+  }
+
+  @Test public void getSpanNames_allReturned() throws IOException {
+    // Assure a default spanstore limit isn't hit by assuming if 50 are returned, all are returned
+    List<String> spanNames = new ArrayList<>();
+    for (int i = 0; i < 50; i++) {
+      String suffix = i < 10 ? "0" + i : String.valueOf(i);
+      accept(CLIENT_SPAN.toBuilder().id(i + 1).name("yak" + suffix).build());
+      spanNames.add("yak" + suffix);
+    }
+
+    assertThat(store().getSpanNames("frontend").execute())
+      .containsExactlyInAnyOrderElementsOf(spanNames);
+  }
+
+  @Test public void getAllServiceNames_noServiceName() throws IOException {
+    accept(Span.newBuilder().traceId("a").id("a").build());
+
+    assertThat(store().getServiceNames().execute()).isEmpty();
+  }
+
+  @Test public void getSpanNames_noSpanName() throws IOException {
+    accept(Span.newBuilder().traceId("a").id("a").localEndpoint(FRONTEND).build());
+
+    assertThat(store().getSpanNames("frontend").execute()).isEmpty();
+  }
+
+  @Test public void spanNamesGoLowercase() throws IOException {
+    accept(CLIENT_SPAN);
+
+    assertThat(store().getTraces(
+      requestBuilder().serviceName("frontend").spanName("GeT").build()
+    ).execute()).hasSize(1);
+  }
+
+  @Test public void serviceNamesGoLowercase() throws IOException {
+    accept(CLIENT_SPAN);
+
+    assertThat(store().getSpanNames("FrOnTeNd").execute()).containsExactly("get");
+
+    assertThat(store().getTraces(requestBuilder().serviceName("FrOnTeNd").build()).execute())
+      .hasSize(1);
+  }
+
+  /** Ensure complete traces are aggregated, even if they complete after endTs */
+  @Test public void getTraces_endTsInsideTheTrace() throws IOException {
+    accept(TRACE);
+
+    assertThat(sortTraces(store().getTraces(
+      requestBuilder().endTs(TRACE_STARTTS + 100).lookback(200).build()
+    ).execute())).containsOnly(TRACE);
   }
 
   protected void accept(List<Span> spans) throws IOException {
@@ -195,7 +764,49 @@ public abstract class ITSpanStore {
     storage().spanConsumer().accept(asList(spans)).execute();
   }
 
-  static QueryRequest.Builder requestBuilder() {
+  void setupDurationData() throws IOException {
+    Endpoint service1 = Endpoint.newBuilder().serviceName("service1").build();
+    Endpoint service2 = Endpoint.newBuilder().serviceName("service2").build();
+    Endpoint service3 = Endpoint.newBuilder().serviceName("service3").build();
+
+    long offsetMicros = (TODAY - 3) * 1000L; // to make sure queries look back properly
+    Span targz = Span.newBuilder().traceId("1").id(1L)
+      .name("targz").timestamp(offsetMicros + 100L).duration(200_000L)
+      .localEndpoint(service1)
+      .putTag("lc", "archiver").build();
+    Span tar = Span.newBuilder().traceId("1").id(2L).parentId(1L)
+      .name("tar").timestamp(offsetMicros + 200L).duration(150_000L)
+      .localEndpoint(service2)
+      .putTag("lc", "archiver").build();
+    Span gz = Span.newBuilder().traceId("1").id(3L).parentId(1L)
+      .name("gz").timestamp(offsetMicros + 250L).duration(50_000L)
+      .localEndpoint(service3)
+      .putTag("lc", "archiver").build();
+    Span zip = Span.newBuilder().traceId("3").id(3L)
+      .name("zip").timestamp(offsetMicros + 130L).duration(50_000L)
+      .addAnnotation(offsetMicros + 130L, "zip")
+      .localEndpoint(service2)
+      .putTag("lc", "archiver").build();
+
+    List<Span> trace1 = asList(targz, tar, gz);
+    List<Span> trace2 = asList(
+      targz.toBuilder().traceId("2").timestamp(offsetMicros + 110L)
+        .localEndpoint(service3)
+        .putTag("lc", "archiver-v2").build(),
+      tar.toBuilder().traceId("2").timestamp(offsetMicros + 210L)
+        .localEndpoint(service2)
+        .putTag("lc", "archiver").build(),
+      gz.toBuilder().traceId("2").timestamp(offsetMicros + 260L)
+        .localEndpoint(service1)
+        .putTag("lc", "archiver").build());
+    List<Span> trace3 = asList(zip);
+
+    accept(trace1.toArray(new Span[0]));
+    accept(trace2.toArray(new Span[0]));
+    accept(trace3.toArray(new Span[0]));
+  }
+
+  protected static QueryRequest.Builder requestBuilder() {
     return QueryRequest.newBuilder().endTs(TODAY + DAY).lookback(DAY * 2).limit(100);
   }
 

--- a/zipkin2/src/test/java/zipkin2/storage/ITStrictTraceIdFalse.java
+++ b/zipkin2/src/test/java/zipkin2/storage/ITStrictTraceIdFalse.java
@@ -50,14 +50,14 @@ public abstract class ITStrictTraceIdFalse {
 
   /** Ensures we can still lookup fully 128-bit traces when strict trace ID id disabled */
   @Test public void getTraces_128BitTraceId() throws IOException {
-    getTraces_128BitTraceId(accept128BitTrace());
+    getTraces_128BitTraceId(accept128BitTrace(storage()));
   }
 
   @Test public void getTraces_128BitTraceId_mixed() throws IOException {
     getTraces_128BitTraceId(acceptMixedTrace());
   }
 
-  void getTraces_128BitTraceId(List<Span> trace) throws IOException {
+  protected void getTraces_128BitTraceId(List<Span> trace) throws IOException {
     assertThat(sortTraces(store().getTraces(requestBuilder().build()).execute()))
       .containsExactly(trace);
 
@@ -75,7 +75,7 @@ public abstract class ITStrictTraceIdFalse {
   }
 
   @Test public void getTrace_retrievesBy64Or128BitTraceId() throws IOException {
-    List<Span> trace = accept128BitTrace();
+    List<Span> trace = accept128BitTrace(storage());
 
     retrievesBy64Or128BitTraceId(trace);
   }
@@ -93,10 +93,10 @@ public abstract class ITStrictTraceIdFalse {
       .containsOnlyElementsOf(trace);
   }
 
-  List<Span> accept128BitTrace() throws IOException {
+  protected List<Span> accept128BitTrace(StorageComponent storage) throws IOException {
     List<Span> trace = new ArrayList<>(TestObjects.TRACE);
     Collections.reverse(trace);
-    accept(trace.toArray(new Span[0]));
+    storage.spanConsumer().accept(trace).execute();
     return TestObjects.TRACE;
   }
 

--- a/zipkin2/src/test/java/zipkin2/storage/StrictTraceIdTest.java
+++ b/zipkin2/src/test/java/zipkin2/storage/StrictTraceIdTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import zipkin2.Span;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+import static zipkin2.TestObjects.FRONTEND;
+import static zipkin2.TestObjects.TODAY;
+import static zipkin2.TestObjects.TRACE;
+import static zipkin2.storage.ITSpanStore.requestBuilder;
+
+public class StrictTraceIdTest {
+
+  @Test public void filterTraces_onSpanName() {
+    assertThat(StrictTraceId.filterTraces(
+      requestBuilder().spanName("11").build()
+    ).map(traces())).flatExtracting(l -> l).isEmpty();
+
+    assertThat(StrictTraceId.filterTraces(
+      requestBuilder().spanName("1").build()
+    ).map(traces())).containsExactly(traces().get(0));
+  }
+
+  @Test public void filterTraces_onTag() {
+    assertThat(StrictTraceId.filterTraces(
+      requestBuilder().parseAnnotationQuery("foo=0").build()
+    ).map(traces())).flatExtracting(l -> l).isEmpty();
+
+    assertThat(StrictTraceId.filterTraces(
+      requestBuilder().parseAnnotationQuery("foo=1").build()
+    ).map(traces())).containsExactly(traces().get(0));
+  }
+
+  @Test public void filterSpans() {
+    assertThat(StrictTraceId.filterSpans(CLIENT_SPAN.traceId()).map(TRACE)).isEqualTo(TRACE);
+
+    ArrayList<Span> trace = new ArrayList<>(TRACE);
+    trace.set(1, CLIENT_SPAN.toBuilder().traceId(CLIENT_SPAN.traceId().substring(16)).build());
+    assertThat(StrictTraceId.filterSpans(CLIENT_SPAN.traceId()).map(trace))
+      .doesNotContain(CLIENT_SPAN);
+  }
+
+  List<List<Span>> traces() {
+    // 64-bit trace ID
+    Span span1 = Span.newBuilder().traceId(CLIENT_SPAN.traceId().substring(16)).id("1")
+      .name("1")
+      .putTag("foo", "1")
+      .timestamp(TODAY * 1000L)
+      .localEndpoint(FRONTEND)
+      .build();
+    // 128-bit trace ID prefixed by above
+    Span span2 =
+      span1.toBuilder().traceId(CLIENT_SPAN.traceId()).name("2").putTag("foo", "2").build();
+    // Different 128-bit trace ID prefixed by above
+    Span span3 =
+      span1.toBuilder().traceId("1" + span1.traceId()).name("3").putTag("foo", "3").build();
+
+    return new ArrayList<>(asList(asList(span1), asList(span2), asList(span3)));
+  }
+}


### PR DESCRIPTION
Note this isn't precisely the same as SpanStoreTest as functionality
moved out of the api and into javascript as a part of defining the v2
api contract.

See #2047