### PR TITLE
Fixes UI display of json annotation values caused by opentracing log messages

### DIFF
--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -44,10 +44,12 @@ export function maybeMarkTransientError(row, anno) {
 export function formatAnnotationValue(value) {
   const type = $.type(value);
   if (type === 'object' || type === 'array' || value == null) {
-    return escapeHtml(JSON.stringify(value));
-  } else {
-    return escapeHtml(value.toString()); // prevents false from coercing to empty!
+    return `<pre><code>${escapeHtml(JSON.stringify(value, null, 2))}</code></pre>`;
   }
+  const result = value.toString();
+  // Preformat if the text includes newlines
+  return result.indexOf('\n') === -1 ? escapeHtml(result)
+    : `<pre><code>${escapeHtml(result)}</code></pre>`;
 }
 
 // Binary annotations are tags, and sometimes the values are large, for example

--- a/zipkin-ui/js/component_ui/spanPanel.js
+++ b/zipkin-ui/js/component_ui/spanPanel.js
@@ -38,18 +38,15 @@ export function maybeMarkTransientError(row, anno) {
 // end up becoming javascript objects later. For this reason, we have to guard
 // and stringify as necessary.
 
-// annotations are named events which shouldn't hold json. If someone passed
-// json, format as a single line. That way the rows corresponding to timestamps
-// aren't disrupted.
+// annotations are named events which can hold json. If someone passed
+// json, wrap it with <pre><code> to display it properly on UI.
+// That way the rows corresponding to timestamps aren't disrupted.
 export function formatAnnotationValue(value) {
   const type = $.type(value);
   if (type === 'object' || type === 'array' || value == null) {
     return `<pre><code>${escapeHtml(JSON.stringify(value, null, 2))}</code></pre>`;
   }
-  const result = value.toString();
-  // Preformat if the text includes newlines
-  return result.indexOf('\n') === -1 ? escapeHtml(result)
-    : `<pre><code>${escapeHtml(result)}</code></pre>`;
+  return escapeHtml(value.toString());
 }
 
 // Binary annotations are tags, and sometimes the values are large, for example

--- a/zipkin-ui/test/component_ui/spanPanel.test.js
+++ b/zipkin-ui/test/component_ui/spanPanel.test.js
@@ -59,13 +59,14 @@ describe('formatAnnotationValue', () => {
 
   it('should format object as one-line json', () => {
     formatAnnotationValue({foo: 'bar'}).should.equal(
-      '<pre><code>{&quot;foo&quot;:&quot;bar&quot;}</code></pre>'
+      '<pre><code>{\n  &quot;foo&quot;: &quot;bar&quot;\n}</code></pre>'
     );
   });
 
   it('should format array as one-line json', () => {
     formatAnnotationValue([{foo: 'bar'}, {baz: 'qux'}]).should.equal(
-      '<pre><code>[{&quot;foo&quot;:&quot;bar&quot;},{&quot;baz&quot;:&quot;qux&quot;}]</code></pre>'
+      '<pre><code>[\n  {\n    &quot;foo&quot;: &quot;bar&quot;\n  },\n'
+      + '  {\n    &quot;baz&quot;: &quot;qux&quot;\n  }\n]</code></pre>'
     );
   });
 

--- a/zipkin-ui/test/component_ui/spanPanel.test.js
+++ b/zipkin-ui/test/component_ui/spanPanel.test.js
@@ -59,18 +59,18 @@ describe('formatAnnotationValue', () => {
 
   it('should format object as one-line json', () => {
     formatAnnotationValue({foo: 'bar'}).should.equal(
-      '{&quot;foo&quot;:&quot;bar&quot;}'
+      '<pre><code>{&quot;foo&quot;:&quot;bar&quot;}</code></pre>'
     );
   });
 
   it('should format array as one-line json', () => {
     formatAnnotationValue([{foo: 'bar'}, {baz: 'qux'}]).should.equal(
-      '[{&quot;foo&quot;:&quot;bar&quot;},{&quot;baz&quot;:&quot;qux&quot;}]'
+      '<pre><code>[{&quot;foo&quot;:&quot;bar&quot;},{&quot;baz&quot;:&quot;qux&quot;}]</code></pre>'
     );
   });
 
   it('should format null as json', () => {
-    formatAnnotationValue(null).should.equal('null');
+    formatAnnotationValue(null).should.equal('<pre><code>null</code></pre>');
   });
 
   it('should escape html', () => {


### PR DESCRIPTION
UI Panel goes out of screen for json values.

Same issue in log messages (normal annotation) as given in this issue https://github.com/openzipkin/zipkin/issues/1113

Request you to merge to the master branch