### PR TITLE
Switch JSON download button to v2 endpoint

### DIFF
--- a/zipkin-ui/js/page/trace.js
+++ b/zipkin-ui/js/page/trace.js
@@ -42,7 +42,7 @@ const TracePageComponent = component(function TracePage() {
         this.trigger('uiRequestJsonPanel', {
           title: `Trace ${this.attr.traceId}`,
           obj: data.trace,
-          link: `${contextRoot}api/v1/trace/${this.attr.traceId}`
+          link: `${contextRoot}api/v2/trace/${this.attr.traceId}`
         });
       });
 

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -7,7 +7,7 @@
     {{#logsUrl}}
     <li class='navbar-right'><a href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-primary btn-xs badge'>Logs</span></a></li>
     {{/logsUrl}}
-    <li class='navbar-right'><a href='{{ contextRoot }}api/v1/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
+    <li class='navbar-right'><a href='{{ contextRoot }}api/v2/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
   </ul>
 
   <form class='form-inline' role='form'>

--- a/zipkin-ui/templates/traceViewer.mustache
+++ b/zipkin-ui/templates/traceViewer.mustache
@@ -15,7 +15,7 @@
     {{#logsUrl}}
     <li class='navbar-right'><a href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-primary btn-xs badge'>Logs</span></a></li>
     {{/logsUrl}}
-    <li class='navbar-right'><a href='{{ contextRoot }}api/v1/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
+    <li class='navbar-right'><a href='{{ contextRoot }}api/v2/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
   </ul>
 
   <form class='form-inline' role='form'>


### PR DESCRIPTION
When we removed the v1 endpoints, we missed updating the link for the JSON download button in the UI. This switches it to the v2 trace endpoint.

Resolves #2143