### PR TITLE
Makes java.util.logging route to log4j2 by default

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
@@ -21,6 +21,11 @@ import zipkin2.server.internal.RegisterZipkinHealthIndicators;
 @SpringBootApplication
 @EnableZipkinServer
 public class ZipkinServer {
+  static {
+    // Make sure java.util.logging goes to log4j2
+    // https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-configure-log4j-for-logging
+    System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+  }
 
   public static void main(String[] args) {
     new SpringApplicationBuilder(ZipkinServer.class)


### PR DESCRIPTION
This fixes the inconvenience of having to specify it in various CLIs.

Fixes #2149