### PR TITLE
Have a less scary search disabled message.

### DIFF
--- a/zipkin-ui/templates/searchDisabled.mustache
+++ b/zipkin-ui/templates/searchDisabled.mustache
@@ -1,3 +1,3 @@
-<div class="alert alert-danger" id="help-msg">
-    <p data-i18n="traces.searchDisabled">Searching has been disabled via the searchEnabled property.</p>
+<div class="alert alert-info" id="help-msg">
+    <p data-i18n="traces.searchDisabled">Searching has been disabled via the searchEnabled property. You can still view specific traces of which you know the trace id by entering it in the "Go to trace" textbox.</p>
 </div>


### PR DESCRIPTION
I've had several people reporting that Zipkin was broken since they saw
this red banner with an error message they didn't understand.

This PR changes the box to be the standard blue (it's not an error
anyway) and hopefully makes the message more clear.