### PR TITLE
Accept a Cassandra running 3.11.3 as well as later

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -101,7 +101,7 @@ final class Schema {
   static KeyspaceMetadata ensureExists(String keyspace, boolean searchEnabled, Session session) {
     session.getCluster().getMetadata().getAllHosts().forEach((host) -> {
       Preconditions.checkState(
-              0 < VersionNumber.parse("3.11.3").compareTo(host.getCassandraVersion()),
+              0 <= VersionNumber.parse("3.11.3").compareTo(host.getCassandraVersion()),
               "All Cassandra nodes must be running 3.11.3+");
     });
     KeyspaceMetadata result = session.getCluster().getMetadata().getKeyspace(keyspace);


### PR DESCRIPTION
The current code in `Schema.java` seems to only accept servers running a later version than C* 3.11.3 (i.e. 3.11.4). Since 3.11.3 is recently released, I'm assuming that the code is meant to accept that version and thus this modification is needed.