### PR TITLE
Upgrades the UI to Bootstrap 4

### DIFF
--- a/zipkin-ui/css/main.scss
+++ b/zipkin-ui/css/main.scss
@@ -1,12 +1,13 @@
 // Import Twitter Bootstrap
 $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
-@import "~bootstrap-sass/assets/stylesheets/bootstrap";
+//@import "~bootstrap-sass/assets/stylesheets/bootstrap";
+@import "~bootstrap/scss/bootstrap.scss";
 
 // We need to wait for this bug to be fixed: https://github.com/harvesthq/chosen/issues/2484
 // @import "~chosen-npm/dist/chosen.css";
 // workaround for now is to commit the css into our project:
-@import "../libs/chosen/chosen.css";
-
+//@import "../libs/chosen/chosen.css";
+@import "~bootstrap4c-chosen/dist/css/component-chosen.min.css";
 @import "~bootstrap-datepicker/dist/css/bootstrap-datepicker3.css";
 
 @import "dependency";
@@ -14,17 +15,12 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 @import "trace";
 @import "traces";
 
-.container {
-  width: 90%;
-  margin: 0 5%;
-}
-
 .content {
-  padding-top: 20px;
+  padding: 2%;
 }
 
 .chosen-container .chosen-single {
-  height: 30px;
+  height: 38px;
 }
 
 .service-filter-label {
@@ -73,4 +69,3 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
   right: 0;
   z-index: 100;
 }
-

--- a/zipkin-ui/css/main.scss
+++ b/zipkin-ui/css/main.scss
@@ -1,15 +1,6 @@
-// Import Twitter Bootstrap
-$icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
-//@import "~bootstrap-sass/assets/stylesheets/bootstrap";
 @import "~bootstrap/scss/bootstrap.scss";
-
-// We need to wait for this bug to be fixed: https://github.com/harvesthq/chosen/issues/2484
-// @import "~chosen-npm/dist/chosen.css";
-// workaround for now is to commit the css into our project:
-//@import "../libs/chosen/chosen.css";
 @import "~bootstrap4c-chosen/dist/css/component-chosen.min.css";
 @import "~bootstrap-datepicker/dist/css/bootstrap-datepicker3.css";
-
 $fa-font-path: "~font-awesome/fonts" !default;
 @import "~font-awesome/scss/font-awesome.scss";    
 

--- a/zipkin-ui/css/main.scss
+++ b/zipkin-ui/css/main.scss
@@ -10,6 +10,9 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 @import "~bootstrap4c-chosen/dist/css/component-chosen.min.css";
 @import "~bootstrap-datepicker/dist/css/bootstrap-datepicker3.css";
 
+$fa-font-path: "~font-awesome/fonts" !default;
+@import "~font-awesome/scss/font-awesome.scss";    
+
 @import "dependency";
 @import "summary";
 @import "trace";

--- a/zipkin-ui/css/trace.css
+++ b/zipkin-ui/css/trace.css
@@ -95,11 +95,11 @@
 }
 
 #trace-container .span .time-marker-0 { left: 0; }
-#trace-container .span .time-marker-1 { left: 20%; }
-#trace-container .span .time-marker-2 { left: 40%; }
-#trace-container .span .time-marker-3 { left: 60%; }
-#trace-container .span .time-marker-4 { left: 80%; }
-#trace-container .span .time-marker-5 { left: 99.5%; }
+#trace-container .span .time-marker-1 { left: 19%; }
+#trace-container .span .time-marker-2 { left: 38%; }
+#trace-container .span .time-marker-3 { left: 57%; }
+#trace-container .span .time-marker-4 { left: 76%; }
+#trace-container .span .time-marker-5 { left: 95%; }
 
 #trace-container .span .duration {
   position: absolute;
@@ -203,7 +203,7 @@
   margin-right: 5px;
 }
 
-.save {
+/* .save {
   opacity: 0.2;
-}
+} */
 

--- a/zipkin-ui/js/component_ui/infoPanel.js
+++ b/zipkin-ui/js/component_ui/infoPanel.js
@@ -1,6 +1,4 @@
 import {component} from 'flightjs';
-// import bootstrap // eslint-disable-line no-unused-vars
-//     from 'bootstrap-sass/assets/javascripts/bootstrap.js';
 import bootstrap // eslint-disable-line no-unused-vars
     from 'bootstrap/dist/js/bootstrap.js';
 

--- a/zipkin-ui/js/component_ui/infoPanel.js
+++ b/zipkin-ui/js/component_ui/infoPanel.js
@@ -1,6 +1,8 @@
 import {component} from 'flightjs';
+// import bootstrap // eslint-disable-line no-unused-vars
+//     from 'bootstrap-sass/assets/javascripts/bootstrap.js';
 import bootstrap // eslint-disable-line no-unused-vars
-    from 'bootstrap-sass/assets/javascripts/bootstrap.js';
+    from 'bootstrap/dist/js/bootstrap.js';
 
 export default component(function infoPanel() {
   this.show = function() {

--- a/zipkin-ui/js/component_ui/jsonPanel.js
+++ b/zipkin-ui/js/component_ui/jsonPanel.js
@@ -3,14 +3,23 @@ import {component} from 'flightjs';
 export default component(function jsonPanel() {
   this.show = function(e, data) {
     this.$node.find('.modal-title').text(data.title);
-
     this.$node.find('.save').attr('href', data.link);
-    this.$node.find('.modal-body pre').text(JSON.stringify(data.obj, null, 2));
+    this.$node.find('.modal-body pre code').text(JSON.stringify(data.obj, null, 2));
     this.$node.modal('show');
   };
-
+  this.copyToClipboard = function() {
+    const traceJson = document.getElementById('trace-json-content');
+    function copyListener(e) {
+      e.clipboardData.setData('text/plain', traceJson.textContent);
+      e.preventDefault();
+    }
+    document.addEventListener('copy', copyListener);
+    document.execCommand('copy');
+    document.removeEventListener('copy', copyListener);
+  };
   this.after('initialize', function() {
     this.$node.modal('hide');
     this.on(document, 'uiRequestJsonPanel', this.show);
+    this.on('#copy2clipboard', 'click', this.copyToClipboard);
   });
 });

--- a/zipkin-ui/js/component_ui/serviceDataModal.js
+++ b/zipkin-ui/js/component_ui/serviceDataModal.js
@@ -1,7 +1,7 @@
 import {component} from 'flightjs';
 import $ from 'jquery';
 import bootstrap // eslint-disable-line no-unused-vars
-    from 'bootstrap-sass/assets/javascripts/bootstrap.js';
+  from 'bootstrap/dist/js/bootstrap.js';
 
 function renderDependencyModal(event, data) {
   const $modal = $('#dependencyModal');

--- a/zipkin-ui/js/component_ui/serviceFilterSearch.js
+++ b/zipkin-ui/js/component_ui/serviceFilterSearch.js
@@ -1,5 +1,5 @@
 import {component} from 'flightjs';
-import chosen from 'chosen-npm/public/chosen.jquery.js'; // eslint-disable-line no-unused-vars
+import 'chosen-js';
 
 export default component(function serviceNameFilter() {
   this.onChange = function(e, params) {

--- a/zipkin-ui/js/component_ui/serviceName.js
+++ b/zipkin-ui/js/component_ui/serviceName.js
@@ -1,8 +1,9 @@
 import {component} from 'flightjs';
 import Cookies from 'js-cookie';
 import $ from 'jquery';
-import chosen from 'chosen-npm/public/chosen.jquery.js'; // eslint-disable-line no-unused-vars
 import queryString from 'query-string';
+
+import 'chosen-js';
 
 export default component(function serviceName() {
   this.onChange = function() {
@@ -40,7 +41,7 @@ export default component(function serviceName() {
     this.triggerChange(name);
 
     this.$node.chosen({search_contains: true});
-    this.$node.next('.chosen-container').css('width', '100%');
+    this.$node.next('.chosen-container');
 
     this.on('change', this.onChange);
     this.on(document, 'dataServiceNames', this.updateServiceNameDropdown);

--- a/zipkin-ui/js/component_ui/spanName.js
+++ b/zipkin-ui/js/component_ui/spanName.js
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-template */
 import {component} from 'flightjs';
-import chosen from 'chosen-npm/public/chosen.jquery.js'; // eslint-disable-line no-unused-vars
+import 'chosen-js';
 import $ from 'jquery';
 import queryString from 'query-string';
 
@@ -30,7 +30,7 @@ export default component(function spanName() {
     this.$node.chosen({
       search_contains: true
     });
-    this.$node.next('.chosen-container').css('width', '100%');
+    this.$node.next('.chosen-container');
 
     this.on(document, 'dataSpanNames', this.updateSpans);
   });

--- a/zipkin-ui/package-lock.json
+++ b/zipkin-ui/package-lock.json
@@ -4544,6 +4544,11 @@
         "debug": "^2.2.0"
       }
     },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/zipkin-ui/package-lock.json
+++ b/zipkin-ui/package-lock.json
@@ -1346,11 +1346,6 @@
         "jquery": ">=1.7.1 <4.0.0"
       }
     },
-    "bootstrap-sass": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
-      "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg="
-    },
     "bootstrap4c-chosen": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/bootstrap4c-chosen/-/bootstrap4c-chosen-1.0.10.tgz",

--- a/zipkin-ui/package-lock.json
+++ b/zipkin-ui/package-lock.json
@@ -228,7 +228,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "are-we-there-yet": {
@@ -1333,10 +1333,15 @@
         "hoek": "4.x.x"
       }
     },
+    "bootstrap": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
+      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
+    },
     "bootstrap-datepicker": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.8.0.tgz",
-      "integrity": "sha1-xjUTkx5vCfFq6fEbYvMtlQ3zlY4=",
+      "integrity": "sha512-213St/G8KT3mjs4qu4qwww74KWysMaIeqgq5OhrboZjIjemIpyuxlSo9FNNI5+KzpkkxkRRba+oewiRGV42B1A==",
       "requires": {
         "jquery": ">=1.7.1 <4.0.0"
       }
@@ -1345,6 +1350,15 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
       "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg="
+    },
+    "bootstrap4c-chosen": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/bootstrap4c-chosen/-/bootstrap4c-chosen-1.0.10.tgz",
+      "integrity": "sha512-nJ8AP5gWQv7tWHqqcfuo+A4CPVU3qtNe+ThfaBTrpdGlMKvdTTdO1UN8ljHzOXR39lsC9HdbkyVO2obk12XkGA==",
+      "requires": {
+        "bootstrap": "^4.1.1",
+        "chosen-js": "^1.8.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2294,10 +2308,10 @@
         }
       }
     },
-    "chosen-npm": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/chosen-npm/-/chosen-npm-1.4.2.tgz",
-      "integrity": "sha1-7Ghq55ZRNHPbwXGxpjcC5tfhUV8="
+    "chosen-js": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/chosen-js/-/chosen-js-1.8.7.tgz",
+      "integrity": "sha512-eVdrZJ2U5ISdObkgsi0od5vIJdLwq1P1Xa/Vj/mgxkMZf14DlgobfB6nrlFi3kW4kkvKLsKk4NDqZj1MU1DCpw=="
     },
     "chownr": {
       "version": "1.0.1",
@@ -4883,7 +4897,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -7488,7 +7502,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -7673,7 +7687,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -10626,7 +10640,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -10888,7 +10902,7 @@
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
@@ -11279,6 +11293,11 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
+    },
+    "popper.js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.4.tgz",
+      "integrity": "sha1-juwdj/AqWjoVLdQ0FKFce3n9abY="
     },
     "portfinder": {
       "version": "1.0.13",
@@ -12346,7 +12365,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -12685,7 +12704,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",

--- a/zipkin-ui/package.json
+++ b/zipkin-ui/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "bootstrap": "^4.1.3",
     "bootstrap-datepicker": "^1.8.0",
-    "bootstrap-sass": "^3.3.6",
     "bootstrap4c-chosen": "^1.0.10",
     "chosen-js": "^1.8.7",
     "crossroads": "^0.12.2",

--- a/zipkin-ui/package.json
+++ b/zipkin-ui/package.json
@@ -17,9 +17,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "bootstrap": "^4.1.3",
     "bootstrap-datepicker": "^1.8.0",
     "bootstrap-sass": "^3.3.6",
-    "chosen-npm": "^1.4.2",
+    "bootstrap4c-chosen": "^1.0.10",
+    "chosen-js": "^1.8.7",
     "crossroads": "^0.12.2",
     "d3": "^3.5.14",
     "flightjs": "^1.5.2",
@@ -28,6 +30,7 @@
     "lodash": "^4.5.0",
     "moment": "^2.11.2",
     "npm": "^6.3.0",
+    "popper.js": "^1.14.4",
     "query-string": "^3.0.0",
     "timeago": "^1.5.1"
   },

--- a/zipkin-ui/package.json
+++ b/zipkin-ui/package.json
@@ -25,6 +25,7 @@
     "crossroads": "^0.12.2",
     "d3": "^3.5.14",
     "flightjs": "^1.5.2",
+    "font-awesome": "^4.7.0",
     "jquery": "^3.0.0",
     "js-cookie": "^2.1.0",
     "lodash": "^4.5.0",

--- a/zipkin-ui/templates/dependency.mustache
+++ b/zipkin-ui/templates/dependency.mustache
@@ -1,24 +1,24 @@
-<div class="row well well-sm">
-  <form id="dependency-query-form" class="form-inline" role="form">
-    <div id="start-ts" class="form-group">
+<div class="row card w-90 bg-light">
+  <form id="dependency-query-form" class="form-inline m-2" role="form">
+    <div id="start-ts" class="form-group mr-3">
       <label for="timeStamp" data-i18n="dep.stime">Start time</label>
-      <input class="form-control input-sm date-input" type="text">
-      <input class="form-control input-sm time-input" type="text">
+      <input class="ml-1 form-control input-sm date-input" type="text">
+      <input class="ml-1 form-control input-sm time-input" type="text">
       <input class="timestamp-value" id="startTs" name="startTs" type="hidden" value="">
     </div>
 
-    <div id="end-ts" class="form-group">
+    <div id="end-ts" class="form-group mr-3">
       <label for="timeStamp" data-i18n="dep.etime">End time</label>
-      <input class="form-control input-sm date-input" type="text">
-      <input class="form-control input-sm time-input" type="text">
+      <input class="ml-1 form-control input-sm date-input" type="text">
+      <input class="ml-1 form-control input-sm time-input" type="text">
       <input class="timestamp-value" id="endTs" name="endTs" type="hidden" value="">
     </div>
 
-    <button type="submit" class="btn btn-default btn-sm" data-i18n="dep.analyze">Analyze Dependencies</button>
+    <button type="submit" class="ml-1 btn btn-primary btn-sm" data-i18n="dep.analyze">Analyze Dependencies</button>
   </form>
 </div>
 
-<div id="service-data-modal-container">
+<div id="service-data-modal-container mt-4">
   <div class="modal" id="serviceModal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -84,7 +84,7 @@
   </div>
 </div>
 
-<div id="dependency-container">
+<div id="dependency-container" class="mt-4">
   <svg width="100%" height="4000" class="rootSvg">
   </svg>
 </div>

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -1,18 +1,18 @@
-<div class="well well-sm">
-  <form role="form" id="submitForm">
-    <div class="row">
+<div class="card border-dark mb-3 w-90">
+  <form role="form" id="submitForm" class="card-body">
+    <div class="form-row">
       <div class="form-group col-md-3">
         <label for="timeStamp" data-i18n="traces.servicename">Service Name</label>
         <div class="clearfix">
-          <select data-placeholder="Service Name" class="form-control input-sm" name="serviceName" id="serviceName">
-        </select>
+          <select data-placeholder="Service Name" class="form-control form-control-chosen" name="serviceName" id="serviceName">
+          </select>
         </div>
       </div>
 
       <div class="form-group col-md-3">
         <label for="timeStamp" data-i18n="traces.spanname">Span Name</label>
         <div class="clearfix">
-          <select data-placeholder="Span Name" class="form-control input-sm" name="spanName" id="spanName">
+          <select data-placeholder="Span Name" class="form-control-chosen" name="spanName" id="spanName">
           </select>
         </div>
       </div>
@@ -20,7 +20,7 @@
       <div class="form-group col-md-6">
         <label for="lookback" data-i18n="traces.lookback">Lookback</label>
         <div class="clearfix">
-          <select class="form-control input-sm" name="lookback" id="lookback">
+          <select class="form-control" name="lookback" id="lookback">
             <option value="3600000" data-i18n="traces.lookback.1hour">1 hour</option>
             <option value="10800000" data-i18n="traces.lookback.3hours">3 hours</option>
             <option value="21600000" data-i18n="traces.lookback.6hours">6 hours</option>
@@ -34,7 +34,7 @@
       </div>
     </div>
 
-    <div class="row" id="custom-lookback" style="display: none;">
+    <div class="form-row" id="custom-lookback" style="display: none;">
       <div class="col-md-6"></div>
 
       <div id="start-ts" class="form-group col-md-3">
@@ -56,7 +56,7 @@
       </div>
     </div>
 
-    <div class="row">
+    <div class="form-row">
       <div class="form-group col-md-6">
         <label for="annotationQuery" data-i18n="traces.annotationQuery">Annotations Query</label>
         <div class="clearfix">
@@ -66,21 +66,28 @@
         </div>
       </div>
 
-      <div class="form-group col-md-3">
+      <div class="form-group col-md-2">
         <label for="minDuration" data-i18n="traces.duration">Duration (μs) >=</label>
         <input class="form-control input-sm" id="minDuration" name="minDuration" type="text" value="{{minDuration}}">
       </div>
 
-      <div class="form-group col-md-3">
+      <div class="form-group col-md-2">
         <label for="limit" data-i18n="traces.limit">Limit</label>
         <input class="form-control input-sm" id="limit" name="limit" type="text" value="{{limit}}">
       </div>
+      <div class="form-group col-md-2">
+        <label for="sortOrder" data-i18n="traces.sort">Sort</label>
+        <select class="sort-order js-sort-order form-control" form="submitForm" name="sortOrder" id="sortOrder">
+          {{#sortOrderOptions}}
+            <option value="{{value}}" {{sortOrderSelected}} data-i18n="{{value}}">{{text}}</option>{{/sortOrderOptions}}
+        </select>
+      </div>
     </div>
 
-    <div class="row">
-      <div class="col-md-6">
+    <div class="form-row">
+      <div class="col-md-12">
         <div class="btn-toolbar">
-          <button type="submit" class="btn btn-primary btn-lg" data-i18n="traces.findBtn">Find Traces</button>
+          <button type="submit" class="btn btn-secondary btn-lg btn-block" data-i18n="traces.findBtn">Find Traces</button>
           <button type="button" class="btn btn-default btn-lg info-request">
             <span class="glyphicon glyphicon-question-sign"></span>
           </button>
@@ -89,18 +96,10 @@
 
       <div class="col-md-3">
       </div>
-
-      <div class="form-group col-md-3">
-        <label for="sortOrder" data-i18n="traces.sort">Sort</label>
-        <select class="sort-order js-sort-order form-control input-sm" form="submitForm" name="sortOrder" id="sortOrder">
-          {{#sortOrderOptions}}
-            <option value="{{value}}" {{sortOrderSelected}} data-i18n="{{value}}">{{text}}</option>{{/sortOrderOptions}}
-        </select>
-      </div>
     </div>
 
     {{#queryWasPerformed}}
-    <div id="trace-filters" class="row">
+    <div id="trace-filters" class="form-row">
       <div class="col-md-3">
         <div>
           Showing:  <span class="filter-current">{{count}}</span>

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -108,7 +108,9 @@
       </div>
 
       <div class="col-md-1 float-right">
-        <a href='{{apiURL}}' id='rawResultsJsonLink'><span class='btn btn-sm btn-secondary'>JSON</span></a>
+        <a href='{{apiURL}}' class="btn btn-sm btn-secondary" id='rawResultsJsonLink'>JSON
+          <span class="fa fa-download"></span>
+        </a>
       </div>
     </div>
     {{/queryWasPerformed}}

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -1,4 +1,4 @@
-<div class="card border-dark mb-3 w-90">
+<div class="card bg-light text-dark border-dark mb-3 w-90">
   <form role="form" id="submitForm" class="card-body">
     <div class="form-row">
       <div class="form-group col-md-3">
@@ -86,21 +86,16 @@
 
     <div class="form-row">
       <div class="col-md-12">
-        <div class="btn-toolbar">
-          <button type="submit" class="btn btn-secondary btn-lg btn-block" data-i18n="traces.findBtn">Find Traces</button>
-          <button type="button" class="btn btn-default btn-lg info-request">
-            <span class="glyphicon glyphicon-question-sign"></span>
-          </button>
-        </div>
-      </div>
-
-      <div class="col-md-3">
+        <button type="submit" class="btn btn-primary btn-lg" data-i18n="traces.findBtn">Find Traces</button>
+        <button type="button" class="btn btn-outline-info info-request">
+          <span class="fa fa-question-circle"></span>
+        </button>
       </div>
     </div>
 
     {{#queryWasPerformed}}
-    <div id="trace-filters" class="form-row">
-      <div class="col-md-3">
+    <div id="trace-filters" class="row">
+      <div class="col-md-11">
         <div>
           Showing:  <span class="filter-current">{{count}}</span>
           of <span class="filter-total">{{count}}</span>
@@ -108,12 +103,12 @@
 
         <div class="service-tags">
           Services:
-          <span class='label service-tag-filtered' data-service-name="{{serviceName}}">{{serviceName}}</span>
+          <span class='badge badge-info' data-service-name="{{serviceName}}">{{serviceName}}</span>
         </div>
       </div>
 
-      <div class="json-badge-container">
-        <a href='{{apiURL}}' id='rawResultsJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a>
+      <div class="col-md-1 float-right">
+        <a href='{{apiURL}}' id='rawResultsJsonLink'><span class='btn btn-sm btn-secondary'>JSON</span></a>
       </div>
     </div>
     {{/queryWasPerformed}}
@@ -126,7 +121,7 @@
   </div>
 {{/queryError}}
 {{^queryWasPerformed}}
-  <div class="alert alert-info" id="help-msg">
+  <div class="alert alert-primary" id="help-msg">
     <p data-i18n="traces.des">Please select the criteria for your trace lookup.</p>
   </div>
 {{/queryWasPerformed}}
@@ -148,7 +143,7 @@
         </a>
         <div class="trace-details services">
           {{#serviceDurations}}
-            <span class="label label-default service-filter-label" data-service-name="{{name}}">{{name}}
+            <span class="badge badge-success service-filter-label" data-service-name="{{name}}">{{name}}
               x{{count}} {{max}}ms</span>
           {{/serviceDurations}}
         </div>
@@ -161,12 +156,14 @@
 {{/queryWasPerformed}}
 
 <!-- help panel for different lookup options -->
-<div class="modal fade" id="infoPanel" tabindex="-1">
+<div class="modal fade" id="infoPanel" tabindex="-1" role="dialog"  aria-hidden="true">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         <h4 class="modal-title" data-i18n="modal.title">How to find a trace</h4>
+         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
       <div class="modal-body">
         <p data-i18n="modal.p1">So you want to find some traces, huh? You've come to the right place!</p>
@@ -215,7 +212,6 @@
           we return traces before that point in time up until the limit number of results.</p>
       </div>
     </div>
-  </div>
 </div>
 
 <div class='modal fade' id='jsonPanel' tabindex='-1'>

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -9,20 +9,19 @@
             <li class="nav-item" data-route="dependency"><a class="nav-link"  href="{{contextRoot}}dependency/" data-i18n="nav.dep">Dependencies</a></li>
           </ul>
         </div>
-                  <form id="traceIdQueryForm" class="form-inline my-2 my-lg-0">
+          <form id="traceIdQueryForm" class="form-inline my-2 my-lg-0">
             <input class="form-control mr-sm-2" type="search" aria-label="Search" id="traceIdQuery" name="traceIdQuery" placeholder='Go to trace' data-i18n='nav.search'>
             <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
           </form>
     </nav>
-
+  <div class="container-fluid">
     <div id="errorPanel" class="alert alert-danger">
     </div>
 
     <div class='content border-dark mb-3'></div>
 
     <div id='fullPageSpinner'>
-      <div class='progress progress-striped active'>
-        <div class='progress-bar' style='width: 100%'>Working...</div>
+      <div class='fa-circle-notch fa-spin active'>
       </div>
     </div>
 
@@ -38,4 +37,4 @@
         </button>
       </div>
     </div>
-
+</div>

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -1,10 +1,11 @@
   <nav class='navbar navbar-expand-lg navbar-dark bg-dark'>
           <a class='navbar-brand' href='{{contextRoot}}'>
-            Zipkin<span class='muted' style='font-size: .75em; padding-left: 10px;' data-i18n="nav.inves">Investigate system behavior</span>
+          <img src="https://zipkin.io/public/img/zipkin-logo-200x119.jpg" width="60" height="40" class="d-inline-block align-top rounded" alt=""/>
+            ZIPKIN <span class='font-weight-light navbar-text' style="font-size: .75em;" data-i18n="nav.inves">Investigate system behavior</span>
           </a>
         <div class="collapse navbar-collapse">
           <ul class="navbar-nav mr-auto">
-            <li class="nav-item active" data-route="index"><a class="nav-link"  href="{{contextRoot}}" data-i18n="nav.find">Find a trace</a></li>
+            <li class="nav-item" data-route="index"><a class="nav-link"  href="{{contextRoot}}" data-i18n="nav.find">Find a trace</a></li>
             <li class="nav-item" data-route="traceViewer"><a class="nav-link"  href="{{contextRoot}}traceViewer" data-i18n="nav.viewSaved">View Saved Trace</a></li>
             <li class="nav-item" data-route="dependency"><a class="nav-link"  href="{{contextRoot}}dependency/" data-i18n="nav.dep">Dependencies</a></li>
           </ul>

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -1,38 +1,24 @@
-    <div id='navbar' class='navbar navbar-inverse' role='navigation'>
-      <div class='container'>
-        <div class='navbar-header'>
+  <nav class='navbar navbar-expand-lg navbar-dark bg-dark'>
           <a class='navbar-brand' href='{{contextRoot}}'>
             Zipkin<span class='muted' style='font-size: .75em; padding-left: 10px;' data-i18n="nav.inves">Investigate system behavior</span>
           </a>
-        </div>
-        <div class="navbar-left">
-          <ul class="nav navbar-nav">
-            <li data-route="index"><a href="{{contextRoot}}" data-i18n="nav.find">Find a trace</a></li>
-            <li data-route="traceViewer"><a href="{{contextRoot}}traceViewer" data-i18n="nav.viewSaved">View Saved Trace</a></li>
-            <li data-route="dependency"><a href="{{contextRoot}}dependency/" data-i18n="nav.dep">Dependencies</a></li>
+        <div class="collapse navbar-collapse">
+          <ul class="navbar-nav mr-auto">
+            <li class="nav-item active" data-route="index"><a class="nav-link"  href="{{contextRoot}}" data-i18n="nav.find">Find a trace</a></li>
+            <li class="nav-item" data-route="traceViewer"><a class="nav-link"  href="{{contextRoot}}traceViewer" data-i18n="nav.viewSaved">View Saved Trace</a></li>
+            <li class="nav-item" data-route="dependency"><a class="nav-link"  href="{{contextRoot}}dependency/" data-i18n="nav.dep">Dependencies</a></li>
           </ul>
         </div>
-        <div class="navbar-right" style="width: 30%">
-          <div class="navbar-right" style='padding-left: 15px'>
-            <p class="navbar-text muted" id="environment"></p>
-          </div>
-          <form id="traceIdQueryForm" class="form-inline" role="form">
-            <div class="navbar-right" style="float: right">
-              <div class="row well-sm clearfix">
-                  <input type="text" class="form-control input-sm" id="traceIdQuery" name="traceIdQuery" placeholder='Go to trace' data-i18n='nav.search'>
-              </div>
-            </div>
+                  <form id="traceIdQueryForm" class="form-inline my-2 my-lg-0">
+            <input class="form-control mr-sm-2" type="search" aria-label="Search" id="traceIdQuery" name="traceIdQuery" placeholder='Go to trace' data-i18n='nav.search'>
+            <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
           </form>
-        </div><!--/.nav-collapse -->
-      </div>
-    </div>
+    </nav>
 
     <div id="errorPanel" class="alert alert-danger">
     </div>
 
-    <div class='container'>
-      <div class='content'></div>
-    </div>
+    <div class='content border-dark mb-3'></div>
 
     <div id='fullPageSpinner'>
       <div class='progress progress-striped active'>

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -1,7 +1,7 @@
   <nav class='navbar navbar-expand-lg navbar-dark bg-dark'>
-          <a class='navbar-brand' href='{{contextRoot}}'>
+          <a class='navbar-brand ml-5' href='{{contextRoot}}'>
           <img src="https://zipkin.io/public/img/zipkin-logo-200x119.jpg" width="60" height="40" class="d-inline-block align-top rounded" alt=""/>
-            ZIPKIN <span class='font-weight-light navbar-text' style="font-size: .75em;" data-i18n="nav.inves">Investigate system behavior</span>
+            <span class='font-weight-light navbar-text' style="font-size: .75em;" data-i18n="nav.inves">Investigate system behavior</span>
           </a>
         <div class="collapse navbar-collapse">
           <ul class="navbar-nav mr-auto">
@@ -10,7 +10,7 @@
             <li class="nav-item" data-route="dependency"><a class="nav-link"  href="{{contextRoot}}dependency/" data-i18n="nav.dep">Dependencies</a></li>
           </ul>
         </div>
-          <form id="traceIdQueryForm" class="form-inline my-2 my-lg-0">
+          <form id="traceIdQueryForm" class="form-inline my-2 my-lg-0 mr-5">
             <input class="form-control mr-sm-2" type="search" aria-label="Search" id="traceIdQuery" name="traceIdQuery" placeholder='Go to trace' data-i18n='nav.search'>
             <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
           </form>

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -1,36 +1,44 @@
-<div id='trace-controls' class='row well well-sm'>
-  <ul class='nav nav-pills'>
-    <li class=''><a href='#'><strong data-i18n="trace.duration">Duration:</strong> <span class='badge'>{{duration}}</span></a></li>
-    <li class=''><a href='#'><strong data-i18n="trace.service">Services:</strong> <span class='badge'>{{services}}</span></a></li>
-    <li class=''><a href='#'><strong data-i18n="trace.depth">Depth:</strong> <span class='badge'>{{depth}}</span></a></li>
-    <li class=''><a href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge'>{{totalSpans}}</span></a></li>
+<div id='trace-controls' class='card w-90 mb-4 bg-light'>
+<div class="clearfix m-3">
+<div class='row justify-content-start'>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.duration">Duration:</strong> <span class='badge badge-dark'>{{duration}}</span></div></div>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.service">Services:</strong> <span class='badge badge-dark'>{{services}}</span></div></div>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.depth">Depth:</strong> <span class='badge badge-dark'>{{depth}}</span></div></div>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge badge-dark'>{{totalSpans}}</span></div></div>
     {{#logsUrl}}
-    <li class='navbar-right'><a href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-primary btn-xs badge'>Logs</span></a></li>
+    <div class='col-md-2'><div href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-sm btn-secondary'>Logs</span></div></div>
     {{/logsUrl}}
-    <li class='navbar-right'><a href='{{ contextRoot }}api/v2/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
-  </ul>
-
-  <form class='form-inline' role='form'>
-    <div class='btn-group btn-group-sm' id='filterAllServices'>
-      <button type='button' class='btn btn-default active' value='uiExpandAllSpans' data-i18n="trace.expand">Expand All</button>
-      <button type='button' class='btn btn-default' value='uiCollapseAllSpans' data-i18n="trace.collapse">Collapse All</button>
+</div>
+  
+  <form class='form-row mt-3' role='form'>
+    <div class='form-group col-md-3' id='filterAllServices'>
+      <button type='button' class='btn btn-primary active' value='uiExpandAllSpans' data-i18n="trace.expand">Expand All</button>
+      <button type='button' class='btn btn-primary' value='uiCollapseAllSpans' data-i18n="trace.collapse">Collapse All</button>
     </div>
-    <select data-placeholder='Filter Service Search' class='form-control input-sm' name='serviceFilterSearch' id='serviceFilterSearch'>
-      <option value=''></option>
-      {{#serviceCounts}}
-      <option value='{{name}}'>{{name}}</option>
-      {{/serviceCounts}}
-    </select>
-  </form>
+    <div class="form-group col-md-2">
+      <select data-placeholder='Filter Service Search' class='form-control' name='serviceFilterSearch' id='serviceFilterSearch'>
+        <option value=''></option>
+        {{#serviceCounts}}
+        <option value='{{name}}'>{{name}}</option>
+        {{/serviceCounts}}
+      </select>
+    </div>
 
+  </form>
+    <div class="float-right">
+      <span class='btn btn-sm btn-secondary' href='{{ contextRoot }}api/v2/trace/{{ traceId }}' id='traceJsonLink'>JSON
+        <span class="fa fa-download"></span>
+      </span> 
+    </div>
   <div class='trace-details services'>
   {{#serviceCounts}}
-    <span class='label label-default service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
+    <span class='badge badge-info service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
   {{/serviceCounts}}
   </div>
+ </div>
 </div>
 
-<div class='row' id='trace-container'>
+<div id='trace-container' class="w-100" style='overflow: hidden;'>
   <div id='timeLabel' class='span'>
     <div class='handle'>Services</div>
     <div class='duration-container'>
@@ -63,12 +71,12 @@
       </div>
     </div>
 
-    <div class='duration-container'>
+    <div class='duration-container row'>
       {{#timeMarkers}}
-      <div class='time-marker time-marker-{{index}}'>.</div>
+      <div class='col time-marker time-marker-{{index}}'>.</div>
       {{/timeMarkers}}
 
-      <div class='duration' style='left: {{left}}%; width: {{width}}%'>
+      <div class='duration ml-3' style='left: {{left}}%; width: {{width}}%'>
         {{durationStr}} : {{spanName}}
         {{#annotations}}
         <div class='annotation{{#isCore}} core{{/isCore}}'
@@ -155,7 +163,7 @@
   </div>
 </div>
 
-<div class='row  hidden' id='trace-container-backup'>
+<div class='row' id='trace-container-backup' hidden>
   <div id='timeLabel-backup' class='span'>
     <div class='handle'>Services</div>
     <div class='duration-container'>
@@ -221,16 +229,23 @@
   {{/spansBackup}}
 </div>
 
-<div class='modal fade' id='jsonPanel' tabindex='-1'>
+<div class='modal fade' id='jsonPanel' tabindex='-1' role="dialog"  aria-hidden="true">
   <div class='modal-dialog modal-lg'>
     <div class='modal-content'>
       <div class='modal-header'>
-        <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&times;</button>
-        <a href='#' class='save'><span class='glyphicon glyphicon-save' aria-hidden='true' aria-label='save'></span></a>
         <h4 class='modal-title'></h4>
+        <a href='#' class='save ml-5'>
+          <span class='fa fa-download fa-2x fa-border' style="color: black;" aria-hidden='true' aria-label='save'></span>
+        </a>
+        <a href='#' class='copy'>
+          <span class='fa fa-copy fa-2x fa-border' style="color: black;" aria-hidden='true' aria-label='save'></span>
+        </a>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
       <div class='modal-body'>
-        <pre></pre>
+        <pre><code /></pre>
       </div>
     </div>
   </div>

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -23,7 +23,6 @@
         {{/serviceCounts}}
       </select>
     </div>
-
   </form>
     <div class="float-right">
       <span class='btn btn-sm btn-secondary' href='{{ contextRoot }}api/v2/trace/{{ traceId }}' id='traceJsonLink'>JSON
@@ -105,17 +104,21 @@
   {{/spans}}
 </div>
 
-<div class='modal fade' id='spanPanel' tabindex='-1'>
+<div class='modal fade' id='spanPanel' tabindex='-1' role="dialog"  aria-hidden="true">
   <div class='modal-dialog modal-lg'>
     <div class='modal-content'>
       <div class='modal-header'>
-        <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&times;</button>
         <h4 class='modal-title'></h4>
-        <h5>AKA: <span class='service-names'></span></h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
       <div class='modal-body'>
-        <table id='annotations' class='table table-striped'>
-          <thead><tr>
+       <div class="card">
+        <h6 class="card-body">AKA: <span class='service-names container'></span></h6>
+       </div> 
+        <table id='annotations' class='table table-striped table-sm table-bordered'>
+          <thead class="table-info"><tr>
             <th>Date Time</th>
             <th>Relative Time</th>
             <th>Annotation</th>
@@ -131,8 +134,8 @@
           </tbody>
         </table>
 
-        <table id='binaryAnnotations' class='table table-striped'>
-          <thead><tr>
+        <table id='binaryAnnotations' class='table table-striped table-sm table-bordered'>
+          <thead class="table-info"><tr>
             <th>Key</th>
             <th>Value</th>
           </tr></thead>
@@ -144,12 +147,14 @@
           </tbody>
         </table>
 
-        <button class="btn btn-info btn-xs pull-right" type="button" data-toggle="collapse"
-                data-target="#moreInfo" aria-expanded="false" aria-controls="moreInfo" data-i18n="trace.more">More Info</button>
+        <button class="btn btn-info btn-sm pull-right mt-1" type="button" data-toggle="collapse"
+                data-target="#moreInfo" aria-expanded="false" aria-controls="moreInfo" data-i18n="trace.more">More Info
+                <span class="fa fa-chevron-circle-down"></span>
+        </button>
         <hr/>
         <div class='clearfix'></div>
         <div id='moreInfo' class='collapse'>
-          <table class='table table-striped'>
+          <table class='table table-striped table-sm table-bordered'>
             <tbody>
               <tr>
                 <td class='key' data-key='key'></td>
@@ -232,20 +237,20 @@
 <div class='modal fade' id='jsonPanel' tabindex='-1' role="dialog"  aria-hidden="true">
   <div class='modal-dialog modal-lg'>
     <div class='modal-content'>
-      <div class='modal-header'>
+      <div class='modal-header bg-light'>
         <h4 class='modal-title'></h4>
-        <a href='#' class='save ml-5'>
-          <span class='fa fa-download fa-2x fa-border' style="color: black;" aria-hidden='true' aria-label='save'></span>
+        <a href='#' class='save ml-5 btn btn-outline-dark'>
+          <span class='fa fa-download fa-2x' style="color: black;" aria-hidden='true' aria-label='save'></span>
         </a>
-        <a href='#' class='copy'>
-          <span class='fa fa-copy fa-2x fa-border' style="color: black;" aria-hidden='true' aria-label='save'></span>
+        <a class='copy btn btn-outline-dark' id="copy2clipboard">
+          <span class='fa fa-copy fa-2x' style="color: black;" aria-hidden='true' aria-label='save'></span>
         </a>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div class='modal-body'>
-        <pre><code /></pre>
+      <div class='modal-body bg-dark'>
+        <pre><code class="text-light" id="trace-json-content"/></pre>
       </div>
     </div>
   </div>

--- a/zipkin-ui/templates/traceViewer.mustache
+++ b/zipkin-ui/templates/traceViewer.mustache
@@ -1,46 +1,49 @@
-<div id='trace-controls' class='row card border-dark mb-3 w-90'>
-
-  <form class="form-inline" role="form">
+<div id='trace-controls' class='card w-90 mb-4 bg-light'>
+<div class="clearfix m-3">
+  <form class="form-inline m-2" role="form">
     <div class="form-group">
-      <input type="file" accept=".json,application/json" id="traceFile" class="form-control">
+    <div class="custom-file">
+      <input type="file" class="custom-file-input" id="traceFile" aria-describedby="traceFile">
+      <label class="custom-file-label" for="traceFile">Choose file</label>
+    </div>
     </div>
   </form>
-
-  {{#traceId}}
-  <ul class='nav nav-pills nav-justified'>
-    <li class='nav-item'><a href='#'><strong data-i18n="trace.duration">Duration:</strong> <span class='badge'>{{duration}}</span></a></li>
-    <li class='nav-item'><a href='#'><strong data-i18n="trace.service">Services:</strong> <span class='badge'>{{services}}</span></a></li>
-    <li class='nav-item'><a href='#'><strong data-i18n="trace.depth">Depth:</strong> <span class='badge'>{{depth}}</span></a></li>
-    <li class='nav-item'><a href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge'>{{totalSpans}}</span></a></li>
+{{#traceId}}
+<hr>
+<div class='row justify-content-start'>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.duration">Duration:</strong> <span class='badge badge-dark'>{{duration}}</span></div></div>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.service">Services:</strong> <span class='badge badge-dark'>{{services}}</span></div></div>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.depth">Depth:</strong> <span class='badge badge-dark'>{{depth}}</span></div></div>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge badge-dark'>{{totalSpans}}</span></div></div>
     {{#logsUrl}}
-    <li class='navbar-right'><a href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-primary btn-xs badge'>Logs</span></a></li>
+    <div class='col-md-2'><div href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-sm btn-secondary'>Logs</span></div></div>
     {{/logsUrl}}
-    <li class='navbar-right'><a href='{{ contextRoot }}api/v2/trace/{{ traceId }}' id='traceJsonLink'><span class='btn btn-primary btn-xs badge'>JSON</span></a></li>
-  </ul>
-
-  <form class='form-inline' role='form'>
-    <div class='btn-group btn-group-sm' id='filterAllServices'>
-      <button type='button' class='btn btn-default active' value='uiExpandAllSpans' data-i18n="trace.expand">Expand All</button>
-      <button type='button' class='btn btn-default' value='uiCollapseAllSpans' data-i18n="trace.collapse">Collapse All</button>
+</div>
+  
+  <form class='form-row mt-3' role='form'>
+    <div class='form-group col-md-3' id='filterAllServices'>
+      <button type='button' class='btn btn-primary active' value='uiExpandAllSpans' data-i18n="trace.expand">Expand All</button>
+      <button type='button' class='btn btn-primary' value='uiCollapseAllSpans' data-i18n="trace.collapse">Collapse All</button>
     </div>
-    <select data-placeholder='Filter Service Search' class='form-control input-sm' name='serviceFilterSearch' id='serviceFilterSearch'>
-      <option value=''></option>
-      {{#serviceCounts}}
-      <option value='{{name}}'>{{name}}</option>
-      {{/serviceCounts}}
-    </select>
+    <div class="form-group col-md-2">
+      <select data-placeholder='Filter Service Search' class='form-control' name='serviceFilterSearch' id='serviceFilterSearch'>
+        <option value=''></option>
+        {{#serviceCounts}}
+        <option value='{{name}}'>{{name}}</option>
+        {{/serviceCounts}}
+      </select>
+    </div>
   </form>
-
   <div class='trace-details services'>
   {{#serviceCounts}}
-    <span class='badge badge-success service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
+    <span class='badge badge-info service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
   {{/serviceCounts}}
   </div>
-  {{/traceId}}
+ </div>
 </div>
-
+{{/traceId}}
 {{#traceId}}
-<div class='row' id='trace-container'>
+<div id='trace-container' class="w-100" style='overflow: hidden;'>
   <div id='timeLabel' class='span'>
     <div class='handle'>Services</div>
     <div class='duration-container'>
@@ -73,12 +76,12 @@
       </div>
     </div>
 
-    <div class='duration-container'>
+    <div class='duration-container row'>
       {{#timeMarkers}}
-      <div class='time-marker time-marker-{{index}}'>.</div>
+      <div class='col time-marker time-marker-{{index}}'>.</div>
       {{/timeMarkers}}
 
-      <div class='duration' style='left: {{left}}%; width: {{width}}%'>
+      <div class='duration ml-3' style='left: {{left}}%; width: {{width}}%'>
         {{durationStr}} : {{spanName}}
         {{#annotations}}
         <div class='annotation{{#isCore}} core{{/isCore}}'
@@ -107,18 +110,21 @@
   {{/spans}}
 </div>
 {{/traceId}}
-
-<div class='modal fade' id='spanPanel' tabindex='-1'>
+<div class='modal fade' id='spanPanel' tabindex='-1' role="dialog"  aria-hidden="true">
   <div class='modal-dialog modal-lg'>
     <div class='modal-content'>
       <div class='modal-header'>
-        <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&times;</button>
         <h4 class='modal-title'></h4>
-        <h5>AKA: <span class='service-names'></span></h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
       <div class='modal-body'>
-        <table id='annotations' class='table table-striped'>
-          <thead><tr>
+       <div class="card">
+        <h6 class="card-body">AKA: <span class='service-names container'></span></h6>
+       </div> 
+        <table id='annotations' class='table table-striped table-sm table-bordered'>
+          <thead class="table-info"><tr>
             <th>Date Time</th>
             <th>Relative Time</th>
             <th>Annotation</th>
@@ -134,8 +140,8 @@
           </tbody>
         </table>
 
-        <table id='binaryAnnotations' class='table table-striped'>
-          <thead><tr>
+        <table id='binaryAnnotations' class='table table-striped table-sm table-bordered'>
+          <thead class="table-info"><tr>
             <th>Key</th>
             <th>Value</th>
           </tr></thead>
@@ -147,12 +153,14 @@
           </tbody>
         </table>
 
-        <button class="btn btn-info btn-xs pull-right" type="button" data-toggle="collapse"
-                data-target="#moreInfo" aria-expanded="false" aria-controls="moreInfo" data-i18n="trace.more">More Info</button>
+        <button class="btn btn-info btn-sm pull-right mt-1" type="button" data-toggle="collapse"
+                data-target="#moreInfo" aria-expanded="false" aria-controls="moreInfo" data-i18n="trace.more">More Info
+                <span class="fa fa-chevron-circle-down"></span>
+        </button>
         <hr/>
         <div class='clearfix'></div>
         <div id='moreInfo' class='collapse'>
-          <table class='table table-striped'>
+          <table class='table table-striped table-sm table-bordered'>
             <tbody>
               <tr>
                 <td class='key' data-key='key'></td>
@@ -166,7 +174,7 @@
   </div>
 </div>
 
-<div class='row  hidden' id='trace-container-backup'>
+<div class='row' id='trace-container-backup' hidden>
   <div id='timeLabel-backup' class='span'>
     <div class='handle'>Services</div>
     <div class='duration-container'>
@@ -232,16 +240,23 @@
   {{/spansBackup}}
 </div>
 
-<div class='modal fade' id='jsonPanel' tabindex='-1'>
+<div class='modal fade' id='jsonPanel' tabindex='-1' role="dialog"  aria-hidden="true">
   <div class='modal-dialog modal-lg'>
     <div class='modal-content'>
-      <div class='modal-header'>
-        <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&times;</button>
-        <a href='#' class='save'><span class='glyphicon glyphicon-save' aria-hidden='true' aria-label='save'></span></a>
+      <div class='modal-header bg-light'>
         <h4 class='modal-title'></h4>
+        <a href='#' class='save ml-5 btn btn-outline-dark'>
+          <span class='fa fa-download fa-2x' style="color: black;" aria-hidden='true' aria-label='save'></span>
+        </a>
+        <a class='copy btn btn-outline-dark' id="copy2clipboard">
+          <span class='fa fa-copy fa-2x' style="color: black;" aria-hidden='true' aria-label='save'></span>
+        </a>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
-      <div class='modal-body'>
-        <pre></pre>
+      <div class='modal-body bg-dark'>
+        <pre><code class="text-light" id="trace-json-content"/></pre>
       </div>
     </div>
   </div>

--- a/zipkin-ui/templates/traceViewer.mustache
+++ b/zipkin-ui/templates/traceViewer.mustache
@@ -1,4 +1,4 @@
-<div id='trace-controls' class='row well well-sm'>
+<div id='trace-controls' class='row card border-dark mb-3 w-90'>
 
   <form class="form-inline" role="form">
     <div class="form-group">
@@ -7,11 +7,11 @@
   </form>
 
   {{#traceId}}
-  <ul class='nav nav-pills'>
-    <li class=''><a href='#'><strong data-i18n="trace.duration">Duration:</strong> <span class='badge'>{{duration}}</span></a></li>
-    <li class=''><a href='#'><strong data-i18n="trace.service">Services:</strong> <span class='badge'>{{services}}</span></a></li>
-    <li class=''><a href='#'><strong data-i18n="trace.depth">Depth:</strong> <span class='badge'>{{depth}}</span></a></li>
-    <li class=''><a href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge'>{{totalSpans}}</span></a></li>
+  <ul class='nav nav-pills nav-justified'>
+    <li class='nav-item'><a href='#'><strong data-i18n="trace.duration">Duration:</strong> <span class='badge'>{{duration}}</span></a></li>
+    <li class='nav-item'><a href='#'><strong data-i18n="trace.service">Services:</strong> <span class='badge'>{{services}}</span></a></li>
+    <li class='nav-item'><a href='#'><strong data-i18n="trace.depth">Depth:</strong> <span class='badge'>{{depth}}</span></a></li>
+    <li class='nav-item'><a href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge'>{{totalSpans}}</span></a></li>
     {{#logsUrl}}
     <li class='navbar-right'><a href='{{ logsUrl }}' id='traceLogsLink'><span class='btn btn-primary btn-xs badge'>Logs</span></a></li>
     {{/logsUrl}}
@@ -33,7 +33,7 @@
 
   <div class='trace-details services'>
   {{#serviceCounts}}
-    <span class='label label-default service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
+    <span class='badge badge-success service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
   {{/serviceCounts}}
   </div>
   {{/traceId}}


### PR DESCRIPTION
This PR is a WIP to upgrade the Zipkin UI to bootstrap-4. At least it will give us a sleek UI and may be a good start when we have bandwidth to rewrite the UI. 

I will limit the scope of this PR is only migrate to bootstrap-4 and fix minor things.

TODO:
* Prune unused dependencies
* Fix UI glitches


![screen shot 2561-08-08 at 16 58 31](https://user-images.githubusercontent.com/4723376/43833140-fd29593a-9b33-11e8-8bfb-cd621192c29f.png)
![screen shot 2561-08-08 at 16 58 49](https://user-images.githubusercontent.com/4723376/43833142-fd845cea-9b33-11e8-9ee9-9336dcf752ab.png)
![screen shot 2561-08-08 at 16 58 56](https://user-images.githubusercontent.com/4723376/43833143-fdc578a6-9b33-11e8-83bf-b27ec7026cb0.png)
![screen shot 2561-08-08 at 16 59 05](https://user-images.githubusercontent.com/4723376/43833145-fe60a9de-9b33-11e8-8fab-0e2091529aa8.png)
