### PR TITLE
Updates dependency versions and enabled errorprone for JDK 10

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -84,7 +84,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>1.6.0</version>
       </extension>
     </extensions>
     <plugins>
@@ -160,39 +160,24 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration combine.self="override">
+              <!-- instead of javac-with-errorprone -->
+              <compilerId>javac</compilerId>
+              <!-- scrub errorprone compiler args -->
+              <compilerArgs/>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <!-- disable errorprone on JMH source tree -->
-      <id>error-prone-off</id>
-      <activation>
-        <!-- error-prone isn't happy in jdk 10 yet https://github.com/google/error-prone/issues/860#issuecomment-396154710 -->
-        <jdk>[1.8,10)</jdk>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-compile</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>compile</goal>
-                </goals>
-                <configuration>
-                  <compilerId>javac-with-errorprone</compilerId>
-                  <compilerArgs>
-                    <arg>-XepDisableAllChecks</arg>
-                  </compilerArgs>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,16 @@
     <main.java.version>1.7</main.java.version>
     <main.signature.artifact>java17</main.signature.artifact>
 
+    <!-- override to set exclusions per-project -->
+    <errorprone.args/>
+    <errorprone.version>2.3.1</errorprone.version>
+
     <main.basedir>${project.basedir}</main.basedir>
 
-    <brave.version>5.1.0</brave.version>
+    <brave.version>5.2.0</brave.version>
     <cassandra-driver-core.version>3.5.1</cassandra-driver-core.version>
-    <okhttp.version>3.10.0</okhttp.version>
-    <okio.version>1.14.1</okio.version>
+    <okhttp.version>3.11.0</okhttp.version>
+    <okio.version>1.15.0</okio.version>
     <!-- important to keep this in sync with spring-boot-dependencies -->
     <jooq.version>3.11.4</jooq.version>
     <micrometer.version>1.0.6</micrometer.version>
@@ -64,15 +68,17 @@
     <!-- Be careful to set this as a provided dep, so that it doesn't interfere with dependencies
          from other projects. For example, cassandra and spring boot set guava versions -->
     <guava.version>19.0</guava.version>
+
     <junit.version>4.12</junit.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <mockito.version>2.21.0</mockito.version>
-    <assertj.version>3.10.0</assertj.version>
+    <assertj.version>3.11.0</assertj.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <testcontainers.version>1.8.0</testcontainers.version>
+    <testcontainers.version>1.8.3</testcontainers.version>
 
+    <auto-value.version>1.6.2</auto-value.version>
     <animal-sniffer-maven-plugin.version>1.17</animal-sniffer-maven-plugin.version>
-    <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
@@ -294,9 +300,15 @@
 
       <dependency>
         <groupId>com.google.auto.value</groupId>
-        <artifactId>auto-value</artifactId>
-        <version>1.5.4</version>
+        <artifactId>auto-value-annotations</artifactId>
+        <version>${auto-value.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.google.auto.value</groupId>
+        <artifactId>auto-value</artifactId>
+        <version>${auto-value.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
@@ -394,7 +406,7 @@
       <dependency>
         <groupId>io.zipkin.brave.cassandra</groupId>
         <artifactId>brave-instrumentation-cassandra-driver</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -521,7 +533,7 @@
         <plugin>
           <groupId>net.orfjackal.retrolambda</groupId>
           <artifactId>retrolambda-maven-plugin</artifactId>
-          <version>2.5.4</version>
+          <version>2.5.5</version>
           <executions>
             <execution>
               <goals>
@@ -697,10 +709,9 @@
 
   <profiles>
     <profile>
-      <id>error-prone</id>
+      <id>error-prone-1.8</id>
       <activation>
-        <!-- error-prone isn't happy in jdk 10 yet https://github.com/google/error-prone/issues/860#issuecomment-396154710 -->
-        <jdk>[1.8,10)</jdk>
+        <jdk>1.8</jdk>
         <activeByDefault>false</activeByDefault>
       </activation>
       <build>
@@ -718,9 +729,8 @@
                 <configuration>
                   <compilerId>javac-with-errorprone</compilerId>
                   <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                  <!-- error-prone doesn't like generated code -->
                   <compilerArgs>
-                    <arg>-XepDisableWarningsInGeneratedCode</arg>
+                    <arg>${errorprone.args}</arg>
                   </compilerArgs>
                 </configuration>
               </execution>
@@ -734,9 +744,54 @@
               <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>2.3.1</version>
+                <version>${errorprone.version}</version>
               </dependency>
             </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>error-prone-9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <!-- only use errorprone on main source tree -->
+                <id>default-compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                  <compilerArgs>
+                    <arg>-XDcompilePolicy=simple</arg>
+                    <arg>-Xplugin:ErrorProne ${errorprone.args}</arg>
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                    <processorPath>
+                      <groupId>com.google.errorprone</groupId>
+                      <artifactId>error_prone_core</artifactId>
+                      <version>${errorprone.version}</version>
+                    </processorPath>
+                    <!-- auto-value is placed here eventhough not needed for all projects as
+                         configuring along with errorprone is tricky in subprojects -->
+                    <processorPath>
+                      <groupId>com.google.auto.value</groupId>
+                      <artifactId>auto-value</artifactId>
+                      <version>${auto-value.version}</version>
+                    </processorPath>
+                  </annotationProcessorPaths>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/zipkin-autoconfigure/collector-kafka/src/test/java/zipkin2/collector/kafka/ZipkinKafkaCollectorPropertiesOverrideTest.java
+++ b/zipkin-autoconfigure/collector-kafka/src/test/java/zipkin2/collector/kafka/ZipkinKafkaCollectorPropertiesOverrideTest.java
@@ -74,6 +74,6 @@ public class ZipkinKafkaCollectorPropertiesOverrideTest {
 
     Assertions.assertThat(Access.collectorBuilder(context))
         .extracting(builderExtractor)
-        .containsExactly(value);
+        .isEqualTo(value);
   }
 }

--- a/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin2/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
+++ b/zipkin-autoconfigure/collector-rabbitmq/src/test/java/zipkin2/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
@@ -81,6 +81,6 @@ public class ZipkinRabbitMQCollectorPropertiesOverrideTest {
 
     assertThat(Access.collectorBuilder(context))
         .extracting(builderExtractor)
-        .containsExactly(value);
+        .isEqualTo(value);
   }
 }

--- a/zipkin-storage/cassandra-v1/pom.xml
+++ b/zipkin-storage/cassandra-v1/pom.xml
@@ -28,6 +28,9 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
+
+    <!-- error-prone doesn't like generated code -->
+    <errorprone.args>-XepDisableWarningsInGeneratedCode</errorprone.args>
   </properties>
 
   <dependencies>
@@ -36,6 +39,10 @@
       <artifactId>zipkin-storage-cassandra</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
@@ -75,7 +82,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-guava</artifactId>
-      <version>3.1.0</version>
+      <version>3.2.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -28,6 +28,9 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
+
+    <!-- error-prone doesn't like generated code -->
+    <errorprone.args>-XepDisableWarningsInGeneratedCode</errorprone.args>
   </properties>
 
   <dependencies>
@@ -37,6 +40,10 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -28,6 +28,9 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
+
+    <!-- error-prone doesn't like generated code -->
+    <errorprone.args>-XepDisableWarningsInGeneratedCode</errorprone.args>
   </properties>
 
   <dependencies>
@@ -41,6 +44,10 @@
       <artifactId>okhttp</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
@@ -74,7 +81,12 @@
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-tls</artifactId>
+      <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchStorageTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchStorageTest.java
@@ -13,18 +13,17 @@
  */
 package zipkin2.elasticsearch;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.internal.tls.SslClient;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import zipkin2.CheckResult;
 
 import static java.util.Arrays.asList;
+import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.DAY;
 
@@ -105,13 +104,12 @@ public class ElasticsearchStorageTest {
   @Test
   public void check_ssl() throws Exception {
     storage.close();
-    SslClient sslClient = SslClient.localhost();
     OkHttpClient client =
         new OkHttpClient.Builder()
-            .sslSocketFactory(sslClient.socketFactory, sslClient.trustManager)
+            .sslSocketFactory(localhost().sslSocketFactory(), localhost().trustManager())
             .hostnameVerifier((host, session) -> true)
             .build();
-    es.useHttps(sslClient.socketFactory, false);
+    es.useHttps(localhost().sslSocketFactory(), false);
 
     storage = ElasticsearchStorage.newBuilder(client).hosts(asList(es.url("").toString())).build();
 
@@ -125,12 +123,11 @@ public class ElasticsearchStorageTest {
   @Test(expected = IllegalArgumentException.class)
   public void multipleSslNotYetSupported() {
     storage.close();
-    SslClient sslClient = SslClient.localhost();
     OkHttpClient client =
         new OkHttpClient.Builder()
-            .sslSocketFactory(sslClient.socketFactory, sslClient.trustManager)
+          .sslSocketFactory(localhost().sslSocketFactory(), localhost().trustManager())
             .build();
-    es.useHttps(sslClient.socketFactory, false);
+    es.useHttps(localhost().sslSocketFactory(), false);
 
     storage =
         ElasticsearchStorage.newBuilder(client)

--- a/zipkin-storage/mysql-v1/pom.xml
+++ b/zipkin-storage/mysql-v1/pom.xml
@@ -28,18 +28,15 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
+
+    <!-- error-prone doesn't like generated code -->
+    <errorprone.args>-XepDisableWarningsInGeneratedCode</errorprone.args>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/zipkin-ui/package-lock.json
+++ b/zipkin-ui/package-lock.json
@@ -228,7 +228,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -1341,7 +1341,7 @@
     "bootstrap-datepicker": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.8.0.tgz",
-      "integrity": "sha512-213St/G8KT3mjs4qu4qwww74KWysMaIeqgq5OhrboZjIjemIpyuxlSo9FNNI5+KzpkkxkRRba+oewiRGV42B1A==",
+      "integrity": "sha1-xjUTkx5vCfFq6fEbYvMtlQ3zlY4=",
       "requires": {
         "jquery": ">=1.7.1 <4.0.0"
       }
@@ -4897,7 +4897,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -7502,7 +7502,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -7687,7 +7687,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -10640,7 +10640,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -10902,7 +10902,7 @@
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
@@ -12365,7 +12365,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -12704,7 +12704,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.2</version>
+      <version>2.8.5</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
It is a little tricky to get errorprone and auto-value working at the
same time.

See https://github.com/openzipkin/brave/pull/761