### PR TITLE
make zipkin2.Span.tag field mutable while it's initialized as empty

### DIFF
--- a/zipkin/src/main/java/zipkin2/Span.java
+++ b/zipkin/src/main/java/zipkin2/Span.java
@@ -637,7 +637,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
   final long timestamp, duration; // zero means null, saving 2 object references
   final Endpoint localEndpoint, remoteEndpoint;
   final List<Annotation> annotations;
-  final Map<String, String> tags;
+  final Map<String, String> tags = new LinkedHashMap<>();
   final int flags; // bit field for timestamp and duration, saving 2 object references
 
   Span(Builder builder) {
@@ -651,7 +651,9 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     localEndpoint = builder.localEndpoint;
     remoteEndpoint = builder.remoteEndpoint;
     annotations = sortedList(builder.annotations);
-    tags = builder.tags == null ? Collections.emptyMap() : new LinkedHashMap<>(builder.tags);
+    if (builder.tags != null) {
+      tags.putAll(builder.tags);
+    }
     flags = builder.flags;
   }
 


### PR DESCRIPTION
I faced the problem for the following scenario:

Given Zipkin2.Span.Builder with 'tags' = null
Then Span(builder) gets initialized with immutable 'tags' field:
`tags =  Collections.emptyMap()`
Then while reporting the span( `zipkin2.reporter.Reporter.report(..))`)
 and modifying it over SpanAdjuster hook:
`span -> span.putTag(..)`
The UnsupportedOperationException occurs


This change implies initializing zipkin2.Span object with a mutable 'tags' field.
