### PR TITLE
Add the ability to specify the complete JDBC url

### DIFF
--- a/zipkin-autoconfigure/storage-mysql/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLStorageAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/storage-mysql/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLStorageAutoConfigurationTest.java
@@ -88,4 +88,31 @@ public class ZipkinMySQLStorageAutoConfigurationTest {
 
     assertThat(context.getBean(MySQLStorage.class).strictTraceId).isFalse();
   }
+
+  @Test
+  public void usesJdbcUrl_whenPresent() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:mysql");
+    addEnvironment(context, "zipkin.storage.mysql.jdbc-url:jdbc:mysql://host1,host2,host3/zipkin");
+    Access.registerMySQL(context);
+    context.refresh();
+
+    assertThat(context.getBean(HikariDataSource.class).getJdbcUrl()).isEqualTo("jdbc:mysql://host1,host2,host3/zipkin");
+  }
+
+  @Test
+  public void usesRegularConfig_whenBlank() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:mysql");
+    addEnvironment(context, "zipkin.storage.mysql.jdbc-url:");
+    addEnvironment(context, "zipkin.storage.mysql.host:host");
+    addEnvironment(context, "zipkin.storage.mysql.port:3306");
+    addEnvironment(context, "zipkin.storage.mysql.username:root");
+    addEnvironment(context, "zipkin.storage.mysql.password:secret");
+    addEnvironment(context, "zipkin.storage.mysql.db:zipkin");
+    Access.registerMySQL(context);
+    context.refresh();
+
+    assertThat(context.getBean(HikariDataSource.class).getJdbcUrl()).isEqualTo("jdbc:mysql://host:3306/zipkin?autoReconnect=true&useSSL=false&useUnicode=yes&characterEncoding=UTF-8");
+  }
 }

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -213,6 +213,11 @@ The following apply when `STORAGE_TYPE` is set to `mysql`:
     * `MYSQL_MAX_CONNECTIONS`: Maximum concurrent connections, defaults to 10
     * `MYSQL_USE_SSL`: Requires `javax.net.ssl.trustStore` and `javax.net.ssl.trustStorePassword`, defaults to false.
 
+Alternatively you can use `MYSQL_JDBC_URL` and specify the complete JDBC url yourself. Note that the URL constructed by
+using the separate settings above will also include the following parameters: 
+`?autoReconnect=true&useSSL=false&useUnicode=yes&characterEncoding=UTF-8`. If you specify the JDBC url yourself, add
+these parameters as well.
+
 Example usage:
 
 ```bash

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -110,6 +110,7 @@ zipkin:
       http-logging: ${ES_HTTP_LOGGING:}
       legacy-reads-enabled: ${ES_LEGACY_READS_ENABLED:true}
     mysql:
+      jdbc-url: ${MYSQL_JDBC_URL:}
       host: ${MYSQL_HOST:localhost}
       port: ${MYSQL_TCP_PORT:3306}
       username: ${MYSQL_USER:}


### PR DESCRIPTION
I know this storage component is deprecated, but I'd still like to be able to specify it while we are implementing another storage backend. 

Closes #2190