### PR TITLE
Updates java build deps, notably to allow JDK 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
       # Quiet Maven invoker logs (Downloading... when running zipkin-server/src/it)
       MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
     docker:
-      # Use java 10 here and 1.8 in travis (so that we test both)
-      - image: circleci/openjdk:10-jdk
+      # Use java 11 here and 1.8 in travis (so that we test both)
+      - image: circleci/openjdk:11-jdk
     steps:
       - checkout
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -84,7 +84,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.1</version>
       </extension>
     </extensions>
     <plugins>
@@ -125,7 +125,7 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.1</version>
+        <version>0.6.1</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -44,14 +44,14 @@
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.3.1</errorprone.version>
+    <errorprone.version>2.3.2</errorprone.version>
 
     <main.basedir>${project.basedir}</main.basedir>
 
-    <brave.version>5.4.0</brave.version>
+    <brave.version>5.4.2</brave.version>
     <cassandra-driver-core.version>3.6.0</cassandra-driver-core.version>
     <okhttp.version>3.11.0</okhttp.version>
-    <okio.version>1.15.0</okio.version>
+    <okio.version>1.16.0</okio.version>
     <!-- important to keep this in sync with spring-boot-dependencies -->
     <jooq.version>3.11.5</jooq.version>
     <micrometer.version>1.0.6</micrometer.version>
@@ -71,7 +71,7 @@
 
     <junit.version>4.12</junit.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
-    <mockito.version>2.22.0</mockito.version>
+    <mockito.version>2.23.0</mockito.version>
     <assertj.version>3.11.1</assertj.version>
     <hamcrest.version>1.3</hamcrest.version>
     <testcontainers.version>1.9.1</testcontainers.version>
@@ -86,8 +86,8 @@
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-    <maven-shade-plugin.version>3.1.1</maven-shade-plugin.version>
-    <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
+    <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
+    <maven-failsafe-plugin.version>2.22.1</maven-failsafe-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
   </properties>
 
@@ -697,7 +697,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,11)</version>
+                  <version>[1.8,12)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/zipkin-autoconfigure/collector-scribe/pom.xml
+++ b/zipkin-autoconfigure/collector-scribe/pom.xml
@@ -88,6 +88,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <!-- to prevent class not found in tests -->
             <configuration>
+              <forkCount>0</forkCount>
               <argLine>--add-modules java.xml.bind</argLine>
             </configuration>
           </plugin>

--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <amqp-client.version>4.8.1</amqp-client.version>
+    <amqp-client.version>4.8.3</amqp-client.version>
   </properties>
 
   <dependencies>

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -47,7 +47,7 @@ import static zipkin2.storage.cassandra.v1.InternalForTests.writeDependencyLinks
 public class ITCassandraStorage {
 
   static CassandraStorageRule classRule() {
-    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.11.0", "test_cassandra3");
+    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.11.6", "test_cassandra3");
   }
 
   public static class ITSpanStore extends zipkin2.storage.ITSpanStore {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -47,7 +47,7 @@ import static zipkin2.storage.cassandra.InternalForTests.writeDependencyLinks;
 public class ITCassandraStorage {
 
   static CassandraStorageRule classRule() {
-    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.11.0", "test_cassandra3");
+    return new CassandraStorageRule("openzipkin/zipkin-cassandra:2.11.6", "test_cassandra3");
   }
 
   public static class ITSpanStore extends zipkin2.storage.ITSpanStore {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
@@ -34,7 +34,7 @@ import static zipkin2.elasticsearch.integration.ElasticsearchStorageRule.index;
 public class ITElasticsearchStorageV2 {
 
   static ElasticsearchStorageRule classRule() {
-    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch:2.11.0",
+    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch:2.11.6",
       "test_elasticsearch3");
   }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
@@ -34,7 +34,7 @@ import static zipkin2.elasticsearch.integration.ElasticsearchStorageRule.index;
 public class ITElasticsearchStorageV5 {
 
   static ElasticsearchStorageRule classRule() {
-    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch5:2.11.0",
+    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch5:2.11.6",
       "test_elasticsearch3");
   }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -34,7 +34,7 @@ import static zipkin2.elasticsearch.integration.ElasticsearchStorageRule.index;
 public class ITElasticsearchStorageV6 {
 
   static ElasticsearchStorageRule classRule() {
-    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch6:2.11.0",
+    return new ElasticsearchStorageRule("openzipkin/zipkin-elasticsearch6:2.11.6",
       "test_elasticsearch3");
   }
 

--- a/zipkin-storage/mysql-v1/pom.xml
+++ b/zipkin-storage/mysql-v1/pom.xml
@@ -44,6 +44,13 @@
       <artifactId>jooq</artifactId>
     </dependency>
 
+    <!-- for Generated annotation -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- for integration tests -->
     <dependency>
       <groupId>io.zipkin.zipkin2</groupId>

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -31,7 +31,7 @@ import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinDependenc
 public class ITMySQLStorage {
 
   static LazyMySQLStorage classRule() {
-    return new LazyMySQLStorage("2.11.0");
+    return new LazyMySQLStorage("2.11.6");
   }
 
   public static class ITSpanStore extends zipkin2.storage.ITSpanStore {


### PR DESCRIPTION
NOTE: our circleci build has been broken a long time.. this was trying to test JDK 10, but broke in the UI due to an openssl problem. It may be the case that updating the the JDK 11 image implicitly fixes the openssl build fail related to the UI. we'll see

```
Exit code: 1 
Output:
[INFO] 
[INFO] 15 10 2018 02:19:29.067:ERROR [launcher]: Cannot start PhantomJS
[INFO] 	Auto configuration failed
[INFO] 140336306921088:error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library:dso_dlfcn.c:185:filename(libssl_conf.so): libssl_conf.so: cannot open shared object file: No such file or directory
```

cc @openzipkin/devops-tooling 