### PR TITLE
Simplifies summary logic by not doing skew correction

### DIFF
--- a/zipkin-ui/js/component_data/default.js
+++ b/zipkin-ui/js/component_data/default.js
@@ -4,7 +4,6 @@ import $ from 'jquery';
 import queryString from 'query-string';
 import {traceSummary, traceSummariesToMustache} from '../component_ui/traceSummary';
 import {SPAN_V1} from '../spanConverter';
-import {correctForClockSkew} from '../skew';
 
 export function convertToApiQuery(source) {
   const query = Object.assign({}, source);
@@ -54,8 +53,7 @@ export default component(function DefaultData() {
       const summaries = traces.map(raw => {
         const v1Trace = raw.map(SPAN_V1.convert);
         const mergedTrace = SPAN_V1.mergeById(v1Trace);
-        const clockSkewCorrectedTrace = correctForClockSkew(mergedTrace);
-        return traceSummary(clockSkewCorrectedTrace);
+        return traceSummary(mergedTrace);
       });
 
       const modelview = {

--- a/zipkin-ui/testdata/README.md
+++ b/zipkin-ui/testdata/README.md
@@ -1,7 +1,8 @@
 # Test json
 For testing the UI, you can simply POST or paste json in this directory.
 
-For example, assuming you started zipkin with `java -jar zipkin.jar`
+For example, assuming you started zipkin allowing it to see up to 5 year old data `QUERY_LOOKBACK=157784630000 java -jar zipkin.jar`
 ```bash
 $ curl -X POST -s localhost:9411/api/v2/spans -H'Content-Type: application/json' -d @netflix.json
+$ open 'http://localhost:9411/zipkin/?lookback=custom&startTs=0'
 ```


### PR DESCRIPTION
The trace summary screen and individual trace screens are served by
different data. At the moment, offsets are not considered when computing
the trace duration broken down by service. Maybe it should be, but
removing clock skew makes migration to v2 simpler and we can then
revisit this logic.

See #2217