### PR TITLE
Brings back relative width in trace query screen

### DIFF
--- a/zipkin-ui/js/component_data/default.js
+++ b/zipkin-ui/js/component_data/default.js
@@ -58,9 +58,9 @@ export default component(function DefaultData() {
       type: 'GET',
       dataType: 'json'
     }).done(traces => {
-      const summaries = traces.map(raw => rawTraceToSummary(raw));
+      const traceSummaries = traces.map(raw => rawTraceToSummary(raw));
       const modelview = {
-        traces: traceSummariesToMustache(apiQuery.serviceName, summaries),
+        traces: traceSummariesToMustache(apiQuery.serviceName, traceSummaries),
         apiURL,
         rawResponse: traces
       };

--- a/zipkin-ui/test/component_data/default.test.js
+++ b/zipkin-ui/test/component_data/default.test.js
@@ -66,28 +66,28 @@ describe('rawTraceToSummary', () => {
       traceId: '1e223ff1f80f1c69',
       timestamp: 1470150004071068,
       duration: 99411,
-      spanTimestamps: [
-        {
-          name: 'servicea',
-          timestamp: 1470150004071068,
-          duration: 99411
-        },
-        {
-          name: 'servicea',
-          timestamp: 1470150004074202,
-          duration: 94539
-        },
-        {
-          name: 'serviceb',
-          timestamp: 1470150004074202,
-          duration: 94539
-        },
-        {
-          name: 'serviceb',
-          timestamp: 1470150004074684,
-          duration: 65000
-        }
-      ],
+      groupedTimestamps: {
+        servicea: [
+          {
+            timestamp: 1470150004071068,
+            duration: 99411
+          },
+          {
+            timestamp: 1470150004074202,
+            duration: 94539
+          }
+        ],
+        serviceb: [
+          {
+            timestamp: 1470150004074202,
+            duration: 94539
+          },
+          {
+            timestamp: 1470150004074684,
+            duration: 65000
+          }
+        ]
+      },
       endpoints: [
         {
           serviceName: 'servicea',

--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -312,19 +312,24 @@ describe('traceSummariesToMustache', () => {
     traceId: 'cafedead',
     timestamp: start,
     duration: 20000,
-    spanTimestamps: [{
-      name: 'A',
-      timestamp: start,
-      duration: 10000
-    }, {
-      name: 'B',
-      timestamp: start + 1000,
-      duration: 20000
-    }, {
-      name: 'B',
-      timestamp: start + 1000,
-      duration: 15000
-    }],
+    groupedTimestamps: {
+      A: [
+        {
+          timestamp: start,
+          duration: 10000
+        }
+      ],
+      B: [
+        {
+          timestamp: start + 1000,
+          duration: 20000
+        },
+        {
+          timestamp: start + 1000,
+          duration: 15000
+        }
+      ]
+    },
     endpoints: [ep1, ep2]
   };
 
@@ -371,8 +376,29 @@ describe('traceSummariesToMustache', () => {
   });
 
   it('should calculate the width in percent', () => {
-    const model = traceSummariesToMustache(null, [summary]);
+    const summary1 = {
+      traceId: 'cafebaby',
+      timestamp: start,
+      duration: 2000,
+      groupedTimestamps: {
+        A: [{timestamp: start + 1, duration: 2000}]
+      },
+      endpoints: [ep1]
+    };
+    const summary2 = {
+      traceId: 'cafedead',
+      timestamp: start,
+      duration: 20000,
+      groupedTimestamps: {
+        A: [{timestamp: start, duration: 20000}]
+      },
+      endpoints: [ep1]
+    };
+
+    // Model is ordered by duration, and the width should be relative (percentage)
+    const model = traceSummariesToMustache(null, [summary1, summary2]);
     model[0].width.should.equal(100);
+    model[1].width.should.equal(10);
   });
 
   it('should pass on timestamp', () => {


### PR DESCRIPTION
This fixes a bug in the trace query screen and reorganizes code to more
easily tell which screens need which data from the trace summary.

Before:
<img width="1007" alt="screen shot 2018-11-01 at 4 56 19 pm" src="https://user-images.githubusercontent.com/64215/47840504-cf574b80-ddf9-11e8-8b6f-06c1198d6c53.png">

After:
<img width="980" alt="screen shot 2018-11-01 at 4 55 35 pm" src="https://user-images.githubusercontent.com/64215/47840510-d41bff80-ddf9-11e8-9629-7eea8bff30d4.png">
