### PR TITLE
Refactors entrypoints into traceSummary and backfills UI tests

### DIFF
--- a/zipkin-ui/js/component_ui/uploadTrace.js
+++ b/zipkin-ui/js/component_ui/uploadTrace.js
@@ -1,9 +1,7 @@
 import {component} from 'flightjs';
 import FullPageSpinnerUI from '../component_ui/fullPageSpinner';
 import traceToMustache from '../../js/component_ui/traceToMustache';
-import _ from 'lodash';
 import {SPAN_V1} from '../spanConverter';
-import {correctForClockSkew} from '../skew';
 
 function ensureV1(trace) {
   if (trace == null || trace.length === 0
@@ -11,7 +9,7 @@ function ensureV1(trace) {
     return trace;
   }
 
-  return _(trace).map(SPAN_V1.convert);
+  return SPAN_V1.convertTrace(trace);
 }
 
 export default component(function uploadTrace() {
@@ -26,10 +24,8 @@ export default component(function uploadTrace() {
       let model;
       try {
         const rawTrace = JSON.parse(evt.target.result);
-        const v1Trace = ensureV1(rawTrace);
-        const mergedTrace = SPAN_V1.mergeById(v1Trace);
-        const clockSkewCorrectedTrace = correctForClockSkew(mergedTrace);
-        const modelview = traceToMustache(clockSkewCorrectedTrace);
+        const v1Trace = ensureV1(rawTrace); // We don't need to convert if it is already a v1 trace
+        const modelview = traceToMustache(v1Trace);
         model = {modelview, trace: rawTrace};
       } catch (e) {
         this.trigger('uiServerError',

--- a/zipkin-ui/js/spanConverter.js
+++ b/zipkin-ui/js/spanConverter.js
@@ -1,3 +1,5 @@
+import {correctForClockSkew} from './skew';
+
 function toV1Endpoint(endpoint) {
   if (endpoint === undefined) {
     return undefined;
@@ -466,6 +468,12 @@ function mergeById(spans) {
 }
 
 module.exports.SPAN_V1 = {
+  // Temporary convenience function until functionality is ported to v2
+  convertTrace(v2Trace) {
+    const v1Trace = v2Trace.map(convertV1);
+    const mergedTrace = mergeById(v1Trace);
+    return correctForClockSkew(mergedTrace);
+  },
   convert(v2Span) {
     return convertV1(v2Span);
   },

--- a/zipkin-ui/test/component_data/default.test.js
+++ b/zipkin-ui/test/component_data/default.test.js
@@ -28,7 +28,8 @@ describe('convertSuccessResponse', () => {
   });
 
   it('should include service percentage from the URL', () => {
-    const urlIncludingServiceName = '/api/v2/traces?serviceName=backend&spanName=all&endTs=1459169770000';
+    const urlIncludingServiceName =
+      '/api/v2/traces?serviceName=backend&spanName=all&endTs=1459169770000';
 
     const expectedTemplate = {
       traceId: 'bb1f0e21882325b8',

--- a/zipkin-ui/test/component_data/default.test.js
+++ b/zipkin-ui/test/component_data/default.test.js
@@ -1,108 +1,123 @@
-import {convertToApiQuery, rawTraceToSummary} from '../../js/component_data/default';
+import {convertSuccessResponse, convertToApiQuery} from '../../js/component_data/default';
+import {errorTrace, httpTrace, skewedTrace} from '../component_ui/traceTestHelpers';
 import queryString from 'query-string';
 
-describe('rawTraceToSummary', () => {
-  it('should create trace summary from skewed trace', () => {
-    // from ../tracedata/skew.json as we can't figure out how to read file with headless chrome env
-    const skewedTrace = [
-      {
-        traceId: '1e223ff1f80f1c69',
-        parentId: '74280ae0c10d8062',
-        id: '43210ae0c10d1234',
-        name: 'async',
-        timestamp: 1470150004008762,
-        duration: 65000,
-        localEndpoint: {
-          serviceName: 'serviceb',
-          ipv4: '192.0.0.0'
-        }
-      },
-      {
-        traceId: '1e223ff1f80f1c69',
-        parentId: 'bf396325699c84bf',
-        id: '74280ae0c10d8062',
-        kind: 'SERVER',
-        name: 'post',
-        timestamp: 1470150004008761,
-        duration: 93577,
-        localEndpoint: {
-          serviceName: 'serviceb',
-          ipv4: '192.0.0.0'
-        },
-        shared: true
-      },
-      {
-        traceId: '1e223ff1f80f1c69',
-        id: 'bf396325699c84bf',
-        kind: 'SERVER',
-        name: 'get',
-        timestamp: 1470150004071068,
-        duration: 99411,
-        localEndpoint: {
-          serviceName: 'servicea',
-          ipv4: '127.0.0.0'
-        },
-        shared: true
-      },
-      {
-        traceId: '1e223ff1f80f1c69',
-        parentId: 'bf396325699c84bf',
-        id: '74280ae0c10d8062',
-        kind: 'CLIENT',
-        name: 'post',
-        timestamp: 1470150004074202,
-        duration: 94539,
-        localEndpoint: {
-          serviceName: 'servicea',
-          ipv4: '127.0.0.0'
-        }
-      }
-    ];
+describe('convertSuccessResponse', () => {
+  const apiURL = '/api/v2/traces?serviceName=all&spanName=all&endTs=1459169770000';
 
+  it('should convert an http trace', () => {
+    const expectedTemplate = {
+      traceId: 'bb1f0e21882325b8',
+      startTs: '11-02-2018T05:56:09.255+0000',
+      timestamp: 1541138169255688,
+      duration: 168.731,
+      durationStr: '168.731ms',
+      width: 100,
+      totalSpans: 2,
+      serviceDurations: [
+        {name: 'backend', count: 1, max: 111},
+        {name: 'frontend', count: 2, max: 168}
+      ],
+      infoClass: ''
+    };
+
+    const rawResponse = [httpTrace];
+    convertSuccessResponse(rawResponse, 'all', apiURL, true).should.deep.equal(
+      {traces: [expectedTemplate], apiURL, rawResponse}
+    );
+  });
+
+  it('should include service percentage from the URL', () => {
+    const urlIncludingServiceName = '/api/v2/traces?serviceName=backend&spanName=all&endTs=1459169770000';
+
+    const expectedTemplate = {
+      traceId: 'bb1f0e21882325b8',
+      startTs: '11-02-2018T05:56:09.255+0000',
+      timestamp: 1541138169255688,
+      duration: 168.731,
+      durationStr: '168.731ms',
+      width: 100,
+      totalSpans: 2,
+      serviceDurations: [
+        {name: 'backend', count: 1, max: 111},
+        {name: 'frontend', count: 2, max: 168}
+      ],
+      infoClass: '',
+      servicePercentage: 65
+    };
+
+    const rawResponse = [httpTrace];
+    convertSuccessResponse(rawResponse, 'backend', urlIncludingServiceName, true).should.deep.equal(
+      {traces: [expectedTemplate], apiURL: urlIncludingServiceName, rawResponse}
+    );
+  });
+
+  it('should convert an error trace', () => {
+    const expectedTemplate = {
+      traceId: '1e223ff1f80f1c69',
+      startTs: '11-02-2018T05:56:09.377+0000',
+      timestamp: 1541138169377997,
+      duration: 0.017,
+      durationStr: '17μ',
+      width: 100,
+      totalSpans: 1,
+      serviceDurations: [
+        {name: 'backend', count: 1, max: 0} // TODO: figure out what max means
+      ],
+      infoClass: 'trace-error-critical'
+    };
+
+    const rawResponse = [errorTrace];
+    convertSuccessResponse(rawResponse, 'all', apiURL, true).should.deep.equal(
+      {traces: [expectedTemplate], apiURL, rawResponse}
+    );
+  });
+
+  it('should skip an empty result', () => {
+    convertSuccessResponse([], 'all', apiURL, true).should.deep.equal(
+      {traces: [], apiURL, rawResponse: []}
+    );
+  });
+
+  it('should skip an invalid trace', () => {
+    const missingTimestamp = [{
+      traceId: '2',
+      id: '2',
+      duration: 1,
+      localEndpoint: {serviceName: 'B'}
+    }];
+
+    const rawResponse = [missingTimestamp];
+    convertSuccessResponse(rawResponse, 'all', apiURL, true).should.deep.equal(
+      {traces: [], apiURL, rawResponse}
+    );
+  });
+
+  // This tests that clock skew is considered when deciding the length of the trace
+  it('should convert a skewed trace', () => {
     // TODO: This test only ensures the behavior of the existing code. For example, if we don't
     // clock skew correct, the result will be a different duration. We haven't verified the logic
     // is correct.. for example, the calculated duration here may be wrong.
-    const expectedTraceSummary = {
+    const expectedTemplate = {
       traceId: '1e223ff1f80f1c69',
+      startTs: '08-02-2016T15:00:04.071+0000',
       timestamp: 1470150004071068,
-      duration: 99411,
-      groupedTimestamps: {
-        servicea: [
-          {
-            timestamp: 1470150004071068,
-            duration: 99411
-          },
-          {
-            timestamp: 1470150004074202,
-            duration: 94539
-          }
-        ],
-        serviceb: [
-          {
-            timestamp: 1470150004074202,
-            duration: 94539
-          },
-          {
-            timestamp: 1470150004074684,
-            duration: 65000
-          }
-        ]
-      },
-      endpoints: [
-        {
-          serviceName: 'servicea',
-          ipv4: '127.0.0.0'
-        },
-        {
-          serviceName: 'serviceb',
-          ipv4: '192.0.0.0'
-        }
+      duration: 99.411,
+      durationStr: '99.411ms',
+      width: 100,
+      totalSpans: 3,
+      serviceDurations: [
+        {name: 'servicea', count: 2, max: 99},
+        {name: 'serviceb', count: 2, max: 94}
       ],
-      errorType: 'none',
-      totalSpans: 3
+      infoClass: '',
+      servicePercentage: 95
     };
 
-    rawTraceToSummary(skewedTrace).should.deep.equal(expectedTraceSummary);
+    const rawResponse = [skewedTrace];
+    convertSuccessResponse(rawResponse, 'serviceb', apiURL, true).should.deep.equal(
+      {traces: [expectedTemplate], apiURL, rawResponse}
+    );
   });
 });
 

--- a/zipkin-ui/test/component_data/trace.test.js
+++ b/zipkin-ui/test/component_data/trace.test.js
@@ -1,22 +1,495 @@
-import {toContextualLogsUrl} from '../../js/component_data/trace';
+import {convertSuccessResponse, toContextualLogsUrl} from '../../js/component_data/trace';
+import {errorTrace, httpTrace, skewedTrace} from '../component_ui/traceTestHelpers';
+
+describe('convertSuccessResponse', () => {
+  it('should convert an http trace', () => {
+    const spans = [
+      {
+        spanId: 'bb1f0e21882325b8',
+        parentId: null,
+        spanName: 'get /',
+        serviceNames: 'frontend',
+        serviceName: 'frontend',
+        duration: 168731,
+        durationStr: '168.731ms',
+        left: 0,
+        width: 100,
+        depth: 10,
+        depthClass: 0,
+        children: 'c8c50ebd2abc179e',
+        annotations: [
+          {
+            isCore: true,
+            left: 0,
+            endpoint: '172.17.0.13 (frontend)',
+            value: 'Server Receive',
+            timestamp: 1541138169255688,
+            relativeTime: '',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 100,
+            endpoint: '172.17.0.13 (frontend)',
+            value: 'Server Send',
+            timestamp: 1541138169424419,
+            relativeTime: '168.731ms',
+            width: 8
+          }
+        ],
+        binaryAnnotations: [
+          {
+            key: 'http.method',
+            value: 'GET',
+            endpoint: {
+              serviceName: 'frontend',
+              ipv4: '172.17.0.13'
+            }
+          },
+          {
+            key: 'http.path',
+            value: '/',
+            endpoint: {
+              serviceName: 'frontend',
+              ipv4: '172.17.0.13'
+            }
+          },
+          {
+            key: 'mvc.controller.class',
+            value: 'Frontend',
+            endpoint: {
+              serviceName: 'frontend',
+              ipv4: '172.17.0.13'
+            }
+          },
+          {
+            key: 'mvc.controller.method',
+            value: 'callBackend',
+            endpoint: {
+              serviceName: 'frontend',
+              ipv4: '172.17.0.13'
+            }
+          },
+          {
+            key: 'Client Address',
+            value: '[110.170.201.178]:63678',
+            endpoint: {
+              serviceName: '',
+              ipv6: '110.170.201.178',
+              port: 63678
+            }
+          }
+        ],
+        errorType: 'none'
+      },
+      {
+        spanId: 'c8c50ebd2abc179e',
+        parentId: 'bb1f0e21882325b8',
+        spanName: 'get /api',
+        serviceNames: 'frontend,backend',
+        serviceName: 'backend',
+        duration: 111121,
+        durationStr: '111.121ms',
+        left: 24.82294302765941,
+        width: 65.8568964801963,
+        depth: 15,
+        depthClass: 1,
+        children: '',
+        annotations: [
+          {
+            isCore: true,
+            left: 0,
+            endpoint: '172.17.0.13 (frontend)',
+            value: 'Client Send',
+            timestamp: 1541138169297572,
+            relativeTime: '41.884ms',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 36.1074864337074,
+            endpoint: '172.17.0.13 (frontend)',
+            value: 'Wire Send',
+            timestamp: 1541138169337695,
+            relativeTime: '82.007ms',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 38.15435426247064,
+            endpoint: '172.17.0.9 (backend)',
+            value: 'Server Receive',
+            timestamp: 1541138169339969.5,
+            relativeTime: '84.281ms',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 61.84564573752937,
+            endpoint: '172.17.0.9 (backend)',
+            value: 'Server Send',
+            timestamp: 1541138169366295.5,
+            relativeTime: '110.608ms',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 63.8925135662926,
+            endpoint: '172.17.0.13 (frontend)',
+            value: 'Wire Receive',
+            timestamp: 1541138169368570,
+            relativeTime: '112.882ms',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 100,
+            endpoint: '172.17.0.13 (frontend)',
+            value: 'Client Receive',
+            timestamp: 1541138169408693,
+            relativeTime: '153.005ms',
+            width: 8
+          }
+        ],
+        binaryAnnotations: [
+          {
+            key: 'http.method',
+            value: 'GET',
+            endpoint: {
+              serviceName: 'frontend',
+              ipv4: '172.17.0.13'
+            }
+          },
+          {
+            key: 'http.path',
+            value: '/api',
+            endpoint: {
+              serviceName: 'frontend',
+              ipv4: '172.17.0.13'
+            }
+          },
+          {
+            key: 'mvc.controller.class',
+            value: 'Backend',
+            endpoint: {
+              serviceName: 'backend',
+              ipv4: '172.17.0.9'
+            }
+          },
+          {
+            key: 'mvc.controller.method',
+            value: 'printDate',
+            endpoint: {
+              serviceName: 'backend',
+              ipv4: '172.17.0.9'
+            }
+          },
+          {
+            key: 'Client Address',
+            value: '172.17.0.13:63679',
+            endpoint: {
+              serviceName: '',
+              ipv4: '172.17.0.13',
+              port: 63679
+            }
+          }
+        ],
+        errorType: 'none'
+      }
+    ];
+
+    const timeMarkers = [
+      {index: 0, time: ''},
+      {index: 1, time: '33.746ms'},
+      {index: 2, time: '67.492ms'},
+      {index: 3, time: '101.239ms'},
+      {index: 4, time: '134.985ms'},
+      {index: 5, time: '168.731ms'}
+    ];
+
+    const expectedTemplate = {
+      traceId: 'bb1f0e21882325b8',
+      duration: '168.731ms',
+      services: 2,
+      depth: 2,
+      totalSpans: 2,
+      serviceCounts: [
+        {name: 'backend', count: 1, max: 111},
+        {name: 'frontend', count: 2, max: 168}
+      ],
+      timeMarkers,
+      timeMarkersBackup: timeMarkers, // TODO: what is backup and why??
+      spans,
+      spansBackup: spans, // TODO: what is backup and why??
+      logsUrl: undefined
+    };
+
+    const rawResponse = httpTrace;
+    convertSuccessResponse(rawResponse).should.deep.equal(
+      {modelview: expectedTemplate, trace: rawResponse}
+    );
+  });
+
+  it('should convert an error trace', () => {
+    const spans = [
+      {
+        spanId: '1e223ff1f80f1c69',
+        parentId: null,
+        spanName: '',
+        serviceNames: 'backend',
+        serviceName: 'backend',
+        duration: 17,
+        durationStr: '17μ',
+        left: 0,
+        width: 100,
+        depth: 10,
+        depthClass: 0,
+        children: '',
+        annotations: [],
+        binaryAnnotations: [
+          {
+            key: 'error',
+            value: 'request failed',
+            endpoint: {
+              serviceName: 'backend',
+              ipv4: '172.17.0.9'
+            }
+          }
+        ],
+        errorType: 'critical'
+      }
+    ];
+
+    const timeMarkers = [
+      {index: 0, time: ''},
+      {index: 1, time: '3.4000000000000004μ'},
+      {index: 2, time: '6.800000000000001μ'},
+      {index: 3, time: '10.2μ'},
+      {index: 4, time: '13.600000000000001μ'},
+      {index: 5, time: '17μ'}
+    ];
+
+    const expectedTemplate = {
+      traceId: '1e223ff1f80f1c69',
+      duration: '17μ',
+      services: 1,
+      depth: 1,
+      totalSpans: 1,
+      serviceCounts: [
+        {name: 'backend', count: 1, max: 0}
+      ],
+      timeMarkers,
+      timeMarkersBackup: timeMarkers, // TODO: what is backup and why??
+      spans,
+      spansBackup: spans, // TODO: what is backup and why??
+      logsUrl: undefined
+    };
+
+    const rawResponse = errorTrace;
+    convertSuccessResponse(rawResponse).should.deep.equal(
+      {modelview: expectedTemplate, trace: rawResponse}
+    );
+  });
+
+  it('should throw error on empty trace', () => {
+    let error;
+    try {
+      convertSuccessResponse([]);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.eql('Trace was empty');
+  });
+
+  it('should throw error on trace missing timestamp', () => {
+    const missingTimestamp = {
+      traceId: '2',
+      id: '2',
+      duration: 1,
+      localEndpoint: {serviceName: 'B'}
+    };
+
+    let error;
+    try {
+      convertSuccessResponse([missingTimestamp]);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.eql('Trace is missing a timestamp');
+  });
+
+  it('should convert a skewed trace', () => {
+    const spans = [
+      {
+        spanId: 'bf396325699c84bf',
+        parentId: null,
+        spanName: 'get',
+        serviceNames: 'servicea',
+        serviceName: 'servicea',
+        duration: 99411,
+        durationStr: '99.411ms',
+        left: 0,
+        width: 100,
+        depth: 10,
+        depthClass: 0,
+        children: '74280ae0c10d8062',
+        annotations: [
+          {
+            isCore: true,
+            left: 0,
+            endpoint: '127.0.0.0 (servicea)',
+            value: 'Server Receive',
+            timestamp: 1470150004071068,
+            relativeTime: '',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 100,
+            endpoint: '127.0.0.0 (servicea)',
+            value: 'Server Send',
+            timestamp: 1470150004170479,
+            relativeTime: '99.411ms',
+            width: 8
+          }
+        ],
+        binaryAnnotations: [],
+        errorType: 'none'
+      },
+      {
+        spanId: '74280ae0c10d8062',
+        parentId: 'bf396325699c84bf',
+        spanName: 'post',
+        serviceNames: 'servicea,serviceb',
+        serviceName: 'serviceb',
+        duration: 94539,
+        durationStr: '94.539ms',
+        left: 3.152568629226142,
+        width: 95.09913389866313,
+        depth: 15,
+        depthClass: 1,
+        children: '43210ae0c10d1234',
+        annotations: [
+          {
+            isCore: true,
+            left: 0,
+            endpoint: '127.0.0.0 (servicea)',
+            value: 'Client Send',
+            timestamp: 1470150004074202,
+            relativeTime: '3.134ms',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 0.5087847343424406,
+            endpoint: '192.0.0.0 (serviceb)',
+            value: 'Server Receive',
+            timestamp: 1470150004074683,
+            relativeTime: '3.615ms',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 99.49121526565756,
+            endpoint: '192.0.0.0 (serviceb)',
+            value: 'Server Send',
+            timestamp: 1470150004168260,
+            relativeTime: '97.192ms',
+            width: 8
+          },
+          {
+            isCore: true,
+            left: 100,
+            endpoint: '127.0.0.0 (servicea)',
+            value: 'Client Receive',
+            timestamp: 1470150004168741,
+            relativeTime: '97.673ms',
+            width: 8
+          }
+        ],
+        binaryAnnotations: [],
+        errorType: 'none'
+      },
+      {
+        spanId: '43210ae0c10d1234',
+        parentId: '74280ae0c10d8062',
+        spanName: 'async',
+        serviceNames: 'serviceb',
+        serviceName: 'serviceb',
+        duration: 65000,
+        durationStr: '65.000ms',
+        left: 3.6374244298920644,
+        width: 65.3851183470642,
+        depth: 20,
+        depthClass: 2,
+        children: '',
+        annotations: [],
+        binaryAnnotations: [
+          {
+            key: 'Local Address',
+            value: '192.0.0.0 (serviceb)',
+            endpoint: {
+              serviceName: 'serviceb',
+              ipv4: '192.0.0.0'
+            }
+          }
+        ],
+        errorType: 'none'
+      }
+    ];
+
+    const timeMarkers = [
+      {index: 0, time: ''},
+      {index: 1, time: '19.882ms'},
+      {index: 2, time: '39.764ms'},
+      {index: 3, time: '59.647ms'},
+      {index: 4, time: '79.529ms'},
+      {index: 5, time: '99.411ms'}
+    ];
+
+    const expectedTemplate = {
+      traceId: '1e223ff1f80f1c69',
+      duration: '99.411ms',
+      services: 2,
+      depth: 3,
+      totalSpans: 3,
+      serviceCounts: [
+        {name: 'servicea', count: 2, max: 99},
+        {name: 'serviceb', count: 2, max: 94}
+      ],
+      timeMarkers,
+      timeMarkersBackup: timeMarkers,
+      spans,
+      spansBackup: spans,
+      logsUrl: undefined
+    };
+
+    const rawResponse = skewedTrace;
+    convertSuccessResponse(rawResponse).should.deep.equal(
+      {modelview: expectedTemplate, trace: rawResponse}
+    );
+  });
+});
 
 describe('toContextualLogsUrl', () => {
   it('replaces token in logsUrl when set', () => {
-    const kibanaLogsUrl = 'http://company.com/kibana/#/discover?_a=(query:(query_string:(query:\'{traceId}\')))';
+    const logsUrl = 'http://company.com/kibana/#/discover?_a=(query:(query_string:(query:\'{traceId}\')))';
     const traceId = '86bad84b319c8379';
-    toContextualLogsUrl(kibanaLogsUrl, traceId)
-      .should.equal(kibanaLogsUrl.replace('{traceId}', traceId));
+    toContextualLogsUrl(logsUrl, traceId)
+      .should.equal(logsUrl.replace('{traceId}', traceId));
   });
 
   it('returns logsUrl when not set', () => {
-    const kibanaLogsUrl = undefined;
+    const logsUrl = undefined;
     const traceId = '86bad84b319c8379';
-    (typeof toContextualLogsUrl(kibanaLogsUrl, traceId)).should.equal('undefined');
+    (typeof toContextualLogsUrl(logsUrl, traceId)).should.equal('undefined');
   });
 
   it('returns the same url when token not present', () => {
-    const kibanaLogsUrl = 'http://mylogqueryservice.com/';
+    const logsUrl = 'http://mylogqueryservice.com/';
     const traceId = '86bad84b319c8379';
-    toContextualLogsUrl(kibanaLogsUrl, traceId).should.equal(kibanaLogsUrl);
+    toContextualLogsUrl(logsUrl, traceId).should.equal(logsUrl);
   });
 });

--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -50,12 +50,26 @@ describe('traceSummary', () => {
 
   const trace = [span1, span2, span3, span4];
 
-  it('should return null when no spans exist', () => {
-    expect(traceSummary([])).to.equal(null);
+  it('should throw error on empty trace', () => {
+    let error;
+    try {
+      traceSummary([]);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.eql('Trace was empty');
   });
 
-  it('should return null when no annotations are present', () => {
-    expect(traceSummary([span5])).to.equal(null);
+  it('should throw error on trace missing timestamp', () => {
+    let error;
+    try {
+      traceSummary([span5]);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.eql('Trace is missing a timestamp');
   });
 
   it('dedupes duplicate endpoints', () => {
@@ -338,8 +352,8 @@ describe('traceSummariesToMustache', () => {
   });
 
   it('should convert duration from micros to millis', () => {
-    const model = traceSummariesToMustache(null, [{duration: 3000}]);
-    model[0].duration.should.equal(3);
+    const model = traceSummariesToMustache(null, [{timestamp: start, duration: 20000}]);
+    model[0].duration.should.equal(20);
   });
 
   it('should get service durations', () => {

--- a/zipkin-ui/test/component_ui/traceTestHelpers.js
+++ b/zipkin-ui/test/component_ui/traceTestHelpers.js
@@ -1,3 +1,141 @@
+export const httpTrace = [
+  {
+    traceId: 'bb1f0e21882325b8',
+    parentId: 'bb1f0e21882325b8',
+    id: 'c8c50ebd2abc179e',
+    kind: 'CLIENT',
+    name: 'get',
+    timestamp: 1541138169297572,
+    duration: 111121,
+    localEndpoint: {
+      serviceName: 'frontend',
+      ipv4: '172.17.0.13'
+    },
+    annotations: [
+      {value: 'ws', timestamp: 1541138169337695},
+      {value: 'wr', timestamp: 1541138169368570}
+    ],
+    tags: {
+      'http.method': 'GET',
+      'http.path': '/api'
+    }
+  },
+  {
+    traceId: 'bb1f0e21882325b8',
+    id: 'bb1f0e21882325b8',
+    kind: 'SERVER',
+    name: 'get /',
+    timestamp: 1541138169255688,
+    duration: 168731,
+    localEndpoint: {
+      serviceName: 'frontend',
+      ipv4: '172.17.0.13'
+    },
+    remoteEndpoint: {
+      ipv6: '110.170.201.178',
+      port: 63678
+    },
+    tags: {
+      'http.method': 'GET',
+      'http.path': '/',
+      'mvc.controller.class': 'Frontend',
+      'mvc.controller.method': 'callBackend'
+    }
+  },
+  {
+    traceId: 'bb1f0e21882325b8',
+    parentId: 'bb1f0e21882325b8',
+    id: 'c8c50ebd2abc179e',
+    kind: 'SERVER',
+    name: 'get /api',
+    timestamp: 1541138169377997,
+    duration: 26326,
+    localEndpoint: {
+      serviceName: 'backend',
+      ipv4: '172.17.0.9'
+    },
+    remoteEndpoint: {
+      ipv4: '172.17.0.13',
+      port: 63679
+    },
+    tags: {
+      'http.method': 'GET',
+      'http.path': '/api',
+      'mvc.controller.class': 'Backend',
+      'mvc.controller.method': 'printDate'
+    },
+    shared: true
+  }
+];
+
+export const errorTrace = [{
+  traceId: '1e223ff1f80f1c69',
+  id: '1e223ff1f80f1c69',
+  timestamp: 1541138169377997,
+  duration: 17,
+  localEndpoint: {
+    serviceName: 'backend',
+    ipv4: '172.17.0.9'
+  },
+  tags: { error: 'request failed' }
+}];
+
+// from ../tracedata/skew.json as we can't figure out how to read file with headless chrome env
+export const skewedTrace = [
+  {
+    traceId: '1e223ff1f80f1c69',
+    parentId: '74280ae0c10d8062',
+    id: '43210ae0c10d1234',
+    name: 'async',
+    timestamp: 1470150004008762,
+    duration: 65000,
+    localEndpoint: {
+      serviceName: 'serviceb',
+      ipv4: '192.0.0.0'
+    }
+  },
+  {
+    traceId: '1e223ff1f80f1c69',
+    parentId: 'bf396325699c84bf',
+    id: '74280ae0c10d8062',
+    kind: 'SERVER',
+    name: 'post',
+    timestamp: 1470150004008761,
+    duration: 93577,
+    localEndpoint: {
+      serviceName: 'serviceb',
+      ipv4: '192.0.0.0'
+    },
+    shared: true
+  },
+  {
+    traceId: '1e223ff1f80f1c69',
+    id: 'bf396325699c84bf',
+    kind: 'SERVER',
+    name: 'get',
+    timestamp: 1470150004071068,
+    duration: 99411,
+    localEndpoint: {
+      serviceName: 'servicea',
+      ipv4: '127.0.0.0'
+    },
+    shared: true
+  },
+  {
+    traceId: '1e223ff1f80f1c69',
+    parentId: 'bf396325699c84bf',
+    id: '74280ae0c10d8062',
+    kind: 'CLIENT',
+    name: 'post',
+    timestamp: 1470150004074202,
+    duration: 94539,
+    localEndpoint: {
+      serviceName: 'servicea',
+      ipv4: '127.0.0.0'
+    }
+  }
+];
+
 export function endpoint(ipv4, port, serviceName) {
   return {ipv4, port, serviceName};
 }

--- a/zipkin-ui/test/component_ui/traceTestHelpers.js
+++ b/zipkin-ui/test/component_ui/traceTestHelpers.js
@@ -77,7 +77,7 @@ export const errorTrace = [{
     serviceName: 'backend',
     ipv4: '172.17.0.9'
   },
-  tags: { error: 'request failed' }
+  tags: {error: 'request failed'}
 }];
 
 // from ../tracedata/skew.json as we can't figure out how to read file with headless chrome env


### PR DESCRIPTION
This refactors some of the call sites into traceSummary to reduce
redundant work. To help expose what UI templates use, this adds some
tests that push an api template up to the point of invoking mustache.

This serves two purposes: sets up trip wires to ensure we don't break
something when migrating to v2. This also will help us identify dead
data or needlessly different named data.