### PR TITLE
Changes index page to order services descending by max span duration

### DIFF
--- a/zipkin-ui/js/component_ui/traceToMustache.js
+++ b/zipkin-ui/js/component_ui/traceToMustache.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {
   traceSummary,
-  getServiceDurations,
+  getServiceNameAndSpanCounts,
   getServiceNames,
   getServiceName,
   mkDurationStr
@@ -93,10 +93,9 @@ export default function traceToMustache(trace, logsUrl = undefined) {
   const t = traceSummary(trace);
   const traceId = t.traceId;
   const duration = t.duration;
-  const serviceDurations = getServiceDurations(t.groupedTimestamps);
+  const serviceNameAndSpanCounts = getServiceNameAndSpanCounts(t.groupedTimestamps);
 
-  const services = serviceDurations.length || 0;
-  const serviceCounts = _(serviceDurations).sortBy('name').value();
+  const services = serviceNameAndSpanCounts.length || 0;
   const groupByParentId = _(trace).groupBy((s) => s.parentId).value();
 
   const traceTimestamp = trace[0].timestamp || 0;
@@ -176,7 +175,7 @@ export default function traceToMustache(trace, logsUrl = undefined) {
     }
   ).value();
 
-  const totalSpans = spans.length;
+  const spanCount = spans.length;
   const timeMarkers = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
       .map((p, index) => ({index, time: mkDurationStr(duration * p)}));
   const timeMarkersBackup = timeMarkers;
@@ -187,8 +186,8 @@ export default function traceToMustache(trace, logsUrl = undefined) {
     duration: mkDurationStr(duration),
     services,
     depth,
-    totalSpans,
-    serviceCounts,
+    spanCount,
+    serviceNameAndSpanCounts,
     timeMarkers,
     timeMarkersBackup,
     spans,

--- a/zipkin-ui/js/page/default.js
+++ b/zipkin-ui/js/page/default.js
@@ -70,7 +70,7 @@ const DefaultPageComponent = component(function DefaultPage() {
         annotationQuery,
         queryWasPerformed,
         contextRoot,
-        count: modelView.traces.length,
+        traceCount: modelView.traces.length,
         sortOrderOptions: sortOptions,
         sortOrderSelected: sortSelected(sortOrder),
         apiURL: modelView.apiURL,

--- a/zipkin-ui/templates/index.mustache
+++ b/zipkin-ui/templates/index.mustache
@@ -97,8 +97,8 @@
     <div id="trace-filters" class="row">
       <div class="col-md-11">
         <div>
-          Showing:  <span class="filter-current">{{count}}</span>
-          of <span class="filter-total">{{count}}</span>
+          Showing:  <span class="filter-current">{{traceCount}}</span>
+          of <span class="filter-total">{{traceCount}}</span>
         </div>
 
         <div class="service-tags">
@@ -136,7 +136,7 @@
           <div class="bar-block">
             <span class="bar-graphic" style="width:{{width}}%;"></span>
             <span class="bar-label">{{durationStr}}</span>
-            <span class="bar-label">{{totalSpans}} spans</span>
+            <span class="bar-label">{{spanCount}} spans</span>
           </div>
           {{#servicePercentage}}
           <div class="bar-block">
@@ -146,10 +146,10 @@
           {{/servicePercentage}}
         </a>
         <div class="trace-details services">
-          {{#serviceDurations}}
-            <span class="badge badge-success service-filter-label" data-service-name="{{name}}">{{name}}
-              x{{count}} {{max}}ms</span>
-          {{/serviceDurations}}
+          {{#serviceSummaries}}
+            <span class="badge badge-success service-filter-label" data-service-name="{{serviceName}}">
+            {{serviceName}} x{{spanCount}} {{maxSpanDurationStr}}</span>
+          {{/serviceSummaries}}
         </div>
         <div class="trace-details timestamp pull-right">
           <time class="label timeago" datetime="{{startTs}}">{{startTs}}</time>

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -4,7 +4,7 @@
     <div class='col-md-2'><div href='#'><strong data-i18n="trace.duration">Duration:</strong> <span class='badge badge-dark'>{{duration}}</span></div></div>
     <div class='col-md-2'><div href='#'><strong data-i18n="trace.service">Services:</strong> <span class='badge badge-dark'>{{services}}</span></div></div>
     <div class='col-md-2'><div href='#'><strong data-i18n="trace.depth">Depth:</strong> <span class='badge badge-dark'>{{depth}}</span></div></div>
-    <div class='col-md-2'><div href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge badge-dark'>{{totalSpans}}</span></div></div>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge badge-dark'>{{spanCount}}</span></div></div>
     {{#logsUrl}}
     <div class='col-md-2'><div id='traceLogsLink'>
       <a class='btn btn-sm btn-secondary'  href='{{ logsUrl }}' target="_blank" role="button">Logs
@@ -28,16 +28,16 @@
     <div class="form-group col-md-2">
       <select data-placeholder='Filter Service Search' class='form-control' name='serviceFilterSearch' id='serviceFilterSearch'>
         <option value=''></option>
-        {{#serviceCounts}}
-        <option value='{{name}}'>{{name}}</option>
-        {{/serviceCounts}}
+        {{#serviceNameAndSpanCounts}}
+        <option value='{{serviceName}}'>{{serviceName}}</option>
+        {{/serviceNameAndSpanCounts}}
       </select>
     </div>
   </form>
   <div class='trace-details services'>
-  {{#serviceCounts}}
-    <span class='badge badge-info service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
-  {{/serviceCounts}}
+  {{#serviceNameAndSpanCounts}}
+    <span class='badge badge-info service-filter-label service-tag-filtered' data-service-name='{{serviceName}}'>{{serviceName}} x{{spanCount}}</span>
+  {{/serviceNameAndSpanCounts}}
   </div>
  </div>
 </div>

--- a/zipkin-ui/templates/traceViewer.mustache
+++ b/zipkin-ui/templates/traceViewer.mustache
@@ -14,7 +14,7 @@
     <div class='col-md-2'><div href='#'><strong data-i18n="trace.duration">Duration:</strong> <span class='badge badge-dark'>{{duration}}</span></div></div>
     <div class='col-md-2'><div href='#'><strong data-i18n="trace.service">Services:</strong> <span class='badge badge-dark'>{{services}}</span></div></div>
     <div class='col-md-2'><div href='#'><strong data-i18n="trace.depth">Depth:</strong> <span class='badge badge-dark'>{{depth}}</span></div></div>
-    <div class='col-md-2'><div href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge badge-dark'>{{totalSpans}}</span></div></div>
+    <div class='col-md-2'><div href='#'><strong data-i18n="trace.spans">Total Spans:</strong> <span class='badge badge-dark'>{{spanCount}}</span></div></div>
     {{#logsUrl}}
     <div class='col-md-2'><div id='traceLogsLink'>
       <a class='btn btn-sm btn-secondary'  href='{{ logsUrl }}' target="_blank" role="button">Logs
@@ -33,16 +33,16 @@
     <div class="form-group col-md-2">
       <select data-placeholder='Filter Service Search' class='form-control' name='serviceFilterSearch' id='serviceFilterSearch'>
         <option value=''></option>
-        {{#serviceCounts}}
-        <option value='{{name}}'>{{name}}</option>
-        {{/serviceCounts}}
+        {{#serviceNameAndSpanCounts}}
+        <option value='{{serviceName}}'>{{serviceName}}</option>
+        {{/serviceNameAndSpanCounts}}
       </select>
     </div>
   </form>
   <div class='trace-details services'>
-  {{#serviceCounts}}
-    <span class='badge badge-info service-filter-label service-tag-filtered' data-service-name='{{name}}'>{{name}} x{{count}}</span>
-  {{/serviceCounts}}
+  {{#serviceNameAndSpanCounts}}
+    <span class='badge badge-info service-filter-label service-tag-filtered' data-service-name='{{serviceName}}'>{{serviceName}} x{{spanCount}}</span>
+  {{/serviceNameAndSpanCounts}}
   </div>
  </div>
 </div>

--- a/zipkin-ui/test/component_data/default.test.js
+++ b/zipkin-ui/test/component_data/default.test.js
@@ -13,10 +13,10 @@ describe('convertSuccessResponse', () => {
       duration: 168.731,
       durationStr: '168.731ms',
       width: 100,
-      totalSpans: 2,
-      serviceDurations: [
-        {name: 'backend', count: 1, max: 111},
-        {name: 'frontend', count: 2, max: 168}
+      spanCount: 2,
+      serviceSummaries: [
+        {serviceName: 'frontend', spanCount: 2, maxSpanDurationStr: '168.731ms'},
+        {serviceName: 'backend', spanCount: 1, maxSpanDurationStr: '111.121ms'}
       ],
       infoClass: ''
     };
@@ -38,10 +38,10 @@ describe('convertSuccessResponse', () => {
       duration: 168.731,
       durationStr: '168.731ms',
       width: 100,
-      totalSpans: 2,
-      serviceDurations: [
-        {name: 'backend', count: 1, max: 111},
-        {name: 'frontend', count: 2, max: 168}
+      spanCount: 2,
+      serviceSummaries: [
+        {serviceName: 'frontend', spanCount: 2, maxSpanDurationStr: '168.731ms'},
+        {serviceName: 'backend', spanCount: 1, maxSpanDurationStr: '111.121ms'}
       ],
       infoClass: '',
       servicePercentage: 65
@@ -61,9 +61,9 @@ describe('convertSuccessResponse', () => {
       duration: 0.017,
       durationStr: '17μ',
       width: 100,
-      totalSpans: 1,
-      serviceDurations: [
-        {name: 'backend', count: 1, max: 0} // TODO: figure out what max means
+      spanCount: 1,
+      serviceSummaries: [
+        {serviceName: 'backend', spanCount: 1, maxSpanDurationStr: '17μ'}
       ],
       infoClass: 'trace-error-critical'
     };
@@ -106,10 +106,10 @@ describe('convertSuccessResponse', () => {
       duration: 99.411,
       durationStr: '99.411ms',
       width: 100,
-      totalSpans: 3,
-      serviceDurations: [
-        {name: 'servicea', count: 2, max: 99},
-        {name: 'serviceb', count: 2, max: 94}
+      spanCount: 3,
+      serviceSummaries: [
+        {serviceName: 'servicea', spanCount: 2, maxSpanDurationStr: '99.411ms'},
+        {serviceName: 'serviceb', spanCount: 2, maxSpanDurationStr: '94.539ms'}
       ],
       infoClass: '',
       servicePercentage: 95

--- a/zipkin-ui/test/component_data/trace.test.js
+++ b/zipkin-ui/test/component_data/trace.test.js
@@ -212,10 +212,10 @@ describe('convertSuccessResponse', () => {
       duration: '168.731ms',
       services: 2,
       depth: 2,
-      totalSpans: 2,
-      serviceCounts: [
-        {name: 'backend', count: 1, max: 111},
-        {name: 'frontend', count: 2, max: 168}
+      spanCount: 2,
+      serviceNameAndSpanCounts: [
+        {serviceName: 'backend', spanCount: 1},
+        {serviceName: 'frontend', spanCount: 2}
       ],
       timeMarkers,
       timeMarkersBackup: timeMarkers, // TODO: what is backup and why??
@@ -262,10 +262,10 @@ describe('convertSuccessResponse', () => {
 
     const timeMarkers = [
       {index: 0, time: ''},
-      {index: 1, time: '3.4000000000000004μ'},
-      {index: 2, time: '6.800000000000001μ'},
-      {index: 3, time: '10.2μ'},
-      {index: 4, time: '13.600000000000001μ'},
+      {index: 1, time: '3μ'},
+      {index: 2, time: '7μ'},
+      {index: 3, time: '10μ'},
+      {index: 4, time: '14μ'},
       {index: 5, time: '17μ'}
     ];
 
@@ -274,9 +274,9 @@ describe('convertSuccessResponse', () => {
       duration: '17μ',
       services: 1,
       depth: 1,
-      totalSpans: 1,
-      serviceCounts: [
-        {name: 'backend', count: 1, max: 0}
+      spanCount: 1,
+      serviceNameAndSpanCounts: [
+        {serviceName: 'backend', spanCount: 1}
       ],
       timeMarkers,
       timeMarkersBackup: timeMarkers, // TODO: what is backup and why??
@@ -419,7 +419,7 @@ describe('convertSuccessResponse', () => {
         serviceNames: 'serviceb',
         serviceName: 'serviceb',
         duration: 65000,
-        durationStr: '65.000ms',
+        durationStr: '65ms',
         left: 3.6374244298920644,
         width: 65.3851183470642,
         depth: 20,
@@ -454,10 +454,10 @@ describe('convertSuccessResponse', () => {
       duration: '99.411ms',
       services: 2,
       depth: 3,
-      totalSpans: 3,
-      serviceCounts: [
-        {name: 'servicea', count: 2, max: 99},
-        {name: 'serviceb', count: 2, max: 94}
+      spanCount: 3,
+      serviceNameAndSpanCounts: [
+        {serviceName: 'servicea', spanCount: 2},
+        {serviceName: 'serviceb', spanCount: 2}
       ],
       timeMarkers,
       timeMarkersBackup: timeMarkers,

--- a/zipkin-ui/test/component_ui/traceSummary.test.js
+++ b/zipkin-ui/test/component_ui/traceSummary.test.js
@@ -83,9 +83,9 @@ describe('traceSummary', () => {
     summary.duration.should.equal(400);
   });
 
-  it('should get total spans count', () => {
+  it('should get span count', () => {
     const summary = traceSummary(trace);
-    summary.totalSpans.should.equal(trace.length);
+    summary.spanCount.should.equal(trace.length);
   });
 });
 
@@ -356,16 +356,16 @@ describe('traceSummariesToMustache', () => {
     model[0].duration.should.equal(20);
   });
 
-  it('should get service durations', () => {
+  it('should get service summaries, ordered descending by max span duration', () => {
     const model = traceSummariesToMustache(null, [summary]);
-    model[0].serviceDurations.should.eql([{
-      name: 'A',
-      count: 1,
-      max: 10
+    model[0].serviceSummaries.should.eql([{
+      serviceName: 'B',
+      spanCount: 2,
+      maxSpanDurationStr: '20ms'
     }, {
-      name: 'B',
-      count: 2,
-      max: 20
+      serviceName: 'A',
+      spanCount: 1,
+      maxSpanDurationStr: '10ms'
     }]);
   });
 
@@ -386,7 +386,7 @@ describe('traceSummariesToMustache', () => {
 
   it('should format duration', () => {
     const model = traceSummariesToMustache(null, [summary]);
-    model[0].durationStr.should.equal('20.000ms');
+    model[0].durationStr.should.equal('20ms');
   });
 
   it('should calculate the width in percent', () => {
@@ -420,7 +420,7 @@ describe('traceSummariesToMustache', () => {
     model[0].timestamp.should.equal(summary.timestamp);
   });
 
-  it('should get correct totalSpans', () => {
+  it('should get correct spanCount', () => {
     const spans = [{
       traceId: 'd397ce70f5192a8b',
       name: 'get',
@@ -456,7 +456,7 @@ describe('traceSummariesToMustache', () => {
     }];
     const testSummary = traceSummary(spans);
     const model = traceSummariesToMustache(null, [testSummary])[0];
-    model.totalSpans.should.equal(1);
+    model.spanCount.should.equal(1);
   });
 
   it('should order traces by duration and tie-break using trace id', () => {
@@ -506,6 +506,10 @@ describe('mkDurationStr', () => {
 
   it('should format ms', () => {
     mkDurationStr(1500).should.equal('1.500ms');
+  });
+
+  it('should format exact ms', () => {
+    mkDurationStr(15000).should.equal('15ms');
   });
 
   it('should format seconds', () => {

--- a/zipkin-ui/test/component_ui/traceToMustache.test.js
+++ b/zipkin-ui/test/component_ui/traceToMustache.test.js
@@ -58,20 +58,17 @@ describe('traceToMustache', () => {
     modelview.logsUrl.should.equal(logsUrl);
   });
 
-  it('should show service counts', () => {
+  it('should show service name and span counts', () => {
     const modelview = traceToMustache(trace);
-    modelview.serviceCounts.should.eql([{
-      name: 'service1',
-      count: 1,
-      max: 0
+    modelview.serviceNameAndSpanCounts.should.eql([{
+      serviceName: 'service1',
+      spanCount: 1
     }, {
-      name: 'service2',
-      count: 2,
-      max: 0
+      serviceName: 'service2',
+      spanCount: 2
     }, {
-      name: 'service3',
-      count: 1,
-      max: 0
+      serviceName: 'service3',
+      spanCount: 1
     }]);
   });
 


### PR DESCRIPTION
I figured out what "max" was in the index page. It corresponds to the
longest duration span in the trace, as attributed to a specific service.

This orders the search results descending by the most likely culprit,
using relevant time units to prevent minutes from showing as huge counts
of milliseconds, or short traces showing up as zero.

Before:
![screen shot 2018-11-03 at 3 18 38 pm](https://user-images.githubusercontent.com/64215/47949351-7237d300-df7c-11e8-8664-21993de3b170.png)

After: (notice the slowest service is the first one listed)
![screen shot 2018-11-03 at 3 18 30 pm](https://user-images.githubusercontent.com/64215/47949352-78c64a80-df7c-11e8-82e6-a80a7d2cfffd.png)
