### PR TITLE
Corrects clock-skew on single host spans

### DIFF
--- a/zipkin-ui/js/spanCleaner.js
+++ b/zipkin-ui/js/spanCleaner.js
@@ -140,7 +140,9 @@ export function mergeV2ById(trace) {
   // sort by timestamp, then name, root first in case of skew
   // TODO: this should be a topological sort
   return result.sort((a, b) => {
-    if (!a.parentId) { // a is root
+    if (!a.parentId && !b.parentId) { // both are root
+      return a.shared ? 1 : -1; // shared is server, so comes after client
+    } if (!a.parentId) { // a is root
       return -1;
     } else if (!b.parentId) { // b is root
       return 1;

--- a/zipkin-ui/test/spanCleaner.test.js
+++ b/zipkin-ui/test/spanCleaner.test.js
@@ -282,4 +282,28 @@ describe('mergeV2ById', () => {
       '0000000000000003'
     ]);
   });
+
+  // in the case of shared spans, root could be a client
+  it('should order earliest root first', () => {
+    const spans = mergeV2ById([
+      {
+        traceId: '1111111111111111',
+        id: '0000000000000001',
+        name: 'server',
+        timestamp: 1,
+        shared: true
+      },
+      {
+        traceId: '1111111111111111',
+        id: '0000000000000001',
+        name: 'client',
+        timestamp: 1
+      }
+    ]);
+
+    expect(spans.map(s => s.name)).to.deep.equal([
+      'client',
+      'server'
+    ]);
+  });
 });


### PR DESCRIPTION
See #1480

Here's before and after

<img width="1018" alt="screen shot 2018-11-08 at 11 27 28 pm" src="https://user-images.githubusercontent.com/64215/48208500-ee338000-e3ad-11e8-97b5-eb2cb257f77a.png">

<img width="1024" alt="screen shot 2018-11-08 at 11 27 33 pm" src="https://user-images.githubusercontent.com/64215/48208508-f25f9d80-e3ad-11e8-8a6d-329b18436e9c.png">



```json
[
  {
    "traceId": "1e223ff1f80f1c69",
    "parentId": "43210ae0c10d1234",
    "id": "43210ae0c10dabcd",
    "name": "async",
    "timestamp": 1470150004008762,
    "duration": 65000,
    "localEndpoint": {
      "serviceName": "serviceb",
      "ipv4": "192.0.0.0"
    }
  },
  {
    "traceId": "1e223ff1f80f1c69",
    "parentId": "74280ae0c10d8062",
    "id": "43210ae0c10d1234",
    "kind": "SERVER",
    "name": "post",
    "timestamp": 1470150004008761,
    "duration": 93577,
    "localEndpoint": {
      "serviceName": "serviceb",
      "ipv4": "192.0.0.0"
    }
  },
  {
    "traceId": "1e223ff1f80f1c69",
    "id": "bf396325699c84bf",
    "kind": "SERVER",
    "name": "get",
    "timestamp": 1470150004071068,
    "duration": 99411,
    "localEndpoint": {
      "serviceName": "servicea",
      "ipv4": "127.0.0.0"
    },
    "shared": true
  },
  {
    "traceId": "1e223ff1f80f1c69",
    "parentId": "bf396325699c84bf",
    "id": "74280ae0c10d8062",
    "kind": "CLIENT",
    "name": "post",
    "timestamp": 1470150004074202,
    "duration": 94539,
    "localEndpoint": {
      "serviceName": "servicea",
      "ipv4": "127.0.0.0"
    }
  }
]
```