### PR TITLE
Adds internal type to merge spans in a trace together

### DIFF
--- a/zipkin-ui/js/spanCleaner.js
+++ b/zipkin-ui/js/spanCleaner.js
@@ -14,7 +14,7 @@ function isEndpoint(endpoint) {
   return endpoint && Object.keys(endpoint).length > 0;
 }
 
-// This cleans potential dirty v2 inputs, like normalizing IDs etc.
+// This cleans potential dirty v2 inputs, like normalizing IDs etc. It does not affect the input
 function clean(span) {
   const res = {
     traceId: normalizeTraceId(span.traceId)
@@ -24,9 +24,7 @@ function clean(span) {
   const id = span.id.padStart(16, '0');
   if (span.parentId) {
     const parentId = span.parentId.padStart(16, '0');
-    if (parentId !== id) {
-      res.parentId = parentId;
-    }
+    if (parentId !== id) res.parentId = parentId;
   }
   res.id = id;
 
@@ -36,10 +34,10 @@ function clean(span) {
   if (span.timestamp) res.timestamp = span.timestamp;
   if (span.duration) res.duration = span.duration;
 
-  if (isEndpoint(span.localEndpoint)) res.localEndpoint = span.localEndpoint;
-  if (isEndpoint(span.remoteEndpoint)) res.remoteEndpoint = span.remoteEndpoint;
+  if (isEndpoint(span.localEndpoint)) res.localEndpoint = Object.assign({}, span.localEndpoint);
+  if (isEndpoint(span.remoteEndpoint)) res.remoteEndpoint = Object.assign({}, span.remoteEndpoint);
 
-  res.annotations = span.annotations || [];
+  res.annotations = span.annotations ? span.annotations.slice(0) : [];
   if (res.annotations.length > 1) {
     res.annotations = _(_.unionWith(res.annotations, _.isEqual))
             .sortBy('timestamp', 'value').value();
@@ -104,41 +102,110 @@ export function compare(a, b) {
 }
 
 /*
+ * Put spans with null endpoints first, so that their data can be attached to the first span with
+ * the same ID and endpoint. It is possible that a server can get the same request on a different
+ * port. Not addressing this.
+ */
+function compareEndpoint(left, right) {
+  // handle nulls first
+  if (!left) return !right ? 0 : -1;
+  if (!right) return 1;
+
+  const byService = compare(left.serviceName, right.serviceName);
+  if (byService !== 0) return byService;
+  const byIpV4 = compare(left.ipv4, right.ipv4);
+  if (byIpV4 !== 0) return byIpV4;
+  return compare(left.ipv6, right.ipv6);
+}
+
+function cleanupComparator(left, right) {
+  const bySpanId = left.id - right.id;
+  if (bySpanId !== 0) return bySpanId;
+  let byShared;
+  if (left.shared === right.shared) {
+    byShared = 0;
+  } else {
+    byShared = left.shared ? 1 : -1; // false first (client first)
+  }
+  if (byShared !== 0) return byShared;
+  return compareEndpoint(left.localEndpoint, right.localEndpoint);
+}
+
+function tryMerge(current, endpoint) {
+  if (!endpoint) return true;
+  if (current.serviceName && endpoint.serviceName && current.serviceName !== endpoint.serviceName) {
+    return false;
+  }
+  if (current.ipv4 && endpoint.ipv4 && current.ipv4 !== endpoint.ipv4) {
+    return false;
+  }
+  if (current.ipv6 && endpoint.ipv6 && current.ipv6 !== endpoint.ipv6) {
+    return false;
+  }
+  if (current.port && endpoint.port && current.port !== endpoint.port) {
+    return false;
+  }
+  if (!current.serviceName) {
+    current.serviceName = endpoint.serviceName; // eslint-disable-line no-param-reassign
+  }
+  if (!current.ipv4) current.ipv4 = endpoint.ipv4; // eslint-disable-line no-param-reassign
+  if (!current.ipv6) current.ipv6 = endpoint.ipv6; // eslint-disable-line no-param-reassign
+  if (!current.port) current.port = endpoint.portAsInt; // eslint-disable-line no-param-reassign
+  return true;
+}
+
+/*
  * Spans can be sent in multiple parts. Also client and server spans can share the same ID. This
  * merges both scenarios.
  */
-export function mergeV2ById(trace) {
+export function mergeV2ById(spans) {
+  let length = spans.length;
+  if (length === 0) return spans;
+
   const result = [];
 
-  if (!trace || trace.length === 0) return result;
-
-  // this will be the longest trace ID, in case instrumentation report different lengths
+  // Let's cleanup any spans and pick the longest ID
   let traceId;
-
-  const spanIdToSpans = {};
-  trace.forEach((s) => {
-    const span = clean(s);
-    if (!traceId || span.traceId.length > traceId.length) traceId = span.traceId;
-
-    // Make sure IDs are grouped together for merging incomplete span data
-    //
-    // Only time IDs may be shared are for server-side of RPC span. We check
-    // for the shared flag as it is often in the trace context, and by
-    // extension also recorded even on incomplete data.
-    const key = span.id + span.shared;
-    spanIdToSpans[key] = spanIdToSpans[key] || [];
-    spanIdToSpans[key].push(span);
+  spans.forEach(span => {
+    const cleaned = clean(span);
+    if (!traceId || traceId.length !== 32) traceId = cleaned.traceId;
+    result.push(cleaned);
   });
 
-  Object.keys(spanIdToSpans).forEach(key => {
-    const spansToMerge = spanIdToSpans[key];
-    let left = spansToMerge[0];
-    left.traceId = traceId;
-    for (let i = 1; i < spansToMerge.length; i++) {
-      left = merge(left, spansToMerge[i]);
+  if (length <= 1) return result;
+  result.sort(cleanupComparator);
+
+  // Now start any fixes or merging
+  for (let i = 0; i < length; i++) {
+    let span = result[i];
+
+    if (span.traceId.length !== traceId.length) {
+      span.traceId = traceId;
     }
-    result.push(left);
-  });
+
+    const localEndpoint = span.localEndpoint ? Object.assign({}, span.localEndpoint) : {};
+    while (i + 1 < length) {
+      const next = result[i + 1];
+      if (next.id !== span.id) break;
+
+      // This cautiously merges with the next span, if we think it was sent in multiple pieces.
+      if (span.shared === next.shared && tryMerge(localEndpoint, next.localEndpoint)) {
+        span = merge(span, next);
+
+        // remove the merged element
+        length--;
+        result.splice(i + 1, 1);
+        continue;
+      }
+
+      if (next.shared && !next.parentId && span.parentId) {
+        // handle a shared RPC server span that wasn't propagated its parent span ID
+        next.parentId = span.parentId;
+      }
+      break;
+    }
+    result[i] = span;
+  }
 
   // sort by timestamp, then name, root first in case of skew
   // TODO: this should be a topological sort

--- a/zipkin-ui/test/spanCleaner.test.js
+++ b/zipkin-ui/test/spanCleaner.test.js
@@ -484,6 +484,290 @@ describe('mergeV2ById', () => {
     ]);
   });
 
+  /*
+   * If a client request is proxied by something that does transparent retried. It can be the case
+   * that two servers share the same ID (accidentally!)
+   */
+  it('should not merge shared spans on different IPs', () => {
+    const spans = mergeV2ById([
+      {
+        traceId: 'a',
+        id: 'a',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'frontend'}
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        kind: 'CLIENT',
+        timestamp: 1,
+        localEndpoint: {serviceName: 'frontend'}
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.4'},
+        shared: true
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.5'},
+        shared: true
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        duration: 10,
+        localEndpoint: {serviceName: 'frontend'}
+      }
+    ]);
+
+    expect(spans).to.deep.equal([
+      {
+        traceId: '000000000000000a',
+        id: '000000000000000a',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'frontend'},
+        annotations: [],
+        tags: {}
+      },
+      {
+        traceId: '000000000000000a',
+        parentId: '000000000000000a',
+        id: '000000000000000b',
+        kind: 'CLIENT',
+        timestamp: 1,
+        duration: 10,
+        localEndpoint: {serviceName: 'frontend'},
+        annotations: [],
+        tags: {}
+      },
+      {
+        traceId: '000000000000000a',
+        parentId: '000000000000000a',
+        id: '000000000000000b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.4'},
+        annotations: [],
+        tags: {},
+        shared: true
+      },
+      {
+        traceId: '000000000000000a',
+        parentId: '000000000000000a',
+        id: '000000000000000b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.5'},
+        annotations: [],
+        tags: {},
+        shared: true
+      }
+    ]);
+  });
+
+  // Same as above, but the late reported data has no parent id or endpoint
+  it('should put random data on first span with endpoint', () => {
+    const spans = mergeV2ById([
+      {
+        traceId: 'a',
+        id: 'a',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'frontend'}
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        kind: 'CLIENT',
+        timestamp: 1,
+        localEndpoint: {serviceName: 'frontend'}
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.4'},
+        shared: true
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.5'},
+        shared: true
+      },
+      {
+        traceId: 'a',
+        id: 'b',
+        duration: 10
+      }
+    ]);
+
+    expect(spans).to.deep.equal([
+      {
+        traceId: '000000000000000a',
+        id: '000000000000000a',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'frontend'},
+        annotations: [],
+        tags: {}
+      },
+      {
+        traceId: '000000000000000a',
+        parentId: '000000000000000a',
+        id: '000000000000000b',
+        kind: 'CLIENT',
+        timestamp: 1,
+        duration: 10,
+        localEndpoint: {serviceName: 'frontend'},
+        annotations: [],
+        tags: {}
+      },
+      {
+        traceId: '000000000000000a',
+        parentId: '000000000000000a',
+        id: '000000000000000b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.4'},
+        annotations: [],
+        tags: {},
+        shared: true
+      },
+      {
+        traceId: '000000000000000a',
+        parentId: '000000000000000a',
+        id: '000000000000000b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.5'},
+        annotations: [],
+        tags: {},
+        shared: true
+      }
+    ]);
+  });
+
+  // not a good idea to send parts of a local endpoint separately, but this helps ensure data isn't
+  // accidentally partitioned in a overly fine grain
+  it('should merge incomplete endpoints', () => {
+    const spans = mergeV2ById([
+      {
+        traceId: 'a',
+        id: 'a',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'frontend'}
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        kind: 'CLIENT',
+        localEndpoint: {serviceName: 'frontend'}
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        localEndpoint: {ipv4: '1.2.3.4'}
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend'},
+        shared: true
+      },
+      {
+        traceId: 'a',
+        parentId: 'a',
+        id: 'b',
+        localEndpoint: {ipv4: '1.2.3.5'},
+        shared: true
+      }
+    ]);
+
+    expect(spans).to.deep.equal([
+      {
+        traceId: '000000000000000a',
+        id: '000000000000000a',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'frontend'},
+        annotations: [],
+        tags: {}
+      },
+      {
+        traceId: '000000000000000a',
+        parentId: '000000000000000a',
+        id: '000000000000000b',
+        kind: 'CLIENT',
+        localEndpoint: {serviceName: 'frontend', ipv4: '1.2.3.4'},
+        annotations: [],
+        tags: {}
+      },
+      {
+        traceId: '000000000000000a',
+        parentId: '000000000000000a',
+        id: '000000000000000b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.5'},
+        annotations: [],
+        tags: {},
+        shared: true
+      }
+    ]);
+  });
+
+  // spans are reported depth first, so it is possible to see incomplete trees with no root.
+  it('should work when missing root span', () => {
+    const missingParentId = '000000000000000a';
+    const spans = mergeV2ById([
+      {
+        traceId: 'a',
+        parentId: missingParentId,
+        id: 'b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.4'}
+      },
+      {
+        traceId: 'a',
+        parentId: missingParentId,
+        id: 'c',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend'}
+      }
+    ]);
+
+    expect(spans).to.deep.equal([
+      {
+        traceId: '000000000000000a',
+        parentId: missingParentId,
+        id: '000000000000000b',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend', ipv4: '1.2.3.4'},
+        annotations: [],
+        tags: {}
+      },
+      {
+        traceId: '000000000000000a',
+        parentId: missingParentId,
+        id: '000000000000000c',
+        kind: 'SERVER',
+        localEndpoint: {serviceName: 'backend'},
+        annotations: [],
+        tags: {}
+      }
+    ]);
+  });
+
   it('should merge incomplete data', () => {
     // let's pretend the client flushed before completion
     const spans = mergeV2ById([

--- a/zipkin/src/main/java/zipkin2/internal/Trace.java
+++ b/zipkin/src/main/java/zipkin2/internal/Trace.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+public class Trace {
+  /*
+   * Spans can be sent in multiple parts. Also client and server spans can share the same ID. This
+   * merges both scenarios.
+   */
+  public static List<Span> merge(List<Span> spans) {
+    int length = spans.size();
+    if (length <= 1) return spans;
+    List<Span> result = new ArrayList<>(spans);
+    Collections.sort(result, CLEANUP_COMPARATOR);
+
+    // Lets pick the longest trace ID
+    String traceId = spans.get(0).traceId();
+    for (int i = 1; i < length; i++) {
+      String nextTraceId = result.get(i).traceId();
+      if (traceId.length() != 32) traceId = nextTraceId;
+    }
+
+    // Now start any fixes or merging
+    for (int i = 0; i < length; i++) {
+      Span previous = result.get(i);
+      String previousId = previous.id();
+      boolean previousShared = Boolean.TRUE.equals(previous.shared());
+
+      Span.Builder replacement = null;
+      if (previous.traceId().length() != traceId.length()) {
+        replacement = previous.toBuilder().traceId(traceId);
+      }
+
+      EndpointTracker localEndpoint = null;
+      while (i + 1 < length) {
+        Span next = result.get(i + 1);
+        String nextId = next.id();
+        if (!nextId.equals(previousId)) break;
+
+        if (localEndpoint == null) {
+          localEndpoint = new EndpointTracker();
+          localEndpoint.tryMerge(previous.localEndpoint());
+        }
+
+        // This cautiously merges with the next span, if we think it was sent in multiple pieces.
+        boolean nextShared = Boolean.TRUE.equals(next.shared());
+        if (previousShared == nextShared && localEndpoint.tryMerge(next.localEndpoint())) {
+          if (replacement == null) replacement = previous.toBuilder();
+          replacement.merge(next);
+
+          previous = next;
+          // remove the merged element
+          length--;
+          result.remove(i + 1);
+          continue;
+        }
+
+        if (nextShared && next.parentId() == null && previous.parentId() != null) {
+          // handle a shared RPC server span that wasn't propagated its parent span ID
+          result.set(i + 1, next.toBuilder().parentId(previous.parentId()).build());
+        }
+        break;
+      }
+
+      if (replacement != null) result.set(i, replacement.build());
+    }
+
+    return result;
+  }
+
+  static final Comparator<Span> CLEANUP_COMPARATOR = new Comparator<Span>() {
+    @Override public int compare(Span left, Span right) {
+      if (left.equals(right)) return 0;
+      int bySpanId = left.id().compareTo(right.id());
+      if (bySpanId != 0) return bySpanId;
+      int byShared = nullSafeCompareTo(left.shared(), right.shared(), true);
+      if (byShared != 0) return byShared;
+      return compareEndpoint(left.localEndpoint(), right.localEndpoint());
+    }
+  };
+
+  /**
+   * Put spans with null endpoints first, so that their data can be attached to the first span with
+   * the same ID and endpoint. It is possible that a server can get the same request on a different
+   * port. Not addressing this.
+   */
+  static int compareEndpoint(Endpoint left, Endpoint right) {
+    if (left == null) { // nulls first
+      return (right == null) ? 0 : -1;
+    } else if (right == null) {
+      return 1;
+    }
+    int byService = nullSafeCompareTo(left.serviceName(), right.serviceName(), false);
+    if (byService != 0) return byService;
+    int byIpV4 = nullSafeCompareTo(left.ipv4(), right.ipv4(), false);
+    if (byIpV4 != 0) return byIpV4;
+    return nullSafeCompareTo(left.ipv6(), right.ipv6(), false);
+  }
+
+  static <T extends Comparable<T>> int nullSafeCompareTo(T left, T right, boolean nullFirst) {
+    if (left == null) {
+      return (right == null) ? 0 : (nullFirst ? -1 : 1);
+    } else if (right == null) {
+      return nullFirst ? 1 : -1;
+    } else {
+      return left.compareTo(right);
+    }
+  }
+
+  /**
+   * Sometimes endpoints can be sent in pieces. This tracks the whether we should merge with
+   * something, or if it has a different identity.
+   */
+  static final class EndpointTracker {
+    String serviceName, ipv4, ipv6;
+    int port;
+
+    boolean tryMerge(Endpoint endpoint) {
+      if (endpoint == null) return true;
+      if (serviceName != null &&
+        endpoint.serviceName() != null && !serviceName.equals(endpoint.serviceName())) {
+        return false;
+      }
+      if (ipv4 != null && endpoint.ipv4() != null && !ipv4.equals(endpoint.ipv4())) {
+        return false;
+      }
+      if (ipv6 != null && endpoint.ipv6() != null && !ipv6.equals(endpoint.ipv6())) {
+        return false;
+      }
+      if (port != 0 && endpoint.portAsInt() != 0 && port != endpoint.portAsInt()) {
+        return false;
+      }
+      if (serviceName == null) serviceName = endpoint.serviceName();
+      if (ipv4 == null) ipv4 = endpoint.ipv4();
+      if (ipv6 == null) ipv6 = endpoint.ipv6();
+      if (port == 0) port = endpoint.portAsInt();
+      return true;
+    }
+  }
+
+  Trace() {
+  }
+}

--- a/zipkin/src/test/java/zipkin2/SpanTest.java
+++ b/zipkin/src/test/java/zipkin2/SpanTest.java
@@ -280,6 +280,15 @@ public class SpanTest {
     );
   }
 
+  @Test public void builder_merge_localEndpoint_redundant() {
+    Span merged = Span.newBuilder().localEndpoint(FRONTEND)
+      .merge(base.toBuilder().localEndpoint(FRONTEND).build()).build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().localEndpoint(FRONTEND).build()
+    );
+  }
+
   @Test public void builder_merge_localEndpoint_merge() {
     Span merged = Span.newBuilder().localEndpoint(Endpoint.newBuilder().serviceName("a").build())
       .merge(
@@ -303,6 +312,15 @@ public class SpanTest {
 
   @Test public void builder_merge_remoteEndpoint() {
     Span merged = Span.newBuilder()
+      .merge(base.toBuilder().remoteEndpoint(FRONTEND).build()).build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().remoteEndpoint(FRONTEND).build()
+    );
+  }
+
+  @Test public void builder_merge_remoteEndpoint_redundant() {
+    Span merged = Span.newBuilder().remoteEndpoint(FRONTEND)
       .merge(base.toBuilder().remoteEndpoint(FRONTEND).build()).build();
 
     assertThat(merged).isEqualToComparingFieldByField(

--- a/zipkin/src/test/java/zipkin2/internal/TraceTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/TraceTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import java.util.List;
+import org.junit.Test;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.Span.Kind;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TraceTest {
+
+  /**
+   * Some don't propagate the server's parent ID which creates a race condition. Try to unwind it.
+   *
+   * <p>See https://github.com/openzipkin/zipkin/pull/1745
+   */
+  @Test public void backfillsMissingParentIdOnSharedSpan() {
+    List<Span> trace = asList(
+      span("a", null, "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, "frontend", null, false),
+      // below the parent ID is null as it wasn't propagated
+      span("a", null, "b", Kind.SERVER, "backend", null, true)
+    );
+
+    assertThat(Trace.merge(trace)).usingFieldByFieldElementComparator().containsExactlyInAnyOrder(
+      span("a", null, "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, "frontend", null, false),
+      span("a", "a", "b", Kind.SERVER, "backend", null, true)
+    );
+  }
+
+  /** Some truncate an incoming trace ID to 64-bits. */
+  @Test public void choosesBestTraceId() {
+    List<Span> trace = asList(
+      span("7180c278b62e8f6a216a2aea45d08fc9", null, "a", Kind.SERVER, "frontend", null, false),
+      span("7180c278b62e8f6a216a2aea45d08fc9", "a", "b", Kind.CLIENT, "frontend", null, false),
+      span("216a2aea45d08fc9", "a", "b", Kind.SERVER, "backend", null, true)
+    );
+
+    assertThat(Trace.merge(trace)).flatExtracting(Span::traceId).containsExactly(
+      "7180c278b62e8f6a216a2aea45d08fc9",
+      "7180c278b62e8f6a216a2aea45d08fc9",
+      "7180c278b62e8f6a216a2aea45d08fc9"
+    );
+  }
+
+  /** Let's pretend people use crappy data, but only on the first hop. */
+  @Test public void mergesWhenMissingEndpoints() {
+    List<Span> trace = asList(
+      Span.newBuilder()
+        .traceId("a")
+        .id("a")
+        .putTag("service", "frontend")
+        .putTag("span.kind", "SERVER")
+        .build(),
+      Span.newBuilder()
+        .traceId("a")
+        .parentId("a")
+        .id("b")
+        .putTag("service", "frontend")
+        .putTag("span.kind", "CLIENT")
+        .timestamp(1L)
+        .build(),
+      span("a", "a", "b", Kind.SERVER, "backend", null, true),
+      Span.newBuilder().traceId("a").parentId("a").id("b").duration(10L).build()
+    );
+
+    assertThat(Trace.merge(trace)).usingFieldByFieldElementComparator().containsExactlyInAnyOrder(
+      Span.newBuilder()
+        .traceId("a")
+        .id("a")
+        .putTag("service", "frontend")
+        .putTag("span.kind", "SERVER")
+        .build(),
+      Span.newBuilder()
+        .traceId("a")
+        .parentId("a")
+        .id("b")
+        .putTag("service", "frontend")
+        .putTag("span.kind", "CLIENT")
+        .timestamp(1L)
+        .duration(10L)
+        .build(),
+      span("a", "a", "b", Kind.SERVER, "backend", null, true)
+    );
+  }
+
+  /**
+   * If a client request is proxied by something that does transparent retried. It can be the case
+   * that two servers share the same ID (accidentally!)
+   */
+  @Test public void doesntMergeSharedSpansOnDifferentIPs() {
+    List<Span> trace = asList(
+      span("a", null, "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, "frontend", null, false).toBuilder()
+        .timestamp(1L).addAnnotation(3L, "brave.flush").build(),
+      span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.4", true),
+      span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.5", true),
+      span("a", "a", "b", Kind.CLIENT, "frontend", null, false).toBuilder()
+        .duration(10L).build()
+    );
+
+    assertThat(Trace.merge(trace)).usingFieldByFieldElementComparator().containsExactlyInAnyOrder(
+      span("a", null, "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, "frontend", null, false).toBuilder()
+        .timestamp(1L).duration(10L).addAnnotation(3L, "brave.flush").build(),
+      span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.4", true),
+      span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.5", true)
+    );
+  }
+
+  @Test public void putsRandomDataOnFirstSpanWithEndpoint() {
+    List<Span> trace = asList(
+      span("a", null, "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, null, null, false),
+      span("a", "a", "b", null, "frontend", null, false).toBuilder()
+        .timestamp(1L).addAnnotation(3L, "brave.flush").build(),
+      span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.4", true),
+      span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.5", true),
+      span("a", "a", "b", null, "frontend", null, false).toBuilder()
+        .duration(10L).build()
+    );
+
+    assertThat(Trace.merge(trace)).usingFieldByFieldElementComparator().containsExactlyInAnyOrder(
+      span("a", null, "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, "frontend", null, false).toBuilder()
+        .timestamp(1L).duration(10L).addAnnotation(3L, "brave.flush").build(),
+      span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.4", true),
+      span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.5", true)
+    );
+  }
+
+  // not a good idea to send parts of a local endpoint separately, but this helps ensure data isn't
+  // accidentally partitioned in a overly fine grain
+  @Test public void mergesIncompleteEndpoints() {
+    List<Span> trace = asList(
+      span("a", null, "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, null, "1.2.3.4", false),
+      span("a", "a", "b", Kind.SERVER, null, "1.2.3.5", true),
+      span("a", "a", "b", Kind.SERVER, "backend", null, true)
+    );
+
+    assertThat(Trace.merge(trace)).usingFieldByFieldElementComparator().containsExactlyInAnyOrder(
+      span("a", null, "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, "frontend", "1.2.3.4", false),
+      span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.5", true)
+    );
+  }
+
+  @Test public void deletesSelfReferencingParentId() {
+    List<Span> trace = asList(
+      span("a", "a", "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, "frontend", null, false)
+    );
+
+    assertThat(Trace.merge(trace)).usingFieldByFieldElementComparator().containsExactlyInAnyOrder(
+      span("a", null, "a", Kind.SERVER, "frontend", null, false),
+      span("a", "a", "b", Kind.CLIENT, "frontend", null, false)
+    );
+  }
+
+  @Test public void worksWhenMissingParentSpan() {
+    String missingParentId = "a";
+    List<Span> trace = asList(
+      span("a", missingParentId, "b", Kind.SERVER, "backend", "1.2.3.4", false),
+      span("a", missingParentId, "c", Kind.SERVER, "backend", null, false)
+    );
+
+    assertThat(Trace.merge(trace)).containsExactlyElementsOf(trace);
+  }
+
+  static Span span(String traceId, @Nullable String parentId, String id, @Nullable Kind kind,
+    @Nullable String local, @Nullable String ip, boolean shared) {
+    Span.Builder result = Span.newBuilder().traceId(traceId).parentId(parentId).id(id).kind(kind);
+    if (local != null || ip != null) {
+      result.localEndpoint(Endpoint.newBuilder().serviceName(local).ip(ip).build());
+    }
+    return result.shared(shared).build();
+  }
+}

--- a/zipkin/src/test/java/zipkin2/internal/TraceTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/TraceTest.java
@@ -124,6 +124,7 @@ public class TraceTest {
     );
   }
 
+  // Same as above, but the late reported data has no parent id or endpoint
   @Test public void putsRandomDataOnFirstSpanWithEndpoint() {
     List<Span> trace = asList(
       span("a", null, "a", Kind.SERVER, "frontend", null, false),
@@ -132,7 +133,7 @@ public class TraceTest {
         .timestamp(1L).addAnnotation(3L, "brave.flush").build(),
       span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.4", true),
       span("a", "a", "b", Kind.SERVER, "backend", "1.2.3.5", true),
-      span("a", "a", "b", null, "frontend", null, false).toBuilder()
+      span("a", "a", "b", null, null, null, false).toBuilder()
         .duration(10L).build()
     );
 


### PR DESCRIPTION
This merges spans that have the same identity together for the purpose
of display or aggregation. This works around instrumentation that
accidentally or purposefully send spans in pieces.

This work was described in issue #2245. Basically, we have multiple
tools that need a stable algo for merging spans. This approach is a
row-processing one. There is a little redundancy as we have to scan for
corrections before performing them.