### PR TITLE
Adds Span.merge and cleans up errorprone warnings

### DIFF
--- a/zipkin/src/main/java/zipkin2/Annotation.java
+++ b/zipkin/src/main/java/zipkin2/Annotation.java
@@ -78,7 +78,7 @@ public final class Annotation implements Comparable<Annotation>, Serializable { 
     if (o == this) return true;
     if (!(o instanceof Annotation)) return false;
     Annotation that = (Annotation) o;
-    return (timestamp == that.timestamp()) && (value.equals(that.value()));
+    return timestamp == that.timestamp() && value.equals(that.value());
   }
 
   @Override public int hashCode() {

--- a/zipkin/src/main/java/zipkin2/DependencyLink.java
+++ b/zipkin/src/main/java/zipkin2/DependencyLink.java
@@ -120,10 +120,10 @@ public final class DependencyLink implements Serializable { // for Spark and Fli
     if (o == this) return true;
     if (!(o instanceof DependencyLink)) return false;
     DependencyLink that = (DependencyLink) o;
-      return (parent.equals(that.parent))
-        && (child.equals(that.child))
-        && (callCount == that.callCount)
-        && (errorCount == that.errorCount);
+    return parent.equals(that.parent)
+      && child.equals(that.child)
+      && callCount == that.callCount
+      && errorCount == that.errorCount;
   }
 
   @Override public int hashCode() {

--- a/zipkin/src/main/java/zipkin2/Endpoint.java
+++ b/zipkin/src/main/java/zipkin2/Endpoint.java
@@ -118,6 +118,16 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
       port = source.port;
     }
 
+    Builder merge(Endpoint source) {
+      if (serviceName == null) serviceName = source.serviceName;
+      if (ipv4 == null) ipv4 = source.ipv4;
+      if (ipv6 == null) ipv6 = source.ipv6;
+      if (ipv4Bytes == null) ipv4Bytes = source.ipv4Bytes;
+      if (ipv6Bytes == null) ipv6Bytes = source.ipv6Bytes;
+      if (port == 0) port = source.port;
+      return this;
+    }
+
     /** @see Endpoint#serviceName */
     public Builder serviceName(@Nullable String serviceName) {
       this.serviceName = serviceName == null || serviceName.isEmpty()

--- a/zipkin/src/main/java/zipkin2/internal/Buffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/Buffer.java
@@ -267,9 +267,9 @@ public final class Buffer {
 
   void writeLongLe(long v) {
     buf[pos++] = (byte) (v & 0xff);
-    buf[pos++] = (byte) ((v >> 8 & 0xff));
-    buf[pos++] = (byte) ((v >> 16 & 0xff));
-    buf[pos++] = (byte) ((v >> 24 & 0xff));
+    buf[pos++] = (byte) ((v >> 8) & 0xff);
+    buf[pos++] = (byte) ((v >> 16) & 0xff);
+    buf[pos++] = (byte) ((v >> 24) & 0xff);
     buf[pos++] = (byte) ((v >> 32) & 0xff);
     buf[pos++] = (byte) ((v >> 40) & 0xff);
     buf[pos++] = (byte) ((v >> 48) & 0xff);

--- a/zipkin/src/main/java/zipkin2/internal/Dependencies.java
+++ b/zipkin/src/main/java/zipkin2/internal/Dependencies.java
@@ -120,7 +120,7 @@ public final class Dependencies {
     if (o == this) return true;
     if (!(o instanceof Dependencies)) return false;
     Dependencies that = (Dependencies) o;
-    return (startTs == that.startTs) && (endTs == that.endTs) && (links.equals(that.links));
+    return startTs == that.startTs && endTs == that.endTs && links.equals(that.links);
   }
 
   @Override

--- a/zipkin/src/main/java/zipkin2/internal/DependencyLinker.java
+++ b/zipkin/src/main/java/zipkin2/internal/DependencyLinker.java
@@ -80,10 +80,8 @@ public final class DependencyLinker {
    * @param spans spans where all spans have the same trace id
    */
   public DependencyLinker putTrace(Iterator<Span> spans) {
-    List<Span> list = new ArrayList<>();
     if (!spans.hasNext()) return this;
     Span first = spans.next();
-    list.add(first);
     if (logger.isLoggable(FINE)) logger.fine("linking trace " + first.traceId());
 
     // Build a tree based on spanId and parentId values
@@ -91,7 +89,6 @@ public final class DependencyLinker {
     builder.addNode(first.parentId(), first.id(), first);
     while (spans.hasNext()) {
       Span next = spans.next();
-      list.add(next);
       builder.addNode(next.parentId(), next.id(), next);
     }
 

--- a/zipkin/src/main/java/zipkin2/v1/V1Span.java
+++ b/zipkin/src/main/java/zipkin2/v1/V1Span.java
@@ -283,7 +283,7 @@ public final class V1Span {
   @Override
   public boolean equals(Object o) {
     if (o == this) return true;
-    if (!(o instanceof Span)) return false;
+    if (!(o instanceof V1Span)) return false;
     V1Span that = (V1Span) o;
     return traceIdHigh == that.traceIdHigh
         && traceId == that.traceId

--- a/zipkin/src/test/java/zipkin2/SpanTest.java
+++ b/zipkin/src/test/java/zipkin2/SpanTest.java
@@ -230,6 +230,12 @@ public class SpanTest {
       .isEqualToComparingFieldByField(builder);
   }
 
+  @Test public void builder_merge_redundant() {
+    Span merged = oneOfEach.toBuilder().merge(oneOfEach).build();
+
+    assertThat(merged).isEqualToComparingFieldByField(oneOfEach);
+  }
+
   @Test public void builder_merge_flags() {
     assertThat(Span.newBuilder().shared(true).merge(base.toBuilder().debug(true).build()).build())
       .isEqualToComparingFieldByField(base.toBuilder().shared(true).debug(true).build());
@@ -242,11 +248,11 @@ public class SpanTest {
   }
 
   @Test public void builder_merge_annotations_concat() {
-    Span merged = Span.newBuilder().addAnnotation(1, "a")
-      .merge(base.toBuilder().addAnnotation(2, "a").build()).build();
+    Span merged = Span.newBuilder().addAnnotation(1, "a").addAnnotation(1, "b")
+      .merge(base.toBuilder().addAnnotation(1, "b").addAnnotation(1, "c").build()).build();
 
     assertThat(merged).isEqualToComparingFieldByField(
-      base.toBuilder().addAnnotation(1, "a").addAnnotation(2, "a").build()
+      base.toBuilder().addAnnotation(1, "a").addAnnotation(1, "b").addAnnotation(1, "c").build()
     );
   }
 
@@ -257,25 +263,16 @@ public class SpanTest {
   }
 
   @Test public void builder_merge_tags_concat() {
-    Span merged = Span.newBuilder().putTag("1", "a")
-      .merge(base.toBuilder().putTag("2", "a").build()).build();
+    Span merged = Span.newBuilder().putTag("1", "a").putTag("2", "a")
+      .merge(base.toBuilder().putTag("2", "a").putTag("3", "a").build()).build();
 
     assertThat(merged).isEqualToComparingFieldByField(
-      base.toBuilder().putTag("1", "a").putTag("2", "a").build()
+      base.toBuilder().putTag("1", "a").putTag("2", "a").putTag("3", "a").build()
     );
   }
 
   @Test public void builder_merge_localEndpoint() {
     Span merged = Span.newBuilder()
-      .merge(base.toBuilder().localEndpoint(FRONTEND).build()).build();
-
-    assertThat(merged).isEqualToComparingFieldByField(
-      base.toBuilder().localEndpoint(FRONTEND).build()
-    );
-  }
-
-  @Test public void builder_merge_localEndpoint_redundant() {
-    Span merged = Span.newBuilder().localEndpoint(FRONTEND)
       .merge(base.toBuilder().localEndpoint(FRONTEND).build()).build();
 
     assertThat(merged).isEqualToComparingFieldByField(
@@ -306,15 +303,6 @@ public class SpanTest {
 
   @Test public void builder_merge_remoteEndpoint() {
     Span merged = Span.newBuilder()
-      .merge(base.toBuilder().remoteEndpoint(FRONTEND).build()).build();
-
-    assertThat(merged).isEqualToComparingFieldByField(
-      base.toBuilder().remoteEndpoint(FRONTEND).build()
-    );
-  }
-
-  @Test public void builder_merge_remoteEndpoint_redundant() {
-    Span merged = Span.newBuilder().remoteEndpoint(FRONTEND)
       .merge(base.toBuilder().remoteEndpoint(FRONTEND).build()).build();
 
     assertThat(merged).isEqualToComparingFieldByField(

--- a/zipkin/src/test/java/zipkin2/SpanTest.java
+++ b/zipkin/src/test/java/zipkin2/SpanTest.java
@@ -21,10 +21,27 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
+import static zipkin2.Span.normalizeTraceId;
+import static zipkin2.TestObjects.BACKEND;
 import static zipkin2.TestObjects.FRONTEND;
 
 public class SpanTest {
   Span base = Span.newBuilder().traceId("1").id("1").localEndpoint(FRONTEND).build();
+  Span oneOfEach = Span.newBuilder()
+    .traceId("7180c278b62e8f6a216a2aea45d08fc9")
+    .parentId("1")
+    .id("2")
+    .name("get")
+    .kind(Span.Kind.SERVER)
+    .localEndpoint(BACKEND)
+    .remoteEndpoint(FRONTEND)
+    .timestamp(1)
+    .duration(3)
+    .addAnnotation(2, "foo")
+    .putTag("http.path", "/api")
+    .shared(true)
+    .debug(true)
+    .build();
 
   @Test public void traceIdString() {
     Span with128BitId = base.toBuilder()
@@ -43,6 +60,20 @@ public class SpanTest {
   @Test public void remoteEndpoint_emptyToNull() {
     assertThat(base.toBuilder().remoteEndpoint(Endpoint.newBuilder().build()).remoteEndpoint)
       .isNull();
+  }
+
+  @Test public void localServiceName() {
+    assertThat(base.toBuilder().localEndpoint(null).build().localServiceName())
+      .isNull();
+    assertThat(base.toBuilder().localEndpoint(FRONTEND).build().localServiceName())
+      .isEqualTo(FRONTEND.serviceName);
+  }
+
+  @Test public void remoteServiceName() {
+    assertThat(base.toBuilder().remoteEndpoint(null).build().remoteServiceName())
+      .isNull();
+    assertThat(base.toBuilder().remoteEndpoint(BACKEND).build().remoteServiceName())
+      .isEqualTo(BACKEND.serviceName);
   }
 
   @Test public void spanNamesLowercase() {
@@ -141,7 +172,7 @@ public class SpanTest {
       .debug(true)
       .build();
 
-    Span objects =  base.toBuilder()
+    Span objects = base.toBuilder()
       .timestamp(Long.valueOf(1L))
       .duration(Long.valueOf(1L))
       .shared(Boolean.TRUE)
@@ -152,19 +183,164 @@ public class SpanTest {
       .isEqualToComparingFieldByField(objects);
   }
 
+  @Test public void debug_canUnset() {
+    assertThat(base.toBuilder().debug(true).debug(null).build().debug())
+      .isNull();
+  }
+
+  @Test public void debug_canDisable() {
+    assertThat(base.toBuilder().debug(true).debug(false).build().debug())
+      .isFalse();
+  }
+
+  @Test public void shared_canUnset() {
+    assertThat(base.toBuilder().shared(true).shared(null).build().shared())
+      .isNull();
+  }
+
+  @Test public void shared_canDisable() {
+    assertThat(base.toBuilder().shared(true).shared(false).build().shared())
+      .isFalse();
+  }
+
   @Test public void nullToZeroOrFalse() {
     Span nulls = base.toBuilder()
       .timestamp(null)
       .duration(null)
       .build();
 
-    Span zeros =  base.toBuilder()
+    Span zeros = base.toBuilder()
       .timestamp(0L)
       .duration(0L)
       .build();
 
     assertThat(nulls)
       .isEqualToComparingFieldByField(zeros);
+  }
+
+  @Test public void builder_clear() {
+    assertThat(oneOfEach.toBuilder().clear().traceId("a").id("a").build())
+      .isEqualToComparingFieldByField(Span.newBuilder().traceId("a").id("a").build());
+  }
+
+  @Test public void builder_clone() {
+    Span.Builder builder = oneOfEach.toBuilder();
+    assertThat(builder.clone())
+      .isNotSameAs(builder)
+      .isEqualToComparingFieldByField(builder);
+  }
+
+  @Test public void builder_merge_flags() {
+    assertThat(Span.newBuilder().shared(true).merge(base.toBuilder().debug(true).build()).build())
+      .isEqualToComparingFieldByField(base.toBuilder().shared(true).debug(true).build());
+  }
+
+  @Test public void builder_merge_annotations() {
+    Span merged = Span.newBuilder().merge(oneOfEach).build();
+
+    assertThat(merged.annotations).containsExactlyElementsOf(oneOfEach.annotations);
+  }
+
+  @Test public void builder_merge_annotations_concat() {
+    Span merged = Span.newBuilder().addAnnotation(1, "a")
+      .merge(base.toBuilder().addAnnotation(2, "a").build()).build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().addAnnotation(1, "a").addAnnotation(2, "a").build()
+    );
+  }
+
+  @Test public void builder_merge_tags() {
+    Span merged = Span.newBuilder().merge(oneOfEach).build();
+
+    assertThat(merged.tags).containsAllEntriesOf(oneOfEach.tags);
+  }
+
+  @Test public void builder_merge_tags_concat() {
+    Span merged = Span.newBuilder().putTag("1", "a")
+      .merge(base.toBuilder().putTag("2", "a").build()).build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().putTag("1", "a").putTag("2", "a").build()
+    );
+  }
+
+  @Test public void builder_merge_localEndpoint() {
+    Span merged = Span.newBuilder()
+      .merge(base.toBuilder().localEndpoint(FRONTEND).build()).build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().localEndpoint(FRONTEND).build()
+    );
+  }
+
+  @Test public void builder_merge_localEndpoint_redundant() {
+    Span merged = Span.newBuilder().localEndpoint(FRONTEND)
+      .merge(base.toBuilder().localEndpoint(FRONTEND).build()).build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().localEndpoint(FRONTEND).build()
+    );
+  }
+
+  @Test public void builder_merge_localEndpoint_merge() {
+    Span merged = Span.newBuilder().localEndpoint(Endpoint.newBuilder().serviceName("a").build())
+      .merge(
+        base.toBuilder().localEndpoint(Endpoint.newBuilder().ip("192.168.99.101").build()).build())
+      .merge(
+        base.toBuilder().localEndpoint(Endpoint.newBuilder().ip("2001:db8::c001").build()).build())
+      .merge(
+        base.toBuilder().localEndpoint(Endpoint.newBuilder().port(80).build()).build())
+      .build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().localEndpoint(Endpoint.newBuilder()
+        .serviceName("a")
+        .ip("192.168.99.101")
+        .ip("2001:db8::c001")
+        .port(80)
+        .build()
+      ).build()
+    );
+  }
+
+  @Test public void builder_merge_remoteEndpoint() {
+    Span merged = Span.newBuilder()
+      .merge(base.toBuilder().remoteEndpoint(FRONTEND).build()).build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().remoteEndpoint(FRONTEND).build()
+    );
+  }
+
+  @Test public void builder_merge_remoteEndpoint_redundant() {
+    Span merged = Span.newBuilder().remoteEndpoint(FRONTEND)
+      .merge(base.toBuilder().remoteEndpoint(FRONTEND).build()).build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().remoteEndpoint(FRONTEND).build()
+    );
+  }
+
+  @Test public void builder_merge_remoteEndpoint_merge() {
+    Span merged = Span.newBuilder().remoteEndpoint(Endpoint.newBuilder().serviceName("a").build())
+      .merge(
+        base.toBuilder().remoteEndpoint(Endpoint.newBuilder().ip("192.168.99.101").build()).build())
+      .merge(
+        base.toBuilder().remoteEndpoint(Endpoint.newBuilder().ip("2001:db8::c001").build()).build())
+      .merge(
+        base.toBuilder().remoteEndpoint(Endpoint.newBuilder().port(80).build()).build())
+      .build();
+
+    assertThat(merged).isEqualToComparingFieldByField(
+      base.toBuilder().remoteEndpoint(Endpoint.newBuilder()
+        .serviceName("a")
+        .ip("192.168.99.101")
+        .ip("2001:db8::c001")
+        .port(80)
+        .build()
+      ).build()
+    );
   }
 
   @Test public void toString_isJson() {
@@ -197,6 +373,27 @@ public class SpanTest {
       .isEqualTo("00000000000004d2000000000000162e");
   }
 
+  /** Some tools like rsocket redundantly pass high bits as zero. */
+  @Test public void normalizeTraceId_truncates64BitZeroPrefix() {
+    assertThat(normalizeTraceId("0000000000000000000000000000162e"))
+      .isEqualTo("000000000000162e");
+  }
+
+  @Test public void normalizeTraceId_padsTo64() {
+    assertThat(normalizeTraceId("162e"))
+      .isEqualTo("000000000000162e");
+  }
+
+  @Test public void normalizeTraceId_padsTo128() {
+    assertThat(normalizeTraceId("4d2000000000000162e"))
+      .isEqualTo("00000000000004d2000000000000162e");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void normalizeTraceId_badCharacters() {
+    normalizeTraceId("000-0000000004d20000000ss000162e");
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void traceIdFromLong_invalid() {
     base.toBuilder().traceId(0, 0);
@@ -209,6 +406,14 @@ public class SpanTest {
 
   @Test public void parentIdFromLong_zeroSameAsNull() {
     assertThat(base.toBuilder().parentId(0L).build().parentId())
+      .isNull();
+    assertThat(base.toBuilder().parentId("0").build().parentId())
+      .isNull();
+  }
+
+  /** Prevents processing tools from looping */
+  @Test public void parentId_sameAsIdCoerseToNull() {
+    assertThat(base.toBuilder().parentId(base.id).build().parentId())
       .isNull();
   }
 
@@ -233,6 +438,11 @@ public class SpanTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
+  public void id_zerosInvalid() {
+    base.toBuilder().id("0000000000000000");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
   public void parentId_emptyInvalid() {
     base.toBuilder().parentId("");
   }
@@ -240,6 +450,11 @@ public class SpanTest {
   @Test(expected = IllegalArgumentException.class)
   public void traceId_emptyInvalid() {
     base.toBuilder().traceId("");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void traceId_zerosInvalid() {
+    base.toBuilder().traceId("0000000000000000");
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/zipkin/src/test/java/zipkin2/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/DependencyLinkerTest.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.junit.Test;
 import zipkin2.DependencyLink;
 import zipkin2.Endpoint;
@@ -93,20 +92,6 @@ public class DependencyLinkerTest {
 
     assertThat(messages)
       .contains("linking trace 000000000000000a");
-  }
-
-  @Test
-  public void dropsSelfReferencingSpans() {
-    List<Span> trace = TRACE.stream()
-      .map(s -> s.toBuilder().parentId(s.parentId() != null ? s.id() : null).build())
-      .collect(Collectors.toList());
-
-    assertThat(new DependencyLinker(logger).putTrace(trace.iterator()).link()).isEmpty();
-
-    assertThat(messages).contains(
-      "skipping circular dependency: traceId=000000000000000a, spanId=000000000000000b",
-      "skipping circular dependency: traceId=000000000000000a, spanId=000000000000000c"
-    );
   }
 
   @Test

--- a/zipkin/src/test/java/zipkin2/internal/NodeTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/NodeTest.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.junit.Ignore;
 import org.junit.Test;
 import zipkin2.Span;
 
@@ -78,7 +79,7 @@ public class NodeTest {
     g.addChild(h);
 
     assertThat(a.traverse()).extracting(Node::value)
-        .containsExactly('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h');
+      .containsExactly('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h');
   }
 
   /**
@@ -102,14 +103,14 @@ public class NodeTest {
     }
     Node<Span> root = treeBuilder.build();
     assertThat(root.value())
-        .isEqualTo(trace.get(0));
+      .isEqualTo(trace.get(0));
 
     assertThat(root.children()).extracting(Node::value)
-        .containsExactly(trace.get(1));
+      .containsExactly(trace.get(1));
 
     Node<Span> child = root.children().iterator().next();
     assertThat(child.children()).extracting(Node::value)
-        .containsExactly(trace.get(2));
+      .containsExactly(trace.get(2));
   }
 
   @Test public void constructsTraceTree_dedupes() {
@@ -196,17 +197,10 @@ public class NodeTest {
     );
   }
 
-  @Test public void addNode_skipsOnCycle() {
-    Span s1 = Span.newBuilder().traceId("a").parentId(null).id("a").name("s1").build();
-    Span s2 = Span.newBuilder().traceId("a").parentId("b").id("b").name("s2").build();
+  @Test @Ignore public void addNode_skipsOnCycle() {
+    Span.newBuilder().traceId("a").parentId("d").id("b").name("s2").build();
+    Span.newBuilder().traceId("a").parentId("b").id("d").name("s3").build();
 
-    Node.TreeBuilder<Span> treeBuilder = new Node.TreeBuilder<>(logger, s2.traceId());
-    treeBuilder.addNode(s1.parentId(), s1.id(), s1);
-    assertThat(treeBuilder.addNode(s2.parentId(), s2.id(), s2)).isFalse();
-
-    treeBuilder.build();
-    assertThat(messages).containsExactly(
-      "skipping circular dependency: traceId=000000000000000a, spanId=000000000000000b"
-    );
+    // TODO: see how spans like ^^ affect the node tree
   }
 }

--- a/zipkin/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
@@ -263,7 +263,7 @@ public class V1ThriftSpanWriterTest {
   @Test
   public void writesParentAnd128BitTraceId() {
     writer.write(
-        span.toBuilder().traceId("00000000000000010000000000000002").parentId("3").id("4").build(),
+        Span.newBuilder().traceId("00000000000000010000000000000002").parentId("3").id("4").build(),
         buf);
 
     assertThat(buf.toByteArray())


### PR DESCRIPTION
This adds Span.merge which should only be used in cases where
instrumentation send late data. This should not be used for merging
client and server spans, as v2 format is explicitly single-host.