### PR TITLE
Fix unformatted timestamps

### DIFF
--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -17,7 +17,7 @@
     <div class="col-md-2">
       <span class='btn btn-sm btn-secondary' href='{{ contextRoot }}api/v2/trace/{{ traceId }}' id='traceJsonLink'>JSON
         <span class="fas fa-download"></span>
-      </span> 
+      </span>
     </div>
   </div>
 
@@ -122,7 +122,7 @@
       <div class='modal-body'>
        <div class="card">
         <h6 class="card-body">AKA: <span class='service-names container'></span></h6>
-       </div> 
+       </div>
         <table id='annotations' class='table table-striped table-sm table-bordered'>
           <thead class="table-info"><tr>
             <th>Date Time</th>
@@ -132,7 +132,7 @@
           </tr></thead>
           <tbody>
             <tr>
-              <td class='key' data-key='timestamp' class="local-datetime"></td>
+              <td class='key local-datetime' data-key='timestamp'></td>
               <td class='key' data-key='relativeTime'></td>
               <td class='value' data-key='value'></td>
               <td class='value' data-key='endpoint'></td>
@@ -261,4 +261,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
Prev
<img width="535" alt="2018-11-20 14 12 59" src="https://user-images.githubusercontent.com/19551419/48752817-6c592600-ecce-11e8-9be4-a25306bd00f7.png">

Now
<img width="519" alt="2018-11-20 14 11 49" src="https://user-images.githubusercontent.com/19551419/48752782-45025900-ecce-11e8-9148-b250e6c3109c.png">
