### PR TITLE
Conditionally filters when strictTraceId == true

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectFromTraces.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectFromTraces.java
@@ -28,6 +28,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import zipkin2.Call;
 import zipkin2.Span;
+import zipkin2.internal.FilterTraces;
 import zipkin2.internal.HexCodec;
 import zipkin2.internal.Nullable;
 import zipkin2.internal.V1ThriftSpanReader;
@@ -111,7 +112,9 @@ final class SelectFromTraces extends ResultSetFutureCall {
     SelectTracesByIds(Factory factory, QueryRequest request) {
       this.factory = factory;
       this.limit = request.limit();
-      this.filter = factory.strictTraceId ? StrictTraceId.filterTraces(request) : null;
+      // Cassandra always looks up traces by 64-bit trace ID, so we have to unconditionally filter
+      // when strict trace ID is enabled.
+      this.filter = factory.strictTraceId ? FilterTraces.create(request) : null;
     }
 
     @Override

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
@@ -29,6 +29,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import zipkin2.Call;
 import zipkin2.Span;
+import zipkin2.internal.FilterTraces;
 import zipkin2.internal.Nullable;
 import zipkin2.storage.GroupByTraceId;
 import zipkin2.storage.QueryRequest;
@@ -134,7 +135,9 @@ final class SelectFromSpan extends ResultSetFutureCall {
     SelectSpansByTraceIds(Factory factory, QueryRequest request) {
       this.factory = factory;
       this.limit = request.limit();
-      this.filter = factory.strictTraceId ? StrictTraceId.filterTraces(request) : null;
+      // Cassandra always looks up traces by 64-bit trace ID, so we have to unconditionally filter
+      // when strict trace ID is enabled.
+      this.filter = factory.strictTraceId ? FilterTraces.create(request) : null;
     }
 
     @Override

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
@@ -106,6 +106,8 @@ final class ElasticsearchSpanStore implements SpanStore {
 
     Call<List<List<Span>>> result =
         traceIdsCall.flatMap(new GetSpansByTraceId(search, indices)).map(groupByTraceId);
+    // Elasticsearch lookup by trace ID is by the full 128-bit length, but there's still a chance of
+    // clash on lower-64 bit. When strict trace ID is enabled, we only filter client-side on clash.
     return strictTraceId ? result.map(StrictTraceId.filterTraces(request)) : result;
   }
 

--- a/zipkin/src/main/java/zipkin2/internal/FilterTraces.java
+++ b/zipkin/src/main/java/zipkin2/internal/FilterTraces.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import java.util.Iterator;
+import java.util.List;
+import zipkin2.Call;
+import zipkin2.Span;
+import zipkin2.storage.QueryRequest;
+
+public final class FilterTraces implements Call.Mapper<List<List<Span>>, List<List<Span>>> {
+  /** Filters the mutable input based on the query */
+  public static Call.Mapper<List<List<Span>>, List<List<Span>>> create(QueryRequest request) {
+    return new FilterTraces(request);
+  }
+
+  final QueryRequest request;
+
+  FilterTraces(QueryRequest request) {
+    this.request = request;
+  }
+
+  @Override public List<List<Span>> map(List<List<Span>> input) {
+    Iterator<List<Span>> i = input.iterator();
+    while (i.hasNext()) { // Not using removeIf as that's java 8+
+      List<Span> next = i.next();
+      if (!request.test(next)) i.remove();
+    }
+    return input;
+  }
+
+  @Override public String toString() {
+    return "FilterTraces{request=" + request + "}";
+  }
+}

--- a/zipkin/src/main/java/zipkin2/storage/GroupByTraceId.java
+++ b/zipkin/src/main/java/zipkin2/storage/GroupByTraceId.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import zipkin2.Call;
 import zipkin2.Span;
 
+import static zipkin2.storage.StrictTraceId.lowerTraceId;
+
 /**
  * A mapper that groups unorganized input spans by trace ID. Useful when preparing a result for
  * {@link SpanStore#getTraces(QueryRequest)}.
@@ -42,10 +44,8 @@ public final class GroupByTraceId implements Call.Mapper<List<Span>, List<List<S
 
     Map<String, List<Span>> groupedByTraceId = new LinkedHashMap<>();
     for (Span span : input) {
-      String traceId =
-          strictTraceId || span.traceId().length() == 16
-              ? span.traceId()
-              : span.traceId().substring(16);
+      String traceId = span.traceId();
+      if (!strictTraceId) traceId = lowerTraceId(traceId);
       if (!groupedByTraceId.containsKey(traceId)) {
         groupedByTraceId.put(traceId, new ArrayList<>());
       }

--- a/zipkin/src/main/java/zipkin2/storage/GroupByTraceId.java
+++ b/zipkin/src/main/java/zipkin2/storage/GroupByTraceId.java
@@ -38,8 +38,7 @@ public final class GroupByTraceId implements Call.Mapper<List<Span>, List<List<S
     this.strictTraceId = strictTraceId;
   }
 
-  @Override
-  public List<List<Span>> map(List<Span> input) {
+  @Override public List<List<Span>> map(List<Span> input) {
     if (input.isEmpty()) return Collections.emptyList();
 
     Map<String, List<Span>> groupedByTraceId = new LinkedHashMap<>();
@@ -54,8 +53,7 @@ public final class GroupByTraceId implements Call.Mapper<List<Span>, List<List<S
     return new ArrayList<>(groupedByTraceId.values());
   }
 
-  @Override
-  public String toString() {
+  @Override public String toString() {
     return "GroupByTraceId{strictTraceId=" + strictTraceId + "}";
   }
 }

--- a/zipkin/src/main/java/zipkin2/storage/StrictTraceId.java
+++ b/zipkin/src/main/java/zipkin2/storage/StrictTraceId.java
@@ -14,7 +14,9 @@
 package zipkin2.storage;
 
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import zipkin2.Call;
 import zipkin2.Span;
 
@@ -28,7 +30,11 @@ public final class StrictTraceId {
     return new FilterSpans(traceId);
   }
 
-  /** Filters the mutable input based on the query */
+  /**
+   * Filters the mutable input client-side when there's a clash on lower 64-bits of a trace ID.
+   *
+   * @see FilterTraces
+   */
   public static Call.Mapper<List<List<Span>>, List<List<Span>>> filterTraces(QueryRequest request) {
     return new FilterTraces(request);
   }
@@ -41,8 +47,9 @@ public final class StrictTraceId {
       this.request = request;
     }
 
-    @Override
-    public List<List<Span>> map(List<List<Span>> input) {
+    @Override public List<List<Span>> map(List<List<Span>> input) {
+      if (!hasClashOnLowerTraceId(input)) return input;
+
       Iterator<List<Span>> i = input.iterator();
       while (i.hasNext()) { // Not using removeIf as that's java 8+
         List<Span> next = i.next();
@@ -51,10 +58,36 @@ public final class StrictTraceId {
       return input;
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "FilterTraces{request=" + request + "}";
     }
+  }
+
+  /** Returns true if any trace clashes on the right-most 16 characters of the trace ID */
+  // Concretely, Netflix have a special index template for a multi-tag, "fit.sessionId". If we
+  // blindly filtered without seeing if we had to, a match that works on the server side would
+  // fail client side. Normally, we wouldn't special case like this, but not filtering unless
+  // necessary is also more efficient.
+  static boolean hasClashOnLowerTraceId(List<List<Span>> input) {
+    int traceCount = input.size();
+    if (traceCount <= 1) return false;
+
+    // NOTE: It is probably more efficient to do clever sorting and peeking here, but the call site
+    // is query side, which is not in the critical path of user code. A set is much easier to grok.
+    Set<String> traceIdLows = new LinkedHashSet<>();
+    boolean clash = false;
+    for (int i = 0; i < traceCount; i++) {
+      String traceId = lowerTraceId(input.get(i).get(0).traceId());
+      if (!traceIdLows.add(traceId)) {
+        clash = true;
+        break;
+      }
+    }
+    return clash;
+  }
+
+  static String lowerTraceId(String traceId) {
+    return traceId.length() == 16 ? traceId : traceId.substring(16);
   }
 
   static final class FilterSpans implements Call.Mapper<List<Span>, List<Span>> {

--- a/zipkin/src/test/java/zipkin2/storage/GroupByTraceIdTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/GroupByTraceIdTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.util.List;
+import org.junit.Test;
+import zipkin2.Span;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GroupByTraceIdTest {
+  Span oneOne = Span.newBuilder().traceId(1, 1).id(1).build();
+  Span twoOne = Span.newBuilder().traceId(2, 1).id(1).build();
+  Span zeroOne = Span.newBuilder().traceId(0, 1).id(1).build();
+
+  @Test public void map_groupsEverythingWhenNotStrict() {
+    List<Span> spans = asList(oneOne, twoOne, zeroOne);
+
+    assertThat(GroupByTraceId.create(false).map(spans)).containsExactly(spans);
+  }
+
+  @Test public void map_groupsByTraceIdHighWheStrict() {
+    List<Span> spans = asList(oneOne, twoOne, zeroOne);
+
+    assertThat(GroupByTraceId.create(true).map(spans))
+      .containsExactly(asList(oneOne), asList(twoOne), asList(zeroOne));
+  }
+}


### PR DESCRIPTION
In order to read data written before switching from strictTraceId == false, we
filter client side even when strictTraceId == true. This broke some behavior
Netflix relied on that allowed multi-tag based query on "fit" experiments.

There are a few ways to address this, including adding another flag to say if
you have any old data or not. In this case, you'd never want to filter client-
side. OTOH introducing a new flag is burdensome from a documentation POV.

This addresses the concern in a different way. The only reason we would have to
filter client side, is if there is a clash on the lower 64-bits of the trace ID.
Knowing this, we can achieve the same with no configuration just by looking for
a clash and doing no filtering if there is no clash.

Fixes #1973