### PR TITLE
Moves UI tests to v2 data, fixes a couple glitches

### DIFF
--- a/zipkin-ui/js/skew.js
+++ b/zipkin-ui/js/skew.js
@@ -288,11 +288,11 @@ function getClockSkew(parent, span) {
   }
 
   let server = serverRecv.endpoint;
-  if (!server && oneWay) server = serverSend.endpoint;
+  if (!server && !oneWay) server = serverSend.endpoint;
   if (!server) return undefined;
 
   let client = clientSend.endpoint;
-  if (!client && oneWay) client = clientRecv.endpoint;
+  if (!client && !oneWay) client = clientRecv.endpoint;
   if (!client) return undefined;
 
   // There's no skew if the RPC is going to itself

--- a/zipkin-ui/test/component_data/default.test.js
+++ b/zipkin-ui/test/component_data/default.test.js
@@ -15,9 +15,10 @@ describe('convertSuccessResponse', () => {
       duration: 168.731,
       durationStr: '168.731ms',
       width: 100,
-      spanCount: 2,
+      spanCount: 2, // TODO: correct: the span count is by ID when it should be by distinct span
       serviceSummaries: [
         {serviceName: 'frontend', spanCount: 2, maxSpanDurationStr: '168.731ms'},
+        // TODO: correct. The backend server duration should be here not client!
         {serviceName: 'backend', spanCount: 1, maxSpanDurationStr: '111.121ms'}
       ],
       infoClass: ''

--- a/zipkin-ui/test/component_ui/spanPanel.test.js
+++ b/zipkin-ui/test/component_ui/spanPanel.test.js
@@ -1,13 +1,10 @@
-import {Constants} from '../../js/component_ui/traceConstants';
 import {
   maybeMarkTransientError,
   formatAnnotationValue,
   formatBinaryAnnotationValue,
   isDupeBinaryAnnotation
 } from '../../js/component_ui/spanPanel';
-import {endpoint, annotation} from './traceTestHelpers';
-
-const ep = endpoint(123, 123, 'service1');
+import {frontend} from './traceTestHelpers';
 
 chai.config.truncateThreshold = 0;
 
@@ -18,14 +15,14 @@ describe('maybeMarkTransientError', () => {
   };
 
   it('should not add class when annotation is not error', () => {
-    const anno = annotation(100, Constants.CLIENT_SEND, ep);
+    const anno = {timestamp: 100, value: 'cs', endpoint: frontend};
 
     maybeMarkTransientError(row, anno);
     row.className.should.equal('');
   });
 
   it('should add class when annotation is error', () => {
-    const anno = annotation(100, Constants.ERROR, ep);
+    const anno = {timestamp: 100, value: 'error', endpoint: frontend};
 
     maybeMarkTransientError(row, anno);
     row.className.should.equal('anno-error-transient');
@@ -33,11 +30,11 @@ describe('maybeMarkTransientError', () => {
 
   // uses an actual value from Finagle
   it('should add class when annotation matches error', () => {
-    const anno = annotation(
-      100,
-      'Server Send Error: TimeoutException: socket timed out',
-      ep
-    );
+    const anno = {
+      timestamp: 100,
+      value: 'Server Send Error: TimeoutException: socket timed out',
+      endpoint: frontend
+    };
 
     maybeMarkTransientError(row, anno);
     row.className.should.equal('anno-error-transient');

--- a/zipkin-ui/test/component_ui/traceTestHelpers.js
+++ b/zipkin-ui/test/component_ui/traceTestHelpers.js
@@ -1,3 +1,11 @@
+export const frontend = {
+  serviceName: 'frontend',
+  ipv4: '172.17.0.13'
+};
+export const backend = {
+  serviceName: 'backend',
+  ipv4: '172.17.0.9'
+};
 export const httpTrace = [
   {
     traceId: 'bb1f0e21882325b8',
@@ -7,10 +15,7 @@ export const httpTrace = [
     name: 'get',
     timestamp: 1541138169297572,
     duration: 111121,
-    localEndpoint: {
-      serviceName: 'frontend',
-      ipv4: '172.17.0.13'
-    },
+    localEndpoint: frontend,
     annotations: [
       {value: 'ws', timestamp: 1541138169337695},
       {value: 'wr', timestamp: 1541138169368570}
@@ -27,10 +32,7 @@ export const httpTrace = [
     name: 'get /',
     timestamp: 1541138169255688,
     duration: 168731,
-    localEndpoint: {
-      serviceName: 'frontend',
-      ipv4: '172.17.0.13'
-    },
+    localEndpoint: frontend,
     remoteEndpoint: {
       ipv6: '110.170.201.178',
       port: 63678
@@ -50,10 +52,7 @@ export const httpTrace = [
     name: 'get /api',
     timestamp: 1541138169377997,
     duration: 26326,
-    localEndpoint: {
-      serviceName: 'backend',
-      ipv4: '172.17.0.9'
-    },
+    localEndpoint: backend,
     remoteEndpoint: {
       ipv4: '172.17.0.13',
       port: 63679
@@ -73,10 +72,7 @@ export const errorTrace = [{
   id: '1e223ff1f80f1c69',
   timestamp: 1541138169377997,
   duration: 17,
-  localEndpoint: {
-    serviceName: 'backend',
-    ipv4: '172.17.0.9'
-  },
+  localEndpoint: backend,
   tags: {error: 'request failed'}
 }];
 
@@ -118,8 +114,7 @@ export const skewedTrace = [
     localEndpoint: {
       serviceName: 'servicea',
       ipv4: '127.0.0.0'
-    },
-    shared: true
+    }
   },
   {
     traceId: '1e223ff1f80f1c69',
@@ -135,40 +130,6 @@ export const skewedTrace = [
     }
   }
 ];
-
-export function endpoint(ipv4, port, serviceName) {
-  return {ipv4, port, serviceName};
-}
-
-export function annotation(timestamp, value, ep) {
-  return {timestamp, value, endpoint: ep};
-}
-
-export function binaryAnnotation(key, value, ep) {
-  return {key, value, endpoint: ep};
-}
-
-export function span(traceId,
-                     name,
-                     id,
-                     parentId = null,
-                     timestamp = null,
-                     duration = null,
-                     annotations = [],
-                     binaryAnnotations = [],
-                     debug = false) {
-  return {
-    traceId,
-    name,
-    id,
-    parentId,
-    timestamp,
-    duration,
-    annotations,
-    binaryAnnotations,
-    debug
-  };
-}
 
 export function traceDetailSpan(id) {
   const expanderText = [];


### PR DESCRIPTION
This fixes a glitch that causes NaN to show in the trace summary. It
also adds some TODOs which will be fixed when the new code merges that
uses v2 native data.

Before (netflix trace):

<img width="954" alt="screen shot 2018-11-22 at 3 11 00 pm" src="https://user-images.githubusercontent.com/64215/48890791-626d2980-ee6c-11e8-8a32-198f4a2dea33.png">

After
<img width="966" alt="screen shot 2018-11-22 at 3 10 55 pm" src="https://user-images.githubusercontent.com/64215/48890814-731d9f80-ee6c-11e8-8066-01edd7816663.png">

