### PR TITLE
Unsupports v1 trace upload

### DIFF
--- a/zipkin-ui/test/component_ui/uploadTrace.test.js
+++ b/zipkin-ui/test/component_ui/uploadTrace.test.js
@@ -1,0 +1,63 @@
+import {
+  convertV2ToV1
+} from '../../js/component_ui/uploadTrace';
+import {mergeV2ById} from '../../js/spanCleaner';
+import {SPAN_V1} from '../../js/spanConverter';
+import {httpTrace} from '../component_ui/traceTestHelpers';
+
+chai.config.truncateThreshold = 0;
+
+describe('convertV2ToV1', () => {
+  // TODO: this is temporary, as soon this will not need to convert
+  it('should convert to v1 format', () => {
+    const v1Trace = convertV2ToV1(httpTrace);
+
+    expect(v1Trace).to.deep.equal(SPAN_V1.convertTrace(mergeV2ById(httpTrace)));
+  });
+
+  it('should raise error if not a list', () => {
+    let error;
+    try {
+      convertV2ToV1();
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.eql('input is not a list');
+
+    try {
+      convertV2ToV1({traceId: 'a', id: 'b'});
+    } catch (err) {
+      expect(err.message).to.eql(error.message);
+    }
+  });
+
+  it('should raise error if missing trace ID or span ID', () => {
+    let error;
+    try {
+      convertV2ToV1([{traceId: 'a'}]);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.eql('List<Span> implies at least traceId and id fields');
+
+    try {
+      convertV2ToV1([{id: 'b'}]);
+    } catch (err) {
+      expect(err.message).to.eql(error.message);
+    }
+  });
+
+  it('should raise error if in v1 format', () => {
+    let error;
+    try {
+      convertV2ToV1([{traceId: 'a', id: 'b', binaryAnnotations: []}]);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.eql(
+      'v1 format is not supported. For help, contact https://gitter.im/openzipkin/zipkin');
+  });
+});


### PR DESCRIPTION
Javascript conversion of v1 trace data to v2 format is a fairly large
task. We will likely do such a thing in the zipkin-js library vs here as
the code is substantial and not specific to the UI.

This unsupports the trace viewer screen for v1 format. A workaround is
to use a local zipkin server to convert the data meanwhile.

Fixes #2269