### PR TITLE
Move glyphicon to font awesome

### DIFF
--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -30,12 +30,12 @@
     <div class="ui-grid-a" id="extraButtonsContainer">
       <div style="display: inline-block">
         <button type="button" class="btn btn-danger btn-sm" id='zoomOutSpans' value='uiZoomOutSpans' style='display: none'>
-          <span class="glyphicon glyphicon-zoom-out"></span>
+          <i class="fas fa-search-minus"></i>
         </button>
       </div>
       <div style="display: inline-block">
         <button type="button" class="btn btn-default btn-sm back-to-top" id="backToTop" style='display: none'>
-          <span class="glyphicon glyphicon-chevron-up"></span>
+          <i class="fas fa-chevron-up"></i>
         </button>
       </div>
     </div>


### PR DESCRIPTION
In bootstrap4, glyphicon is removed.
So we cannot use backToTop button & zoomOut button now.
This PR move glyphicon to font awesome.