### PR TITLE
Makes UI merge logic lenient to missing shared flag on server side

### DIFF
--- a/zipkin-ui/js/spanNode.js
+++ b/zipkin-ui/js/spanNode.js
@@ -106,7 +106,6 @@ class SpanNode {
 }
 
 // In javascript, dict keys can't be objects
-// TODO: see if we can accomodate shared server spans that accidentally didn't add the shared flag
 function keyString(id, shared = false, endpoint) {
   if (!shared) return id;
   const endpointString = endpoint ? JSON.stringify(endpoint) : 'x';

--- a/zipkin-ui/test/skew.test.js
+++ b/zipkin-ui/test/skew.test.js
@@ -117,6 +117,31 @@ describe('treeCorrectedForClockSkew', () => {
     expect(getClockSkew(child).endpoint).to.deep.equal(backend);
   });
 
+  it('clock skew should be attributed to the server endpoint even if missing shared flag', () => {
+    const parent = new SpanNode(clean({
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      kind: 'CLIENT',
+      localEndpoint: frontend,
+      timestamp: 20,
+      duration: 20
+    }));
+    const child = new SpanNode(clean({
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      kind: 'SERVER',
+      localEndpoint: backend,
+      timestamp: 10, // skew
+      duration: 10
+    }));
+    parent.addChild(child);
+
+    // Skew correction pushes the server side forward, so the skew endpoint is the server
+    expect(getClockSkew(child).endpoint).to.deep.equal(backend);
+  });
+
   /*
    * Skew is relative to the server receive and centered by the difference between the server
    * duration and the client duration.

--- a/zipkin-ui/test/spanCleaner.test.js
+++ b/zipkin-ui/test/spanCleaner.test.js
@@ -1,4 +1,4 @@
-const {merge, mergeV2ById} = require('../js/spanCleaner');
+const {cleanupComparator, merge, mergeV2ById} = require('../js/spanCleaner');
 
 // endpoints from zipkin2.TestObjects
 const frontend = {
@@ -929,6 +929,32 @@ describe('mergeV2ById', () => {
     expect(spans.map(s => s.name)).to.deep.equal([
       'client',
       'server'
+    ]);
+  });
+});
+
+describe('cleanupComparator', () => {
+  // some instrumentation don't add shared flag to servers
+  it('should order server after client', () => {
+    const spans = [
+      {
+        traceId: '1111111111111111',
+        parentId: '0000000000000001',
+        id: '0000000000000004',
+        name: 'a',
+        kind: 'SERVER'
+      },
+      {
+        traceId: '1111111111111111',
+        parentId: '0000000000000001',
+        id: '0000000000000004',
+        name: 'a',
+        kind: 'CLIENT'
+      }
+    ];
+
+    expect(spans.sort(cleanupComparator).map(s => `${s.id}-${s.kind}`)).to.deep.equal([
+      '0000000000000004-CLIENT', '0000000000000004-SERVER'
     ]);
   });
 });

--- a/zipkin-ui/testdata/netflix.json
+++ b/zipkin-ui/testdata/netflix.json
@@ -93,8 +93,7 @@
       "salp.trace_id": "7c6451ad-b111-459f-8310-cc80f1da5e10-147517",
       "service_asg_name": "session_logs-int-v549",
       "service_cluster_name": "session_logs-int"
-    },
-    "shared": true
+    }
   },
   {
     "traceId": "5982fe77008310cc80f1da5e10147517",
@@ -215,8 +214,7 @@
       "salp.trace_id": "7c6451ad-b111-459f-8310-cc80f1da5e10-147517",
       "service_asg_name": "api-int-v606",
       "service_cluster_name": "api-int"
-    },
-    "shared": true
+    }
   },
   {
     "traceId": "5982fe77008310cc80f1da5e10147517",


### PR DESCRIPTION
Last PR, I cheated by backfilling missing shared flag on netflix data.
This, removes it as now the logic can work around missing shared flag
under the most common circumstances.

cc @narayaruna