### PR TITLE
Reverts accidental inclusion of annotation timestamps in trace plotting

### DIFF
--- a/zipkin-ui/js/component_ui/traceSummary.js
+++ b/zipkin-ui/js/component_ui/traceSummary.js
@@ -6,7 +6,6 @@ import {getErrorType} from './spanRow';
 // To ensure data doesn't scroll off the screen, we need all timestamps, not just
 // client/server ones.
 export function addTimestamps(span, timestamps) {
-  span.annotations.forEach(a => timestamps.push(a.timestamp));
   if (!span.timestamp) return;
   timestamps.push(span.timestamp);
   if (!span.duration) return;


### PR DESCRIPTION
annotations are relative to span, not a trace. This was a bug. sorry @drolando, as this affected you.