### PR TITLE
Coerces accidental shared flag to null when on a client span

### DIFF
--- a/zipkin-ui/js/component_data/spanCleaner.js
+++ b/zipkin-ui/js/component_data/spanCleaner.js
@@ -46,7 +46,8 @@ export function clean(span) {
   res.tags = span.tags || {};
 
   if (span.debug) res.debug = true;
-  if (span.shared) res.shared = true;
+  // shared is for the server side, unset it if accidentally set on the client side
+  if (span.shared && span.kind !== 'CLIENT') res.shared = true;
 
   return res;
 }

--- a/zipkin-ui/test/component_data/spanCleaner.test.js
+++ b/zipkin-ui/test/component_data/spanCleaner.test.js
@@ -1,4 +1,9 @@
-const {cleanupComparator, merge, mergeV2ById} = require('../../js/component_data/spanCleaner');
+const {
+  clean,
+  cleanupComparator,
+  merge,
+  mergeV2ById
+} = require('../../js/component_data/spanCleaner');
 
 // endpoints from zipkin2.TestObjects
 const frontend = {
@@ -57,6 +62,19 @@ const oneOfEach = { // has every field set
   shared: true,
   debug: true
 };
+
+describe('clean', () => {
+  it('should remove shared flag if set on client', () => {
+    const cleaned = clean({
+      traceId: '0000000000000001',
+      id: '0000000000000002',
+      kind: 'CLIENT',
+      shared: true
+    });
+
+    (typeof cleaned.shared).should.equal('undefined');
+  });
+});
 
 describe('merge', () => {
   it('should work on redundant data', () => {

--- a/zipkin/src/test/java/zipkin2/SpanTest.java
+++ b/zipkin/src/test/java/zipkin2/SpanTest.java
@@ -441,6 +441,11 @@ public class SpanTest {
       .isNull();
   }
 
+  @Test public void removesSharedFlagFromClientSpans() {
+    assertThat(base.toBuilder().kind(Span.Kind.CLIENT).build().shared())
+      .isNull();
+  }
+
   @Test public void idFromLong() {
     assertThat(base.toBuilder().id(3405691582L).build().id())
       .isEqualTo("00000000cafebabe");

--- a/zipkin/src/test/java/zipkin2/internal/Proto3ZipkinFieldsTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/Proto3ZipkinFieldsTest.java
@@ -179,7 +179,7 @@ public class Proto3ZipkinFieldsTest {
   }
 
   @Test public void span_write_shared() {
-    SPAN.write(buf, CLIENT_SPAN.toBuilder().shared(true).build());
+    SPAN.write(buf, CLIENT_SPAN.toBuilder().kind(Span.Kind.SERVER).shared(true).build());
 
     assertThat(buf.toByteArray())
       .contains(0b01101000, atIndex(buf.pos - 2)) // (field_number << 3) | wire_type = 13 << 3 | 0


### PR DESCRIPTION
The shared flag is probably something we'll get rid of eventually. It is
only for the server, but it could be passed accidentally on the client
side. This change cleans it when that's the case so that other logic is
not burdened by this condition.