### PR TITLE
Adds quick integration for lens in the default server build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,14 @@ jobs:
           command: |
             sudo apt-get install xsltproc
             ./circleci/go-offline.sh
-            ./mvnw frontend:install-node-and-npm frontend:npm -pl zipkin-ui
+            ./mvnw frontend:install-node-and-npm frontend:npm -pl zipkin-ui,zipkin-lens
 
       - save_cache:
           key: offline-dependencies-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
             - zipkin-ui/node_modules
+            - zipkin-lens/node_modules
 
       - run:
           name: Tests

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,12 @@
       </dependency>
 
       <dependency>
+        <groupId>io.zipkin.zipkin2</groupId>
+        <artifactId>zipkin-lens</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
         <!-- TODO: group ID change: https://github.com/openzipkin/zipkin/issues/2132 -->
         <groupId>io.zipkin.java</groupId>
         <artifactId>zipkin-ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
   <modules>
     <module>zipkin</module>
     <module>zipkin-ui</module>
+    <module>zipkin-lens</module>
     <module>zipkin-junit</module>
     <module>benchmarks</module>
     <module>zipkin-storage</module>

--- a/zipkin-autoconfigure/ui/pom.xml
+++ b/zipkin-autoconfigure/ui/pom.xml
@@ -61,6 +61,11 @@
       <artifactId>zipkin-ui</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-lens</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <!-- HTML library for injecting configurable <base> tag -->
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>

--- a/zipkin-autoconfigure/ui/pom.xml
+++ b/zipkin-autoconfigure/ui/pom.xml
@@ -63,7 +63,6 @@
     <dependency>
       <groupId>io.zipkin.zipkin2</groupId>
       <artifactId>zipkin-lens</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <!-- HTML library for injecting configurable <base> tag -->

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -27,8 +27,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
@@ -37,11 +35,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.servlet.HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE;
@@ -78,7 +74,7 @@ class ZipkinUiAutoConfiguration {
   @Autowired
   ZipkinUiProperties ui;
 
-  @Value("classpath:zipkin-ui/index.html")
+  @Value("${zipkin.ui.source-root}/index.html")
   Resource indexHtml;
 
   @Bean
@@ -97,13 +93,14 @@ class ZipkinUiAutoConfiguration {
     soup.head().getElementsByTag("base").attr("href", baseTagValue);
     return soup.html();
   }
+
   @Bean
-  public WebMvcConfigurer resourceConfigurer() {
+  public WebMvcConfigurer resourceConfigurer(@Value("${zipkin.ui.source-root}") String sourceRoot) {
     return new WebMvcConfigurer() {
       @Override
       public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/zipkin/**")
-          .addResourceLocations("classpath:/zipkin-ui/")
+          .addResourceLocations(sourceRoot + "/")
           .setCachePeriod((int) TimeUnit.DAYS.toSeconds(365));      }
     };
   }

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -74,7 +74,7 @@ class ZipkinUiAutoConfiguration {
   @Autowired
   ZipkinUiProperties ui;
 
-  @Value("${zipkin.ui.source-root}/index.html")
+  @Value("${zipkin.ui.source-root:classpath:zipkin-ui}/index.html")
   Resource indexHtml;
 
   @Bean
@@ -95,7 +95,7 @@ class ZipkinUiAutoConfiguration {
   }
 
   @Bean
-  public WebMvcConfigurer resourceConfigurer(@Value("${zipkin.ui.source-root}") String sourceRoot) {
+  public WebMvcConfigurer resourceConfigurer(@Value("${zipkin.ui.source-root:classpath:zipkin-ui}") String sourceRoot) {
     return new WebMvcConfigurer() {
       @Override
       public void addResourceHandlers(ResourceHandlerRegistry registry) {

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/ZipkinUiProperties.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/ZipkinUiProperties.java
@@ -21,6 +21,8 @@ import org.springframework.util.StringUtils;
 class ZipkinUiProperties {
   static final String DEFAULT_BASEPATH = "/zipkin";
 
+  // TODO: temporary hack to allow people to choose classpath:zipkin-lens
+  private String sourceRoot = "classpath:zipkin-ui";
   private String environment;
   private int queryLimit = 10;
   private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);
@@ -29,6 +31,14 @@ class ZipkinUiProperties {
   private String basepath = DEFAULT_BASEPATH;
   private boolean searchEnabled = true;
   private Dependency dependency = new Dependency();
+
+  public String getSourceRoot() {
+    return sourceRoot;
+  }
+
+  public void setSourceRoot(String sourceRoot) {
+    this.sourceRoot = sourceRoot;
+  }
 
   public int getDefaultLookback() {
     return defaultLookback;

--- a/zipkin-autoconfigure/ui/src/test/java/zipkin2/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
+++ b/zipkin-autoconfigure/ui/src/test/java/zipkin2/autoconfigure/ui/ZipkinUiAutoConfigurationTest.java
@@ -155,6 +155,14 @@ public class ZipkinUiAutoConfigurationTest {
   }
 
   @Test
+  public void canOverideProperty_sourceRoot() throws IOException {
+    context = createContextWithOverridenProperty("zipkin.ui.source-root:classpath:zipkin-lens");
+
+    assertThat(context.getBean(ZipkinUiAutoConfiguration.class).indexHtml.getDescription())
+      .contains("zipkin-lens");
+  }
+
+  @Test
   public void canOverideProperty_specialCaseRoot() throws IOException {
     context = createContextWithOverridenProperty("zipkin.ui.basepath:/");
 

--- a/zipkin-lens/.babelrc
+++ b/zipkin-lens/.babelrc
@@ -1,0 +1,16 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": ["last 2 versions", "safari 7"],
+        }
+      },
+    ],
+    "react"
+  ],
+  "plugins": [
+    "transform-object-rest-spread"
+  ]
+}

--- a/zipkin-lens/.eslintrc
+++ b/zipkin-lens/.eslintrc
@@ -1,0 +1,25 @@
+{
+  "extends": "airbnb",
+  "rules": {
+    "import/prefer-default-export": "off",
+    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+    "react/no-array-index-key": "off",
+    "no-console": 0,
+    "no-underscore-dangle": ["off"],
+    "no-continue": ["off"],
+    "prefer-destructuring": ["error", {
+      "AssignmentExpression": {"array": false, "object": false},
+      "VariableDeclarator": {"array": true, "object": true}
+    }],
+  },
+  "plugins": ["jest"],
+  "globals": {
+    "fetch": false,
+    "document": false
+  },
+  "env": {
+      "browser": true,
+      "jquery": true,
+      "jest/globals": true,
+  }
+}

--- a/zipkin-lens/.gitignore
+++ b/zipkin-lens/.gitignore
@@ -1,0 +1,4 @@
+# Ignores are placed here to allow node.js-idiomatic builds
+*.log
+node_modules
+dist

--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2018 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.zipkin2</groupId>
+    <artifactId>parent</artifactId>
+    <version>2.11.13-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-lens</artifactId>
+  <name>Zipkin Lens</name>
+  <description>Repackages Zipkin Lens into a jar so we can use it in Spring Boot</description>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
+  </properties>
+
+  <dependencies>
+    <!-- no dependencies as this is just javascript -->
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <version>${frontend-maven-plugin.version}</version>
+        <configuration>
+          <installDirectory>target</installDirectory>
+          <nodeVersion>v10.12.0</nodeVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>install node and npm</id>
+            <goals>
+              <goal>install-node-and-npm</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>npm install</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>install</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm lint</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <arguments>run lint</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm run build</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <arguments>run build</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm run test</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <arguments>run test</arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- TODO: decide how we want to handle this -->
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- disable retrolambda as this module doesn't include Java -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/zipkin-lens/src/constants/api.js
+++ b/zipkin-lens/src/constants/api.js
@@ -16,7 +16,7 @@
 
 const { API_BASE } = process.env;
 
-export const ZIPKIN_API = `${API_BASE}/zipkin/api/v2`;
+export const ZIPKIN_API = `${API_BASE || ''}/zipkin/api/v2`;
 export const SERVICES = `${ZIPKIN_API}/services`;
 export const SPANS = `${ZIPKIN_API}/spans`;
 export const TRACES = `${ZIPKIN_API}/traces`;

--- a/zipkin-lens/webpack.prod.config.js
+++ b/zipkin-lens/webpack.prod.config.js
@@ -9,9 +9,9 @@ module.exports = {
   mode: 'production',
   entry: path.join(__dirname, './src/index.js'),
   output: {
-    path: path.join(__dirname, './dist'),
-    filename: 'bundle.js',
-    publicPath: '/zipkin/',
+      path: __dirname + '/target/classes/zipkin-lens/',
+      filename: 'app-[hash].min.js',
+      publicPath: '/zipkin/'
   },
   module: {
     rules: [
@@ -61,7 +61,7 @@ module.exports = {
     extensions: ['.js'],
   },
   plugins: [
-    new ExtractTextPlugin('style.css'),
+    new ExtractTextPlugin("style-[hash].min.css", {allChunks: true}),
     new HtmlWebpackPlugin({
       template: path.join(__dirname, './static/index.html'),
     }),

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -119,7 +119,6 @@ zipkin:
       max-active: ${MYSQL_MAX_CONNECTIONS:10}
       use-ssl: ${MYSQL_USE_SSL:false}
   ui:
-    source-root: classpath:zipkin-ui
     enabled: ${QUERY_ENABLED:true}
     ## Values below here are mapped to ZipkinUiProperties, served as /config.json
     # Default limit for Find Traces

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -119,6 +119,7 @@ zipkin:
       max-active: ${MYSQL_MAX_CONNECTIONS:10}
       use-ssl: ${MYSQL_USE_SSL:false}
   ui:
+    source-root: classpath:zipkin-ui
     enabled: ${QUERY_ENABLED:true}
     ## Values below here are mapped to ZipkinUiProperties, served as /config.json
     # Default limit for Find Traces


### PR DESCRIPTION
This integrates lens into CI and also the server build. It packages the
application into a jar named zipkin-lens under a path /zipkin-lens. The
server can select which UI via a configuration property that defaults to
the old UI. This can be overridden like so:

```bash
$ java -jar zipkin.jar --zipkin.ui.source-root=classpath:zipkin-lens
```