### PR TITLE
Documents Zipkin Lens development URL.

### DIFF
--- a/zipkin-lens/README.md
+++ b/zipkin-lens/README.md
@@ -16,6 +16,11 @@ $ npm install --dev
 $ API_BASE="http://localhost:9411" npm run start
 ```
 
+## URL to view development build
+```
+http://localhost:9000/zipkin
+```
+
 ## Production build
 
 ```


### PR DESCRIPTION
- for backwards compatability, Zipkin Lens router prefix is /zipkin.  This can be confusing during development mode so adding some docs for clarity.