### PR TITLE
Fix bugs that lens shows a blank page after something is clicked

### DIFF
--- a/zipkin-lens/src/components/Browser/Traces/index.js
+++ b/zipkin-lens/src/components/Browser/Traces/index.js
@@ -48,8 +48,8 @@ class Traces extends React.Component {
     return traceSummaries
       .filter((summary) => {
         for (let i = 0; i < filters.length; i += 1) {
-          if (!summary.serviceDurations.find(
-            service => service.name === filters[i],
+          if (!summary.serviceSummaries.find(
+            serviceSummary => serviceSummary.serviceName === filters[i],
           )) {
             return false;
           }

--- a/zipkin-lens/src/components/Timeline/index.js
+++ b/zipkin-lens/src/components/Timeline/index.js
@@ -123,8 +123,8 @@ class Timeline extends React.Component {
               /* Skip closed spans */
               if (closed[span.spanId]) {
                 if (hasChildren) {
-                  for (let i = 0; i < span.children.length; i += 1) {
-                    closed[span.children[i]] = true;
+                  for (let i = 0; i < span.childIds.length; i += 1) {
+                    closed[span.childIds[i]] = true;
                   }
                 }
                 return null;


### PR DESCRIPTION
Fix #2326 
Thank you @beckje01 !

In #2320 , some fields of objects related to trace information have been renamed.
These bugs occurred because I forgot to use this new field name in some components.