### PR TITLE
Adds gRPC endpoint /zipkin.proto3.SpanService/Report

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -80,8 +80,21 @@
       <version>${wire.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.zipkin.proto3</groupId>
+      <groupId>io.zipkin.proto3</groupId>
       <artifactId>zipkin-proto3</artifactId>
+    </dependency>
+    <!-- TODO: This only resolves google empty. Remove this once using org.apache.zipkin.proto3 -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.7.1</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -80,7 +80,7 @@
       <version>${wire.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.zipkin.proto3</groupId>
+      <groupId>org.apache.zipkin.proto3</groupId>
       <artifactId>zipkin-proto3</artifactId>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,26 @@
     <url>https://github.com/openzipkin/zipkin/issues</url>
   </issueManagement>
 
+  <repositories>
+    <repository>
+      <id>apache.snapshots.https</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>apache.snapshots.https</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -362,9 +382,9 @@
       </dependency>
 
       <dependency>
-        <groupId>io.zipkin.proto3</groupId>
+        <groupId>org.apache.zipkin.proto3</groupId>
         <artifactId>zipkin-proto3</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.wire</groupId>
@@ -627,6 +647,7 @@
           <mapping>
             <!-- Don't use javadoc style as this makes code formatters break it by adding tags! -->
             <java>SLASHSTAR_STYLE</java>
+            <kt>SLASHSTAR_STYLE</kt>
           </mapping>
           <excludes>
             <exclude>.travis.yml</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -154,26 +154,6 @@
     <url>https://github.com/openzipkin/zipkin/issues</url>
   </issueManagement>
 
-  <repositories>
-    <repository>
-      <id>apache.snapshots.https</id>
-      <url>https://repository.apache.org/content/repositories/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>apache.snapshots.https</id>
-      <url>https://repository.apache.org/content/repositories/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </pluginRepository>
-  </pluginRepositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -382,9 +362,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.zipkin.proto3</groupId>
+        <groupId>io.zipkin.proto3</groupId>
         <artifactId>zipkin-proto3</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.0</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.wire</groupId>
@@ -546,7 +526,8 @@
                 <goal>unpack-dependencies</goal>
               </goals>
               <configuration>
-                <includeArtifactIds>zipkin-proto3</includeArtifactIds>
+                <!-- TODO: Remove protobuf-java once using org.apache.zipkin.proto3 -->
+                <includeArtifactIds>protobuf-java,zipkin-proto3</includeArtifactIds>
                 <includes>**/*.proto</includes>
                 <outputDirectory>${unpack-proto.directory}</outputDirectory>
               </configuration>
@@ -566,6 +547,8 @@
               <configuration>
                 <protoSourceDirectory>${unpack-proto.directory}</protoSourceDirectory>
                 <includes>
+                  <!-- TODO: Remove google.protobuf.Empty once using org.apache.zipkin.proto3 -->
+                  <include>google.protobuf.Empty</include>
                   <include>zipkin.proto3.*</include>
                 </includes>
               </configuration>

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -370,6 +370,19 @@ Example usage:
 $ RABBIT_ADDRESSES=localhost java -jar zipkin.jar
 ```
 
+### gRPC Collector (Experimental)
+You can enable a gRPC span collector endpoint by setting `COLLECTOR_GRPC_ENABLED=true`. The
+`zipkin.proto3.SpanService/Report` endpoint will run on the same port as normal http (9411).
+
+
+Example usage:
+
+```bash
+COLLECTOR_GRPC_ENABLED=true java -jar zipkin.jar
+```
+
+As this service is experimental, it is not recommended to run this in production environments.
+
 ### 128-bit trace IDs
 
 Zipkin supports 64 and 128-bit trace identifiers, typically serialized

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -34,7 +34,9 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
     <start-class>zipkin.server.ZipkinServer</start-class>
+    <kotlin.version>1.3.30</kotlin.version>
     <maven-invoker-plugin.version>3.2.0</maven-invoker-plugin.version>
+    <proto.generatedSourceDirectory>${project.build.directory}/generated-test-sources/wire</proto.generatedSourceDirectory>
   </properties>
 
   <dependencyManagement>
@@ -82,6 +84,10 @@
       <groupId>com.linecorp.armeria</groupId>
       <artifactId>armeria-zipkin</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.linecorp.armeria</groupId>
+      <artifactId>armeria-grpc-protocol</artifactId>
+    </dependency>
 
     <!-- zipkin requires exporting /health endpoint -->
     <dependency>
@@ -123,6 +129,25 @@
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
       <version>1.11.3</version>
+    </dependency>
+
+    <!-- to test the experimental grpc endpoint with the square/wire library -->
+    <dependency>
+      <groupId>org.apache.zipkin.proto3</groupId>
+      <artifactId>zipkin-proto3</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.wire</groupId>
+      <artifactId>wire-grpc-client</artifactId>
+      <version>${wire.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Cassandra and Cassandra 3 backends -->
@@ -348,6 +373,90 @@
       </resource>
     </resources>
     <plugins>
+      <!-- wire-maven-plugin cannot get proto definitions from dependencies, so we will -->
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.squareup.wire</groupId>
+        <artifactId>wire-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>generate-sources</goal>
+            </goals>
+            <configuration>
+              <generatedSourceDirectory>${proto.generatedSourceDirectory}</generatedSourceDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <configuration>
+          <experimentalCoroutines>enable</experimentalCoroutines>
+        </configuration>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                <sourceDir>${proto.generatedSourceDirectory}</sourceDir>
+              </sourceDirs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Adds the output directory from proto source generation for the test compiler -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${proto.generatedSourceDirectory}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <executions>
+          <!-- Defer test compilation to the kotlin plugin -->
+          <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>java-test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -133,9 +133,22 @@
 
     <!-- to test the experimental grpc endpoint with the square/wire library -->
     <dependency>
-      <groupId>org.apache.zipkin.proto3</groupId>
+      <groupId>io.zipkin.proto3</groupId>
       <artifactId>zipkin-proto3</artifactId>
       <scope>test</scope>
+    </dependency>
+    <!-- TODO: This only resolves google empty. Remove this once using org.apache.zipkin.proto3 -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.7.1</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.squareup.wire</groupId>

--- a/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
@@ -39,6 +39,7 @@ import zipkin2.server.internal.ui.ZipkinUiConfiguration;
   TracingConfiguration.class,
   ZipkinQueryApiV2.class,
   ZipkinHttpCollector.class,
+  ZipkinGrpcCollector.class,
   ZipkinKafkaCollectorConfiguration.class,
   ZipkinRabbitMQCollectorConfiguration.class,
   MetricsHealthController.class,

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinGrpcCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinGrpcCollector.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zipkin2.server.internal;
+
+import com.linecorp.armeria.common.grpc.protocol.AbstractUnaryGrpcService;
+import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import zipkin2.Callback;
+import zipkin2.codec.SpanBytesDecoder;
+import zipkin2.collector.Collector;
+import zipkin2.collector.CollectorMetrics;
+import zipkin2.collector.CollectorSampler;
+import zipkin2.storage.StorageComponent;
+
+/** Collector for receiving spans on a gRPC endpoint. */
+@ConditionalOnProperty(name = "zipkin.collector.grpc.enabled") // disabled by default
+final class ZipkinGrpcCollector {
+  static final byte[] EMPTY = new byte[0];
+
+  @Bean ArmeriaServerConfigurator grpcCollectorConfigurator(StorageComponent storage,
+    CollectorSampler sampler, CollectorMetrics metrics) {
+    CollectorMetrics grpcMetrics = metrics.forTransport("grpc");
+    Collector collector = Collector.newBuilder(getClass())
+      .storage(storage)
+      .sampler(sampler)
+      .metrics(grpcMetrics)
+      .build();
+
+    return sb ->
+      sb.service("/zipkin.proto3.SpanService/Report", new SpanService(collector, grpcMetrics));
+  }
+
+  static final class SpanService extends AbstractUnaryGrpcService {
+
+    final Collector collector;
+    final CollectorMetrics metrics;
+
+    SpanService(Collector collector, CollectorMetrics metrics) {
+      this.collector = collector;
+      this.metrics = metrics;
+    }
+
+    @Override protected CompletableFuture<byte[]> handleMessage(byte[] bytes) {
+      metrics.incrementMessages();
+      CompletableFutureCallback result = new CompletableFutureCallback();
+      collector.acceptSpans(bytes, SpanBytesDecoder.PROTO3, result);
+      return result;
+    }
+  }
+
+  static final class CompletableFutureCallback extends CompletableFuture<byte[]>
+    implements Callback<Void> {
+
+    @Override public void onSuccess(Void value) {
+      complete(EMPTY);
+    }
+
+    @Override public void onError(Throwable t) {
+      completeExceptionally(t);
+    }
+  }
+}

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
@@ -98,7 +98,10 @@ public class ZipkinServerConfiguration implements WebMvcConfigurer {
       // could split the collector's CORS policy into a different property, still allowing POST
       // with content-type by default.
       .allowRequestMethods(HttpMethod.GET, HttpMethod.POST)
-      .allowRequestHeaders(HttpHeaderNames.CONTENT_TYPE);
+      .allowRequestHeaders(HttpHeaderNames.CONTENT_TYPE,
+        // Use literals to avoid a runtime dependency on armeria-grpc types
+        HttpHeaderNames.of("X-GRPC-WEB"))
+      .exposeHeaders("grpc-status", "grpc-message", "armeria.grpc.ThrowableProto-bin");
     return builder -> builder.decorator(corsBuilder::build);
   }
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -12,6 +12,9 @@ zipkin:
     http:
       # Set to false to disable creation of spans via HTTP collector API
       enabled: ${HTTP_COLLECTOR_ENABLED:true}
+    grpc:
+      # Set to true to enable the GRPC collector
+      enabled: ${COLLECTOR_GRPC_ENABLED:false}
     kafka:
       # Kafka bootstrap broker list, comma-separated host:port values. Setting this activates the
       # Kafka 0.10+ collector.

--- a/zipkin-server/src/test/kotlin/zipkin2/server/internal/ITZipkinGrpcCollector.kt
+++ b/zipkin-server/src/test/kotlin/zipkin2/server/internal/ITZipkinGrpcCollector.kt
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zipkin2.server.internal
+
+import com.linecorp.armeria.server.Server
+import com.squareup.wire.GrpcClient
+import com.squareup.wire.Service
+import com.squareup.wire.WireRpc
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.junit4.SpringRunner
+import zipkin.server.ZipkinServer
+import zipkin2.Span
+import zipkin2.TestObjects
+import zipkin2.codec.SpanBytesDecoder
+import zipkin2.codec.SpanBytesEncoder
+import zipkin2.proto3.ListOfSpans
+import zipkin2.proto3.ReportResponse
+import zipkin2.storage.InMemoryStorage
+
+@SpringBootTest(classes = [ZipkinServer::class],
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  properties = ["spring.config.name=zipkin-server", "zipkin.collector.grpc.enabled=true"])
+@RunWith(SpringRunner::class)
+// Written in Kotlin as Square Wire's grpc client is Kotlin.
+// Also, the first author of this test wanted an excuse to write Kotlin.
+class ITZipkinGrpcCollector {
+  @Autowired lateinit var storage: InMemoryStorage
+  @Autowired lateinit var server: Server
+
+  var request = ListOfSpans.ADAPTER.decode(SpanBytesEncoder.PROTO3.encodeList(TestObjects.TRACE))
+  lateinit var spanService: SpanService
+
+  interface SpanService : Service {
+    @WireRpc(
+      path = "/zipkin.proto3.SpanService/Report",
+      requestAdapter = "zipkin2.proto3.ListOfSpans#ADAPTER",
+      responseAdapter = "zipkin2.proto3.ReportResponse#ADAPTER"
+    )
+    suspend fun Report(request: ListOfSpans): ReportResponse
+  }
+
+  @Before fun sanityCheckCodecCompatible() {
+    assertThat(SpanBytesDecoder.PROTO3.decodeList(request.encode()))
+      .containsExactlyElementsOf(TestObjects.TRACE)
+  }
+
+  @Before fun createClient() {
+    spanService = GrpcClient.Builder()
+      .client(OkHttpClient.Builder().protocols(listOf(Protocol.H2_PRIOR_KNOWLEDGE)).build())
+      .baseUrl("http://localhost:" + server.activePort().get().localAddress().port)
+      .build().create(SpanService::class)
+  }
+
+  /** This tests that we accept messages constructed by other clients. */
+  @Test fun report_withWireGrpcLibrary() {
+    runBlocking {
+      spanService.Report(request) // Result is effectively void
+    }
+    assertThat<List<Span>>(storage.traces)
+      .containsExactly(TestObjects.TRACE)
+  }
+}

--- a/zipkin-server/src/test/kotlin/zipkin2/server/internal/ITZipkinGrpcCollector.kt
+++ b/zipkin-server/src/test/kotlin/zipkin2/server/internal/ITZipkinGrpcCollector.kt
@@ -17,6 +17,7 @@
 
 package zipkin2.server.internal
 
+import com.google.protobuf.Empty
 import com.linecorp.armeria.server.Server
 import com.squareup.wire.GrpcClient
 import com.squareup.wire.Service
@@ -37,7 +38,6 @@ import zipkin2.TestObjects
 import zipkin2.codec.SpanBytesDecoder
 import zipkin2.codec.SpanBytesEncoder
 import zipkin2.proto3.ListOfSpans
-import zipkin2.proto3.ReportResponse
 import zipkin2.storage.InMemoryStorage
 
 @SpringBootTest(classes = [ZipkinServer::class],
@@ -57,9 +57,9 @@ class ITZipkinGrpcCollector {
     @WireRpc(
       path = "/zipkin.proto3.SpanService/Report",
       requestAdapter = "zipkin2.proto3.ListOfSpans#ADAPTER",
-      responseAdapter = "zipkin2.proto3.ReportResponse#ADAPTER"
+      responseAdapter = "com.google.protobuf.Empty#ADAPTER"
     )
-    suspend fun Report(request: ListOfSpans): ReportResponse
+    suspend fun Report(request: ListOfSpans): Empty
   }
 
   @Before fun sanityCheckCodecCompatible() {


### PR DESCRIPTION
This adds an opt-in gRPC endpoint for reporting spans. A request to the 
gRPC `/zipkin.proto3.SpanService/Report` service is the same proto used
with our `POST /api/v2/spans`, `Content-Type: application/x-protobuf` 
endpoint: `zipkin.proto3.ListOfSpans`.

This is currently disabled by default, as the feature is experimental.
Enable it like so:
```bash
$ COLLECTOR_GRPC_ENABLED=true java -jar zipkin.jar
```

Under the scenes the runtime is the same as the POST endpoint (Armeria), 
and uses the same port (9411).

---
former description:

This PR is an offshoot of a discussion in openzipkin/zipkin-api#57 . There are a number of issues that need to be addressed before consideration of merge:

- [x] Finalize the API and merge it into `zipkin-api`
- [ ] Find a zero-duplication and zero-copy approach for the deserialization of spans on the server side
- [x] Add additional configuration options for configuring the server (i.e. SSL)
- [ ] Integration test with GCP
- [ ] Performance testing

Also, there is still some discussion about whether the project as a whole wants to support a gRPC endpoint in `zipkin-server` due to potential bloat. See the discussion in zipkin-api#57 for background.