### PR TITLE
Adds AutocompleteTags and corresponding REST api

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -129,6 +129,7 @@ Defaults to true
 * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 24 hours (two daily buckets: one for today and one for yesterday)
 * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`
 * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
+* `AUTOCOMPLETE_KEYS`: list of span tag keys which will be returned by the `/api/v2/autocompleteTags` endpoint
 
 ### Cassandra Storage
 Zipkin's [Cassandra storage component](../zipkin-storage/cassandra)

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
@@ -23,6 +23,7 @@ import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -52,19 +53,22 @@ public class ZipkinQueryApiV2 {
   final long defaultLookback;
   /** The Cache-Control max-age (seconds) for /api/v2/services and /api/v2/spans */
   final int namesMaxAge;
+  final List<String> autocompleteKeys;
 
   volatile int serviceCount; // used as a threshold to start returning cache-control headers
 
   ZipkinQueryApiV2(
-      StorageComponent storage,
-      @Value("${zipkin.storage.type:mem}") String storageType,
-      @Value("${zipkin.query.lookback:86400000}") long defaultLookback, // 1 day in millis
-      @Value("${zipkin.query.names-max-age:300}") int namesMaxAge // 5 minutes
-      ) {
+    StorageComponent storage,
+    @Value("${zipkin.storage.type:mem}") String storageType,
+    @Value("${zipkin.query.lookback:86400000}") long defaultLookback, // 1 day in millis
+    @Value("${zipkin.query.names-max-age:300}") int namesMaxAge, // 5 minutes
+    @Value("${zipkin.storage.autocompleteKeys:}") List<String> autocompleteKeys
+  ) {
     this.storage = storage;
     this.storageType = storageType;
     this.defaultLookback = defaultLookback;
     this.namesMaxAge = namesMaxAge;
+    this.autocompleteKeys = autocompleteKeys;
   }
 
   @RequestMapping(
@@ -89,7 +93,7 @@ public class ZipkinQueryApiV2 {
 
   @RequestMapping(value = "/spans", method = RequestMethod.GET)
   public ResponseEntity<List<String>> getSpanNames(
-      @RequestParam(value = "serviceName", required = true) String serviceName) throws IOException {
+      @RequestParam(value = "serviceName") String serviceName) throws IOException {
     return maybeCacheNames(storage.spanStore().getSpanNames(serviceName).execute());
   }
 
@@ -130,6 +134,17 @@ public class ZipkinQueryApiV2 {
     return new String(SpanBytesEncoder.JSON_V2.encodeList(trace), UTF_8);
   }
 
+  @GetMapping(value = "/autocompleteKeys", produces = APPLICATION_JSON_VALUE)
+  public ResponseEntity<List<String>> getAutocompleteKeys() {
+    return ResponseEntity.ok(autocompleteKeys);
+  }
+
+  @GetMapping(value = "/autocompleteValues", produces = APPLICATION_JSON_VALUE)
+  public ResponseEntity<List<String>> getAutocompleteValues(@RequestParam String key)
+    throws IOException {
+    return maybeCacheAutocompleteValues(storage.autocompleteTags().getValues(key).execute());
+  }
+
   @ExceptionHandler(TraceNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public void notFound() {}
@@ -151,6 +166,19 @@ public class ZipkinQueryApiV2 {
       response.cacheControl(CacheControl.maxAge(namesMaxAge, TimeUnit.SECONDS).mustRevalidate());
     }
     return response.body(names);
+  }
+
+  /**
+   * We cache tag values to minimize the number of requests made to the storage backend. The tag
+   * values doesn't change frequently and cache expires in 5 minutes
+   *
+   */
+  ResponseEntity<List<String>> maybeCacheAutocompleteValues(List<String> values) {
+    ResponseEntity.BodyBuilder response = ResponseEntity.ok();
+    if (values.size() > 3) {
+      response.cacheControl(CacheControl.maxAge(namesMaxAge, TimeUnit.SECONDS).mustRevalidate());
+    }
+    return response.body(values);
   }
 
   // This is inlined here as there isn't enough re-use to warrant it being in the zipkin2 library

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
@@ -16,6 +16,7 @@ package zipkin2.server.internal;
 import brave.Tracing;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -147,11 +148,13 @@ public class ZipkinServerConfiguration implements WebMvcConfigurer {
     StorageComponent storage(
         @Value("${zipkin.storage.strict-trace-id:true}") boolean strictTraceId,
         @Value("${zipkin.storage.search-enabled:true}") boolean searchEnabled,
-        @Value("${zipkin.storage.mem.max-spans:500000}") int maxSpans) {
+        @Value("${zipkin.storage.mem.max-spans:500000}") int maxSpans,
+        @Value("${zipkin.storage.autocomplete-keys:}") List<String> autocompleteKeys) {
       return InMemoryStorage.newBuilder()
           .strictTraceId(strictTraceId)
           .searchEnabled(searchEnabled)
           .maxSpanCount(maxSpans)
+          .autocompleteKeys(autocompleteKeys)
           .build();
     }
   }

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -46,7 +46,7 @@ zipkin:
   storage:
     strict-trace-id: ${STRICT_TRACE_ID:true}
     search-enabled: ${SEARCH_ENABLED:true}
-    autocompleteKeys: ${AUTOCOMPLETEKEYS:}
+    autocomplete-keys: ${AUTOCOMPLETE_KEYS:}
     type: ${STORAGE_TYPE:mem}
     mem:
       # Maximum number of spans to keep in memory.  When exceeded, oldest traces (and their spans) will be purged.

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -46,6 +46,7 @@ zipkin:
   storage:
     strict-trace-id: ${STRICT_TRACE_ID:true}
     search-enabled: ${SEARCH_ENABLED:true}
+    autocompleteKeys: ${AUTOCOMPLETEKEYS:}
     type: ${STORAGE_TYPE:mem}
     mem:
       # Maximum number of spans to keep in memory.  When exceeded, oldest traces (and their spans) will be purged.

--- a/zipkin/src/main/java/zipkin2/storage/AutocompleteTags.java
+++ b/zipkin/src/main/java/zipkin2/storage/AutocompleteTags.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin2.storage;
+
+import java.util.List;
+import zipkin2.Call;
+
+/**
+ * Provides autocomplete functionality by providing values for a given tag key, usually derived from
+ * {@link SpanConsumer}.
+ */
+public interface AutocompleteTags {
+
+  /**
+   * Retrieves the list of tag getKeys whose values may be returned by {@link #getValues(String)}.
+   *
+   * @see StorageComponent.Builder#autocompleteKeys(List)
+   */
+  Call<List<String>> getKeys();
+
+  /**
+   * Retrieves the list of values, if the input is configured for autocompletion. If a key is not
+   * configured, or there are no values available, an empty result will be returned.
+   *
+   * @throws IllegalArgumentException if the input is empty.
+   * @see StorageComponent.Builder#autocompleteKeys(List)
+   */
+  Call<List<String>> getValues(String key);
+}

--- a/zipkin/src/main/java/zipkin2/storage/StorageComponent.java
+++ b/zipkin/src/main/java/zipkin2/storage/StorageComponent.java
@@ -14,6 +14,7 @@
 package zipkin2.storage;
 
 import java.util.List;
+import java.util.logging.Logger;
 import zipkin2.Call;
 import zipkin2.Component;
 import zipkin2.Span;
@@ -110,7 +111,10 @@ public abstract class StorageComponent extends Component {
      *
      * @param keys controls the span values stored for auto-complete.
      */
-    public abstract Builder autocompleteKeys(List<String> keys);
+    public Builder autocompleteKeys(List<String> keys) {
+      Logger.getLogger(getClass().getName()).info("autocompleteKeys not yet supported");
+      return this;
+    }
 
     public abstract StorageComponent build();
   }

--- a/zipkin/src/test/java/zipkin2/storage/ITAutocompleteTags.java
+++ b/zipkin/src/test/java/zipkin2/storage/ITAutocompleteTags.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Span;
+import zipkin2.TestObjects;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base test for when {@link StorageComponent.Builder#autocompleteKeys(List)} has values.
+ *
+ * <p>Subtypes should create a connection to a real backend, even if that backend is in-process.
+ */
+public abstract class ITAutocompleteTags {
+  protected final StorageComponent storage;
+
+  protected ITAutocompleteTags() {
+    storage = storageBuilder().autocompleteKeys(asList("http.host")).build();
+  }
+
+  protected abstract StorageComponent.Builder storageBuilder();
+
+  /** Clears store between tests. */
+  @Before public abstract void clear() throws Exception;
+
+  @Test public void Should_not_store_when_key_not_in_autocompleteTags() throws IOException {
+    accept(TestObjects.LOTS_OF_SPANS[0].toBuilder()
+      .timestamp(Instant.now().toEpochMilli())
+      .putTag("http.method", "GET")
+      .build());
+
+    assertThat(storage.autocompleteTags().getKeys().execute()).doesNotContain("http.method");
+
+    assertThat(storage.autocompleteTags().getValues("http.method").execute()).isEmpty();
+  }
+
+  @Test public void getTagsAndValues() throws IOException {
+    for (int i = 0; i < 2; i++) {
+      accept(TestObjects.LOTS_OF_SPANS[i].toBuilder()
+        .putTag("http.method", "GET")
+        .putTag("http.host", "host1")
+        .build());
+    }
+
+    assertThat(storage.autocompleteTags().getKeys().execute())
+      .containsOnlyOnce("http.host");
+
+    assertThat(storage.autocompleteTags().getValues("http.host").execute())
+      .containsOnlyOnce("host1");
+  }
+
+  protected void accept(Span... spans) throws IOException {
+    storage.spanConsumer().accept(asList(spans)).execute();
+  }
+}

--- a/zipkin/src/test/java/zipkin2/storage/ITInMemoryStorage.java
+++ b/zipkin/src/test/java/zipkin2/storage/ITInMemoryStorage.java
@@ -13,7 +13,6 @@
  */
 package zipkin2.storage;
 
-import java.io.IOException;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
@@ -49,6 +48,17 @@ public class ITInMemoryStorage {
 
     @Override protected InMemoryStorage storage() {
       return storage;
+    }
+
+    @Override public void clear() {
+      // no need.. the test rule does this
+    }
+  }
+
+  public static class ITAutocompleteTags extends zipkin2.storage.ITAutocompleteTags {
+
+    @Override protected StorageComponent.Builder storageBuilder() {
+      return InMemoryStorage.newBuilder();
     }
 
     @Override public void clear() {


### PR DESCRIPTION
This adds an optional storage interface `AutocompleteTags` to the
`StorageComponent` and corresponding endpoints to support the UI.

`/api/v2/autocompleteKeys` and `/api/v2/autocompleteValues?key=http.host`

Cache control is always set on the keys, and it is set conditionally on values when there are more than 3. The "more than 3" allows for a freshly booting system to not confuse users (we do the same thing on `/api/v2/spans?serviceName=foo` endpoint).

The server accepts an environment variable `AUTOCOMPLETE_KEYS`
which acts as a whitelist as storing values for every tag would be
expensive.