### PR TITLE
Fix autocompleteTags bugs for Elasticsearch

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchAutocompleteTags.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchAutocompleteTags.java
@@ -57,7 +57,7 @@ final class ElasticsearchAutocompleteTags implements AutocompleteTags {
     if (indices.isEmpty()) return Call.emptyList();
 
     SearchRequest.Filters filters =
-      new SearchRequest.Filters().addTerm("tagKey", key.toLowerCase(Locale.ROOT));
+      new SearchRequest.Filters().addTerm("tagKey", key);
 
     SearchRequest request = SearchRequest.create(indices)
       .filters(filters)

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
@@ -261,7 +261,7 @@ final class VersionSpecificTemplates {
     } else if (version >= 5) {
       return autocompleteIndexTemplate
         .replace("TEMPLATE", version >= 6 ? "index_patterns" : "template")
-        .replace("KEYWORD", "\"type\": \"text\",\"fielddata\": true\n");
+        .replace("KEYWORD", "\"type\": \"keyword\",\"norms\": false\n");
     }else {
       throw new IllegalStateException(
         "Elasticsearch 2.x, 5.x and 6.x are supported, was: " + version);


### PR DESCRIPTION
If the type of tagValue is `text`, it will be splitted with some characters (hyphen, space, etc...) when aggregating.
So I use `keyword` type for tagValue.

---

## Example

If I post the following trace data,

```
[{
  ...
  "tags":{"instanceId":"hello-zipkin-world"}
  ...
}],
```

* Previous response for `api/v2/autocompleteValues?key=instanceId`

```
["hello","world","zipkin"]
```

* Current(This PR) response for `api/v2/autocompleteValues?key=instanceId`

```
["hello-zipkin-world"]
```