### PR TITLE
Add links of GitHub/Twitter/Gitter to sidebar

### DIFF
--- a/zipkin-lens/scss/components/_sidebar.scss
+++ b/zipkin-lens/scss/components/_sidebar.scss
@@ -12,8 +12,7 @@
 
 .sidebar__menu {
   & a {
-    color: #dedede;
-  color: $gray-11;
+    color: $gray-11;
     text-decoration: none;
   }
 }
@@ -56,4 +55,23 @@
   & * {
     fill: $gray-11;
   }
+}
+
+.sidebar__other-links {
+  position: absolute;
+  bottom: 24px;
+  width: 100%;
+  font-size: 24px;
+
+  & a {
+    color: $gray-11;
+    text-decoration: none;
+  }
+}
+
+.sidebar__other-link {
+  padding: 10px 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }

--- a/zipkin-lens/src/components/App/Sidebar.js
+++ b/zipkin-lens/src/components/App/Sidebar.js
@@ -58,6 +58,17 @@ class Sidebar extends React.Component {
           {this.renderPageOption('browser')}
           {this.renderPageOption('dependencies')}
         </div>
+        <div className="sidebar__other-links">
+          <a href="https://github.com/openzipkin/zipkin" target="_blank" rel="noopener noreferrer">
+            <div className="sidebar__other-link fab fa-github" />
+          </a>
+          <a href="https://twitter.com/zipkinproject" target="_blank" rel="noopener noreferrer">
+            <div className="sidebar__other-link fab fa-twitter" />
+          </a>
+          <a href="https://gitter.im/openzipkin/zipkin/" target="_blank" rel="noopener noreferrer">
+            <div className="sidebar__other-link fab fa-gitter" />
+          </a>
+        </div>
       </div>
     );
   }

--- a/zipkin-lens/src/components/App/Sidebar.js
+++ b/zipkin-lens/src/components/App/Sidebar.js
@@ -59,6 +59,9 @@ class Sidebar extends React.Component {
           {this.renderPageOption('dependencies')}
         </div>
         <div className="sidebar__other-links">
+          <a href="https://zipkin.apache.org/" target="_blank" rel="noopener noreferrer">
+            <div className="sidebar__other-link fas fa-home" />
+          </a>
           <a href="https://github.com/openzipkin/zipkin" target="_blank" rel="noopener noreferrer">
             <div className="sidebar__other-link fab fa-github" />
           </a>


### PR DESCRIPTION
This is an experimental PR.
If you don't like this, please close this PR... 🙇 

**Before**:

<img width="1507" alt="before" src="https://user-images.githubusercontent.com/19551419/52105405-f825f180-2631-11e9-8ab2-3ccacf148824.png">

**After**

<img width="1505" alt="after" src="https://user-images.githubusercontent.com/19551419/52105375-d6c50580-2631-11e9-9e95-7f6e3d9902b0.png">


