### PR TITLE
Fixes regression in cassandra autocomplete tags

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
@@ -49,7 +49,8 @@ final class CassandraSpanConsumer implements SpanConsumer {
     insertTrace = new InsertTrace.Factory(session, metadata, spanTtl);
     insertServiceName = new InsertServiceName.Factory(storage, indexTtl);
     insertSpanName = new InsertSpanName.Factory(storage, indexTtl);
-    insertAutocompleteValue = new InsertAutocompleteValue.Factory(storage, indexTtl);
+    insertAutocompleteValue = !storage.autocompleteKeys.isEmpty()
+      ? new InsertAutocompleteValue.Factory(storage, indexTtl) : null;
     indexer = new CompositeIndexer(session, indexCacheSpec, storage.bucketCount, indexTtl);
     autocompleteKeys = new LinkedHashSet<>(storage.autocompleteKeys);
   }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageRule.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -90,7 +90,7 @@ public class CassandraStorageRule extends ExternalResource {
         .keyspace(keyspace);
   }
 
-  private InetSocketAddress contactPoint() {
+  InetSocketAddress contactPoint() {
     if (container != null && container.isRunning()) {
       return new InetSocketAddress(
           container.getContainerIpAddress(), container.getMappedPort(CASSANDRA_PORT));

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -18,6 +18,7 @@ import com.datastax.driver.core.Session;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -223,6 +224,10 @@ public class ITCassandraStorage {
 
     @Override protected Session session() {
       return backend.session;
+    }
+
+    @Override InetSocketAddress contactPoint() {
+      return backend.contactPoint();
     }
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
@@ -52,7 +52,8 @@ class CassandraSpanConsumer implements SpanConsumer { // not final for testing
     if (searchEnabled) {
       insertTraceByServiceSpan = new InsertTraceByServiceSpan.Factory(session, strictTraceId);
       insertServiceSpanName = new InsertServiceSpan.Factory(storage);
-      insertAutocompleteValue = new InsertAutocompleteValue.Factory(storage);
+      insertAutocompleteValue =
+        !storage.autocompleteKeys().isEmpty() ? new InsertAutocompleteValue.Factory(storage) : null;
     } else {
       insertTraceByServiceSpan = null;
       insertServiceSpanName = null;

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageRule.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -90,7 +90,7 @@ public class CassandraStorageRule extends ExternalResource {
         .keyspace(keyspace);
   }
 
-  private InetSocketAddress contactPoint() {
+  InetSocketAddress contactPoint() {
     if (container != null && container.isRunning()) {
       return new InetSocketAddress(
           container.getContainerIpAddress(), container.getMappedPort(CASSANDRA_PORT));

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -19,6 +19,7 @@ import com.datastax.driver.core.Session;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -254,6 +255,10 @@ public class ITCassandraStorage {
 
     @Override protected Session session() {
       return backend.session;
+    }
+
+    @Override protected InetSocketAddress contactPoint() {
+      return backend.contactPoint();
     }
   }
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -15,7 +15,9 @@ package zipkin2.storage.cassandra;
 
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
+import java.net.InetSocketAddress;
 import org.junit.Test;
+import zipkin2.TestObjects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,6 +26,8 @@ abstract class ITEnsureSchema {
   abstract protected String keyspace();
 
   abstract protected Session session();
+
+  abstract InetSocketAddress contactPoint();
 
   @Test public void installsKeyspaceWhenMissing() {
     Schema.ensureExists(keyspace(), false, session());
@@ -62,5 +66,23 @@ abstract class ITEnsureSchema {
     KeyspaceMetadata metadata = session().getCluster().getMetadata().getKeyspace(keyspace());
     assertThat(metadata).isNotNull();
     assertThat(Schema.hasUpgrade1_autocompleteTags(metadata)).isTrue();
+  }
+
+  /** This tests we don't accidentally rely on new indexes such as autocomplete tags */
+  @Test public void worksWithOldSchema() throws Exception {
+    Schema.applyCqlFile(keyspace(), session(), "/zipkin2-schema.cql");
+    Schema.applyCqlFile(keyspace(), session(), "/zipkin2-schema-indexes-original.cql");
+
+    InetSocketAddress contactPoint = contactPoint();
+    try (CassandraStorage storage = CassandraStorage.newBuilder()
+      .contactPoints(contactPoint.getHostString() + ":" + contactPoint.getPort())
+      .ensureSchema(false)
+      .keyspace(keyspace()).build()) {
+
+      storage.spanConsumer().accept(TestObjects.TRACE).execute();
+
+      assertThat(storage.spanStore().getTrace(TestObjects.TRACE.get(0).traceId()).execute())
+        .containsExactlyInAnyOrderElementsOf(TestObjects.TRACE);
+    }
   }
 }


### PR DESCRIPTION
We didn't defensively check if autocomplete tags were in use. This means
people needed to upgrade their schema just to continue working. This
puts defense around autocomplete tags and avoids using the tables unless
autocomplete is actually enabled.