### PR TITLE
Use the remote service name instead of the local service name in Lens

### DIFF
--- a/zipkin-lens/src/zipkin/span-row.js
+++ b/zipkin-lens/src/zipkin/span-row.js
@@ -262,7 +262,7 @@ function getServiceName(endpoint) {
 }
 
 // Merges the data into a single span row, which is lacking presentation information
-export function newSpanRow(spansToMerge) {
+export function newSpanRow(spansToMerge, isLeafSpan) {
   const [first] = spansToMerge;
   const res = {
     spanId: first.id,
@@ -288,13 +288,19 @@ export function newSpanRow(spansToMerge) {
       if (!res.duration && next.duration) res.duration = next.duration;
     }
 
-    const nextServiceName = getServiceName(next.localEndpoint);
-    if (nextServiceName && (!res.serviceName || next.kind === 'SERVER')) {
-      res.serviceName = nextServiceName; // prefer the server's service name
+    const nextLocalServiceName = getServiceName(next.localEndpoint);
+    const nextRemoteServiceName = getServiceName(next.remoteEndpoint);
+    if (nextLocalServiceName && next.kind === 'SERVER') {
+      res.serviceName = nextLocalServiceName; // prefer the server's service name
+    } else if (isLeafSpan && nextRemoteServiceName && next.kind === 'CLIENT' && !res.serviceName) {
+      // use the client's remote service name only on leaf spans
+      res.serviceName = nextRemoteServiceName;
+    } else if (nextLocalServiceName && !res.serviceName) {
+      res.serviceName = nextLocalServiceName;
     }
 
-    maybePushServiceName(res.serviceNames, nextServiceName);
-    maybePushServiceName(res.serviceNames, getServiceName(next.remoteEndpoint));
+    maybePushServiceName(res.serviceNames, nextLocalServiceName);
+    maybePushServiceName(res.serviceNames, nextRemoteServiceName);
 
     parseAnnotationRows(next).forEach(a => maybePushAnnotation(res.annotations, a));
     parseTagRows(next).forEach(t => maybePushTag(res.tags, t));

--- a/zipkin-lens/src/zipkin/span-row.test.js
+++ b/zipkin-lens/src/zipkin/span-row.test.js
@@ -174,7 +174,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   it('should not duplicate service names', () => {
@@ -183,7 +183,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       id: '3',
       localEndpoint: frontend,
       remoteEndpoint: frontend,
-    })]);
+    })], false);
 
     expect(converted.serviceNames).toEqual(['frontend']);
   });
@@ -226,7 +226,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.client_kindInferredFromAnnotation
@@ -268,7 +268,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.lateRemoteEndpoint_cr
@@ -302,7 +302,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.lateRemoteEndpoint_sa
@@ -323,7 +323,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.noAnnotationsExceptAddresses
@@ -355,7 +355,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.server
@@ -405,7 +405,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.missingEndpoints
@@ -431,7 +431,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    const expected = newSpanRow([v2]);
+    const expected = newSpanRow([v2], false);
     expect(spanRow).toEqual(expected);
   });
 
@@ -463,7 +463,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    const expected = newSpanRow([v2]);
+    const expected = newSpanRow([v2], false);
     expect(spanRow).toEqual(expected);
   });
 
@@ -507,7 +507,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    const expected = newSpanRow([v2]);
+    const expected = newSpanRow([v2], false);
     expect(spanRow).toEqual(expected);
   });
 
@@ -543,7 +543,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    const expected = newSpanRow([v2]);
+    const expected = newSpanRow([v2], false);
     expect(spanRow).toEqual(expected);
   });
 
@@ -576,7 +576,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.lateRemoteEndpoint_ca
@@ -596,7 +596,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.localSpan_emptyComponent
@@ -622,7 +622,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.producer_remote
@@ -656,7 +656,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.producer_duration
@@ -698,7 +698,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.consumer
@@ -732,7 +732,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.consumer_remote
@@ -767,7 +767,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   // originally zipkin2.v1.SpanConverterTest.consumer_duration
@@ -809,7 +809,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       errorType: 'none',
     };
 
-    expect(newSpanRow([v2])).toEqual(spanRow);
+    expect(newSpanRow([v2], false)).toEqual(spanRow);
   });
 
   it('should prefer ipv6', () => {
@@ -826,7 +826,7 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       localEndpoint,
     });
 
-    const spanRow = newSpanRow([v2]);
+    const spanRow = newSpanRow([v2], false);
     expect(spanRow.tags.map(s => s.value)).toEqual(['[2001:db8::c001]:80 (there)']);
   });
 
@@ -841,8 +841,85 @@ describe('SPAN v2 -> spanRow Conversion', () => {
       },
     });
 
-    const spanRow = newSpanRow([v2]);
+    const spanRow = newSpanRow([v2], false);
     expect(spanRow.annotations.map(s => s.endpoint)).toEqual(['[2001:db8::c001]']);
+  });
+
+  it('converts client leaf spans using its remote service name', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'get',
+      kind: 'CLIENT',
+      timestamp: 1472470996199000,
+      duration: 207000,
+      localEndpoint: frontend,
+      remoteEndpoint: backend,
+      annotations: [
+        { value: 'ws', timestamp: 1472470996238000 },
+        { value: 'wr', timestamp: 1472470996403000 },
+      ],
+      tags: {
+        'http.path': '/api',
+        'clnt/finagle.version': '6.45.0',
+      },
+    };
+
+    const spanRow = {
+      parentId: '2',
+      spanId: '3',
+      spanName: 'get',
+      timestamp: 1472470996199000,
+      duration: 207000,
+      annotations: [
+        {
+          isDerived: true,
+          value: 'Client Start',
+          timestamp: 1472470996199000,
+          endpoint: '127.0.0.1:8080 (frontend)',
+        },
+        {
+          isDerived: false,
+          value: 'Wire Send',
+          timestamp: 1472470996238000,
+          endpoint: '127.0.0.1:8080 (frontend)',
+        },
+        {
+          isDerived: false,
+          value: 'Wire Receive',
+          timestamp: 1472470996403000,
+          endpoint: '127.0.0.1:8080 (frontend)',
+        },
+        {
+          isDerived: true,
+          value: 'Client Finish',
+          timestamp: 1472470996406000,
+          endpoint: '127.0.0.1:8080 (frontend)',
+        },
+      ],
+      tags: [
+        {
+          key: 'http.path',
+          value: '/api',
+          endpoint: '127.0.0.1:8080 (frontend)',
+        },
+        {
+          key: 'clnt/finagle.version',
+          value: '6.45.0',
+          endpoint: '127.0.0.1:8080 (frontend)',
+        },
+        {
+          key: 'Server Address',
+          value: '192.168.99.101:9000 (backend)',
+        },
+      ],
+      serviceName: 'backend', // prefer client remote address on leaf client-only spans
+      serviceNames: ['backend', 'frontend'],
+      errorType: 'none',
+    };
+
+    expect(newSpanRow([v2], true)).toEqual(spanRow);
   });
 });
 
@@ -907,13 +984,13 @@ describe('newSpanRow', () => {
   };
 
   it('should merge server and client span', () => {
-    const spanRow = newSpanRow([serverSpan, clientSpan]);
+    const spanRow = newSpanRow([serverSpan, clientSpan], false);
 
     expect(spanRow).toEqual(expectedSpanRow);
   });
 
   it('should merge client and server span', () => {
-    const spanRow = newSpanRow([clientSpan, serverSpan]);
+    const spanRow = newSpanRow([clientSpan, serverSpan], false);
 
     expect(spanRow).toEqual(expectedSpanRow);
   });
@@ -924,7 +1001,7 @@ describe('newSpanRow', () => {
       traceId: '1',
       id: '3',
       remoteEndpoint: backend,
-    })]);
+    })], false);
 
     expect(spanRow.tags).toEqual(
       [{ key: 'Server Address', value: '192.168.99.101:9000 (backend)' }],
@@ -941,7 +1018,7 @@ describe('newSpanRow', () => {
       kind: 'SERVER',
       localEndpoint: backend,
       shared: true,
-    })]);
+    })], false);
 
     expect(spanRow.spanName).toBe('get /users/:userId');
   });
@@ -976,8 +1053,8 @@ describe('newSpanRow', () => {
       shared: true,
     });
 
-    const leftFirst = newSpanRow([leftSpan, rightSpan]);
-    const rightFirst = newSpanRow([rightSpan, leftSpan]);
+    const leftFirst = newSpanRow([leftSpan, rightSpan], false);
+    const rightFirst = newSpanRow([rightSpan, leftSpan], false);
 
     [leftFirst, rightFirst].forEach((completeSpan) => {
       expect(completeSpan.timestamp).toEqual(leftTimestamp);
@@ -996,7 +1073,7 @@ describe('newSpanRow', () => {
       kind: 'SERVER',
       localEndpoint: backend,
       shared: true,
-    })]);
+    })], false);
 
     expect(spanRow.spanName).toBe(clientSpan.name);
   });

--- a/zipkin-lens/src/zipkin/trace.js
+++ b/zipkin-lens/src/zipkin/trace.js
@@ -266,6 +266,7 @@ export function detailedTraceSummary(root, logsUrl) {
     // This is more than a normal tree traversal, as we are merging any server spans that share the
     // same ID. When that's the case, we pull up any of their children as if they are our own.
     const spansToMerge = [current.span];
+    const isLeafSpan = current.children.length === 0;
     const childIds = [];
     const toPrefix = [];
     current.children.forEach((child) => {
@@ -292,7 +293,7 @@ export function detailedTraceSummary(root, logsUrl) {
     // If we are the deepest span, mark the trace accordingly
     if (depth > modelview.depth) modelview.depth = depth;
 
-    const spanRow = newSpanRow(spansToMerge);
+    const spanRow = newSpanRow(spansToMerge, isLeafSpan);
     addLayoutDetails(spanRow, timestamp, duration, depth, childIds);
     // NOTE: This will increment both the local and remote service name
     //


### PR DESCRIPTION
Synchronized zipkin-lens with zipkin-ui.

Related: #2345 