### PR TITLE
Show both client and server timings

### DIFF
--- a/zipkin-lens/scss/components/_timeline.scss
+++ b/zipkin-lens/scss/components/_timeline.scss
@@ -149,24 +149,36 @@
   position: relative;
 }
 
+.timeline__double-span-bar {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  display: flex;
+  align-items: center;
+}
+
 .timeline__span-bar {
   position: absolute;
   border-radius: 4px;
-  opacity: 0.8;
-  height: 80%;
+  height: 70%;
+
+  &--client {
+    background-color: $gray-9;
+  }
+
+  &--server {}
 }
 
 .timeline__span-duration {
   color: $dark-4;
   font-size: 12px;
+  position: absolute;
 
-  &.left {
-    float: left;
+  &--left {
     padding-left: 8px;
   }
 
-  &.right {
-    float: right;
+  &--right {
     padding-right: 8px;
   }
 }

--- a/zipkin-lens/src/components/Timeline/Span.js
+++ b/zipkin-lens/src/components/Timeline/Span.js
@@ -295,10 +295,8 @@ class Span extends React.Component {
               width: `${(1 - (serviceNameColumnWidth + spanNameColumnWidth)) * 100}%`,
             }}
           >
-            <div>
-              {this.renderTimeMarkers()}
-              {this.renderSpanBar()}
-            </div>
+            {this.renderTimeMarkers()}
+            {this.renderSpanBar()}
           </div>
         </div>
         {

--- a/zipkin-lens/src/components/Timeline/Span.js
+++ b/zipkin-lens/src/components/Timeline/Span.js
@@ -8,6 +8,7 @@ const propTypes = {
   startTs: PropTypes.number.isRequired,
   endTs: PropTypes.number.isRequired,
   traceDuration: PropTypes.number.isRequired,
+  traceTimestamp: PropTypes.number.isRequired,
   numTimeMarkers: PropTypes.number.isRequired,
   serviceNameColumnWidth: PropTypes.number.isRequired,
   spanNameColumnWidth: PropTypes.number.isRequired,
@@ -25,6 +26,68 @@ class Span extends React.Component {
 
     this.handleChildrenToggle = this.handleChildrenToggle.bind(this);
     this.handleInfoToggle = this.handleInfoToggle.bind(this);
+  }
+
+  calculateLeftAndWidth(baseLeft, baseWidth) {
+    const {
+      startTs,
+      endTs,
+      traceDuration,
+    } = this.props;
+
+    const spanStartTs = baseLeft * traceDuration / 100;
+    const spanEndTs = spanStartTs + (baseWidth * traceDuration / 100);
+    const newDuration = endTs - startTs;
+
+    let left;
+    let width;
+
+    if (spanStartTs < startTs && spanEndTs < startTs) {
+      //  SPAN   |------------------------------|
+      //  DRAG                                    |-------|
+      left = 0;
+      width = 0;
+    } else if (spanStartTs >= endTs) {
+      // SPAN              |------------------------------|
+      // DRAG |----------|
+      left = 100;
+      width = 0;
+    } else if (spanStartTs < startTs && spanEndTs > startTs && spanEndTs < endTs) {
+      // SPAN |--------------------------------------|
+      // DRAG                                   |---------|
+      left = 0;
+      width = (spanEndTs - startTs) / newDuration * 100;
+    } else if (spanStartTs < startTs && spanEndTs > startTs && spanEndTs > endTs) {
+      // SPAN |-------------------------------------------|
+      // DRAG                 |------|
+      left = 0;
+      width = 100;
+    } else if (spanStartTs >= startTs && spanStartTs < endTs && spanEndTs <= endTs) {
+      // SPAN         |---------------------------|
+      // DRAG |-------------------------------------------|
+      left = (spanStartTs - startTs) / newDuration * 100;
+      width = (spanEndTs - spanStartTs) / newDuration * 100;
+    } else if (spanStartTs >= startTs && spanStartTs < endTs && spanEndTs > endTs) {
+      // SPAN       |-------------------------------------|
+      // DRAG |------------------------------------|
+      left = (spanStartTs - startTs) / newDuration * 100;
+      width = (endTs - spanStartTs) / newDuration * 100;
+    } else {
+      left = 0;
+      width = 0;
+    }
+
+    return { left, width };
+  }
+
+  calculateBaseWidth(finishTs, startTs) {
+    const { traceDuration } = this.props;
+    return (finishTs - startTs) / traceDuration * 100;
+  }
+
+  calculateBaseLeft(startTs) {
+    const { traceDuration, traceTimestamp } = this.props;
+    return (startTs - traceTimestamp) / traceDuration * 100;
   }
 
   handleChildrenToggle(e) {
@@ -80,14 +143,8 @@ class Span extends React.Component {
     );
   }
 
-  renderTimeMarkersAndBar() {
-    const {
-      startTs,
-      endTs,
-      span,
-      numTimeMarkers,
-      traceDuration,
-    } = this.props;
+  renderTimeMarkers() {
+    const { numTimeMarkers } = this.props;
 
     const timeMarkers = [];
     for (let i = 1; i < numTimeMarkers - 1; i += 1) {
@@ -101,67 +158,105 @@ class Span extends React.Component {
       );
     }
 
-    const spanStartTs = span.left * traceDuration / 100;
-    const spanEndTs = spanStartTs + (span.width * traceDuration / 100);
-    const newDuration = endTs - startTs;
-    let left;
-    let width;
+    return timeMarkers;
+  }
 
-    if (spanStartTs < startTs && spanEndTs < startTs) {
-      //  SPAN   |------------------------------|
-      //  DRAG                                    |-------|
-      left = 0;
-      width = 0;
-    } else if (spanStartTs >= endTs) {
-      // SPAN              |------------------------------|
-      // DRAG |----------|
-      left = 100;
-      width = 0;
-    } else if (spanStartTs < startTs && spanEndTs > startTs && spanEndTs < endTs) {
-      // SPAN |--------------------------------------|
-      // DRAG                                   |---------|
-      left = 0;
-      width = (spanEndTs - startTs) / newDuration * 100;
-    } else if (spanStartTs < startTs && spanEndTs > startTs && spanEndTs > endTs) {
-      // SPAN |-------------------------------------------|
-      // DRAG                 |------|
-      left = 0;
-      width = 100;
-    } else if (spanStartTs >= startTs && spanStartTs < endTs && spanEndTs <= endTs) {
-      // SPAN         |---------------------------|
-      // DRAG |-------------------------------------------|
-      left = (spanStartTs - startTs) / newDuration * 100;
-      width = (spanEndTs - spanStartTs) / newDuration * 100;
-    } else if (spanStartTs >= startTs && spanStartTs < endTs && spanEndTs > endTs) {
-      // SPAN       |-------------------------------------|
-      // DRAG |------------------------------------|
-      left = (spanStartTs - startTs) / newDuration * 100;
-      width = (endTs - spanStartTs) / newDuration * 100;
-    } else {
-      left = 0;
-      width = 0;
+  renderSpanDuration(left, width) {
+    const { span } = this.props;
+
+    if (parseInt(left, 10) > 50) {
+      return (
+        <span
+          className="timeline__span-duration timeline__span-duration--right"
+          style={{ right: `${100 - (left + width)}%` }}
+        >
+          {span.durationStr}
+        </span>
+      );
     }
 
     return (
-      <div>
-        {timeMarkers}
+      <span
+        className="timeline__span-duration timeline__span-duration--left"
+        style={{ left: `${left}%` }}
+      >
+        {span.durationStr}
+      </span>
+    );
+  }
+
+  renderSpanBar() {
+    const { span } = this.props;
+
+    const { annotations } = span;
+    const clientStart = annotations.find(annotation => annotation.value === 'Client Start');
+    const serverStart = annotations.find(annotation => annotation.value === 'Server Start');
+    const clientFinish = annotations.find(annotation => annotation.value === 'Client Finish');
+    const serverFinish = annotations.find(annotation => annotation.value === 'Server Finish');
+
+    if (clientStart && serverStart && clientFinish && serverFinish) {
+      const clientBaseWidth = this.calculateBaseWidth(
+        clientFinish.timestamp, clientStart.timestamp,
+      );
+      const serverBaseWidth = this.calculateBaseWidth(
+        serverFinish.timestamp, serverStart.timestamp,
+      );
+      const clientBaseLeft = this.calculateBaseLeft(clientStart.timestamp);
+      const serverBaseLeft = this.calculateBaseLeft(serverStart.timestamp);
+
+      const {
+        left: clientLeft,
+        width: clientWidth,
+      } = this.calculateLeftAndWidth(clientBaseLeft, clientBaseWidth);
+
+      const {
+        left: serverLeft,
+        width: serverWidth,
+      } = this.calculateLeftAndWidth(serverBaseLeft, serverBaseWidth);
+
+      return (
         <div className="timeline__span-bar-wrapper">
           <span
-            className="timeline__span-bar"
+            className="timeline__span-bar timeline__span-bar--client"
             style={{
-              left: `${left}%`,
-              width: `${width}%`,
+              left: `${clientLeft}%`,
+              width: `${clientWidth}%`,
+            }}
+          />
+          <span
+            className="timeline__span-bar timeline__span-bar--server"
+            style={{
+              left: `${serverLeft}%`,
+              width: `${serverWidth}%`,
               background: `${getErrorTypeColor(span.errorType)}`,
             }}
-          >
-            <span
-              className={`timeline__span-duration ${parseInt(left, 10) > 50
-                ? 'right' : 'left'}`}
-            >
-              {span.durationStr}
-            </span>
-          </span>
+          />
+          {this.renderSpanDuration(clientLeft, clientWidth)}
         </div>
+      );
+    }
+
+    const { left, width } = this.calculateLeftAndWidth(span.left, span.width);
+    return (
+      <div className="timeline__span-bar-wrapper">
+        <span
+          className="timeline__span-bar"
+          style={{
+            left: `${left}%`,
+            width: `${width}%`,
+            background: `${getErrorTypeColor(span.errorType)}`,
+          }}
+        />
+        {this.renderSpanDuration(left, width)}
+      </div>
+    );
+  }
+
+  renderTimeMarkersAndBar() {
+    return (
+      <div>
+        {this.renderTimeMarkers()}
+        {this.renderSpanBar()}
       </div>
     );
   }
@@ -200,7 +295,10 @@ class Span extends React.Component {
               width: `${(1 - (serviceNameColumnWidth + spanNameColumnWidth)) * 100}%`,
             }}
           >
-            { this.renderTimeMarkersAndBar() }
+            <div>
+              {this.renderTimeMarkers()}
+              {this.renderSpanBar()}
+            </div>
           </div>
         </div>
         {

--- a/zipkin-lens/src/components/Timeline/index.js
+++ b/zipkin-lens/src/components/Timeline/index.js
@@ -135,6 +135,7 @@ class Timeline extends React.Component {
                   startTs={startTs}
                   endTs={endTs}
                   traceDuration={traceSummary.duration}
+                  traceTimestamp={traceSummary.spans[0].timestamp}
                   numTimeMarkers={DEFAULT_NUM_TICKS}
                   serviceNameColumnWidth={serviceNameColumnWidth}
                   spanNameColumnWidth={spanNameColumnWidth}


### PR DESCRIPTION
Related #2365 

### How to implement

If the span's annotation contains `Client Start` and `Client Finish` and `Server Start` and `Server Finish`, use them for rendering the span bar instead of `span.left` and `span.width`. 

---

### Example1

**Before**
<img width="600" alt="before1" src="https://user-images.githubusercontent.com/19551419/52611218-bd407b00-2ec7-11e9-82a2-57dfc4f6f450.png">
**After**
<img width="600" alt="after1" src="https://user-images.githubusercontent.com/19551419/52611103-3b505200-2ec7-11e9-915b-a0c7d77dca3d.png">

### Example2

**Before**
<img width="600" alt="before2" src="https://user-images.githubusercontent.com/19551419/52611197-a39f3380-2ec7-11e9-9395-61cbec67cb70.png">
**After**
<img width="600" alt="after2" src="https://user-images.githubusercontent.com/19551419/52611145-689d0000-2ec7-11e9-96dd-4b12917acaf2.png">

cc @drolando 






