### PR TITLE
Fix a bug of custom lookback in Safari

### DIFF
--- a/zipkin-lens/scss/custom/_rc-time-picker.scss
+++ b/zipkin-lens/scss/custom/_rc-time-picker.scss
@@ -10,4 +10,5 @@
   padding-left: 4px;
   color: $white;
   background-color: $dark-4;
+  line-height: normal;
 }


### PR DESCRIPTION
I tried using lens in safari.
Then I found an UI bug.

**Before**

<img width="341" alt="before-custom" src="https://user-images.githubusercontent.com/19551419/52617931-bf630380-2ee0-11e9-8f51-d76e53c56c70.png">

**After**

<img width="343" alt="after-custom" src="https://user-images.githubusercontent.com/19551419/52617941-c4c04e00-2ee0-11e9-8c01-4a7234cb9c50.png">
