### PR TITLE
Fixes UI ordering of subtrees

### DIFF
--- a/zipkin-lens/src/zipkin/span-node.test.js
+++ b/zipkin-lens/src/zipkin/span-node.test.js
@@ -213,4 +213,39 @@ describe('SpanNodeBuilder', () => {
     expect(root.children.map(n => n.span))
       .toEqual([trace[3], trace[2], trace[1]]); // null first
   });
+
+  it('should order children by timestamp when IPs change ', () => {
+    const trace = [
+      {
+        traceId: '1',
+        parentId: 'a',
+        id: 'c',
+        kind: 'SERVER',
+        shared: true,
+        timestamp: 1,
+        localEndpoint: { serviceName: 'my-service', ipv4: '10.2.3.4' },
+      },
+      {
+        traceId: '1',
+        parentId: 'c',
+        id: 'b',
+        kind: 'CLIENT',
+        timestamp: 2,
+        localEndpoint: { serviceName: 'my-service', ipv4: '169.2.3.4' },
+      },
+      {
+        traceId: '1',
+        parentId: 'c',
+        id: 'a',
+        timestamp: 3,
+        localEndpoint: { serviceName: 'my-service', ipv4: '10.2.3.4' },
+      },
+    ].map(clean);
+
+    const root = new SpanNodeBuilder({}).build(trace);
+
+    const spans = [];
+    root.traverse(span => spans.push(span));
+    expect(spans).toEqual(trace);
+  });
 });

--- a/zipkin-lens/src/zipkin/trace.test.js
+++ b/zipkin-lens/src/zipkin/trace.test.js
@@ -524,4 +524,110 @@ describe('detailedTraceSummary', () => {
       '000000000000000d',
     ]);
   });
+
+  it('should order rows by topologically, then timestamp when endpoints are inconsistent', () => {
+    const traceWithEndpointProblems = [
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '5',
+        name: 'get /header',
+        timestamp: 359175,
+        duration: 108123,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '10.1.1.123',
+          port: 31107,
+        },
+      },
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '4',
+        name: 'get /footer',
+        timestamp: 341172,
+        duration: 16640,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '10.1.1.123',
+          port: 31107,
+        },
+      },
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '3',
+        kind: 'CLIENT',
+        name: 'get',
+        timestamp: 30000,
+        duration: 123000,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '169.254.0.3',
+          port: 43193,
+        },
+      },
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '2',
+        kind: 'SERVER',
+        name: 'get /token',
+        timestamp: 12137,
+        duration: 12785,
+        localEndpoint: {
+          serviceName: 'phantom',
+          ipv4: '10.1.1.123',
+          port: 32767,
+        },
+        shared: true,
+      },
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '2',
+        kind: 'CLIENT',
+        name: 'get',
+        timestamp: 11000,
+        duration: 13000,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '169.254.0.2',
+          port: 49647,
+        },
+      },
+      {
+        traceId: 'a',
+        id: '1',
+        kind: 'SERVER',
+        name: 'get /sad',
+        timestamp: 4857,
+        duration: 525280,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '10.1.1.123',
+          port: 31107,
+        },
+        shared: true,
+      },
+      {
+        traceId: 'a',
+        id: '1',
+        kind: 'CLIENT',
+        name: 'get',
+        timestamp: 1,
+        duration: 537000,
+        localEndpoint: {
+          serviceName: 'whelp-main',
+          ipv4: '169.254.0.1',
+          port: 43237,
+        },
+      },
+    ];
+
+    const { spans } = detailedTraceSummary(treeCorrectedForClockSkew(traceWithEndpointProblems));
+    expect(spans.map(s => s.timestamp)).toEqual([
+      1, 11000, 30000, 341172, 359175, // increasing order
+    ]);
+  });
 });

--- a/zipkin-ui/test/component_ui/traceToMustache.test.js
+++ b/zipkin-ui/test/component_ui/traceToMustache.test.js
@@ -200,5 +200,111 @@ describe('traceToMustache', () => {
       '000000000000000d'
     ]);
   });
+
+  it('should order rows by topologically, then timestamp when endpoints are inconsistent', () => {
+    const traceWithEndpointProblems = [
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '5',
+        name: 'get /header',
+        timestamp: 359175,
+        duration: 108123,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '10.1.1.123',
+          port: 31107
+        }
+      },
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '4',
+        name: 'get /footer',
+        timestamp: 341172,
+        duration: 16640,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '10.1.1.123',
+          port: 31107
+        }
+      },
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '3',
+        kind: 'CLIENT',
+        name: 'get',
+        timestamp: 30000,
+        duration: 123000,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '169.254.0.3',
+          port: 43193
+        }
+      },
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '2',
+        kind: 'SERVER',
+        name: 'get /token',
+        timestamp: 12137,
+        duration: 12785,
+        localEndpoint: {
+          serviceName: 'phantom',
+          ipv4: '10.1.1.123',
+          port: 32767
+        },
+        shared: true
+      },
+      {
+        traceId: 'a',
+        parentId: '1',
+        id: '2',
+        kind: 'CLIENT',
+        name: 'get',
+        timestamp: 11000,
+        duration: 13000,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '169.254.0.2',
+          port: 49647
+        }
+      },
+      {
+        traceId: 'a',
+        id: '1',
+        kind: 'SERVER',
+        name: 'get /sad',
+        timestamp: 4857,
+        duration: 525280,
+        localEndpoint: {
+          serviceName: 'sad_pages',
+          ipv4: '10.1.1.123',
+          port: 31107
+        },
+        shared: true
+      },
+      {
+        traceId: 'a',
+        id: '1',
+        kind: 'CLIENT',
+        name: 'get',
+        timestamp: 1,
+        duration: 537000,
+        localEndpoint: {
+          serviceName: 'whelp-main',
+          ipv4: '169.254.0.1',
+          port: 43237
+        }
+      }
+    ];
+
+    const {spans} = traceToMustache(treeCorrectedForClockSkew(traceWithEndpointProblems));
+    spans.map(s => s.timestamp).should.deep.equal([
+      1, 11000, 30000, 341172, 359175 // increasing order
+    ]);
+  });
 });
 


### PR DESCRIPTION
Before, order was inconsistent for subtrees with regards to timestamps.
Particularly, when a shared span was present, and endpoint details were
mixed between local spans, order could end up backwards. This fixes it.

Below is a real trace from Yelp, zoomed out to the point where you can
see the problem, but not the actual details.

Before
![screen shot 2019-02-16 at 6 21 09 pm](https://user-images.githubusercontent.com/64215/52898356-b5f6d580-3217-11e9-9f9b-c034525541a6.png)
![screen shot 2019-02-16 at 6 20 56 pm](https://user-images.githubusercontent.com/64215/52898358-b98a5c80-3217-11e9-8b13-ec2c6283b610.png)

After
![screen shot 2019-02-16 at 6 20 11 pm](https://user-images.githubusercontent.com/64215/52898361-bf803d80-3217-11e9-8126-ba751aa1ef3a.png)
![screen shot 2019-02-16 at 6 20 38 pm](https://user-images.githubusercontent.com/64215/52898359-bc854d00-3217-11e9-9927-966ddaad0437.png)

See #2385