### PR TITLE
Shows different tag values when client and server differ

### DIFF
--- a/zipkin-lens/src/zipkin/span-row.js
+++ b/zipkin-lens/src/zipkin/span-row.js
@@ -196,7 +196,7 @@ function parseTagRows(span) {
         key: ConstantNames[key] || key,
         value: span.tags[key],
       };
-      if (localFormatted) tagRow.endpoint = localFormatted;
+      if (localFormatted) tagRow.endpoints = [localFormatted];
       tagRows.push(tagRow);
     });
   }
@@ -235,18 +235,32 @@ function parseTagRows(span) {
   return tagRows;
 }
 
-// This guards to ensure we don't add duplicate annotations on merge
+// This ensures we don't add duplicate annotations on merge
 function maybePushAnnotation(annotations, a) {
-  if (annotations.findIndex(b => a.value === b.value) === -1) {
+  if (annotations.findIndex(b => a.timestamp === b.timestamp && a.value === b.value) === -1) {
     annotations.push(a);
   }
 }
 
-// This guards to ensure we don't add duplicate binary annotations on merge
+// This ensures we only add rows for tags that are unique on key and value on merge
 function maybePushTag(tags, a) {
-  if (tags.findIndex(b => a.key === b.key) === -1) {
+  const sameKeyAndValue = tags.filter(b => a.key === b.key && a.value === b.value);
+  if (sameKeyAndValue.length === 0) {
     tags.push(a);
+    return;
   }
+  if ((a.endpoints || []).length === 0) {
+    return; // no endpoints to merge
+  }
+  // Handle when tags are reported by different endpoints
+  sameKeyAndValue.forEach((t) => {
+    if (!t.endpoints) t.endpoints = []; // eslint-disable-line no-param-reassign
+    a.endpoints.forEach((endpoint) => {
+      if (t.endpoints.indexOf(endpoint) === -1) {
+        t.endpoints.push(endpoint);
+      }
+    });
+  });
 }
 
 // This guards to ensure we don't add duplicate service names on merge

--- a/zipkin-lens/src/zipkin/span-row.test.js
+++ b/zipkin-lens/src/zipkin/span-row.test.js
@@ -157,12 +157,12 @@ describe('SPAN v2 -> spanRow Conversion', () => {
         {
           key: 'http.path',
           value: '/api',
-          endpoint: '127.0.0.1:8080 (frontend)',
+          endpoints: ['127.0.0.1:8080 (frontend)'],
         },
         {
           key: 'clnt/finagle.version',
           value: '6.45.0',
-          endpoint: '127.0.0.1:8080 (frontend)',
+          endpoints: ['127.0.0.1:8080 (frontend)'],
         },
         {
           key: 'Server Address',
@@ -396,8 +396,8 @@ describe('SPAN v2 -> spanRow Conversion', () => {
         },
       ],
       tags: [
-        { key: 'http.path', value: '/api', endpoint: '192.168.99.101:9000 (backend)' },
-        { key: 'finagle.version', value: '6.45.0', endpoint: '192.168.99.101:9000 (backend)' },
+        { key: 'http.path', value: '/api', endpoints: ['192.168.99.101:9000 (backend)'] },
+        { key: 'finagle.version', value: '6.45.0', endpoints: ['192.168.99.101:9000 (backend)'] },
         { key: 'Client Address', value: '127.0.0.1:8080 (frontend)' },
       ],
       serviceName: 'backend',
@@ -902,12 +902,12 @@ describe('SPAN v2 -> spanRow Conversion', () => {
         {
           key: 'http.path',
           value: '/api',
-          endpoint: '127.0.0.1:8080 (frontend)',
+          endpoints: ['127.0.0.1:8080 (frontend)'],
         },
         {
           key: 'clnt/finagle.version',
           value: '6.45.0',
-          endpoint: '127.0.0.1:8080 (frontend)',
+          endpoints: ['127.0.0.1:8080 (frontend)'],
         },
         {
           key: 'Server Address',
@@ -1076,6 +1076,90 @@ describe('newSpanRow', () => {
     })], false);
 
     expect(spanRow.spanName).toBe(clientSpan.name);
+  });
+
+  it('should dedupe annotations with same timestamp and value', () => {
+    const spanRow = newSpanRow([
+      clean({
+        traceId: '1',
+        parentId: '2',
+        id: '3',
+        kind: 'CLIENT',
+        localEndpoint: frontend,
+        annotations: [{ timestamp: 1, value: 'hit' }],
+      }),
+      clean({
+        traceId: '1',
+        parentId: '2',
+        id: '3',
+        kind: 'CLIENT',
+        localEndpoint: frontend,
+        annotations: [{ timestamp: 1, value: 'hit' }],
+      }),
+    ], false);
+
+    expect(spanRow.annotations).toEqual([
+      {
+        timestamp: 1, value: 'hit', endpoint: '127.0.0.1:8080 (frontend)', isDerived: false,
+      },
+    ]);
+  });
+
+  it('should merge endpoints on shared tag', () => {
+    const spanRow = newSpanRow([
+      clean({
+        traceId: '1',
+        parentId: '2',
+        id: '3',
+        kind: 'CLIENT',
+        localEndpoint: frontend,
+        tags: { 'http.path': '/foo' },
+      }),
+      clean({
+        traceId: '1',
+        parentId: '2',
+        id: '3',
+        shared: true,
+        kind: 'SERVER',
+        localEndpoint: backend,
+        tags: { 'http.path': '/foo' },
+      }),
+    ], false);
+
+    expect(spanRow.tags).toEqual([
+      {
+        key: 'http.path',
+        value: '/foo',
+        endpoints: ['127.0.0.1:8080 (frontend)', '192.168.99.101:9000 (backend)'],
+      },
+    ]);
+  });
+
+  it('should show difference in tag values per endpoint', () => {
+    const spanRow = newSpanRow([
+      clean({
+        traceId: '1',
+        parentId: '2',
+        id: '3',
+        kind: 'CLIENT',
+        localEndpoint: frontend,
+        tags: { 'http.path': '/foo' },
+      }),
+      clean({
+        traceId: '1',
+        parentId: '2',
+        id: '3',
+        shared: true,
+        kind: 'SERVER',
+        localEndpoint: backend,
+        tags: { 'http.path': '/foo/redirected' },
+      }),
+    ], false);
+
+    expect(spanRow.tags).toEqual([
+      { key: 'http.path', value: '/foo', endpoints: ['127.0.0.1:8080 (frontend)'] },
+      { key: 'http.path', value: '/foo/redirected', endpoints: ['192.168.99.101:9000 (backend)'] },
+    ]);
   });
 });
 

--- a/zipkin-ui/templates/trace.mustache
+++ b/zipkin-ui/templates/trace.mustache
@@ -95,10 +95,9 @@
 
     {{#tags}}
     <div class='tag'
-      data-keys='key,value,type'
+      data-keys='key,value'
       data-key='{{key}}'
       data-value='{{value}}'
-      data-type='{{annotationType}}'
     ></div>
     {{/tags}}
   </div>
@@ -225,10 +224,9 @@
 
     {{#tags}}
     <div class='tag'
-      data-keys='key,value,type'
+      data-keys='key,value'
       data-key='{{key}}'
       data-value='{{value}}'
-      data-type='{{annotationType}}'
     ></div>
     {{/tags}}
   </div>

--- a/zipkin-ui/templates/traceViewer.mustache
+++ b/zipkin-ui/templates/traceViewer.mustache
@@ -99,10 +99,9 @@
 
     {{#tags}}
     <div class='tag'
-      data-keys='key,value,type'
+      data-keys='key,value'
       data-key='{{key}}'
       data-value='{{value}}'
-      data-type='{{annotationType}}'
     ></div>
     {{/tags}}
   </div>
@@ -229,10 +228,9 @@
 
     {{#tags}}
     <div class='tag'
-      data-keys='key,value,type'
+      data-keys='key,value'
       data-key='{{key}}'
       data-value='{{value}}'
-      data-type='{{annotationType}}'
     ></div>
     {{/tags}}
   </div>

--- a/zipkin-ui/test/component_data/trace.test.js
+++ b/zipkin-ui/test/component_data/trace.test.js
@@ -98,22 +98,22 @@ describe('convertSuccessResponse', () => {
           {
             key: 'http.method',
             value: 'GET',
-            endpoint: '172.17.0.13 (frontend)'
+            endpoints: ['172.17.0.13 (frontend)']
           },
           {
             key: 'http.path',
             value: '/',
-            endpoint: '172.17.0.13 (frontend)'
+            endpoints: ['172.17.0.13 (frontend)']
           },
           {
             key: 'mvc.controller.class',
             value: 'Frontend',
-            endpoint: '172.17.0.13 (frontend)'
+            endpoints: ['172.17.0.13 (frontend)']
           },
           {
             key: 'mvc.controller.method',
             value: 'callBackend',
-            endpoint: '172.17.0.13 (frontend)'
+            endpoints: ['172.17.0.13 (frontend)']
           },
           {
             key: 'Client Address',
@@ -196,22 +196,22 @@ describe('convertSuccessResponse', () => {
           {
             key: 'http.method',
             value: 'GET',
-            endpoint: '172.17.0.13 (frontend)'
+            endpoints: ['172.17.0.13 (frontend)', '172.17.0.9 (backend)']
           },
           {
             key: 'http.path',
             value: '/api',
-            endpoint: '172.17.0.13 (frontend)'
+            endpoints: ['172.17.0.13 (frontend)', '172.17.0.9 (backend)']
           },
           {
             key: 'mvc.controller.class',
             value: 'Backend',
-            endpoint: '172.17.0.9 (backend)'
+            endpoints: ['172.17.0.9 (backend)']
           },
           {
             key: 'mvc.controller.method',
             value: 'printDate',
-            endpoint: '172.17.0.9 (backend)'
+            endpoints: ['172.17.0.9 (backend)']
           },
           {
             key: 'Client Address',
@@ -270,7 +270,7 @@ describe('convertSuccessResponse', () => {
           {
             key: 'error',
             value: 'request failed',
-            endpoint: '172.17.0.9 (backend)'
+            endpoints: ['172.17.0.9 (backend)']
           }
         ],
         errorType: 'critical'


### PR DESCRIPTION
This does the minimal needed to show that there are different values for
the same tag, between a client and a server. Future work could be
considered to answer who sent what value. In the mean time, users can
inspect the JSON button when this occurs.

Fixes #2390

## Before: different values were swallowed

![screen shot 2019-02-17 at 11 31 02 am](https://user-images.githubusercontent.com/64215/52907994-9dce9700-32a7-11e9-9d4c-122c3b2b2e8b.png)
![screen shot 2019-02-17 at 11 31 15 am](https://user-images.githubusercontent.com/64215/52907993-9a3b1000-32a7-11e9-87e8-7992cfff2311.png)

## After: different values are displayed

![screen shot 2019-02-17 at 11 27 56 am](https://user-images.githubusercontent.com/64215/52907997-a3c47800-32a7-11e9-80e0-746197f1be95.png)
![screen shot 2019-02-17 at 11 27 42 am](https://user-images.githubusercontent.com/64215/52907998-a626d200-32a7-11e9-9ea0-2d8fca6ba7a9.png)
