### PR TITLE
Consistently fail when endTs or lookback are set to zero

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -166,6 +166,8 @@ public final class CassandraSpanStore implements SpanStore {
 
   @Override
   public Call<List<DependencyLink>> getDependencies(long endTs, long lookback) {
+    if (endTs <= 0) throw new IllegalArgumentException("endTs <= 0");
+    if (lookback <= 0) throw new IllegalArgumentException("lookback <= 0");
     return dependencies.create(endTs, lookback);
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
@@ -214,6 +214,8 @@ class CassandraSpanStore implements SpanStore { // not final for testing
 
   @Override
   public Call<List<DependencyLink>> getDependencies(long endTs, long lookback) {
+    if (endTs <= 0) throw new IllegalArgumentException("endTs <= 0");
+    if (lookback <= 0) throw new IllegalArgumentException("lookback <= 0");
     return dependencies.create(endTs, lookback);
   }
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
@@ -172,6 +172,9 @@ final class ElasticsearchSpanStore implements SpanStore{
 
   @Override
   public Call<List<DependencyLink>> getDependencies(long endTs, long lookback) {
+    if (endTs <= 0) throw new IllegalArgumentException("endTs <= 0");
+    if (lookback <= 0) throw new IllegalArgumentException("lookback <= 0");
+
     long beginMillis = Math.max(endTs - lookback, EARLIEST_MS);
 
     // We just return all dependencies in the days that fall within endTs and lookback as

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/MySQLSpanStore.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/MySQLSpanStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -79,6 +79,9 @@ final class MySQLSpanStore implements SpanStore {
   }
 
   @Override public Call<List<DependencyLink>> getDependencies(long endTs, long lookback) {
+    if (endTs <= 0) throw new IllegalArgumentException("endTs <= 0");
+    if (lookback <= 0) throw new IllegalArgumentException("lookback <= 0");
+
     if (schema.hasPreAggregatedDependencies) {
       return dataSourceCallFactory.create(new SelectDependencies(schema, getDays(endTs, lookback)));
     }

--- a/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -67,6 +67,13 @@ public class QueryRequestTest {
     thrown.expectMessage("endTs <= 0");
 
     queryBuilder.endTs(0L).build();
+  }
+
+  @Test public void lookbackMustBePositive() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("lookback <= 0");
+
+    queryBuilder.lookback(0).build();
   }
 
   @Test public void limitMustBePositive() {


### PR DESCRIPTION
Currently, we only fail when spans are searched on endTs or lookback
zero. This fails the same way for dependency queries.

Fixes #2356