### PR TITLE
Works around encoding bug in zipkin-ruby by leniently parsing

### DIFF
--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/LazyMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/LazyMySQLStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -37,9 +37,9 @@ public class LazyMySQLStorage implements TestRule {
     if (storage != null) return storage;
 
     try {
-      container = new ZipkinMySQLContainer(version);
-      container.start();
-      System.out.println("Will use TestContainers MySQL instance");
+      //container = new ZipkinMySQLContainer(version);
+      //container.start();
+      //System.out.println("Will use TestContainers MySQL instance");
     } catch (Exception e) {
       // Ignored
     }

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/LazyMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/LazyMySQLStorage.java
@@ -37,9 +37,9 @@ public class LazyMySQLStorage implements TestRule {
     if (storage != null) return storage;
 
     try {
-      //container = new ZipkinMySQLContainer(version);
-      //container.start();
-      //System.out.println("Will use TestContainers MySQL instance");
+      container = new ZipkinMySQLContainer(version);
+      container.start();
+      System.out.println("Will use TestContainers MySQL instance");
     } catch (Exception e) {
       // Ignored
     }

--- a/zipkin/src/main/java/zipkin2/v1/V1SpanConverter.java
+++ b/zipkin/src/main/java/zipkin2/v1/V1SpanConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -216,14 +216,19 @@ public final class V1SpanConverter {
     zipkin2.Endpoint ca = null, sa = null, ma = null;
     for (int i = 0, length = source.binaryAnnotations.size(); i < length; i++) {
       V1BinaryAnnotation b = source.binaryAnnotations.get(i);
-      if (b.stringValue == null) {
-        if ("ca".equals(b.key)) {
-          ca = b.endpoint;
-        } else if ("sa".equals(b.key)) {
-          sa = b.endpoint;
-        } else if ("ma".equals(b.key)) {
-          ma = b.endpoint;
-        }
+
+      // Peek to see if this is an address annotation. Strictly speaking, address annotations should
+      // have a value of true (not "true" or "1"). However, there are versions of zipkin-ruby in the
+      // wild that create "1" and misinterpreting confuses the question of what is the local
+      // endpoint. Hence, we leniently parse.
+      if ("ca".equals(b.key)) {
+        ca = b.endpoint;
+        continue;
+      } else if ("sa".equals(b.key)) {
+        sa = b.endpoint;
+        continue;
+      } else if ("ma".equals(b.key)) {
+        ma = b.endpoint;
         continue;
       }
 

--- a/zipkin/src/test/java/zipkin2/v1/V1SpanConverterTest.java
+++ b/zipkin/src/test/java/zipkin2/v1/V1SpanConverterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.v1;
+
+import org.junit.Test;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.Span.Kind;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.BACKEND;
+import static zipkin2.TestObjects.FRONTEND;
+
+public class V1SpanConverterTest {
+  Endpoint kafka = Endpoint.newBuilder().serviceName("kafka").build();
+  V1SpanConverter v1SpanConverter = new V1SpanConverter();
+
+  @Test public void convert_ma() {
+    V1Span v1 = V1Span.newBuilder()
+      .traceId(1L)
+      .id(2L)
+      .addAnnotation(1472470996199000L, "mr", BACKEND)
+      .addBinaryAnnotation("ma",  kafka)
+      .build();
+
+    Span v2 = Span.newBuilder().traceId("1").id("2")
+      .kind(Kind.CONSUMER)
+      .timestamp(1472470996199000L)
+      .localEndpoint(BACKEND)
+      .remoteEndpoint(kafka)
+      .build();
+
+    assertThat(v1SpanConverter.convert(v1)).containsExactly(v2);
+  }
+
+  @Test public void convert_sa() {
+    V1Span v1 = V1Span.newBuilder()
+      .traceId(1L)
+      .id(2L)
+      .addAnnotation(1472470996199000L, "cs", FRONTEND)
+      .addBinaryAnnotation("sa",  BACKEND)
+      .build();
+
+    Span v2 = Span.newBuilder().traceId("1").id("2")
+      .kind(Kind.CLIENT)
+      .timestamp(1472470996199000L)
+      .localEndpoint(FRONTEND)
+      .remoteEndpoint(BACKEND)
+      .build();
+
+    assertThat(v1SpanConverter.convert(v1)).containsExactly(v2);
+  }
+
+  @Test public void convert_ca() {
+    V1Span v1 = V1Span.newBuilder()
+      .traceId(1L)
+      .id(2L)
+      .addAnnotation(1472470996199000L, "sr", BACKEND)
+      .addBinaryAnnotation("ca",  FRONTEND)
+      .build();
+
+    Span v2 = Span.newBuilder().traceId("1").id("2")
+      .kind(Kind.SERVER)
+      .timestamp(1472470996199000L)
+      .localEndpoint(BACKEND)
+      .remoteEndpoint(FRONTEND)
+      .shared(true)
+      .build();
+
+    assertThat(v1SpanConverter.convert(v1)).containsExactly(v2);
+  }
+
+  // Following 3 tests show leniency for old versions of zipkin-ruby which serialized address binary
+  // annotations as "1" instead of true
+  @Test public void convert_ma_incorrect_value() {
+    V1Span v1 = V1Span.newBuilder()
+      .traceId(1L)
+      .id(2L)
+      .addAnnotation(1472470996199000L, "mr", BACKEND)
+      .addBinaryAnnotation("ma", "1", kafka)
+      .build();
+
+    Span v2 = Span.newBuilder().traceId("1").id("2")
+      .kind(Kind.CONSUMER)
+      .timestamp(1472470996199000L)
+      .localEndpoint(BACKEND)
+      .remoteEndpoint(kafka)
+      .build();
+
+    assertThat(v1SpanConverter.convert(v1)).containsExactly(v2);
+  }
+
+  @Test public void convert_sa_incorrect_value() {
+    V1Span v1 = V1Span.newBuilder()
+      .traceId(1L)
+      .id(2L)
+      .addAnnotation(1472470996199000L, "cs", FRONTEND)
+      .addBinaryAnnotation("sa", "1", BACKEND)
+      .build();
+
+    Span v2 = Span.newBuilder().traceId("1").id("2")
+      .kind(Kind.CLIENT)
+      .timestamp(1472470996199000L)
+      .localEndpoint(FRONTEND)
+      .remoteEndpoint(BACKEND)
+      .build();
+
+    assertThat(v1SpanConverter.convert(v1)).containsExactly(v2);
+  }
+
+  @Test public void convert_ca_incorrect_value() {
+    V1Span v1 = V1Span.newBuilder()
+      .traceId(1L)
+      .id(2L)
+      .addAnnotation(1472470996199000L, "sr", BACKEND)
+      .addBinaryAnnotation("ca", "1", FRONTEND)
+      .build();
+
+    Span v2 = Span.newBuilder().traceId("1").id("2")
+      .kind(Kind.SERVER)
+      .timestamp(1472470996199000L)
+      .localEndpoint(BACKEND)
+      .remoteEndpoint(FRONTEND)
+      .shared(true)
+      .build();
+
+    assertThat(v1SpanConverter.convert(v1)).containsExactly(v2);
+  }
+}


### PR DESCRIPTION
In zipkin-ruby (zipkin-tracer up to 0.32.3), the "sa" annotation was
incorrectly encoded as "1" not `true`. This likely was due to the fact
that thrift encodes boolean as 1. This caused the remote endpoint to be
mistaken for a local endpoint as the parser thought "sa" was a normal
string tag with the local endpoint attached. The impact was
mis-rendering and also service graph aggregation would likely be
incorrect in some cases as well.

Definitely, zipkin-ruby should update as even if we leniently parse,
clones will not likely be as tolerant and this could hurt things.
However, it is best to be lenient as it is cheap and low impact. There
is unlikely any valid tag named "sa" "ca" or "sa" used for a purpose
besides the remote endpoint.

Fixes #2414