### PR TITLE
Offer go back to classic when switched to lens

### DIFF
--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -795,7 +795,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -8460,6 +8460,11 @@
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
       "dev": true
     },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9041,7 +9046,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -12085,7 +12090,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
@@ -12834,7 +12839,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "chart.js": "^2.7.2",
+    "js-cookie": "^2.2.0",
     "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",

--- a/zipkin-lens/scss/components/_sidebar.scss
+++ b/zipkin-lens/scss/components/_sidebar.scss
@@ -75,3 +75,17 @@
   display: flex;
   justify-content: center;
 }
+
+.sidebar__go-back-to-classic-button-wrapper {
+  width: 100%;
+  padding: 18px 4px 4px 4px;
+  box-sizing: border-box;
+}
+
+.sidebar__go-back-to-classic-button {
+  border-radius: 3px;
+  color: $gray-2;
+  background: linear-gradient(to bottom, $gray-10, $gray-9);
+  font-weight: bold;
+  cursor: pointer;
+}

--- a/zipkin-lens/src/components/App/Sidebar.js
+++ b/zipkin-lens/src/components/App/Sidebar.js
@@ -1,7 +1,7 @@
-import Cookies from 'js-cookie';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
+import Cookies from 'js-cookie';
 
 import Logo from '../../img/zipkin-logo.svg';
 
@@ -24,15 +24,15 @@ const pageInfo = {
   },
 };
 
-class Sidebar extends React.Component {
-  // Before Zipkin 2.13, Lens was optionally available based on a cookie named 'lens'.
-  // To revert to the classic UI, remove the cookie and reload.
-  goBackToClassic(evt) {
-    evt.preventDefault();
-    Cookies.remove('lens');
-    this.window.location.reload(true);
-  }
+// Before Zipkin 2.13, Lens was optionally available based on a cookie named 'lens'.
+// To revert to the classic UI, remove the cookie and reload.
+const goBackToClassic = (event) => {
+  Cookies.remove('lens');
+  window.location.reload(true);
+  event.preventDefault();
+};
 
+class Sidebar extends React.Component {
   renderPageOption(pageName) {
     const { location } = this.props;
     const { url } = pageInfo[pageName];
@@ -84,7 +84,7 @@ class Sidebar extends React.Component {
         {Cookies.get('lens')
         && (
           <div>
-            <button type="button" onClick={this.goBackToClassic.bind(this)}>
+            <button type="button" onClick={goBackToClassic}>
               <span>Go back to classic Zipkin</span>
             </button>
           </div>

--- a/zipkin-lens/src/components/App/Sidebar.js
+++ b/zipkin-lens/src/components/App/Sidebar.js
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -24,6 +25,14 @@ const pageInfo = {
 };
 
 class Sidebar extends React.Component {
+  // Before Zipkin 2.13, Lens was optionally available based on a cookie named 'lens'.
+  // To revert to the classic UI, remove the cookie and reload.
+  goBackToClassic(evt) {
+    evt.preventDefault();
+    Cookies.remove('lens');
+    this.window.location.reload(true);
+  }
+
   renderPageOption(pageName) {
     const { location } = this.props;
     const { url } = pageInfo[pageName];
@@ -72,6 +81,14 @@ class Sidebar extends React.Component {
             <div className="sidebar__other-link fab fa-gitter" />
           </a>
         </div>
+        {Cookies.get('lens')
+        && (
+          <div>
+            <button type="button" onClick={this.goBackToClassic.bind(this)}>
+              <span>Go back to classic Zipkin</span>
+            </button>
+          </div>
+        )}
       </div>
     );
   }

--- a/zipkin-lens/src/components/App/Sidebar.js
+++ b/zipkin-lens/src/components/App/Sidebar.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { withRouter } from 'react-router';
 import { Link } from 'react-router-dom';
 import Cookies from 'js-cookie';
 
@@ -8,6 +9,9 @@ import Logo from '../../img/zipkin-logo.svg';
 const propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
+  }).isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
   }).isRequired,
 };
 
@@ -24,15 +28,25 @@ const pageInfo = {
   },
 };
 
-// Before Zipkin 2.13, Lens was optionally available based on a cookie named 'lens'.
-// To revert to the classic UI, remove the cookie and reload.
-const goBackToClassic = (event) => {
-  Cookies.remove('lens');
-  window.location.reload(true);
-  event.preventDefault();
-};
-
 class Sidebar extends React.Component {
+  constructor(props) {
+    super(props);
+    this.goBackToClassic = this.goBackToClassic.bind(this);
+  }
+
+  goBackToClassic(event) {
+    const { location, history } = this.props;
+
+    Cookies.remove('lens');
+    if (location.pathname === '/zipkin') {
+      history.push('/zipkin/');
+    } else {
+      history.push(`${location.pathname}`);
+    }
+    window.location.reload(true);
+    event.preventDefault();
+  }
+
   renderPageOption(pageName) {
     const { location } = this.props;
     const { url } = pageInfo[pageName];
@@ -67,6 +81,21 @@ class Sidebar extends React.Component {
           {this.renderPageOption('browser')}
           {this.renderPageOption('dependencies')}
         </div>
+        {
+          Cookies.get('lens')
+            ? (
+              <div className="sidebar__go-back-to-classic-button-wrapper">
+                <button
+                  type="button"
+                  className="sidebar__go-back-to-classic-button"
+                  onClick={this.goBackToClassic}
+                >
+                  Go back to classic Zipkin
+                </button>
+              </div>
+            )
+            : null
+        }
         <div className="sidebar__other-links">
           <a href="https://zipkin.apache.org/" target="_blank" rel="noopener noreferrer">
             <div className="sidebar__other-link fas fa-home" />
@@ -81,14 +110,6 @@ class Sidebar extends React.Component {
             <div className="sidebar__other-link fab fa-gitter" />
           </a>
         </div>
-        {Cookies.get('lens')
-        && (
-          <div>
-            <button type="button" onClick={goBackToClassic}>
-              <span>Go back to classic Zipkin</span>
-            </button>
-          </div>
-        )}
       </div>
     );
   }
@@ -96,4 +117,4 @@ class Sidebar extends React.Component {
 
 Sidebar.propTypes = propTypes;
 
-export default Sidebar;
+export default withRouter(Sidebar);

--- a/zipkin-ui/templates/layout.mustache
+++ b/zipkin-ui/templates/layout.mustache
@@ -7,7 +7,7 @@
           <ul class="navbar-nav mr-auto">
             <li class="nav-item" data-route="index"><a class="nav-link"  href="{{contextRoot}}" data-i18n="nav.find">Find a trace</a></li>
             <li class="nav-item" data-route="traceViewer"><a class="nav-link"  href="{{contextRoot}}traceViewer" data-i18n="nav.viewSaved">View Saved Trace</a></li>
-            <li class="nav-item" data-route="dependency"><a class="nav-link"  href="{{contextRoot}}dependency/" data-i18n="nav.dep">Dependencies</a></li>
+            <li class="nav-item" data-route="dependency"><a class="nav-link"  href="{{contextRoot}}dependency" data-i18n="nav.dep">Dependencies</a></li>
           </ul>
         </div>
         {{#suggestLens}}


### PR DESCRIPTION
In a previous change, we offered to switch to Lens. This offers to
switch back, based on the same cookie (`lens`). This should help
reduce risk of people not wanting to deploy.

Note: this needs css work and also I'm not sure why the page isn't
reloading completely. I would like some help finishing this.