### PR TITLE
Fails on incorrect format sent to http endpoints

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
@@ -139,6 +139,7 @@ class ZipkinHttpCollector implements HttpHandler, HandlerWrapper {
       try {
         detectedDecoder = SpanBytesDecoderDetector.decoderForListMessage(body);
       } catch (IllegalArgumentException e) {
+        metrics.incrementMessagesDropped();
         exchange
           .setStatusCode(400)
           .getResponseSender()
@@ -147,6 +148,7 @@ class ZipkinHttpCollector implements HttpHandler, HandlerWrapper {
       }
 
       if (detectedDecoder != decoder) {
+        metrics.incrementMessagesDropped();
         exchange
           .setStatusCode(400)
           .getResponseSender()

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -98,7 +98,16 @@ public class ITZipkinServer {
     Response response = post("/api/v2/spans", body);
     assertThat(response.code()).isEqualTo(400);
     assertThat(response.body().string())
-      .startsWith("Malformed reading List<Span> from json");
+      .startsWith("Expected a JSON_V2 encoded list\n");
+  }
+
+  @Test public void writeSpans_incorrectJsonFormatIsBadRequest() throws Exception {
+    byte[] message = SpanBytesEncoder.JSON_V1.encodeList(TRACE);
+
+    Response response = post("/api/v2/spans", message);
+    assertThat(response.code()).isEqualTo(400);
+    assertThat(response.body().string())
+      .startsWith("Expected a JSON_V2 encoded list, but received: JSON_V1\n");
   }
 
   @Test public void writeSpans_malformedGzipIsBadRequest() throws Exception {
@@ -137,7 +146,7 @@ public class ITZipkinServer {
 
     assertThat(response.code()).isEqualTo(400);
     assertThat(response.body().string())
-      .endsWith("reading List<Span> from TBinary");
+      .endsWith("Expected a THRIFT encoded list\n");
   }
 
   @Test public void writeSpans_contentTypeXProtobuf() throws Exception {
@@ -162,7 +171,7 @@ public class ITZipkinServer {
 
     assertThat(response.code()).isEqualTo(400);
     assertThat(response.body().string())
-      .startsWith("Truncated: length 101 > bytes remaining 3 reading List<Span> from proto3");
+      .startsWith("Expected a PROTO3 encoded list\n");
   }
 
   @Test public void v2WiresUp() throws Exception {


### PR DESCRIPTION
This gives a message instead of parsing the valid bits of json encoding. Thanks for the nudge by @drolando though I think we've been nudged before, too!

Ex.
```bash
$ curl -X POST -s localhost:9411/api/v1/spans -H'Content-Type: application/json' -d @netflix.json
Expected a JSON_V1 encoded list, but received: JSON_V2
```

```bash
$ curl -X POST -s localhost:9411/api/v1/spans -H'Content-Type: application/json' -d 'adssa'
Expected a JSON_V1 encoded list
```

```bash
$ curl -X POST -s localhost:9411/api/v2/spans -H'Content-Type: application/json' -d '[{"traceId":"49d20272a7a8f41d","id":"49d20272a7a8f41d","name":"post /cxf/catalog","timestamp":1536918355807036,"duration":10341,"annotations":[{"timestamp":1536918355807036,"value":"sr","endpoint":{"serviceName":"catalog-service","ipv4":"192.168.1.113"}},{"timestamp":1536918355817377,"value":"ss","endpoint":{"serviceName":"catalog-service","ipv4":"192.168.1.113"}}],"binaryAnnotations":[{"key":"http.path","value":"/cxf/catalog","endpoint":{"serviceName":"catalog-service","ipv4":"192.168.1.113"}}]}]'
Expected a JSON_V2 encoded list, but received: JSON_V1
```