### PR TITLE
Configure CorsService without catch-all path mapping

### DIFF
--- a/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin2/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin2/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
@@ -71,7 +71,8 @@ import org.springframework.util.StringUtils;
   @Bean
   @Order(1)
   ArmeriaServerConfigurator notFoundMetricCollector() {
-    return sb -> sb.service(PathMapping.ofCatchAll(), (ctx, req) -> HttpResponse.of(HttpStatus.NOT_FOUND));
+    // Use glob instead of catch-all to avoid adding it to the trie router.
+    return sb -> sb.service(PathMapping.ofGlob("/**"), (ctx, req) -> HttpResponse.of(HttpStatus.NOT_FOUND));
   }
 
   static final class MetricCollectingService<I extends Request, O extends Response>

--- a/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin2/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
+++ b/zipkin-autoconfigure/metrics-prometheus/src/main/java/zipkin2/autoconfigure/prometheus/ZipkinPrometheusMetricsAutoConfiguration.java
@@ -20,6 +20,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
+import com.linecorp.armeria.server.PathMapping;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingService;
@@ -65,12 +66,12 @@ import org.springframework.util.StringUtils;
   }
 
   // We need to make sure not-found requests are still handled by a service to be decorated for
-  // adding metrics. We add a lowest-precedence path mapping so anything not mapped by another
+  // adding metrics. We add a lower precedence path mapping so anything not mapped by another
   // service is handled by this.
   @Bean
-  @Order
+  @Order(1)
   ArmeriaServerConfigurator notFoundMetricCollector() {
-    return sb -> sb.serviceUnder("/", (ctx, req) -> HttpResponse.of(HttpStatus.NOT_FOUND));
+    return sb -> sb.service(PathMapping.ofCatchAll(), (ctx, req) -> HttpResponse.of(HttpStatus.NOT_FOUND));
   }
 
   static final class MetricCollectingService<I extends Request, O extends Response>

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerCORS.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerCORS.java
@@ -96,6 +96,7 @@ public class ITZipkinServerCORS {
     return client.newCall(new Request.Builder()
       .url(url(server, path))
       .header("Origin", origin)
+      .header("access-control-request-method",  "GET")
       .method("OPTIONS", null)
       .build()).execute();
   }


### PR DESCRIPTION
Modifications:
- Specified Spring `@Order` annotation to the `corsConfigurator` in order that the bean is evaluated at the last.
  - Removed a dummy service of the catch-all path mapping with OPTIONS header.
- Added `access-control-request-method: GET` header when sending a preflight request in IT.