### PR TITLE
Tolerates thrift encoding bug we made a long time ago

### DIFF
--- a/zipkin/src/main/java/zipkin2/SpanBytesDecoderDetector.java
+++ b/zipkin/src/main/java/zipkin2/SpanBytesDecoderDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -69,7 +69,9 @@ public final class SpanBytesDecoderDetector {
   /** @throws IllegalArgumentException if the input isn't a json, proto3 or thrift list message. */
   public static BytesDecoder<Span> decoderForListMessage(byte[] spans) {
     BytesDecoder<Span> decoder = detectDecoder(spans);
-    if (spans[0] != 12 /* List[ThriftSpan] */ && !protobuf3(spans) && spans[0] != '[') {
+    if (spans[0] != 12 /* List[ThriftSpan] */
+      && spans[0] != 11 /* openzipkin/zipkin-reporter-java#133 */
+      && !protobuf3(spans) && spans[0] != '[') {
       throw new IllegalArgumentException("Expected json, proto3 or thrift list encoding");
     }
     return decoder;

--- a/zipkin/src/test/java/zipkin2/SpanBytesDecoderDetectorTest.java
+++ b/zipkin/src/test/java/zipkin2/SpanBytesDecoderDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -154,6 +154,20 @@ public class SpanBytesDecoderDetectorTest {
     byte[] message = SpanBytesEncoder.THRIFT.encodeList(asList(span1, span2));
     assertThat(SpanBytesDecoderDetector.decoderForListMessage(message))
         .isEqualTo(SpanBytesDecoder.THRIFT);
+  }
+
+
+  /**
+   * We encoded incorrectly for years, so we have to read this data eventhough it is wrong.
+   *
+   * <p>See openzipkin/zipkin-reporter-java#133
+   */
+  @Test
+  public void decoderForListMessage_thrift_incorrectFirstByte() {
+    byte[] message = SpanBytesEncoder.THRIFT.encodeList(asList(span1, span2));
+    message[0] = 11; // We made a typo.. it should have been 12
+    assertThat(SpanBytesDecoderDetector.decoderForListMessage(message))
+      .isEqualTo(SpanBytesDecoder.THRIFT);
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
While zipkin2 reporters encode properly, the okhttp v1 reporter encodes
thrift slightly wrong. This passed before as we weren't strict on the
POST endpoint. This makes detection more lenient as we know we can't
viably change all tools that historically used v1 libraries and okhttp.

See openzipkin/zipkin-reporter-java#133
See bizreach/play-zipkin-tracing#42

Thanks @takezoe for reporting (pun intended)