### PR TITLE
Fixes some lens UI bugs

### DIFF
--- a/zipkin-lens/src/actions/services-action.js
+++ b/zipkin-lens/src/actions/services-action.js
@@ -22,7 +22,9 @@ export const fetchServices = () => async (dispatch) => {
       throw Error(res.statusText);
     }
     const services = await res.json();
-    dispatch(fetchServicesSuccess(services));
+    // alphabetically sort service names since the api returns
+    // them out of order
+    dispatch(fetchServicesSuccess(services.sort()));
   } catch (err) {
     dispatch(fetchServicesFailure());
   }

--- a/zipkin-lens/src/actions/services-action.js
+++ b/zipkin-lens/src/actions/services-action.js
@@ -22,8 +22,8 @@ export const fetchServices = () => async (dispatch) => {
       throw Error(res.statusText);
     }
     const services = await res.json();
-    // alphabetically sort service names since the api returns
-    // them out of order
+    // alphabetically sort service names since the api might
+    // return them out of order
     dispatch(fetchServicesSuccess(services.sort()));
   } catch (err) {
     dispatch(fetchServicesFailure());

--- a/zipkin-lens/src/components/Browser/TraceSummary.js
+++ b/zipkin-lens/src/components/Browser/TraceSummary.js
@@ -124,7 +124,7 @@ class TraceSummary extends React.Component {
     const upperBarLabel = (
       <div className="trace-summary__upper-bar-label">
         <div>
-          {`${traceSummary.spanCount}spans ${traceSummary.durationStr}`}
+          {`${traceSummary.spanCount} spans ${traceSummary.durationStr}`}
         </div>
         <div>
           {moment(traceSummary.timestamp / 1000).format('MM/DD HH:mm:ss:SSS')}

--- a/zipkin-lens/src/components/Timeline/TimelineSpanData.js
+++ b/zipkin-lens/src/components/Timeline/TimelineSpanData.js
@@ -41,7 +41,11 @@ const renderInfo = span => (
       data={
         span.annotations.map(a => (
           {
-            duration: moment(a.timestamp / 1000).format('MM/DD HH:mm:ss:SSS'),
+            // moment.js only supports millisecond precision, however our timestamps have microsecond
+            // precision. So we use moment.js to generate the human readable time with just milliseconds
+            // and then append the last 3 digits of the timestamp which are the microseconds.
+            // NOTE: a.timestamp % 1000 would save a string conversion but drops leading zeros.
+            duration: moment(a.timestamp / 1000).format('MM/DD HH:mm:ss.SSS') + a.timestamp.toString().slice(-3),
             relativeTime: a.relativeTime,
             annotation: a.value,
             address: a.endpoint,
@@ -64,7 +68,8 @@ const renderInfo = span => (
       columns={
         [
           { Header: 'Key', accessor: 'key' },
-          { Header: 'Value', accessor: 'value' },
+          // `white-space: normal` makes long text wrap correctly.
+          { Header: 'Value', accessor: 'value', style: {'white-space': 'normal'} },
         ]
       }
     />

--- a/zipkin-lens/src/components/Timeline/TimelineSpanData.js
+++ b/zipkin-lens/src/components/Timeline/TimelineSpanData.js
@@ -41,11 +41,13 @@ const renderInfo = span => (
       data={
         span.annotations.map(a => (
           {
-            // moment.js only supports millisecond precision, however our timestamps have microsecond
-            // precision. So we use moment.js to generate the human readable time with just milliseconds
-            // and then append the last 3 digits of the timestamp which are the microseconds.
+            // moment.js only supports millisecond precision, however our timestamps have
+            // microsecond precision. So we use moment.js to generate the human readable time
+            // with just milliseconds and then append the last 3 digits of the timestamp
+            // which are the microseconds.
             // NOTE: a.timestamp % 1000 would save a string conversion but drops leading zeros.
-            duration: moment(a.timestamp / 1000).format('MM/DD HH:mm:ss.SSS') + a.timestamp.toString().slice(-3),
+            duration:
+              moment(a.timestamp / 1000).format('MM/DD HH:mm:ss.SSS') + a.timestamp.toString().slice(-3),
             relativeTime: a.relativeTime,
             annotation: a.value,
             address: a.endpoint,
@@ -69,7 +71,7 @@ const renderInfo = span => (
         [
           { Header: 'Key', accessor: 'key' },
           // `white-space: normal` makes long text wrap correctly.
-          { Header: 'Value', accessor: 'value', style: {'white-space': 'normal'} },
+          { Header: 'Value', accessor: 'value', style: { 'white-space': 'normal' } },
         ]
       }
     />

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -156,6 +157,7 @@ public class ZipkinQueryApiV2 {
    * active use, and active use usually implies more than 3 services.
    */
   AggregatedHttpMessage maybeCacheNames(boolean shouldCacheControl, List<String> values) {
+    Collections.sort(values);
     byte[] body = JsonCodec.writeList(QUOTED_STRING_WRITER, values);
     HttpHeaders headers = HttpHeaders.of(200)
       .contentType(MediaType.JSON)

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -247,6 +247,10 @@ public class ITZipkinServer {
 
     assertThat(get("/api/v2/spans?serviceName=web").header("Cache-Control"))
       .isEqualTo("max-age=300, must-revalidate");
+
+    // Check that the response is alphabetically sorted.
+    assertThat(get("/api/v2/services").body().string())
+      .isEqualTo("[\"bar\",\"baz\",\"foo\",\"quz\"]");
   }
 
   @Test public void shouldAllowAnyOriginByDefault() throws Exception {


### PR DESCRIPTION
Service names are now alphabetically sorted. The API seems to return
them out of order, so let's sort them just to be sure.

Added missing space between span count and the "span" word.

Timestamps in the span details view now have microsecond precision.
moment.js doesn't support that, so I had to append the last 3 digits of
the timestamp to the human readable string.

CSS is weird. Apparently it's enough to set `white-space: normal` to
make long text wrap correctly in the span details view. I also tested
with a single very long word and if that doesn't fit in the screen it
gets split automatically.