### PR TITLE
Adds patch until quoting bug is fixed upstream

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
@@ -14,23 +14,17 @@
 package zipkin2.server.internal;
 
 import brave.Tracing;
-import com.google.gson.JsonParser;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpMethod;
-import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.RedirectService;
-import com.linecorp.armeria.server.Service;
-import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.cors.CorsServiceBuilder;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import java.util.List;
-import java.util.function.Function;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
@@ -74,7 +74,7 @@ public class ZipkinServerConfiguration implements WebMvcConfigurer {
       // Redirects the info endpoint for backward compatibility
       sb.service("/info", new RedirectService("/actuator/info"));
 
-      // Workaround for https://github.com/line/armeria/issues/1637
+      // TODO: Workaround for https://github.com/line/armeria/issues/1637
       MediaType promMedia = MediaType.parse("text/plain; version=0.0.4; charset=utf-8");
       sb.decorator(
         delegate -> (ctx, req) -> {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinServerConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinServerConfigurationTest.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.health.OrderedHealthAggregator;
+import org.springframework.boot.actuate.metrics.export.prometheus.PrometheusScrapeEndpoint;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -45,6 +46,7 @@ public class ZipkinServerConfigurationTest {
   @Test public void httpCollector_enabledByDefault() {
     context.register(
       ArmeriaSpringActuatorAutoConfiguration.class,
+      PrometheusScrapeEndpointConfiguration.class,
       EndpointAutoConfiguration.class,
       PropertyPlaceholderAutoConfiguration.class,
       ZipkinServerConfigurationTest.Config.class,
@@ -56,11 +58,19 @@ public class ZipkinServerConfigurationTest {
     assertThat(context.getBean(ZipkinHttpCollector.class)).isNotNull();
   }
 
+  // TODO: Remove when removing workaround for https://github.com/line/armeria/issues/1637
+  @Deprecated static class PrometheusScrapeEndpointConfiguration {
+    @Bean PrometheusScrapeEndpoint prometheusEndpoint() {
+      return new PrometheusScrapeEndpoint(null);
+    }
+  }
+
   @Test(expected = NoSuchBeanDefinitionException.class)
   public void httpCollector_canDisable() {
     TestPropertyValues.of("zipkin.collector.http.enabled:false").applyTo(context);
     context.register(
       ArmeriaSpringActuatorAutoConfiguration.class,
+      PrometheusScrapeEndpointConfiguration.class,
       EndpointAutoConfiguration.class,
       PropertyPlaceholderAutoConfiguration.class,
       ZipkinServerConfigurationTest.Config.class,
@@ -75,6 +85,7 @@ public class ZipkinServerConfigurationTest {
   @Test public void query_enabledByDefault() {
     context.register(
       ArmeriaSpringActuatorAutoConfiguration.class,
+      PrometheusScrapeEndpointConfiguration.class,
       EndpointAutoConfiguration.class,
       PropertyPlaceholderAutoConfiguration.class,
       ZipkinServerConfigurationTest.Config.class,
@@ -90,6 +101,7 @@ public class ZipkinServerConfigurationTest {
     TestPropertyValues.of("zipkin.query.enabled:false").applyTo(context);
     context.register(
       ArmeriaSpringActuatorAutoConfiguration.class,
+      PrometheusScrapeEndpointConfiguration.class,
       EndpointAutoConfiguration.class,
       PropertyPlaceholderAutoConfiguration.class,
       ZipkinServerConfigurationTest.Config.class,
@@ -109,6 +121,7 @@ public class ZipkinServerConfigurationTest {
     TestPropertyValues.of("zipkin.self-tracing.enabled:true").applyTo(context);
     context.register(
       ArmeriaSpringActuatorAutoConfiguration.class,
+      PrometheusScrapeEndpointConfiguration.class,
       EndpointAutoConfiguration.class,
       PropertyPlaceholderAutoConfiguration.class,
       ZipkinServerConfigurationTest.Config.class,
@@ -124,6 +137,7 @@ public class ZipkinServerConfigurationTest {
     TestPropertyValues.of("zipkin.storage.search-enabled:false").applyTo(context);
     context.register(
       ArmeriaSpringActuatorAutoConfiguration.class,
+      PrometheusScrapeEndpointConfiguration.class,
       EndpointAutoConfiguration.class,
       PropertyPlaceholderAutoConfiguration.class,
       ZipkinServerConfigurationTest.Config.class,


### PR DESCRIPTION
We need to cut this immediately as prometheus scraping is broke.

See https://github.com/line/armeria/issues/1637

Before the prom data was quoted by accident as it was accidentally set to json
```bash
$ curl -vs http://localhost:9411/actuator/prometheus|head -c 140
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 9411 (#0)
> GET /actuator/prometheus HTTP/1.1
> Host: localhost:9411
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< content-type: application/json; charset=utf-8
< content-length: 8833
< 
{ [8833 bytes data]
* Connection #0 to host localhost left intact
"# HELP armeria_server_router_virtualHostCache_evictions_total  \n# TYPE armeria_server_router_virtualHostCache_evictions_total counter\narm
```

Now, it is ok
```bash
$ curl -vs http://localhost:9411/actuator/prometheus|head -c 140
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 9411 (#0)
> GET /actuator/prometheus HTTP/1.1
> Host: localhost:9411
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< content-type: text/plain; version=0.0.4; charset=utf-8
< content-length: 8986
< 
{ [8986 bytes data]
* Connection #0 to host localhost left intact
# HELP zipkin_collector_message_bytes size of a message containing serialized spans
# TYPE zipkin_collector_message_bytes gauge
zipkin_colle
```