### PR TITLE
Extracts byte array specific code to ByteArrayBuffer

### DIFF
--- a/benchmarks/src/main/java/zipkin2/internal/BufferBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/internal/BufferBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
  */
 package zipkin2.internal;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -41,25 +42,25 @@ public class BufferBenchmarks {
   static final Charset UTF_8 = Charset.forName("UTF-8");
   // Order id = d07c4daa-0fa9-4c03-90b1-e06c4edae250 doesn't exist
   static final String CHINESE_UTF8 = "订单d07c4daa-0fa9-4c03-90b1-e06c4edae250不存在";
-  static final int CHINESE_UTF8_SIZE = CHINESE_UTF8.getBytes(UTF_8).length;
+  static final int CHINESE_UTF8_SIZE = UTF_8.encode(CHINESE_UTF8).remaining();
   /* length-prefixing a 1 KiB span */
   static final int TEST_INT = 1024;
   /* epoch micros timestamp */
   static final long TEST_LONG = 1472470996199000L;
-  Buffer buffer = new Buffer(8);
+  Buffer buffer = Buffer.allocate(8);
 
   @Benchmark public int utf8SizeInBytes_chinese() {
     return Buffer.utf8SizeInBytes(CHINESE_UTF8);
   }
 
   @Benchmark public byte[] writeUtf8_chinese() {
-    Buffer bufferUtf8 = new Buffer(CHINESE_UTF8_SIZE);
+    Buffer bufferUtf8 = Buffer.allocate(CHINESE_UTF8_SIZE);
     bufferUtf8.writeUtf8(CHINESE_UTF8);
     return bufferUtf8.toByteArray();
   }
 
-  @Benchmark public byte[] writeUtf8_chinese_jdk() {
-    return CHINESE_UTF8.getBytes(UTF_8);
+  @Benchmark public ByteBuffer writeUtf8_chinese_jdk() {
+    return UTF_8.encode(CHINESE_UTF8);
   }
 
   @Benchmark public int varIntSizeInBytes_32() {
@@ -71,21 +72,21 @@ public class BufferBenchmarks {
   }
 
   @Benchmark public int writeVarint_32() {
-    buffer.pos = 0;
+    buffer.reset();
     buffer.writeVarint(TEST_INT);
-    return buffer.pos;
+    return buffer.pos();
   }
 
   @Benchmark public int writeVarint_64() {
-    buffer.pos = 0;
+    buffer.reset();
     buffer.writeVarint(TEST_LONG);
-    return buffer.pos;
+    return buffer.pos();
   }
 
   @Benchmark public int writeLongLe() {
-    buffer.pos = 0;
+    buffer.reset();
     buffer.writeLongLe(TEST_LONG);
-    return buffer.pos;
+    return buffer.pos();
   }
 
   // Convenience main entry-point

--- a/benchmarks/src/test/java/zipkin2/internal/Proto3CodecInteropTest.java
+++ b/benchmarks/src/test/java/zipkin2/internal/Proto3CodecInteropTest.java
@@ -158,7 +158,7 @@ public class Proto3CodecInteropTest {
     zipkin2.Annotation zipkinAnnotation = ZIPKIN_SPAN.annotations().get(0);
     Annotation protoAnnotation = PROTO_SPAN.getAnnotations(0);
 
-    Buffer zipkinBytes = new Buffer(ANNOTATION.sizeInBytes(zipkinAnnotation));
+    Buffer zipkinBytes = Buffer.allocate(ANNOTATION.sizeInBytes(zipkinAnnotation));
     ANNOTATION.write(zipkinBytes, zipkinAnnotation);
 
     assertThat(zipkinBytes.toByteArray())
@@ -170,7 +170,7 @@ public class Proto3CodecInteropTest {
     Annotation protoAnnotation = PROTO_SPAN.getAnnotations(0);
 
     Buffer zipkinBytes =
-      new Buffer(writeSpan(Span.newBuilder().addAnnotations(protoAnnotation).build()), 0);
+      Buffer.wrap(writeSpan(Span.newBuilder().addAnnotations(protoAnnotation).build()), 0);
     assertThat(zipkinBytes.readVarint32())
       .isEqualTo(ANNOTATION.key);
 
@@ -189,7 +189,7 @@ public class Proto3CodecInteropTest {
   }
 
   @Test public void localEndpoint_write_matchesProto3() throws IOException {
-    Buffer zipkinBytes = new Buffer(LOCAL_ENDPOINT.sizeInBytes(ZIPKIN_SPAN.localEndpoint()));
+    Buffer zipkinBytes = Buffer.allocate(LOCAL_ENDPOINT.sizeInBytes(ZIPKIN_SPAN.localEndpoint()));
     LOCAL_ENDPOINT.write(zipkinBytes, ZIPKIN_SPAN.localEndpoint());
 
     assertThat(zipkinBytes.toByteArray())
@@ -198,7 +198,7 @@ public class Proto3CodecInteropTest {
   }
 
   @Test public void remoteEndpoint_write_matchesProto3() throws IOException {
-    Buffer zipkinBytes = new Buffer(REMOTE_ENDPOINT.sizeInBytes(ZIPKIN_SPAN.remoteEndpoint()));
+    Buffer zipkinBytes = Buffer.allocate(REMOTE_ENDPOINT.sizeInBytes(ZIPKIN_SPAN.remoteEndpoint()));
     REMOTE_ENDPOINT.write(zipkinBytes, ZIPKIN_SPAN.remoteEndpoint());
 
     assertThat(zipkinBytes.toByteArray())
@@ -220,7 +220,7 @@ public class Proto3CodecInteropTest {
   @Test public void writeTagField_matchesProto3() throws IOException {
     MapEntry<String, String> entry = entry("clnt/finagle.version", "6.45.0");
     TagField field = new TagField(TAG_KEY);
-    Buffer zipkinBytes = new Buffer(field.sizeInBytes(entry));
+    Buffer zipkinBytes = Buffer.allocate(field.sizeInBytes(entry));
     field.write(zipkinBytes, entry);
 
     Span oneField = Span.newBuilder().putTags(entry.key, entry.value).build();
@@ -235,7 +235,7 @@ public class Proto3CodecInteropTest {
   @Test public void writeTagField_matchesProto3_emptyValue() throws IOException {
     MapEntry<String, String> entry = entry("error", "");
     TagField field = new TagField(TAG_KEY);
-    Buffer zipkinBytes = new Buffer(field.sizeInBytes(entry));
+    Buffer zipkinBytes = Buffer.allocate(field.sizeInBytes(entry));
     field.write(zipkinBytes, entry);
 
     Span oneField = Span.newBuilder().putTags(entry.key, entry.value).build();

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
@@ -136,7 +136,9 @@ public class ZipkinQueryApiV2 {
     }
 
     @Override public void write(String value, Buffer buffer) {
-      buffer.writeByte('"').writeUtf8(value).writeByte('"');
+      buffer.writeByte('"');
+      buffer.writeUtf8(value);
+      buffer.writeByte('"');
     }
   };
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanConsumer.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanConsumer.java
@@ -128,9 +128,11 @@ class ElasticsearchSpanConsumer implements SpanConsumer { // not final for testi
         int sizeInBytes = 27; // {"tagKey":"","tagValue":""}
         sizeInBytes += jsonEscapedSizeInBytes(tag.getKey());
         sizeInBytes += jsonEscapedSizeInBytes(tag.getValue());
-        zipkin2.internal.Buffer b = new zipkin2.internal.Buffer(sizeInBytes);
-        b.writeAscii("{\"tagKey\":\"").writeUtf8(jsonEscape(tag.getKey()));
-        b.writeAscii("\",\"tagValue\":\"").writeUtf8(jsonEscape(tag.getValue()));
+        zipkin2.internal.Buffer b = zipkin2.internal.Buffer.allocate(sizeInBytes);
+        b.writeAscii("{\"tagKey\":\"");
+        b.writeUtf8(jsonEscape(tag.getKey()));
+        b.writeAscii("\",\"tagValue\":\"");
+        b.writeUtf8(jsonEscape(tag.getValue()));
         b.writeAscii("\"}");
         byte[] document = b.toByteArray();
         indexer.add(idx, AUTOCOMPLETE, document, id);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/HttpBulkIndexer.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/HttpBulkIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -95,7 +95,7 @@ public final class HttpBulkIndexer {
     // the _type parameter is needed for Elasticsearch <6.x
     body.writeUtf8(",\"_type\":\"").writeUtf8(typeName).writeByte('"');
     if (id != null) {
-      body.writeUtf8(",\"_id\":\"").writeUtf8(jsonEscape(id)).writeByte('"');
+      body.writeUtf8(",\"_id\":\"").writeUtf8(jsonEscape(id).toString()).writeByte('"');
     }
     body.writeUtf8("}}\n");
   }

--- a/zipkin/src/main/java/zipkin2/codec/DependencyLinkBytesEncoder.java
+++ b/zipkin/src/main/java/zipkin2/codec/DependencyLinkBytesEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -55,11 +55,15 @@ public enum DependencyLinkBytesEncoder implements BytesEncoder<DependencyLink> {
     }
 
     @Override public void write(DependencyLink value, Buffer b) {
-      b.writeAscii("{\"parent\":\"").writeUtf8(jsonEscape(value.parent()));
-      b.writeAscii("\",\"child\":\"").writeUtf8(jsonEscape(value.child()));
-      b.writeAscii("\",\"callCount\":").writeAscii(value.callCount());
+      b.writeAscii("{\"parent\":\"");
+      b.writeUtf8(jsonEscape(value.parent()));
+      b.writeAscii("\",\"child\":\"");
+      b.writeUtf8(jsonEscape(value.child()));
+      b.writeAscii("\",\"callCount\":");
+      b.writeAscii(value.callCount());
       if (value.errorCount() > 0) {
-        b.writeAscii(",\"errorCount\":").writeAscii(value.errorCount());
+        b.writeAscii(",\"errorCount\":");
+        b.writeAscii(value.errorCount());
       }
       b.writeByte('}');
     }

--- a/zipkin/src/main/java/zipkin2/internal/Buffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/Buffer.java
@@ -36,7 +36,7 @@ public abstract class Buffer {
    *
    * <p>Later, ASCII run and malformed surrogate logic borrowed from okio.Utf8
    */
-  public static int utf8SizeInBytes(String string) {
+  public static int utf8SizeInBytes(CharSequence string) {
     int sizeInBytes = 0;
     for (int i = 0, len = string.length(); i < len; i++) {
       char ch = string.charAt(i);
@@ -154,7 +154,7 @@ public abstract class Buffer {
    * <p>This looks most similar to {@code io.netty.buffer.ByteBufUtil.writeUtf8(AbstractByteBuf,
    * int, CharSequence, int)} v4.1, modified including features to address ASCII runs of text.
    */
-  public void writeUtf8(String string) {
+  public void writeUtf8(CharSequence string) {
     for (int i = 0, len = string.length(); i < len; i++) {
       char ch = string.charAt(i);
       if (ch < 0x80) { // 7-bit ASCII character

--- a/zipkin/src/main/java/zipkin2/internal/ByteArrayBuffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/ByteArrayBuffer.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+final class ByteArrayBuffer extends Buffer {
+
+  private final byte[] buf;
+  int pos; // visible for testing
+
+  ByteArrayBuffer(int size) {
+    buf = new byte[size];
+  }
+
+  ByteArrayBuffer(byte[] buf, int pos) {
+    this.buf = buf;
+    this.pos = pos;
+  }
+
+  @Override public void writeByte(int v) {
+    buf[pos++] = (byte) (v & 0xff);
+  }
+
+  @Override public void write(byte[] v) {
+    System.arraycopy(v, 0, buf, pos, v.length);
+    pos += v.length;
+  }
+
+  @Override void writeBackwards(long v) {
+    int pos = this.pos += asciiSizeInBytes(v); // We write backwards from right to left.
+    while (v != 0) {
+      int digit = (int) (v % 10);
+      buf[--pos] = DIGITS[digit];
+      v /= 10;
+    }
+  }
+
+  /** Inspired by {@code okio.Buffer.writeLong} */
+  @Override public void writeLongHex(long v) {
+    writeHexByte(buf, pos + 0, (byte) ((v >>> 56L) & 0xff));
+    writeHexByte(buf, pos + 2, (byte) ((v >>> 48L) & 0xff));
+    writeHexByte(buf, pos + 4, (byte) ((v >>> 40L) & 0xff));
+    writeHexByte(buf, pos + 6, (byte) ((v >>> 32L) & 0xff));
+    writeHexByte(buf, pos + 8, (byte) ((v >>> 24L) & 0xff));
+    writeHexByte(buf, pos + 10, (byte) ((v >>> 16L) & 0xff));
+    writeHexByte(buf, pos + 12, (byte) ((v >>> 8L) & 0xff));
+    writeHexByte(buf, pos + 14, (byte) (v & 0xff));
+    pos += 16;
+  }
+
+  @Override public void reset() {
+    pos = 0;
+  }
+
+  @Override byte readByteUnsafe() {
+    return buf[pos++];
+  }
+
+  @Override byte[] readByteArray(int length) {
+    ensureLength(this, length);
+    byte[] result = new byte[length];
+    System.arraycopy(buf, pos, result, 0, length);
+    pos += length;
+    return result;
+  }
+
+  @Override int remaining() {
+    return buf.length - pos;
+  }
+
+  @Override boolean skip(int maxCount) {
+    int nextPos = pos + maxCount;
+    if (nextPos > buf.length) {
+      pos = buf.length;
+      return false;
+    }
+    pos = nextPos;
+    return true;
+  }
+
+  @Override public int pos() {
+    return pos;
+  }
+
+  @Override public byte[] toByteArray() {
+    // assert pos == buf.length;
+    return buf;
+  }
+}

--- a/zipkin/src/main/java/zipkin2/internal/Dependencies.java
+++ b/zipkin/src/main/java/zipkin2/internal/Dependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -73,7 +73,7 @@ public final class Dependencies {
 
   /** Writes the current instance in TBinaryProtocol */
   public ByteBuffer toThrift() {
-    Buffer buffer = new Buffer(sizeInBytes());
+    Buffer buffer = Buffer.allocate(sizeInBytes());
     write(buffer);
     return ByteBuffer.wrap(buffer.toByteArray());
   }

--- a/zipkin/src/main/java/zipkin2/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin2/internal/JsonCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -166,7 +166,7 @@ public final class JsonCodec {
 
   /** Inability to encode is a programming bug. */
   public static <T> byte[] write(Buffer.Writer<T> writer, T value) {
-    Buffer b = new Buffer(writer.sizeInBytes(value));
+    Buffer b = Buffer.allocate(writer.sizeInBytes(value));
     try {
       writer.write(value, b);
     } catch (RuntimeException e) {
@@ -205,7 +205,7 @@ public final class JsonCodec {
 
   public static <T> byte[] writeList(Buffer.Writer<T> writer, List<T> value) {
     if (value.isEmpty()) return new byte[] {'[', ']'};
-    Buffer result = new Buffer(sizeInBytes(writer, value));
+    Buffer result = Buffer.allocate(sizeInBytes(writer, value));
     writeList(writer, value, result);
     return result.toByteArray();
   }
@@ -217,9 +217,9 @@ public final class JsonCodec {
       return 2;
     }
     int initialPos = pos;
-    Buffer result = new Buffer(out, pos);
+    Buffer result = Buffer.wrap(out, pos);
     writeList(writer, value, result);
-    return result.pos - initialPos;
+    return result.pos() - initialPos;
   }
 
   public static <T> void writeList(Buffer.Writer<T> writer, List<T> value, Buffer b) {

--- a/zipkin/src/main/java/zipkin2/internal/Proto3Codec.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Codec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -43,7 +43,7 @@ public final class Proto3Codec {
 
   public static boolean read(byte[] bytes, Collection<Span> out) {
     if (bytes.length == 0) return false;
-    Buffer buffer = new Buffer(bytes, 0);
+    Buffer buffer = Buffer.wrap(bytes, 0);
     try {
       Span span = SPAN.read(buffer);
       if (span == null) return false;
@@ -55,15 +55,15 @@ public final class Proto3Codec {
   }
 
   public static @Nullable Span readOne(byte[] bytes) {
-    return SPAN.read(new Buffer(bytes, 0));
+    return SPAN.read(Buffer.wrap(bytes, 0));
   }
 
   public static boolean readList(byte[] bytes, Collection<Span> out) {
     int length = bytes.length;
     if (length == 0) return false;
-    Buffer buffer = new Buffer(bytes, 0);
+    Buffer buffer = Buffer.wrap(bytes, 0);
     try {
-      while (buffer.pos < length) {
+      while (buffer.pos() < length) {
         Span span = SPAN.read(buffer);
         if (span == null) return false;
         out.add(span);

--- a/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
@@ -85,7 +85,7 @@ final class Proto3Fields {
           return buffer.skip(4);
         default:
           throw new IllegalArgumentException(
-            "Malformed: invalid wireType " + wireType + " at byte " + buffer.pos);
+            "Malformed: invalid wireType " + wireType + " at byte " + buffer.pos());
       }
     }
   }
@@ -128,9 +128,7 @@ final class Proto3Fields {
     }
 
     final int readLengthPrefix(Buffer b) {
-      int length = b.readVarint32();
-      Proto3Fields.ensureLength(b, length);
-      return length;
+      return b.readVarint32();
     }
 
     abstract int sizeOfValue(T value);
@@ -155,10 +153,7 @@ final class Proto3Fields {
     }
 
     @Override byte[] readValue(Buffer b, int length) {
-      byte[] result = new byte[length];
-      System.arraycopy(b.toByteArray(), b.pos, result, 0, length);
-      b.pos += length;
-      return result;
+      return b.readByteArray(length);
     }
   }
 
@@ -218,9 +213,7 @@ final class Proto3Fields {
     }
 
     @Override String readValue(Buffer buffer, int length) {
-      String result = new String(buffer.toByteArray(), buffer.pos, length, UTF_8);
-      buffer.pos += length;
-      return result;
+      return new String(buffer.readByteArray(length), UTF_8);
     }
   }
 
@@ -242,7 +235,6 @@ final class Proto3Fields {
     }
 
     long readValue(Buffer buffer) {
-      ensureLength(buffer, 8);
       return buffer.readLongLe();
     }
   }
@@ -293,7 +285,7 @@ final class Proto3Fields {
     boolean read(Buffer b) {
       byte bool = b.readByte();
       if (bool < 0 || bool > 1) {
-        throw new IllegalArgumentException("Malformed: invalid boolean value at byte " + b.pos);
+        throw new IllegalArgumentException("Malformed: invalid boolean value at byte " + b.pos());
       }
       return bool == 1;
     }
@@ -314,12 +306,5 @@ final class Proto3Fields {
 
   static int sizeOfLengthDelimitedField(int sizeInBytes) {
     return 1 + Buffer.varintSizeInBytes(sizeInBytes) + sizeInBytes; // tag + len + bytes
-  }
-
-  static void ensureLength(Buffer buffer, int length) {
-    if (length > buffer.remaining()) {
-      throw new IllegalArgumentException(
-        "Truncated: length " + length + " > bytes remaining " + buffer.remaining());
-    }
   }
 }

--- a/zipkin/src/main/java/zipkin2/internal/Proto3SpanWriter.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3SpanWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -48,7 +48,7 @@ final class Proto3SpanWriter implements Buffer.Writer<Span> {
       int sizeOfValue = sizeOfValues[i] = SPAN.sizeOfValue(spans.get(i));
       sizeInBytes += sizeOfLengthDelimitedField(sizeOfValue);
     }
-    Buffer result = new Buffer(sizeInBytes);
+    Buffer result = Buffer.allocate(sizeInBytes);
     for (int i = 0; i < lengthOfSpans; i++) {
       writeSpan(spans.get(i), sizeOfValues[i], result);
     }
@@ -57,7 +57,7 @@ final class Proto3SpanWriter implements Buffer.Writer<Span> {
 
   byte[] write(Span onlySpan) {
     int sizeOfValue = SPAN.sizeOfValue(onlySpan);
-    Buffer result = new Buffer(sizeOfLengthDelimitedField(sizeOfValue));
+    Buffer result = Buffer.allocate(sizeOfLengthDelimitedField(sizeOfValue));
     writeSpan(onlySpan, sizeOfValue, result);
     return result.toByteArray();
   }
@@ -73,10 +73,10 @@ final class Proto3SpanWriter implements Buffer.Writer<Span> {
     int lengthOfSpans = spans.size();
     if (lengthOfSpans == 0) return 0;
 
-    Buffer result = new Buffer(out, pos);
+    Buffer result = Buffer.wrap(out, pos);
     for (int i = 0; i < lengthOfSpans; i++) {
       SPAN.write(result, spans.get(i));
     }
-    return result.pos - pos;
+    return result.pos() - pos;
   }
 }

--- a/zipkin/src/main/java/zipkin2/internal/Proto3ZipkinFields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3ZipkinFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -74,11 +74,11 @@ final class Proto3ZipkinFields {
     }
 
     @Override Endpoint readValue(Buffer buffer, int length) {
-      int endPos = buffer.pos + length;
+      int endPos = buffer.pos() + length;
 
       // now, we are in the endpoint fields
       Endpoint.Builder builder = Endpoint.newBuilder();
-      while (buffer.pos < endPos) {
+      while (buffer.pos() < endPos) {
         int nextKey = buffer.readVarint32();
         switch (nextKey) {
           case SERVICE_NAME_KEY:
@@ -138,12 +138,12 @@ final class Proto3ZipkinFields {
     @Override boolean readLengthPrefixAndValue(Buffer b, Span.Builder builder) {
       int length = readLengthPrefix(b);
       if (length == 0) return false;
-      int endPos = b.pos + length;
+      int endPos = b.pos() + length;
 
       // now, we are in the annotation fields
       long timestamp = 0L;
       String value = null;
-      while (b.pos < endPos) {
+      while (b.pos() < endPos) {
         int nextKey = b.readVarint32();
         switch (nextKey) {
           case TIMESTAMP_KEY:
@@ -186,11 +186,11 @@ final class Proto3ZipkinFields {
     @Override boolean readLengthPrefixAndValue(Buffer b, Span.Builder builder) {
       int length = readLengthPrefix(b);
       if (length == 0) return false;
-      int endPos = b.pos + length;
+      int endPos = b.pos() + length;
 
       // now, we are in the tag fields
       String key = null, value = ""; // empty tags allowed
-      while (b.pos < endPos) {
+      while (b.pos() < endPos) {
         int nextKey = b.readVarint32();
         switch (nextKey) {
           case KEY_KEY:
@@ -312,11 +312,11 @@ final class Proto3ZipkinFields {
     }
 
     @Override Span readValue(Buffer buffer, int length) {
-      int endPos = buffer.pos + length;
+      int endPos = buffer.pos() + length;
 
       // now, we are in the span fields
       Span.Builder builder = Span.newBuilder();
-      while (buffer.pos < endPos) {
+      while (buffer.pos() < endPos) {
         int nextKey = buffer.readVarint32();
         switch (nextKey) {
           case TRACE_ID_KEY:
@@ -370,11 +370,11 @@ final class Proto3ZipkinFields {
   }
 
   static void logAndSkip(Buffer buffer, int nextKey) {
-    int nextWireType = wireType(nextKey, buffer.pos);
+    int nextWireType = wireType(nextKey, buffer.pos());
     if (LOG.isLoggable(FINE)) {
-      int nextFieldNumber = fieldNumber(nextKey, buffer.pos);
+      int nextFieldNumber = fieldNumber(nextKey, buffer.pos());
       LOG.fine(String.format("Skipping field: byte=%s, fieldNumber=%s, wireType=%s",
-        buffer.pos, nextFieldNumber, nextWireType));
+        buffer.pos(), nextFieldNumber, nextWireType));
     }
     skipValue(buffer, nextWireType);
   }

--- a/zipkin/src/main/java/zipkin2/internal/V1ThriftSpanWriter.java
+++ b/zipkin/src/main/java/zipkin2/internal/V1ThriftSpanWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -167,13 +167,13 @@ public final class V1ThriftSpanWriter implements Buffer.Writer<Span> {
     int lengthOfSpans = spans.size();
     if (lengthOfSpans == 0) return EMPTY_ARRAY;
 
-    Buffer result = new Buffer(ThriftCodec.listSizeInBytes(this, spans));
+    Buffer result = Buffer.allocate(ThriftCodec.listSizeInBytes(this, spans));
     ThriftCodec.writeList(this, spans, result);
     return result.toByteArray();
   }
 
   public byte[] write(Span onlySpan) {
-    Buffer result = new Buffer(sizeInBytes(onlySpan));
+    Buffer result = Buffer.allocate(sizeInBytes(onlySpan));
     write(onlySpan, result);
     return result.toByteArray();
   }
@@ -182,7 +182,7 @@ public final class V1ThriftSpanWriter implements Buffer.Writer<Span> {
     int lengthOfSpans = spans.size();
     if (lengthOfSpans == 0) return 0;
 
-    Buffer result = new Buffer(out, pos);
+    Buffer result = Buffer.wrap(out, pos);
     ThriftCodec.writeList(this, spans, result);
 
     return result.pos() - pos;
@@ -190,7 +190,7 @@ public final class V1ThriftSpanWriter implements Buffer.Writer<Span> {
 
   static byte[] legacyEndpointBytes(@Nullable Endpoint localEndpoint) {
     if (localEndpoint == null) return null;
-    Buffer buffer = new Buffer(ThriftEndpointCodec.sizeInBytes(localEndpoint));
+    Buffer buffer = Buffer.allocate(ThriftEndpointCodec.sizeInBytes(localEndpoint));
     ThriftEndpointCodec.write(localEndpoint, buffer);
     return buffer.toByteArray();
   }

--- a/zipkin/src/main/java/zipkin2/internal/V2SpanWriter.java
+++ b/zipkin/src/main/java/zipkin2/internal/V2SpanWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -87,22 +87,34 @@ public final class V2SpanWriter implements Buffer.Writer<Span> {
 
   @Override
   public void write(Span value, Buffer b) {
-    b.writeAscii("{\"traceId\":\"").writeAscii(value.traceId()).writeByte('"');
+    b.writeAscii("{\"traceId\":\"");
+    b.writeAscii(value.traceId());
+    b.writeByte('"');
     if (value.parentId() != null) {
-      b.writeAscii(",\"parentId\":\"").writeAscii(value.parentId()).writeByte('"');
+      b.writeAscii(",\"parentId\":\"");
+      b.writeAscii(value.parentId());
+      b.writeByte('"');
     }
-    b.writeAscii(",\"id\":\"").writeAscii(value.id()).writeByte('"');
+    b.writeAscii(",\"id\":\"");
+    b.writeAscii(value.id());
+    b.writeByte('"');
     if (value.kind() != null) {
-      b.writeAscii(",\"kind\":\"").writeAscii(value.kind().toString()).writeByte('"');
+      b.writeAscii(",\"kind\":\"");
+      b.writeAscii(value.kind().toString());
+      b.writeByte('"');
     }
     if (value.name() != null) {
-      b.writeAscii(",\"name\":\"").writeUtf8(jsonEscape(value.name())).writeByte('"');
+      b.writeAscii(",\"name\":\"");
+      b.writeUtf8(jsonEscape(value.name()));
+      b.writeByte('"');
     }
     if (value.timestampAsLong() != 0L) {
-      b.writeAscii(",\"timestamp\":").writeAscii(value.timestampAsLong());
+      b.writeAscii(",\"timestamp\":");
+      b.writeAscii(value.timestampAsLong());
     }
     if (value.durationAsLong() != 0L) {
-      b.writeAscii(",\"duration\":").writeAscii(value.durationAsLong());
+      b.writeAscii(",\"duration\":");
+      b.writeAscii(value.durationAsLong());
     }
     if (value.localEndpoint() != null) {
       b.writeAscii(",\"localEndpoint\":");
@@ -127,8 +139,11 @@ public final class V2SpanWriter implements Buffer.Writer<Span> {
       Iterator<Map.Entry<String, String>> i = value.tags().entrySet().iterator();
       while (i.hasNext()) {
         Map.Entry<String, String> entry = i.next();
-        b.writeByte('"').writeUtf8(jsonEscape(entry.getKey())).writeAscii("\":\"");
-        b.writeUtf8(jsonEscape(entry.getValue())).writeByte('"');
+        b.writeByte('"');
+        b.writeUtf8(jsonEscape(entry.getKey()));
+        b.writeAscii("\":\"");
+        b.writeUtf8(jsonEscape(entry.getValue()));
+        b.writeByte('"');
         if (i.hasNext()) b.writeByte(',');
       }
       b.writeByte('}');
@@ -181,25 +196,29 @@ public final class V2SpanWriter implements Buffer.Writer<Span> {
     if (serviceName == null && writeEmptyServiceName) serviceName = "";
     if (serviceName != null) {
       b.writeAscii("\"serviceName\":\"");
-      b.writeUtf8(jsonEscape(serviceName)).writeByte('"');
+      b.writeUtf8(jsonEscape(serviceName));
+      b.writeByte('"');
       wroteField = true;
     }
     if (value.ipv4() != null) {
       if (wroteField) b.writeByte(',');
       b.writeAscii("\"ipv4\":\"");
-      b.writeAscii(value.ipv4()).writeByte('"');
+      b.writeAscii(value.ipv4());
+      b.writeByte('"');
       wroteField = true;
     }
     if (value.ipv6() != null) {
       if (wroteField) b.writeByte(',');
       b.writeAscii("\"ipv6\":\"");
-      b.writeAscii(value.ipv6()).writeByte('"');
+      b.writeAscii(value.ipv6());
+      b.writeByte('"');
       wroteField = true;
     }
     int port = value.portAsInt();
     if (port != 0) {
       if (wroteField) b.writeByte(',');
-      b.writeAscii("\"port\":").writeAscii(port);
+      b.writeAscii("\"port\":");
+      b.writeAscii(port);
     }
     b.writeByte('}');
   }
@@ -216,9 +235,15 @@ public final class V2SpanWriter implements Buffer.Writer<Span> {
   }
 
   static void writeAnnotation(long timestamp, String value, @Nullable byte[] endpoint, Buffer b) {
-    b.writeAscii("{\"timestamp\":").writeAscii(timestamp);
-    b.writeAscii(",\"value\":\"").writeUtf8(jsonEscape(value)).writeByte('"');
-    if (endpoint != null) b.writeAscii(",\"endpoint\":").write(endpoint);
+    b.writeAscii("{\"timestamp\":");
+    b.writeAscii(timestamp);
+    b.writeAscii(",\"value\":\"");
+    b.writeUtf8(jsonEscape(value));
+    b.writeByte('"');
+    if (endpoint != null) {
+      b.writeAscii(",\"endpoint\":");
+      b.write(endpoint);
+    }
     b.writeByte('}');
   }
 }

--- a/zipkin/src/test/java/zipkin2/codec/SpanBytesDecoderTest.java
+++ b/zipkin/src/test/java/zipkin2/codec/SpanBytesDecoderTest.java
@@ -133,7 +133,7 @@ public class SpanBytesDecoderTest {
 
   @Test public void niceErrorOnMalformed_inputSpans_PROTO3() {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Truncated: length 101 > bytes remaining 3 reading List<Span> from proto3");
+    thrown.expectMessage("Malformed reading List<Span> from proto3");
 
     SpanBytesDecoder.PROTO3.decodeList(new byte[] {'h', 'e', 'l', 'l', 'o'});
   }

--- a/zipkin/src/test/java/zipkin2/internal/JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/JsonCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -57,7 +57,9 @@ public class JsonCodecTest {
       }
 
       @Override public void write(Object value, Buffer buffer) {
-        buffer.writeByte('a').writeByte('b').writeByte('c'); // wrote larger than size!
+        buffer.writeByte('a');
+        buffer.writeByte('b');
+        buffer.writeByte('c'); // wrote larger than size!
       }
     }
 

--- a/zipkin/src/test/java/zipkin2/internal/JsonEscaperTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/JsonEscaperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
  */
 package zipkin2.internal;
 
-import java.io.IOException;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,15 +35,15 @@ public class JsonEscaperTest {
   }
 
   @Test public void testJsonEscape() {
-    assertThat(jsonEscape(new String(new char[] {0, 'a', 1})))
+    assertThat(jsonEscape(new String(new char[] {0, 'a', 1})).toString())
       .isEqualTo("\\u0000a\\u0001");
-    assertThat(jsonEscape(new String(new char[] {'"', '\\', '\t', '\b'})))
+    assertThat(jsonEscape(new String(new char[] {'"', '\\', '\t', '\b'})).toString())
       .isEqualTo("\\\"\\\\\\t\\b");
-    assertThat(jsonEscape(new String(new char[] {'\n', '\r', '\f'})))
+    assertThat(jsonEscape(new String(new char[] {'\n', '\r', '\f'})).toString())
       .isEqualTo("\\n\\r\\f");
-    assertThat(jsonEscape("\u2028 and \u2029"))
+    assertThat(jsonEscape("\u2028 and \u2029").toString())
       .isEqualTo("\\u2028 and \\u2029");
-    assertThat(jsonEscape("\"foo"))
+    assertThat(jsonEscape("\"foo").toString())
       .isEqualTo("\\\"foo");
   }
 }

--- a/zipkin/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,7 +21,7 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.internal.Proto3ZipkinFields.SPAN;
 
 public class Proto3SpanWriterTest {
-  Buffer buf = new Buffer(2048); // bigger than needed to test sizeOf
+  Buffer buf = Buffer.allocate(2048); // bigger than needed to test sizeOf
 
   Proto3SpanWriter writer = new Proto3SpanWriter();
 

--- a/zipkin/src/test/java/zipkin2/internal/V1JsonSpanWriterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/V1JsonSpanWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,13 +24,13 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 
 public class V1JsonSpanWriterTest {
   V1JsonSpanWriter writer = new V1JsonSpanWriter();
-  Buffer buf = new Buffer(2048); // bigger than needed to test sizeOf
+  Buffer buf = Buffer.allocate(2048); // bigger than needed to test sizeOf
 
   @Test
   public void sizeInBytes() {
     writer.write(CLIENT_SPAN, buf);
 
-    assertThat(writer.sizeInBytes(CLIENT_SPAN)).isEqualTo(buf.pos);
+    assertThat(writer.sizeInBytes(CLIENT_SPAN)).isEqualTo(buf.pos());
   }
 
   @Test

--- a/zipkin/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -35,14 +35,14 @@ import static zipkin2.internal.ThriftField.TYPE_STRUCT;
 public class V1ThriftSpanWriterTest {
   Span span = Span.newBuilder().traceId("1").id("2").build();
   Endpoint endpoint = Endpoint.newBuilder().serviceName("frontend").ip("1.2.3.4").build();
-  Buffer buf = new Buffer(2048); // bigger than needed to test sizeOf
+  Buffer buf = Buffer.allocate(2048); // bigger than needed to test sizeOf
 
   V1ThriftSpanWriter writer = new V1ThriftSpanWriter();
   byte[] endpointBytes;
 
   @Before
   public void init() {
-    Buffer endpointBuffer = new Buffer(ThriftEndpointCodec.sizeInBytes(endpoint));
+    Buffer endpointBuffer = Buffer.allocate(ThriftEndpointCodec.sizeInBytes(endpoint));
     ThriftEndpointCodec.write(endpoint, endpointBuffer);
     endpointBytes = endpointBuffer.toByteArray();
   }
@@ -52,7 +52,7 @@ public class V1ThriftSpanWriterTest {
   public void endpoint_highPort() {
     int highPort = 63840;
     Endpoint endpoint = Endpoint.newBuilder().ip("127.0.0.1").port(63840).build();
-    Buffer endpointBuffer = new Buffer(ThriftEndpointCodec.sizeInBytes(endpoint));
+    Buffer endpointBuffer = Buffer.allocate(ThriftEndpointCodec.sizeInBytes(endpoint));
     ThriftEndpointCodec.write(endpoint, endpointBuffer);
     byte[] buff = endpointBuffer.toByteArray();
 
@@ -111,7 +111,7 @@ public class V1ThriftSpanWriterTest {
   public void doesntWriteAnnotationsWhenMissingTimestamp() {
     writer.write(span.toBuilder().kind(CLIENT).build(), buf);
 
-    Buffer buf2 = new Buffer(2048);
+    Buffer buf2 = Buffer.allocate(2048);
     writer.write(span, buf2);
 
     assertThat(buf.toByteArray()).containsExactly(buf.toByteArray());
@@ -234,7 +234,7 @@ public class V1ThriftSpanWriterTest {
   public void skipsTimestampAndDuration_shared() {
     writer.write(span.toBuilder().kind(SERVER).timestamp(5).duration(10).shared(true).build(), buf);
 
-    Buffer buf2 = new Buffer(2048);
+    Buffer buf2 = Buffer.allocate(2048);
     writer.write(span.toBuilder().kind(SERVER).build(), buf2);
 
     assertThat(buf.toByteArray()).containsExactly(buf.toByteArray());

--- a/zipkin/src/test/java/zipkin2/internal/V2SpanWriterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/V2SpanWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,14 +27,14 @@ import static zipkin2.TestObjects.TODAY;
 
 public class V2SpanWriterTest {
   V2SpanWriter writer = new V2SpanWriter();
-  Buffer buf = new Buffer(2048); // bigger than needed to test sizeOf
+  Buffer buf = Buffer.allocate(2048); // bigger than needed to test sizeOf
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test public void sizeInBytes() {
     writer.write(CLIENT_SPAN, buf);
     assertThat(writer.sizeInBytes(CLIENT_SPAN))
-      .isEqualTo(buf.pos);
+      .isEqualTo(buf.pos());
   }
 
   @Test public void writes128BitTraceId() throws UnsupportedEncodingException {


### PR DESCRIPTION
This starts transitioning the internals of our codec library so that
other buffers can be used directly.

The first step is to separate out certain things that have to be done
from how to do it with byte arrays. A few frequently used functions
are directly implemented with byte array and hopefully can be trivially
reimplemented with other types of buffers.

See #2435