### PR TITLE
Fix piechart no-space bug

### DIFF
--- a/zipkin-lens/scss/components/_dependencies-sidebar.scss
+++ b/zipkin-lens/scss/components/_dependencies-sidebar.scss
@@ -72,6 +72,4 @@
 }
 
 .dependencies-sidebar__doughnut {
-  width: 420px;
-  height: 540px;
 }

--- a/zipkin-lens/src/components/Dependencies/DependenciesSidebar.js
+++ b/zipkin-lens/src/components/Dependencies/DependenciesSidebar.js
@@ -57,8 +57,6 @@ const renderDoughnut = (edges, isTarget) => {
   }
 
   const data = {
-    maintainAspectRatio: false,
-    responsive: false,
     labels: isTarget ? edges.map(edge => edge.target) : edges.map(edge => edge.source),
     datasets: [{
       data: edges.map(e => e.metrics.normal + e.metrics.danger),
@@ -67,12 +65,19 @@ const renderDoughnut = (edges, isTarget) => {
         : edges.map(e => getServiceNameColor(e.source)),
     }],
   };
+  const options = {
+    maintainAspectRatio: false,
+    legend: {
+      display: false,
+    },
+  };
   return (
     <div className="dependencies-sidebar__doughnut">
       <Doughnut
+        width={320}
+        height={320}
         data={data}
-        width={420}
-        height={540}
+        options={options}
       />
     </div>
   );


### PR DESCRIPTION
#2425 

Delete legends that display service names because it puts pressure on pie chart.
These legends are not necessary because similar information is on the top.

**before**

<img src="https://user-images.githubusercontent.com/19551419/54404432-c31fbb00-4716-11e9-81a2-1102b96285e5.png" width="300">

**after**

<img src="https://user-images.githubusercontent.com/19551419/54404437-c7e46f00-4716-11e9-8070-a68d1ff9ad04.png" width="300">
