### PR TITLE
Backfills integration test around late duration reporting

### DIFF
--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -77,6 +77,9 @@ public class ITCassandraStorage {
     @Override @Test @Ignore("Duration unsupported") public void getTraces_maxDuration() {
     }
 
+    @Override @Test @Ignore("Duration unsupported") public void getTraces_lateDuration() {
+    }
+
     @Test public void overFetchesToCompensateForDuplicateIndexData() throws IOException {
       int traceCount = 2000;
 

--- a/zipkin/src/test/java/zipkin2/storage/ITSpanStore.java
+++ b/zipkin/src/test/java/zipkin2/storage/ITSpanStore.java
@@ -224,7 +224,7 @@ public abstract class ITSpanStore {
       .build()).execute()).isEmpty();
 
     assertThat(store().getTraces(requestBuilder()
-      .minDuration(CLIENT_SPAN.duration())
+      .minDuration(CLIENT_SPAN.durationAsLong())
       .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
   }
 
@@ -236,6 +236,7 @@ public abstract class ITSpanStore {
       .id(CLIENT_SPAN.id())
       .timestamp(CLIENT_SPAN.timestampAsLong())
       .duration(CLIENT_SPAN.durationAsLong())
+      .localEndpoint(CLIENT_SPAN.localEndpoint())
       .build();
     accept(missingDuration);
     accept(lateDuration);
@@ -245,7 +246,7 @@ public abstract class ITSpanStore {
       .build()).execute()).isEmpty();
 
     assertThat(store().getTraces(requestBuilder()
-      .minDuration(CLIENT_SPAN.duration())
+      .minDuration(CLIENT_SPAN.durationAsLong())
       .build()).execute()).flatExtracting(Trace::merge).containsExactly(CLIENT_SPAN);
   }
 
@@ -253,13 +254,13 @@ public abstract class ITSpanStore {
     accept(CLIENT_SPAN);
 
     assertThat(store().getTraces(requestBuilder()
-      .minDuration(CLIENT_SPAN.duration() - 2)
-      .maxDuration(CLIENT_SPAN.duration() - 1)
+      .minDuration(CLIENT_SPAN.durationAsLong() - 2)
+      .maxDuration(CLIENT_SPAN.durationAsLong() - 1)
       .build()).execute()).isEmpty();
 
     assertThat(store().getTraces(requestBuilder()
-      .minDuration(CLIENT_SPAN.duration())
-      .maxDuration(CLIENT_SPAN.duration())
+      .minDuration(CLIENT_SPAN.durationAsLong())
+      .maxDuration(CLIENT_SPAN.durationAsLong())
       .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
   }
 


### PR DESCRIPTION
This should clarify that late updates to duration are supported.

See #2452