### PR TITLE
Temporarily prefers gRPC's guava

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,6 @@
     <!-- Java 8 dep, which is ok as zipkin-mysql is Java 8 anyway -->
     <HikariCP.version>3.3.1</HikariCP.version>
     <log4j.version>2.11.2</log4j.version>
-    <!-- Be careful to set this as a provided dep, so that it doesn't interfere with dependencies
-         from other projects. For example, cassandra and spring boot set guava versions -->
-    <guava.version>19.0</guava.version>
 
     <junit.version>4.12</junit.version>
     <powermock.version>2.0.0</powermock.version>
@@ -236,6 +233,19 @@
         <groupId>io.zipkin.java</groupId>
         <artifactId>zipkin-server</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <!-- Borrowing grpc 0.19 version of guava until we port zipkin-gcp to armeria -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>26.0-android</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SessionFactory.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -101,7 +101,7 @@ public interface SessionFactory {
       List<InetSocketAddress> result = new ArrayList<>();
       for (String contactPoint : cassandra.contactPoints.split(",")) {
         HostAndPort parsed = HostAndPort.fromString(contactPoint);
-        result.add(new InetSocketAddress(parsed.getHostText(), parsed.getPortOrDefault(9042)));
+        result.add(new InetSocketAddress(parsed.getHost(), parsed.getPortOrDefault(9042)));
       }
       return result;
     }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageRule.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageRule.java
@@ -131,7 +131,7 @@ public class CassandraStorageRule extends ExternalResource {
             }
 
             HostAndPort hap = HostAndPort.fromParts(getContainerIpAddress(), getMappedPort(9042));
-            InetSocketAddress address = new InetSocketAddress(hap.getHostText(), hap.getPort());
+            InetSocketAddress address = new InetSocketAddress(hap.getHost(), hap.getPort());
 
             try (Cluster cluster = getCluster(address);
                 Session session = cluster.newSession()) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -126,7 +126,7 @@ final class DefaultSessionFactory implements CassandraStorage.SessionFactory {
     List<InetSocketAddress> result = new ArrayList<>();
     for (String contactPoint : cassandra.contactPoints().split(",")) {
       HostAndPort parsed = HostAndPort.fromString(contactPoint);
-      result.add(new InetSocketAddress(parsed.getHostText(), parsed.getPortOrDefault(9042)));
+      result.add(new InetSocketAddress(parsed.getHost(), parsed.getPortOrDefault(9042)));
     }
     return result;
   }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageRule.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageRule.java
@@ -131,7 +131,7 @@ public class CassandraStorageRule extends ExternalResource {
             }
 
             HostAndPort hap = HostAndPort.fromParts(getContainerIpAddress(), getMappedPort(9042));
-            InetSocketAddress address = new InetSocketAddress(hap.getHostText(), hap.getPort());
+            InetSocketAddress address = new InetSocketAddress(hap.getHost(), hap.getPort());
 
             try (Cluster cluster = getCluster(address);
                 Session session = cluster.newSession()) {

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -77,7 +77,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
This temporarily prefers gRPC 0.19's guava while we figure out what
better options exist. Cassandra is recently flexible wrt guava version.
gRPC, used by zipkin-gcp is the least flexible in dependencies. Likley,
we will port that project to direct use of armeria to lower the push
and pull.

maybe obviated with https://github.com/openzipkin/zipkin-gcp/issues/119