### PR TITLE
De-conflate local from remote service names

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,20 @@ It stores spans as json and has been designed for larger scale.
 Note: This store requires a [spark job](https://github.com/openzipkin/zipkin-dependencies) to aggregate dependency links.
 
 ### Disabling search
-Search is enabled by default, primarily in support of the `GET /traces`,
-`GET /spans` and `GET /services` endpoints used by the "Find a Trace"
-screen in Zipkin's UI. When search is disabled, traces can only be
-retrieved by ID.
+The following API endpoints provide search features, and are enabled by
+default. Search primarily allows the trace list screen of the UI operate.
+* `GET /services` - Distinct Span.localServiceName
+* `GET /remoteServices?serviceName=X` - Distinct Span.remoteServiceName by Span.localServiceName
+* `GET /spans?serviceName=X` - Distinct Span.name by Span.localServiceName
+* `GET /autocompleteKeys` - Distinct keys of Span.tags subject to configurable whitelist
+* `GET /autocompleteValues?key=X` - Distinct values of Span.tags by key
+* `GET /traces` - Traces matching a query possibly including the above criteria
 
-Sites who use another service (such as logs) to find trace IDs can
-disable search to reduce storage costs or increase write throughput.
+
+When search is disabled, traces can only be retrieved by ID
+(`GET /trace/{traceId}`). Disabling search is only viable when there is
+an alternative way to find trace IDs, such as logs. Disabling search can
+reduce storage costs or increase write throughput.
 
 `StorageComponent.Builder.searchEnabled(false)` is implied when a zipkin
 is run with the env variable `SEARCH_ENABLED=false`.

--- a/zipkin-server/src/it/execjar/src/test/java/zipkin/execjar/NonAsciiServiceNameTest.java
+++ b/zipkin-server/src/it/execjar/src/test/java/zipkin/execjar/NonAsciiServiceNameTest.java
@@ -36,4 +36,13 @@ public class NonAsciiServiceNameTest {
 
     assertEquals(200, response.code());
   }
+
+  @Test
+  public void remoteServiceNameQueryWorksWithNonAsciiServiceName() throws IOException {
+    Response response = client.newCall(new Request.Builder()
+      .url("http://localhost:" + zipkin.port() + "/api/v2/remoteServices?serviceName=个人信息服务")
+      .build()).execute();
+
+    assertEquals(200, response.code());
+  }
 }

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -38,7 +38,7 @@ zipkin:
     enabled: ${QUERY_ENABLED:true}
     # 1 day in millis
     lookback: ${QUERY_LOOKBACK:86400000}
-    # The Cache-Control max-age (seconds) for /api/v2/services and /api/v2/spans
+    # The Cache-Control max-age (seconds) for /api/v2/services, /api/v2/remoteServices and /api/v2/spans
     names-max-age: 300
     # CORS allowed-origins.
     allowed-origins: "*"

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraAutocompleteTags.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraAutocompleteTags.java
@@ -23,7 +23,9 @@ final class CassandraAutocompleteTags implements AutocompleteTags {
   final SelectAutocompleteValues.Factory valuesCallFactory;
 
   CassandraAutocompleteTags(CassandraStorage storage) {
-    enabled = storage.searchEnabled && !storage.autocompleteKeys.isEmpty();
+    enabled = storage.searchEnabled
+      && !storage.autocompleteKeys.isEmpty()
+      && storage.metadata().hasAutocompleteTags;
     keysCall = Call.create(storage.autocompleteKeys);
     valuesCallFactory = enabled ? new SelectAutocompleteValues.Factory(storage.session()) : null;
   }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
@@ -49,7 +49,7 @@ final class CassandraSpanConsumer implements SpanConsumer {
     insertTrace = new InsertTrace.Factory(session, metadata, spanTtl);
     insertServiceName = new InsertServiceName.Factory(storage, indexTtl);
     insertSpanName = new InsertSpanName.Factory(storage, indexTtl);
-    if (metadata.hasRemoteServiceByService) {
+    if (metadata.hasRemoteService) {
       insertRemoteServiceName = new InsertRemoteServiceName.Factory(storage, indexTtl);
     } else {
       insertRemoteServiceName = null;

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
@@ -59,7 +59,7 @@ final class CassandraSpanConsumer implements SpanConsumer {
     } else {
       insertAutocompleteValue = null;
     }
-    indexer = new CompositeIndexer(session, indexCacheSpec, storage.bucketCount, indexTtl);
+    indexer = new CompositeIndexer(storage, indexCacheSpec, indexTtl);
     autocompleteKeys = new LinkedHashSet<>(storage.autocompleteKeys);
   }
 

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
@@ -96,6 +96,7 @@ final class CassandraSpanConsumer implements SpanConsumer {
       // service span and remote service indexes is refreshed regardless of timestamp
       String serviceName = v2.localServiceName();
       if (serviceName != null) {
+        insertServiceNames.add(serviceName);
         if (v2.name() != null) insertSpanNames.add(insertSpanName.newInput(serviceName, v2.name()));
         if (insertRemoteServiceName != null && v2.remoteServiceName() != null) {
           insertRemoteServiceNames.add(
@@ -129,7 +130,7 @@ final class CassandraSpanConsumer implements SpanConsumer {
   @VisibleForTesting
   void clear() {
     insertServiceName.clear();
-    insertRemoteServiceName.clear();
+    if (insertRemoteServiceName != null) insertRemoteServiceName.clear();
     insertSpanName.clear();
     indexer.clear();
     if (insertAutocompleteValue != null) insertAutocompleteValue.clear();

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
@@ -16,7 +16,6 @@ package zipkin2.storage.cassandra.v1;
 import com.datastax.driver.core.Session;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -123,7 +122,7 @@ final class CassandraSpanConsumer implements SpanConsumer {
     for (Map.Entry<String, String> autocompleteTag : autocompleteTags) {
       insertAutocompleteValue.maybeAdd(autocompleteTag, calls);
     }
-    return AggregateCall.newVoidCall(calls);
+    return calls.isEmpty() ? Call.create(null) : AggregateCall.newVoidCall(calls);
   }
 
   /** Clears any caches */

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
@@ -69,7 +69,7 @@ public final class CassandraSpanStore implements SpanStore, ServiceAndSpanNames 
 
     spans = new SelectFromTraces.Factory(session, strictTraceId, maxTraceCols);
     dependencies = new SelectDependencies.Factory(session);
-    if (storage.metadata().hasRemoteServiceByService) {
+    if (storage.metadata().hasRemoteService) {
       remoteServiceNames = new SelectRemoteServiceNames.Factory(session);
     } else {
       remoteServiceNames = null;

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
@@ -23,6 +23,7 @@ import zipkin2.CheckResult;
 import zipkin2.internal.Nullable;
 import zipkin2.storage.AutocompleteTags;
 import zipkin2.storage.QueryRequest;
+import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
@@ -325,9 +326,12 @@ public final class CassandraStorage extends StorageComponent {
     return session.get();
   }
 
+  Schema.Metadata metadata() {
+    return session.metadata();
+  }
+
   /** {@inheritDoc} Memoized in order to avoid re-preparing statements */
-  @Override
-  public SpanStore spanStore() {
+  @Override public SpanStore spanStore() {
     if (spanStore == null) {
       synchronized (this) {
         if (spanStore == null) {
@@ -336,6 +340,10 @@ public final class CassandraStorage extends StorageComponent {
       }
     }
     return spanStore;
+  }
+
+  @Override public ServiceAndSpanNames serviceAndSpanNames() {
+    return (ServiceAndSpanNames) spanStore();
   }
 
   @Override public AutocompleteTags autocompleteTags() {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
@@ -213,7 +213,8 @@ public final class CassandraStorage extends StorageComponent {
      * Defaults to 100000.
      *
      * <p>This is used to obviate redundant inserts into {@link Tables#SERVICE_NAME_INDEX}, {@link
-     * Tables#SERVICE_SPAN_NAME_INDEX} and {@link Tables#ANNOTATIONS_INDEX}.
+     * Tables#SERVICE_REMOTE_SERVICE_NAME_INDEX}, {@link Tables#SERVICE_SPAN_NAME_INDEX} and {@link
+     * Tables#ANNOTATIONS_INDEX}.
      *
      * <p>Corresponds to the count of rows inserted into between {@link #indexCacheTtl} and now.
      * This is bounded so that collectors that get large trace volume don't run out of memory before

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
@@ -42,7 +42,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * <p>Schema is installed by default from "/cassandra-schema-cql3.txt"
  */
-public final class CassandraStorage extends StorageComponent {
+public class CassandraStorage extends StorageComponent { // not final for mocking
 
   public static Builder newBuilder() {
     return new Builder();

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraUtil.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraUtil.java
@@ -35,7 +35,6 @@ import zipkin2.Call;
 import zipkin2.Span;
 import zipkin2.internal.Nullable;
 import zipkin2.storage.QueryRequest;
-import zipkin2.v1.V1Span;
 
 import static com.google.common.base.Preconditions.checkArgument;
 

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertRemoteServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertRemoteServiceName.java
@@ -42,7 +42,7 @@ final class InsertRemoteServiceName extends ResultSetFutureCall<Void> {
     Factory(CassandraStorage storage, int indexTtl) {
       super(storage.autocompleteTtl, storage.autocompleteCardinality);
       session = storage.session();
-      Insert insertQuery = QueryBuilder.insertInto(Tables.SPAN_NAMES)
+      Insert insertQuery = QueryBuilder.insertInto(Tables.REMOTE_SERVICE_NAMES)
         .value("service_name", QueryBuilder.bindMarker("service_name"))
         .value("remote_service_name", QueryBuilder.bindMarker("remote_service_name"));
       if (indexTtl > 0) insertQuery.using(QueryBuilder.ttl(indexTtl));

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertRemoteServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertRemoteServiceName.java
@@ -27,6 +27,10 @@ final class InsertRemoteServiceName extends ResultSetFutureCall<Void> {
 
   @AutoValue
   abstract static class Input {
+    static Input create(String service_name, String remote_service_name) {
+      return new AutoValue_InsertRemoteServiceName_Input(service_name, remote_service_name);
+    }
+
     abstract String service_name();
 
     abstract String remote_service_name();
@@ -50,7 +54,7 @@ final class InsertRemoteServiceName extends ResultSetFutureCall<Void> {
     }
 
     Input newInput(String service_name, String remote_service_name) {
-      return new AutoValue_InsertRemoteServiceName_Input(service_name, remote_service_name);
+      return Input.create(service_name, remote_service_name);
     }
 
     @Override protected InsertRemoteServiceName newCall(Input input) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertSpanName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertSpanName.java
@@ -27,6 +27,10 @@ final class InsertSpanName extends ResultSetFutureCall<Void> {
 
   @AutoValue
   abstract static class Input {
+    static Input create(String service_name, String span_name) {
+      return new AutoValue_InsertSpanName_Input(service_name, span_name);
+    }
+
     abstract String service_name();
 
     abstract String span_name();
@@ -51,7 +55,7 @@ final class InsertSpanName extends ResultSetFutureCall<Void> {
     }
 
     Input newInput(String service_name, String span_name) {
-      return new AutoValue_InsertSpanName_Input(service_name, span_name);
+      return Input.create(service_name, span_name);
     }
 
     @Override protected InsertSpanName newCall(Input input) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTraceIdByRemoteServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTraceIdByRemoteServiceName.java
@@ -16,32 +16,36 @@ package zipkin2.storage.cassandra.v1;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.Set;
 import zipkin2.Span;
+import zipkin2.v1.V1Span;
 
-// QueryRequest.spanName
-final class InsertTraceIdBySpanName implements Indexer.IndexSupport {
+// QueryRequest.remoteServiceName
+final class InsertTraceIdByRemoteServiceName implements Indexer.IndexSupport {
 
   @Override
   public String table() {
-    return Tables.SERVICE_SPAN_NAME_INDEX;
+    return Tables.SERVICE_REMOTE_SERVICE_NAME_INDEX;
   }
 
   @Override
   public Insert declarePartitionKey(Insert insert) {
-    return insert.value("service_span_name", QueryBuilder.bindMarker("service_span_name"));
+    return insert.value("service_remote_service_name",
+      QueryBuilder.bindMarker("service_remote_service_name"));
   }
 
   @Override
   public BoundStatement bindPartitionKey(BoundStatement bound, String partitionKey) {
-    return bound.setString("service_span_name", partitionKey);
+    return bound.setString("service_remote_service_name", partitionKey);
   }
 
   @Override
   public Set<String> partitionKeys(Span span) {
-    if (span.localServiceName() == null || span.name() == null) return Collections.emptySet();
-    String serviceSpan = span.localServiceName() + "." + span.name();
-    return Collections.singleton(serviceSpan);
+    if (span.localServiceName() == null || span.remoteServiceName() == null) {
+      return Collections.emptySet();
+    }
+    return Collections.singleton(span.localServiceName() + "." + span.remoteServiceName());
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTraceIdByRemoteServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTraceIdByRemoteServiceName.java
@@ -16,11 +16,9 @@ package zipkin2.storage.cassandra.v1;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.Set;
 import zipkin2.Span;
-import zipkin2.v1.V1Span;
 
 // QueryRequest.remoteServiceName
 final class InsertTraceIdByRemoteServiceName implements Indexer.IndexSupport {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTraceIdByServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTraceIdByServiceName.java
@@ -16,7 +16,6 @@ package zipkin2.storage.cassandra.v1;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -54,9 +53,6 @@ final class InsertTraceIdByServiceName implements Indexer.IndexSupport {
   @Override
   public Set<String> partitionKeys(Span span) {
     if (span.localServiceName() == null) return Collections.emptySet();
-    if (span.remoteServiceName() == null) return Collections.singleton(span.localServiceName());
-
-    // TODO: https://github.com/openzipkin/zipkin/pull/2484 will obviate this
-    return ImmutableSet.of(span.localServiceName(), span.remoteServiceName());
+    return Collections.singleton(span.localServiceName());
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
@@ -62,27 +62,27 @@ final class Schema {
         UPGRADE_2);
     }
 
-    boolean hasRemoteServiceByService = hasUpgrade3_remoteService(keyspaceMetadata);
-    if (!hasRemoteServiceByService) {
+    boolean hasRemoteService = hasUpgrade3_remoteService(keyspaceMetadata);
+    if (!hasRemoteService) {
       LOG.warn(
         "schema lacks remote service indexing: apply {}, or set CassandraStorage.ensureSchema=true",
         UPGRADE_2);
     }
 
     return new Metadata(compactionClass, hasDefaultTtl, hasAutocompleteTags,
-      hasRemoteServiceByService);
+      hasRemoteService);
   }
 
   static final class Metadata {
     final String compactionClass;
-    final boolean hasDefaultTtl, hasAutocompleteTags, hasRemoteServiceByService;
+    final boolean hasDefaultTtl, hasAutocompleteTags, hasRemoteService;
 
     Metadata(String compactionClass, boolean hasDefaultTtl, boolean hasAutocompleteTags,
-      boolean hasRemoteServiceByService) {
+      boolean hasRemoteService) {
       this.compactionClass = compactionClass;
       this.hasDefaultTtl = hasDefaultTtl;
       this.hasAutocompleteTags = hasAutocompleteTags;
-      this.hasRemoteServiceByService = hasRemoteServiceByService;
+      this.hasRemoteService = hasRemoteService;
     }
   }
 

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static zipkin2.storage.cassandra.v1.Tables.AUTOCOMPLETE_TAGS;
-import static zipkin2.storage.cassandra.v1.Tables.TABLE_SERVICE_REMOTE_SERVICES;
+import static zipkin2.storage.cassandra.v1.Tables.REMOTE_SERVICE_NAMES;
 
 final class Schema {
   private static final Logger LOG = LoggerFactory.getLogger(Schema.class);
@@ -134,7 +134,7 @@ final class Schema {
   }
 
   static boolean hasUpgrade3_remoteService(KeyspaceMetadata keyspaceMetadata) {
-    return keyspaceMetadata.getTable(TABLE_SERVICE_REMOTE_SERVICES) != null;
+    return keyspaceMetadata.getTable(REMOTE_SERVICE_NAMES) != null;
   }
 
   static void applyCqlFile(String keyspace, Session session, String resource) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
@@ -15,6 +15,7 @@ package zipkin2.storage.cassandra.v1;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.Session;
 import com.google.common.io.CharStreams;
 import java.io.IOException;
@@ -66,19 +67,24 @@ final class Schema {
     if (!hasRemoteService) {
       LOG.warn(
         "schema lacks remote service indexing: apply {}, or set CassandraStorage.ensureSchema=true",
-        UPGRADE_2);
+        UPGRADE_3);
     }
 
-    return new Metadata(compactionClass, hasDefaultTtl, hasAutocompleteTags,
+    ProtocolVersion protocolVersion =
+      session.getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
+
+    return new Metadata(protocolVersion, compactionClass, hasDefaultTtl, hasAutocompleteTags,
       hasRemoteService);
   }
 
   static final class Metadata {
+    final ProtocolVersion protocolVersion;
     final String compactionClass;
     final boolean hasDefaultTtl, hasAutocompleteTags, hasRemoteService;
 
-    Metadata(String compactionClass, boolean hasDefaultTtl, boolean hasAutocompleteTags,
-      boolean hasRemoteService) {
+    Metadata(ProtocolVersion protocolVersion, String compactionClass, boolean hasDefaultTtl,
+      boolean hasAutocompleteTags, boolean hasRemoteService) {
+      this.protocolVersion = protocolVersion;
       this.compactionClass = compactionClass;
       this.hasDefaultTtl = hasDefaultTtl;
       this.hasAutocompleteTags = hasAutocompleteTags;

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectAutocompleteValues.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectAutocompleteValues.java
@@ -16,15 +16,11 @@ package zipkin2.storage.cassandra.v1;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
-import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 import zipkin2.Call;
-import zipkin2.storage.cassandra.internal.call.AccumulateAllResults;
+import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
 import static zipkin2.storage.cassandra.v1.Tables.AUTOCOMPLETE_TAGS;
@@ -33,7 +29,7 @@ final class SelectAutocompleteValues extends ResultSetFutureCall<ResultSet> {
   static class Factory {
     final Session session;
     final PreparedStatement preparedStatement;
-    final AccumulateAutocompleteValues accumulateAutocompleteValues;
+    final DistinctSortedStrings values = new DistinctSortedStrings("value");
 
     Factory(Session session) {
       this.session = session;
@@ -42,11 +38,10 @@ final class SelectAutocompleteValues extends ResultSetFutureCall<ResultSet> {
           .from(AUTOCOMPLETE_TAGS)
           .where(QueryBuilder.eq("key", QueryBuilder.bindMarker("key")))
           .limit(QueryBuilder.bindMarker("limit_")));
-      this.accumulateAutocompleteValues = new AccumulateAutocompleteValues();
     }
 
     Call<List<String>> create(String key) {
-      return new SelectAutocompleteValues(this, key).flatMap(accumulateAutocompleteValues);
+      return new SelectAutocompleteValues(this, key).flatMap(values);
     }
   }
 
@@ -59,8 +54,7 @@ final class SelectAutocompleteValues extends ResultSetFutureCall<ResultSet> {
   }
 
   @Override protected ResultSetFuture newFuture() {
-    return factory.session.executeAsync(factory.preparedStatement
-      .bind()
+    return factory.session.executeAsync(factory.preparedStatement.bind()
       .setString("key", key)
       .setInt("limit_", 1000)); // no one is ever going to browse so many tag values
   }
@@ -71,23 +65,5 @@ final class SelectAutocompleteValues extends ResultSetFutureCall<ResultSet> {
 
   @Override public Call<ResultSet> clone() {
     return new SelectAutocompleteValues(factory, key);
-  }
-
-  static class AccumulateAutocompleteValues extends AccumulateAllResults<List<String>> {
-    @Override protected Supplier<List<String>> supplier() {
-      return ArrayList::new; // list is ok because it is distinct results
-    }
-
-    @Override protected BiConsumer<Row, List<String>> accumulator() {
-      return (row, list) -> {
-        String result = row.getString("value");
-        if (!result.isEmpty()) list.add(result);
-      };
-    }
-
-    @Override
-    public String toString() {
-      return "AccumulateAutocompleteValues{}";
-    }
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectRemoteServiceNames.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectRemoteServiceNames.java
@@ -23,31 +23,45 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-final class SelectServiceNames extends ResultSetFutureCall<ResultSet> {
+import static com.google.common.base.Preconditions.checkNotNull;
+
+final class SelectRemoteServiceNames extends ResultSetFutureCall<ResultSet> {
+
   static class Factory {
     final Session session;
     final PreparedStatement preparedStatement;
-    final DistinctSortedStrings services = new DistinctSortedStrings("service");
+    final DistinctSortedStrings remoteServiceNames =
+      new DistinctSortedStrings("remote_service_name");
 
     Factory(Session session) {
       this.session = session;
-      this.preparedStatement = session.prepare(
-        QueryBuilder.select("service_name").distinct().from(Tables.SERVICE_NAMES));
+      this.preparedStatement = session.prepare(QueryBuilder.select("remote_service_name")
+        .from(Tables.REMOTE_SERVICE_NAMES)
+        .where(QueryBuilder.eq("service_name", QueryBuilder.bindMarker("service_name")))
+        .limit(QueryBuilder.bindMarker("limit_")));
     }
 
-    Call<List<String>> create() {
-      return new SelectServiceNames(this).flatMap(services);
+    Call<List<String>> create(String serviceName) {
+      if (serviceName == null || serviceName.isEmpty()) return Call.emptyList();
+      String service = checkNotNull(serviceName, "serviceName").toLowerCase();
+      return new SelectRemoteServiceNames(this, service).flatMap(remoteServiceNames);
     }
   }
 
   final Factory factory;
+  final String service_name;
 
-  SelectServiceNames(Factory factory) {
+  SelectRemoteServiceNames(Factory factory, String service_name) {
     this.factory = factory;
+    this.service_name = service_name;
   }
 
-  @Override protected ResultSetFuture newFuture() {
-    return factory.session.executeAsync(factory.preparedStatement.bind());
+  @Override
+  protected ResultSetFuture newFuture() {
+    return factory.session.executeAsync(factory.preparedStatement.bind()
+      .setString("service_name", service_name)
+      // no one is ever going to browse so many remote service names
+      .setInt("limit_", 1000));
   }
 
   @Override public ResultSet map(ResultSet input) {
@@ -55,10 +69,10 @@ final class SelectServiceNames extends ResultSetFutureCall<ResultSet> {
   }
 
   @Override public String toString() {
-    return "SelectServiceNames{}";
+    return "SelectRemoteServiceNames{service_name=" + service_name + "}";
   }
 
-  @Override public SelectServiceNames clone() {
-    return new SelectServiceNames(factory);
+  @Override public SelectRemoteServiceNames clone() {
+    return new SelectRemoteServiceNames(factory, service_name);
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectServiceNames.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectServiceNames.java
@@ -27,7 +27,7 @@ final class SelectServiceNames extends ResultSetFutureCall<ResultSet> {
   static class Factory {
     final Session session;
     final PreparedStatement preparedStatement;
-    final DistinctSortedStrings services = new DistinctSortedStrings("service");
+    final DistinctSortedStrings services = new DistinctSortedStrings("service_name");
 
     Factory(Session session) {
       this.session = session;

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceRemoteServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceRemoteServiceName.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra.v1;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.auto.value.AutoValue;
+import java.util.Set;
+import zipkin2.Call;
+import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+final class SelectTraceIdTimestampFromServiceRemoteServiceName
+  extends ResultSetFutureCall<ResultSet> {
+  @AutoValue abstract static class Input {
+    abstract String service_remote_service_name();
+
+    abstract long start_ts();
+
+    abstract long end_ts();
+
+    abstract int limit_();
+  }
+
+  static class Factory {
+    final Session session;
+    final PreparedStatement preparedStatement;
+    final TimestampCodec timestampCodec;
+
+    Factory(Session session, TimestampCodec timestampCodec) {
+      this.session = session;
+      this.timestampCodec = timestampCodec;
+      this.preparedStatement = session.prepare(QueryBuilder.select("ts", "trace_id")
+        .from(Tables.SERVICE_REMOTE_SERVICE_NAME_INDEX)
+        .where(QueryBuilder.eq("service_remote_service_name",
+          QueryBuilder.bindMarker("service_remote_service_name")))
+        .and(QueryBuilder.gte("ts", QueryBuilder.bindMarker("start_ts")))
+        .and(QueryBuilder.lte("ts", QueryBuilder.bindMarker("end_ts")))
+        .limit(QueryBuilder.bindMarker("limit_"))
+        .orderBy(QueryBuilder.desc("ts")));
+    }
+
+    Call<Set<Pair>> newCall(
+      String serviceName, String remoteServiceName, long endTs, long lookback, int limit) {
+      checkArgument(serviceName != null, "serviceName required on remote_serviceName query");
+      checkArgument(remoteServiceName != null,
+        "remoteServiceName required on remoteServiceName query");
+      String serviceSpanName = serviceName + "." + remoteServiceName;
+      long startTs = Math.max(endTs - lookback, 0); // >= 1970
+      Input input = new AutoValue_SelectTraceIdTimestampFromServiceRemoteServiceName_Input(
+        serviceSpanName, startTs, endTs, limit);
+
+      return new SelectTraceIdTimestampFromServiceRemoteServiceName(this, input)
+        .flatMap(new AccumulateTraceIdTsLong(timestampCodec));
+    }
+  }
+
+  final Factory factory;
+  final Input input;
+
+  SelectTraceIdTimestampFromServiceRemoteServiceName(Factory factory, Input input) {
+    this.factory = factory;
+    this.input = input;
+  }
+
+  @Override
+  protected ResultSetFuture newFuture() {
+    Statement bound = factory.preparedStatement.bind()
+      .setString("service_remote_service_name", input.service_remote_service_name())
+      .setBytesUnsafe("start_ts", factory.timestampCodec.serialize(input.start_ts()))
+      .setBytesUnsafe("end_ts", factory.timestampCodec.serialize(input.end_ts()))
+      .setInt("limit_", input.limit_())
+      .setFetchSize(Integer.MAX_VALUE); // NOTE in the new driver, we also set this to limit
+    return factory.session.executeAsync(bound);
+  }
+
+  @Override public ResultSet map(ResultSet input) {
+    return input;
+  }
+
+  @Override
+  public String toString() {
+    return input.toString().replace("Input", "SelectTraceIdTimestampFromServiceRemoteServiceName");
+  }
+
+  @Override
+  public SelectTraceIdTimestampFromServiceRemoteServiceName clone() {
+    return new SelectTraceIdTimestampFromServiceRemoteServiceName(factory, input);
+  }
+}

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Tables.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Tables.java
@@ -93,9 +93,6 @@ final class Tables {
    */
   static final String ANNOTATIONS_INDEX = "annotations_index";
 
-  /** This table supports {@link ServiceAndSpanNames#getRemoteServiceNames(String)}. */
-  static final String TABLE_SERVICE_REMOTE_SERVICES = "remote_service_by_service";
-
   private Tables() {
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Tables.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Tables.java
@@ -16,12 +16,12 @@ package zipkin2.storage.cassandra.v1;
 import zipkin2.Span;
 import zipkin2.storage.AutocompleteTags;
 import zipkin2.storage.QueryRequest;
-import zipkin2.storage.SpanStore;
+import zipkin2.storage.ServiceAndSpanNames;
 
 final class Tables {
 
   /**
-   * This index supports {@link SpanStore#getServiceNames()}}.
+   * This index supports {@link ServiceAndSpanNames#getServiceNames()}}.
    *
    * <p>The cardinality of {@link Span#localServiceName()} values is expected to be stable and low.
    * There may be hot partitions, but each partition only includes a single column. Hence bucketing
@@ -30,10 +30,19 @@ final class Tables {
   static final String SERVICE_NAMES = "service_names";
 
   /**
-   * This index supports {@link SpanStore#getSpanNames(String)}.
+   * This index supports {@link ServiceAndSpanNames#getRemoteServiceNames(String)}.
    *
-   * <p>The compound partition key includes {@link Span#localServiceName()} and a constant bucket (0).
-   * This is because span names are bounded (and will throw an exception if aren't!).
+   * <p>The cardinality of {@link Span#remoteServiceName()} values is expected to be stable and
+   * low. There may be hot partitions, but each partition only includes a single column. Hence
+   * bucketing would be unnecessary.
+   */
+  static final String REMOTE_SERVICE_NAMES = "remote_service_names";
+
+  /**
+   * This index supports {@link ServiceAndSpanNames#getSpanNames(String)}.
+   *
+   * <p>The compound partition key includes {@link Span#localServiceName()} and a constant bucket
+   * (0). This is because span names are bounded (and will throw an exception if aren't!).
    */
   static final String SPAN_NAMES = "span_names";
 
@@ -83,6 +92,9 @@ final class Tables {
    * (random number between 0 and 9).
    */
   static final String ANNOTATIONS_INDEX = "annotations_index";
+
+  /** This table supports {@link ServiceAndSpanNames#getRemoteServiceNames(String)}. */
+  static final String TABLE_SERVICE_REMOTE_SERVICES = "remote_service_by_service";
 
   private Tables() {
   }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Tables.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Tables.java
@@ -61,11 +61,22 @@ final class Tables {
 
   /**
    * This index supports trace id lookups by {@link QueryRequest#serviceName()} and {@link
+   * QueryRequest#remoteServiceName()}, within the interval of {@link QueryRequest#endTs()} - {@link
+   * QueryRequest#lookback()}.
+   *
+   * <p>The partition key is "{@link Span#localServiceName() $serviceName}.{@link
+   * Span#remoteServiceName() $remoteServiceName}", which is expected to be diverse enough to not
+   * cause hot partitions.
+   */
+  static final String SERVICE_REMOTE_SERVICE_NAME_INDEX = "service_remote_service_name_index";
+
+  /**
+   * This index supports trace id lookups by {@link QueryRequest#serviceName()} and {@link
    * QueryRequest#spanName()}, within the interval of {@link QueryRequest#endTs()} - {@link
    * QueryRequest#lookback()}.
    *
-   * <p>The partition key is "{@link Span#localServiceName() $serviceName}.{@link Span#name()
-   * $spanName}", which is expected to be diverse enough to not cause hot partitions.
+   * <p>The partition key is "{@link Span#localServiceName() $serviceName}.{@link
+   * Span#name() $spanName}", which is expected to be diverse enough to not cause hot partitions.
    */
   static final String SERVICE_SPAN_NAME_INDEX = "service_span_name_index";
 

--- a/zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema-cql3-upgrade-3.txt
+++ b/zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema-cql3-upgrade-3.txt
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS zipkin.remote_service_names (
+    service_name text,
+    remote_service_name text,
+    PRIMARY KEY (service_name, remote_service_name)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND default_time_to_live =  259200;

--- a/zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema-cql3-upgrade-3.txt
+++ b/zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema-cql3-upgrade-3.txt
@@ -5,3 +5,13 @@ CREATE TABLE IF NOT EXISTS zipkin.remote_service_names (
 )
     WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
     AND default_time_to_live =  259200;
+
+CREATE TABLE IF NOT EXISTS zipkin.service_remote_service_name_index (
+    service_remote_service_name text,      // Span.localServiceName + "." + Span.remoteServiceName
+    ts                          timestamp, // start timestamp of the span, truncated to millisecond precision
+    trace_id                    bigint,    // trace ID. Included as a clustering column to avoid clashes (however unlikely)
+    PRIMARY KEY (service_remote_service_name, ts, trace_id)
+)
+    WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_window_size_seconds': '86400'}
+    AND default_time_to_live =  259200;

--- a/zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema-cql3.txt
+++ b/zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema-cql3.txt
@@ -72,4 +72,12 @@ CREATE TABLE IF NOT EXISTS zipkin.autocomplete_tags (
     PRIMARY KEY (key, value)
 )
     WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
-    AND default_time_to_live =  259200
+    AND default_time_to_live =  259200;
+
+CREATE TABLE IF NOT EXISTS zipkin.remote_service_names (
+    service_name text,
+    remote_service_name text,
+    PRIMARY KEY (service_name, remote_service_name)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND default_time_to_live =  259200;

--- a/zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema-cql3.txt
+++ b/zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema-cql3.txt
@@ -1,7 +1,17 @@
 CREATE KEYSPACE IF NOT EXISTS zipkin WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
 
+CREATE TABLE IF NOT EXISTS zipkin.service_remote_service_name_index (
+    service_remote_service_name text,      // Span.localServiceName + "." + Span.remoteServiceName
+    ts                          timestamp, // start timestamp of the span, truncated to millisecond precision
+    trace_id                    bigint,    // trace ID. Included as a clustering column to avoid clashes (however unlikely)
+    PRIMARY KEY (service_remote_service_name, ts, trace_id)
+)
+    WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.DateTieredCompactionStrategy', 'max_window_size_seconds': '86400'}
+    AND default_time_to_live =  259200;
+
 CREATE TABLE IF NOT EXISTS zipkin.service_span_name_index (
-    service_span_name text,      // Endpoint.serviceName + "." + Span.name
+    service_span_name text,      // Span.localServiceName + "." + Span.name
     ts                timestamp, // start timestamp of the span, truncated to millisecond precision
     trace_id          bigint,    // trace ID. Included as a clustering column to avoid clashes (however unlikely)
     PRIMARY KEY (service_span_name, ts, trace_id)
@@ -11,7 +21,7 @@ CREATE TABLE IF NOT EXISTS zipkin.service_span_name_index (
     AND default_time_to_live =  259200;
 
 CREATE TABLE IF NOT EXISTS zipkin.service_name_index (
-    service_name      text,      // Endpoint.serviceName
+    service_name      text,      // Span.localServiceName
     bucket            int,       // avoids hot spots by distributing writes across each bucket, usually 0-9
     ts                timestamp, // start timestamp of the span, truncated to millisecond precision
     trace_id          bigint,    // trace ID. Included as a clustering column to avoid clashes (however unlikely)

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra.v1;
+
+import com.google.common.cache.CacheBuilderSpec;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import zipkin2.Call;
+import zipkin2.Span;
+import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static zipkin2.TestObjects.BACKEND;
+import static zipkin2.TestObjects.FRONTEND;
+
+public class CassandraSpanConsumerTest {
+  CassandraSpanConsumer consumer = spanConsumer(CassandraStorage.newBuilder());
+
+  Span spanWithoutAnnotationsOrTags =
+    Span.newBuilder()
+      .traceId("a")
+      .id("1")
+      .name("get")
+      .localEndpoint(FRONTEND)
+      .timestamp(1472470996199000L)
+      .duration(207000L)
+      .build();
+
+  @Test public void emptyInput_emptyCall() {
+    Call<Void> call = consumer.accept(Collections.emptyList());
+    assertThat(call).hasSameClassAs(Call.create(null));
+  }
+
+  @Test public void doesntIndexWhenMissingLocalServiceName() {
+    Span span = spanWithoutAnnotationsOrTags.toBuilder().localEndpoint(null).build();
+
+    assertThat(consumer.accept(singletonList(span)))
+      .isInstanceOf(ResultSetFutureCall.class);
+  }
+
+  @Test public void indexesLocalServiceNameAndSpanName() {
+    Span span = spanWithoutAnnotationsOrTags;
+
+    Call<Void> call = consumer.accept(singletonList(span));
+
+    assertEnclosedCalls(call)
+      .filteredOn(c -> c instanceof Indexer.IndexCall)
+      .extracting("input.partitionKey")
+      .containsExactly("frontend", "frontend.get");
+  }
+
+  @Test public void doesntIndexWhenMissingTimestamp() {
+    Span span = spanWithoutAnnotationsOrTags.toBuilder().timestamp(null).build();
+
+    Call<Void> call = consumer.accept(singletonList(span));
+
+    assertEnclosedCalls(call)
+      .filteredOn(c -> c instanceof Indexer.IndexCall)
+      .extracting("input.partitionKey")
+      .isEmpty();
+  }
+
+  @Test public void indexKeysBasedOnLocalServiceNotRemote() {
+    Span span = spanWithoutAnnotationsOrTags.toBuilder().remoteEndpoint(BACKEND).build();
+
+    Call<Void> call = consumer.accept(singletonList(span));
+
+    assertEnclosedCalls(call)
+      .filteredOn(c -> c instanceof Indexer.IndexCall)
+      .extracting("input.partitionKey")
+      .containsExactly("frontend", "frontend.backend", "frontend.get");
+  }
+
+  @Test public void indexesServiceNameWhenNoSpanName() {
+    Span span = spanWithoutAnnotationsOrTags.toBuilder().name(null).build();
+
+    Call<Void> call = consumer.accept(singletonList(span));
+
+    assertEnclosedCalls(call)
+      .filteredOn(c -> c instanceof Indexer.IndexCall)
+      .extracting("input.partitionKey")
+      .containsExactly(FRONTEND.serviceName());
+  }
+
+  static AbstractListAssert<?, List<? extends Call<Void>>, Call<Void>, ObjectAssert<Call<Void>>>
+  assertEnclosedCalls(Call<Void> call) {
+    return assertThat(call)
+      .extracting("calls")
+      .flatExtracting(calls -> (Collection<Call<Void>>) calls);
+  }
+
+  static CassandraSpanConsumer spanConsumer(CassandraStorage.Builder builder) {
+    CassandraStorage storage =
+      spy(builder.sessionFactory(mock(SessionFactory.class, Mockito.RETURNS_MOCKS)).build());
+    doReturn(new Schema.Metadata("", true, true, true))
+      .when(storage).metadata();
+    return new CassandraSpanConsumer(storage, CacheBuilderSpec.parse(""));
+  }
+}

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -179,6 +179,25 @@ public class ITCassandraStorage {
     }
   }
 
+  public static class ITServiceAndSpanNames extends zipkin2.storage.ITServiceAndSpanNames {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    CassandraStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() {
+      dropKeyspace(backend.session(), keyspace(testName));
+    }
+  }
+
   public static class ITAutocompleteTags extends zipkin2.storage.ITAutocompleteTags {
     @ClassRule public static CassandraStorageRule backend = classRule();
     @Rule public TestName testName = new TestName();

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -65,7 +65,16 @@ public class ITCassandraStorage {
       return storage;
     }
 
-    @Override @Test @Ignore("Multiple services unsupported") public void getTraces_tags() {
+    @Override @Test @Ignore("All services query unsupported when combined with other qualifiers")
+    public void getTraces_tags() {
+    }
+
+    @Override @Test @Ignore("All services query unsupported when combined with other qualifiers")
+    public void getTraces_remoteServiceName_withoutServiceName() {
+    }
+
+    @Override @Test @Ignore("All services query unsupported when combined with other qualifiers")
+    public void getTraces_spanName_noServiceName() {
     }
 
     @Override @Test @Ignore("Duration unsupported") public void getTraces_duration() {
@@ -168,7 +177,7 @@ public class ITCassandraStorage {
 
     @Before public void connect() {
       storage =
-        backend.computeStorageBuilder().keyspace(keyspace(testName)).strictTraceId(false).build();
+        backend.computeStorageBuilder().keyspace(keyspace(testName)).searchEnabled(false).build();
     }
 
     @Override protected StorageComponent storage() {

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
@@ -18,9 +18,12 @@ import com.datastax.driver.core.Session;
 import java.net.InetSocketAddress;
 import org.junit.Test;
 import zipkin2.TestObjects;
+import zipkin2.storage.QueryRequest;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.DAY;
+import static zipkin2.TestObjects.TODAY;
 
 abstract class ITEnsureSchema {
 
@@ -81,6 +84,12 @@ abstract class ITEnsureSchema {
         .isEmpty(); // instead of an exception
       String serviceName = TestObjects.TRACE.get(0).localServiceName();
       assertThat(storage.serviceAndSpanNames().getRemoteServiceNames(serviceName).execute())
+        .isEmpty(); // instead of an exception
+      assertThat(storage.spanStore().getTraces(QueryRequest.newBuilder()
+        .endTs(TODAY)
+        .lookback(DAY)
+        .limit(10)
+        .remoteServiceName("foo").build()).execute())
         .isEmpty(); // instead of an exception
     }
   }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
@@ -22,6 +22,8 @@ import zipkin2.storage.QueryRequest;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.DAY;
 import static zipkin2.TestObjects.TODAY;
 
@@ -85,13 +87,21 @@ abstract class ITEnsureSchema {
       String serviceName = TestObjects.TRACE.get(0).localServiceName();
       assertThat(storage.serviceAndSpanNames().getRemoteServiceNames(serviceName).execute())
         .isEmpty(); // instead of an exception
-      assertThat(storage.spanStore().getTraces(QueryRequest.newBuilder()
-        .endTs(TODAY)
-        .lookback(DAY)
-        .limit(10)
-        .serviceName("invalid1")
-        .remoteServiceName("invalid2").build()).execute())
-        .isEmpty(); // instead of an exception
+
+      // Make sure there is a good message if a query will return incorrectly
+      try {
+        storage.spanStore().getTraces(QueryRequest.newBuilder()
+          .endTs(TODAY)
+          .lookback(DAY)
+          .limit(10)
+          .serviceName(serviceName)
+          .remoteServiceName(CLIENT_SPAN.remoteServiceName()).build()).execute();
+
+        failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+      } catch (IllegalArgumentException e) { // instead of returning invalid results
+        assertThat(e).hasMessage(
+          "remoteService=backend unsupported due to missing table service_remote_service_name_index");
+      }
     }
   }
 }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
@@ -89,8 +89,8 @@ abstract class ITEnsureSchema {
         .endTs(TODAY)
         .lookback(DAY)
         .limit(10)
-        .serviceName("frontend")
-        .remoteServiceName("backend").build()).execute())
+        .serviceName("invalid1")
+        .remoteServiceName("invalid2").build()).execute())
         .isEmpty(); // instead of an exception
     }
   }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
@@ -89,7 +89,8 @@ abstract class ITEnsureSchema {
         .endTs(TODAY)
         .lookback(DAY)
         .limit(10)
-        .remoteServiceName("foo").build()).execute())
+        .serviceName("frontend")
+        .remoteServiceName("backend").build()).execute())
         .isEmpty(); // instead of an exception
     }
   }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
@@ -78,15 +78,17 @@ abstract class ITSpanConsumer {
     }
 
     accept(storage.spanConsumer(), trace);
-    assertThat(rowCount("annotations_index")).isEqualTo(5L);
-    assertThat(rowCount("service_span_name_index")).isEqualTo(2L);
-    assertThat(rowCount("service_name_index")).isEqualTo(2L);
+    assertThat(rowCount(Tables.ANNOTATIONS_INDEX)).isEqualTo(5L);
+    assertThat(rowCount(Tables.SERVICE_REMOTE_SERVICE_NAME_INDEX)).isEqualTo(1L);
+    assertThat(rowCount(Tables.SERVICE_NAME_INDEX)).isEqualTo(1L);
+    assertThat(rowCount(Tables.SERVICE_SPAN_NAME_INDEX)).isEqualTo(1L);
 
     // redundant store doesn't change the indexes
     accept(storage.spanConsumer(), trace);
-    assertThat(rowCount("annotations_index")).isEqualTo(5L);
-    assertThat(rowCount("service_span_name_index")).isEqualTo(2L);
-    assertThat(rowCount("service_name_index")).isEqualTo(2L);
+    assertThat(rowCount(Tables.ANNOTATIONS_INDEX)).isEqualTo(5L);
+    assertThat(rowCount(Tables.SERVICE_REMOTE_SERVICE_NAME_INDEX)).isEqualTo(1L);
+    assertThat(rowCount(Tables.SERVICE_NAME_INDEX)).isEqualTo(1L);
+    assertThat(rowCount(Tables.SERVICE_SPAN_NAME_INDEX)).isEqualTo(1L);
   }
 
   void accept(SpanConsumer consumer, Span... spans) throws IOException {
@@ -123,7 +125,7 @@ abstract class ITSpanConsumer {
         .name("1")
         .putTag("environment", "dev")
         .putTag("a", "b")
-        .timestamp(trace[0].timestamp() * 1000) // child span timestamps happen 1 ms later
+        .timestamp(trace[0].timestampAsLong()  * 1000) // child span timestamps happen 1 ms later
         .addAnnotation(trace[0].annotations().get(0).timestamp() + 1000, "bar")
         .build();
     accept(storage.spanConsumer(), trace);

--- a/zipkin-storage/cassandra-v1/src/test/resources/log4j2.properties
+++ b/zipkin-storage/cassandra-v1/src/test/resources/log4j2.properties
@@ -7,10 +7,10 @@ rootLogger.level=warn
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT
 # Note: this will dump a large amount of data in the logs
-logger.cassandraquery.name=com.datastax.driver.core.QueryLogger
-logger.cassandraquery.level=trace
-logger.cassandra.name=zipkin2.storage.cassandra.v1
-logger.cassandra.level=info
+#logger.cassandraquery.name=com.datastax.driver.core.QueryLogger
+#logger.cassandraquery.level=trace
+#logger.cassandra.name=zipkin2.storage.cassandra.v1
+#logger.cassandra.level=info
 # don't spam about round-robin
 logger.cassandra-policies.name=com.datastax.driver.core.policies
 logger.cassandra-policies.level=off

--- a/zipkin-storage/cassandra-v1/src/test/resources/log4j2.properties
+++ b/zipkin-storage/cassandra-v1/src/test/resources/log4j2.properties
@@ -7,10 +7,10 @@ rootLogger.level=warn
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT
 # Note: this will dump a large amount of data in the logs
-#logger.cassandraquery.name=com.datastax.driver.core.QueryLogger
-#logger.cassandraquery.level=trace
-#logger.cassandra.name=zipkin2.storage.cassandra.v1
-#logger.cassandra.level=info
+logger.cassandraquery.name=com.datastax.driver.core.QueryLogger
+logger.cassandraquery.level=trace
+logger.cassandra.name=zipkin2.storage.cassandra.v1
+logger.cassandra.level=info
 # don't spam about round-robin
 logger.cassandra-policies.name=com.datastax.driver.core.policies
 logger.cassandra-policies.level=off

--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -83,8 +83,10 @@ of tables from 7 down to 4 (from the original cassandra schema). SASI
 also moves some write-amplification from CassandraSpanConsumer into C*.
 
 CassandraSpanConsumer directly writes to the tables `span`,
-`trace_by_service_span` and `span_by_service`. The latter two
-amplify writes by a factor of the distinct service names in a span.
+`trace_by_service_remote_service` `trace_by_service_span` and
+`span_by_service`. The latter service based indexes amplify writes by a
+factor of the distinct service names (`Span.localServiceName`).
+
 Other amplification happens internally to C*, visible in the increase
 write latency (although write latency remains performant at single digit
 milliseconds).
@@ -104,21 +106,46 @@ in a single trace ID query against the above two indexes.
 Note: annotations with values longer than 256 characters are not written to the
 `annotation_query` SASI, as they aren't intended for use in user queries.
 
+#### `trace_by_service_X` indexing
+
+`trace_by_service_X` rows are answers to a shard of trace query. A query
+request is broken down into possibly multiple shards based on our index
+implementation.
+
+Ex. `GET /api/v2/traces?serviceName=tweetiebird%remoteService=s3`
+
+Breaks down into two query shards (this example omits time range and limit)
+* `(service=tweetiebird, span=)`
+* `(service=tweetiebird, remote_service=s3)`
+
+The results intersect prioritizing on timestamp to return the distinct
+trace IDs needed for a follow-up fetch.
+
+#### `trace_by_service_remote_service` indexing
+
+For example, a span in trace ID 1 named "get" created by "tweetiebird",
+accessing the remote service "s3" results in the following row:
+
+* `service=service1, span=remote_service, ts=timestamp_millis, trace_id=1`
+
+This index is only used when the `remoteServiceName` query is used. Ex.
+1. `GET /api/v2/traces?serviceName=tweetiebird&remoteServiceName=s3`
+1. `GET /api/v2/traces?serviceName=tweetiebird&maxDuration=199500&remoteServiceName=s3`
+
 #### `trace_by_service_span` indexing
 
-`trace_by_service_span` rows represent a shard of a user query. For example, a
-span in trace ID 1 named "get" created by "service1", taking 20 milliseconds
-results in the following rows:
+For example, a span in trace ID 1 named "get" created by "service1",
+taking 20 milliseconds results in the following rows:
 
-1. `service=service1, span=targz, trace_id=1, duration=200`
-2. `service=service1, span=, trace_id=1, duration=200`
+1. `service=service1, span=get, trace_id=1, ts=timestamp_millis, duration=200`
+2. `service=service1, span=, trace_id=1, ts=timestamp_millis, duration=200`
 
 Here are corresponding queries that relate to the above rows:
-1. `GET /api/v2/traces?serviceName=service1&spanName=targz`
-1. `GET /api/v2/traces?serviceName=service1&spanName=targz&minDuration=200000`
+1. `GET /api/v2/traces?serviceName=service1&spanName=get`
+1. `GET /api/v2/traces?serviceName=service1&spanName=get&minDuration=200000`
 1. `GET /api/v2/traces?serviceName=service1&minDuration=200000`
-2. `GET /api/v2/traces?spanName=targz`
-2. `GET /api/v2/traces?duration=199500`
+1. `GET /api/v2/traces?spanName=get`
+1. `GET /api/v2/traces?maxDuration=199500`
 
 As you'll notice, the duration component is optional, and stored in
 millisecond resolution as opposed to microsecond (which the query represents).
@@ -128,10 +155,6 @@ The reason we can query on `duration` is due to a SASI index. Eventhough the
 search granularity is millisecond, original duration data remains microsecond
 granularity. Meanwhile, write performance is dramatically better than writing
 discrete values, due to fewer distinct writes.
-
-You might wonder how the last two queries work, considering they don't know
-the service name associated with index rows. When needed, this implementation
-performs a service name fetch, resulting in a fan-out composition over row 2.
 
 #### Disabling indexing
 Indexing is a good default, but some sites who don't use Zipkin UI's

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraAutocompleteTags.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraAutocompleteTags.java
@@ -23,7 +23,9 @@ class CassandraAutocompleteTags implements AutocompleteTags {
   final SelectAutocompleteValues.Factory valuesCallFactory;
 
   CassandraAutocompleteTags(CassandraStorage storage) {
-    enabled = storage.searchEnabled() && !storage.autocompleteKeys().isEmpty();
+    enabled = storage.searchEnabled()
+      && !storage.autocompleteKeys().isEmpty()
+      && storage.metadata().hasAutocompleteTags;
     keysCall = Call.create(storage.autocompleteKeys());
     valuesCallFactory = enabled ? new SelectAutocompleteValues.Factory(storage.session()) : null;
   }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
@@ -50,7 +50,7 @@ class CassandraSpanConsumer implements SpanConsumer { // not final for testing
     insertSpan = new InsertSpan.Factory(session, strictTraceId, searchEnabled);
     if (searchEnabled) {
       insertTraceByServiceSpan = new InsertTraceByServiceSpan.Factory(session, strictTraceId);
-      if (metadata.hasRemoteServiceByService) {
+      if (metadata.hasRemoteService) {
         insertServiceRemoteService = new InsertServiceRemoteService.Factory(storage);
       } else {
         insertServiceRemoteService = null;

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
@@ -100,6 +100,8 @@ class CassandraSpanConsumer implements SpanConsumer { // not final for testing
 
       // Empty values allow for api queries with blank service or span name
       String service = s.localServiceName() != null ? s.localServiceName() : "";
+      String span =
+        null != s.name() ? s.name() : ""; // Empty value allows for api queries without span name
 
       if (null == s.localServiceName()) continue; // don't index further w/o a service name
 
@@ -108,13 +110,11 @@ class CassandraSpanConsumer implements SpanConsumer { // not final for testing
         serviceRemoteServices.add(
           insertServiceRemoteService.newInput(service, s.remoteServiceName()));
       }
-      if (s.name() != null) serviceSpans.add(insertServiceSpan.newInput(service, s.name()));
+      serviceSpans.add(insertServiceSpan.newInput(service, span));
 
       if (ts_micro == 0L) continue; // search is only valid with a timestamp, don't index w/o it!
       int bucket = durationIndexBucket(ts_micro); // duration index is milliseconds not microseconds
       long duration = s.durationAsLong() / 1000L;
-      String span =
-        null != s.name() ? s.name() : ""; // Empty value allows for api queries without span name
       traceByServiceSpans.add(
         insertTraceByServiceSpan.newInput(service, span, bucket, ts_uuid, s.traceId(), duration));
       if (span.isEmpty()) continue;

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
@@ -65,7 +65,7 @@ class CassandraSpanStore implements SpanStore, ServiceAndSpanNames { // not fina
     if (searchEnabled) {
       KeyspaceMetadata md = Schema.ensureKeyspaceMetadata(session, storage.keyspace());
       indexTtl = md.getTable(TABLE_TRACE_BY_SERVICE_SPAN).getOptions().getDefaultTimeToLive();
-      if (metadata.hasRemoteServiceByService) {
+      if (metadata.hasRemoteService) {
         remoteServiceNames = new SelectRemoteServiceNames.Factory(session);
       } else {
         remoteServiceNames = null;

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
@@ -26,6 +26,7 @@ import zipkin2.CheckResult;
 import zipkin2.internal.Nullable;
 import zipkin2.storage.AutocompleteTags;
 import zipkin2.storage.QueryRequest;
+import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
@@ -211,6 +212,10 @@ public abstract class CassandraStorage extends StorageComponent {
   @Override
   public SpanStore spanStore() {
     return new CassandraSpanStore(this);
+  }
+
+  @Override public ServiceAndSpanNames serviceAndSpanNames() {
+    return (CassandraSpanStore) spanStore();
   }
 
   /** {@inheritDoc} Memoized in order to avoid re-preparing statements */

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
@@ -232,6 +232,10 @@ public abstract class CassandraStorage extends StorageComponent {
     return new CassandraSpanConsumer(this);
   }
 
+  @Memoized Schema.Metadata metadata() { // warn once when schema problems exist
+    return Schema.readMetadata(session());
+  }
+
   @Override
   public CheckResult check() {
     try {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
@@ -232,7 +232,7 @@ public abstract class CassandraStorage extends StorageComponent {
     return new CassandraSpanConsumer(this);
   }
 
-  @Memoized Schema.Metadata metadata() { // warn once when schema problems exist
+  @Memoized Schema.Metadata metadata() { // warn only once when schema problems exist
     return Schema.readMetadata(session());
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraUtil.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraUtil.java
@@ -42,8 +42,8 @@ final class CassandraUtil {
   static final int LONGEST_VALUE_TO_INDEX = 256;
 
   /**
-   * Time window covered by a single bucket of the {@link Schema#TABLE_TRACE_BY_SERVICE_SPAN}, in
-   * seconds. Default: 1 day
+   * Time window covered by a single bucket of the {@link Schema#TABLE_TRACE_BY_SERVICE_SPAN} and
+   * {@link Schema#TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE}, in seconds. Default: 1 day
    */
   private static final long DURATION_INDEX_BUCKET_WINDOW_SECONDS =
       Long.getLong("zipkin.store.cassandra.internal.durationIndexBucket", 24 * 60 * 60);

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceRemoteService.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceRemoteService.java
@@ -29,6 +29,10 @@ final class InsertServiceRemoteService extends ResultSetFutureCall<Void> {
 
   @AutoValue
   abstract static class Input {
+    static Input create(String service_name, String remote_service_name) {
+      return new AutoValue_InsertServiceRemoteService_Input(service_name, remote_service_name);
+    }
+
     abstract String service();
 
     abstract String remoteService();
@@ -51,7 +55,7 @@ final class InsertServiceRemoteService extends ResultSetFutureCall<Void> {
     }
 
     Input newInput(String service_name, String remote_service_name) {
-      return new AutoValue_InsertServiceRemoteService_Input(service_name, remote_service_name);
+      return Input.create(service_name, remote_service_name);
     }
 
     @Override protected InsertServiceRemoteService newCall(Input input) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceRemoteService.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceRemoteService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.auto.value.AutoValue;
+import zipkin2.storage.cassandra.internal.call.DeduplicatingVoidCallFactory;
+import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
+
+import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_REMOTE_SERVICES;
+
+final class InsertServiceRemoteService extends ResultSetFutureCall<Void> {
+
+  @AutoValue
+  abstract static class Input {
+    abstract String service();
+
+    abstract String remoteService();
+
+    Input() {
+    }
+  }
+
+  static class Factory extends DeduplicatingVoidCallFactory<Input> {
+    final Session session;
+    final PreparedStatement preparedStatement;
+
+    Factory(CassandraStorage storage) {
+      super(storage.autocompleteTtl(), storage.autocompleteCardinality());
+      session = storage.session();
+      Insert insertQuery = QueryBuilder.insertInto(TABLE_SERVICE_REMOTE_SERVICES)
+        .value("service", QueryBuilder.bindMarker("service"))
+        .value("remote_service", QueryBuilder.bindMarker("remote_service"));
+      preparedStatement = session.prepare(insertQuery);
+    }
+
+    Input newInput(String service_name, String remote_service_name) {
+      return new AutoValue_InsertServiceRemoteService_Input(service_name, remote_service_name);
+    }
+
+    @Override protected InsertServiceRemoteService newCall(Input input) {
+      return new InsertServiceRemoteService(this, input);
+    }
+  }
+
+  final Factory factory;
+  final Input input;
+
+  InsertServiceRemoteService(Factory factory, Input input) {
+    this.factory = factory;
+    this.input = input;
+  }
+
+  @Override protected ResultSetFuture newFuture() {
+    return factory.session.executeAsync(factory.preparedStatement.bind()
+      .setString("service", input.service())
+      .setString("remote_service", input.remoteService()));
+  }
+
+  @Override public Void map(ResultSet input) {
+    return null;
+  }
+
+  @Override public String toString() {
+    return input.toString().replace("Input", "InsertServiceRemoteService");
+  }
+
+  @Override public InsertServiceRemoteService clone() {
+    return new InsertServiceRemoteService(factory, input);
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceSpan.java
@@ -29,8 +29,8 @@ final class InsertServiceSpan extends ResultSetFutureCall<Void> {
 
   @AutoValue
   abstract static class Input {
-    static Input create(String service_name, String span_name) {
-      return new AutoValue_InsertServiceSpan_Input(service_name, span_name);
+    static Input create(String service, String span) {
+      return new AutoValue_InsertServiceSpan_Input(service, span);
     }
 
     abstract String service();
@@ -54,8 +54,8 @@ final class InsertServiceSpan extends ResultSetFutureCall<Void> {
       preparedStatement = session.prepare(insertQuery);
     }
 
-    Input newInput(String service_name, String span_name) {
-      return Input.create(service_name, span_name);
+    Input newInput(String service, String span) {
+      return Input.create(service, span);
     }
 
     @Override protected InsertServiceSpan newCall(Input input) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceSpan.java
@@ -29,6 +29,10 @@ final class InsertServiceSpan extends ResultSetFutureCall<Void> {
 
   @AutoValue
   abstract static class Input {
+    static Input create(String service_name, String span_name) {
+      return new AutoValue_InsertServiceSpan_Input(service_name, span_name);
+    }
+
     abstract String service();
 
     abstract String span();
@@ -51,7 +55,7 @@ final class InsertServiceSpan extends ResultSetFutureCall<Void> {
     }
 
     Input newInput(String service_name, String span_name) {
-      return new AutoValue_InsertServiceSpan_Input(service_name, span_name);
+      return Input.create(service_name, span_name);
     }
 
     @Override protected InsertServiceSpan newCall(Input input) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertTraceByServiceRemoteService.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertTraceByServiceRemoteService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.auto.value.AutoValue;
+import java.util.UUID;
+import zipkin2.Call;
+import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
+
+import static zipkin2.storage.cassandra.Schema.TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE;
+
+final class InsertTraceByServiceRemoteService extends ResultSetFutureCall<Void> {
+
+  @AutoValue abstract static class Input {
+    abstract String service();
+
+    abstract String remote_service();
+
+    abstract int bucket();
+
+    abstract UUID ts();
+
+    abstract String trace_id();
+  }
+
+  static class Factory {
+    final Session session;
+    final PreparedStatement preparedStatement;
+    final boolean strictTraceId;
+
+    Factory(Session session, boolean strictTraceId) {
+      this.session = session;
+      this.preparedStatement =
+        session.prepare(QueryBuilder.insertInto(TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE)
+          .value("service", QueryBuilder.bindMarker("service"))
+          .value("remote_service", QueryBuilder.bindMarker("remote_service"))
+          .value("bucket", QueryBuilder.bindMarker("bucket"))
+          .value("ts", QueryBuilder.bindMarker("ts"))
+          .value("trace_id", QueryBuilder.bindMarker("trace_id")));
+      this.strictTraceId = strictTraceId;
+    }
+
+    Input newInput(String service, String remote_service, int bucket, UUID ts, String trace_id) {
+      return new AutoValue_InsertTraceByServiceRemoteService_Input(
+        service,
+        remote_service,
+        bucket,
+        ts,
+        !strictTraceId && trace_id.length() == 32 ? trace_id.substring(16) : trace_id);
+    }
+
+    Call<Void> create(Input input) {
+      return new InsertTraceByServiceRemoteService(this, input);
+    }
+  }
+
+  final Factory factory;
+  final Input input;
+
+  InsertTraceByServiceRemoteService(Factory factory, Input input) {
+    this.factory = factory;
+    this.input = input;
+  }
+
+  @Override protected ResultSetFuture newFuture() {
+    return factory.session.executeAsync(factory.preparedStatement.bind()
+      .setString("service", input.service())
+      .setString("remote_service", input.remote_service())
+      .setInt("bucket", input.bucket())
+      .setUUID("ts", input.ts())
+      .setString("trace_id", input.trace_id()));
+  }
+
+  @Override public Void map(ResultSet input) {
+    return null;
+  }
+
+  @Override public String toString() {
+    return input.toString().replace("Input", "InsertTraceByServiceRemoteService");
+  }
+
+  @Override public InsertTraceByServiceRemoteService clone() {
+    return new InsertTraceByServiceRemoteService(factory, input);
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -82,25 +82,25 @@ final class Schema {
         UPGRADE_1);
     }
 
-    boolean hasRemoteServiceByService = hasUpgrade2_remoteService(keyspaceMetadata);
-    if (!hasRemoteServiceByService) {
+    boolean hasRemoteService = hasUpgrade2_remoteService(keyspaceMetadata);
+    if (!hasRemoteService) {
       LOG.warn(
         "schema lacks remote service indexing: apply {}, or set CassandraStorage.ensureSchema=true",
         UPGRADE_2);
     }
 
-    return new Metadata(compactionClass, hasAutocompleteTags, hasRemoteServiceByService);
+    return new Metadata(compactionClass, hasAutocompleteTags, hasRemoteService);
   }
 
   static final class Metadata {
     final String compactionClass;
-    final boolean hasAutocompleteTags, hasRemoteServiceByService;
+    final boolean hasAutocompleteTags, hasRemoteService;
 
     Metadata(String compactionClass, boolean hasAutocompleteTags,
-      boolean hasRemoteServiceByService) {
+      boolean hasRemoteService) {
       this.compactionClass = compactionClass;
       this.hasAutocompleteTags = hasAutocompleteTags;
-      this.hasRemoteServiceByService = hasRemoteServiceByService;
+      this.hasRemoteService = hasRemoteService;
     }
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -75,11 +75,21 @@ final class Schema {
     String compactionClass =
       keyspaceMetadata.getTable("span").getOptions().getCompaction().get("class");
 
-    return new Metadata(
-      compactionClass,
-      hasUpgrade1_autocompleteTags(keyspaceMetadata),
-      hasUpgrade2_remoteService(keyspaceMetadata)
-    );
+    boolean hasAutocompleteTags = hasUpgrade1_autocompleteTags(keyspaceMetadata);
+    if (!hasAutocompleteTags) {
+      LOG.warn(
+        "schema lacks autocomplete indexing: apply {}, or set CassandraStorage.ensureSchema=true",
+        UPGRADE_1);
+    }
+
+    boolean hasRemoteServiceByService = hasUpgrade2_remoteService(keyspaceMetadata);
+    if (!hasRemoteServiceByService) {
+      LOG.warn(
+        "schema lacks remote service indexing: apply {}, or set CassandraStorage.ensureSchema=true",
+        UPGRADE_2);
+    }
+
+    return new Metadata(compactionClass, hasAutocompleteTags, hasRemoteServiceByService);
   }
 
   static final class Metadata {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -43,6 +43,7 @@ final class Schema {
   static final String TABLE_SPAN = "span";
   static final String TABLE_TRACE_BY_SERVICE_SPAN = "trace_by_service_span";
   static final String TABLE_SERVICE_SPANS = "span_by_service";
+  static final String TABLE_SERVICE_REMOTE_SERVICES = "remote_service_by_service";
   static final String TABLE_DEPENDENCY = "dependency";
   static final String TABLE_AUTOCOMPLETE_TAGS = "autocomplete_tags";
 
@@ -50,6 +51,7 @@ final class Schema {
   static final String SCHEMA_RESOURCE = "/zipkin2-schema.cql";
   static final String INDEX_RESOURCE = "/zipkin2-schema-indexes.cql";
   static final String UPGRADE_1 = "/zipkin2-schema-upgrade-1.cql";
+  static final String UPGRADE_2 = "/zipkin2-schema-upgrade-2.cql";
 
   private Schema() {
   }
@@ -123,11 +125,19 @@ final class Schema {
       LOG.info("Upgrading schema {}", UPGRADE_1);
       applyCqlFile(keyspace, session, UPGRADE_1);
     }
+    if (!hasUpgrade2_remoteService(result)) {
+      LOG.info("Upgrading schema {}", UPGRADE_2);
+      applyCqlFile(keyspace, session, UPGRADE_2);
+    }
     return result;
   }
 
   static boolean hasUpgrade1_autocompleteTags(KeyspaceMetadata keyspaceMetadata) {
     return keyspaceMetadata.getTable(TABLE_AUTOCOMPLETE_TAGS) != null;
+  }
+
+  static boolean hasUpgrade2_remoteService(KeyspaceMetadata keyspaceMetadata) {
+    return keyspaceMetadata.getTable(TABLE_SERVICE_REMOTE_SERVICES) != null;
   }
 
   static void applyCqlFile(String keyspace, Session session, String resource) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -75,14 +75,22 @@ final class Schema {
     String compactionClass =
       keyspaceMetadata.getTable("span").getOptions().getCompaction().get("class");
 
-    return new Metadata(compactionClass);
+    return new Metadata(
+      compactionClass,
+      hasUpgrade1_autocompleteTags(keyspaceMetadata),
+      hasUpgrade2_remoteService(keyspaceMetadata)
+    );
   }
 
   static final class Metadata {
     final String compactionClass;
+    final boolean hasAutocompleteTags, hasRemoteServiceByService;
 
-    Metadata(String compactionClass) {
+    Metadata(String compactionClass, boolean hasAutocompleteTags,
+      boolean hasRemoteServiceByService) {
       this.compactionClass = compactionClass;
+      this.hasAutocompleteTags = hasAutocompleteTags;
+      this.hasRemoteServiceByService = hasRemoteServiceByService;
     }
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -42,6 +42,7 @@ final class Schema {
 
   static final String TABLE_SPAN = "span";
   static final String TABLE_TRACE_BY_SERVICE_SPAN = "trace_by_service_span";
+  static final String TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE = "trace_by_service_remote_service";
   static final String TABLE_SERVICE_SPANS = "span_by_service";
   static final String TABLE_SERVICE_REMOTE_SERVICES = "remote_service_by_service";
   static final String TABLE_DEPENDENCY = "dependency";

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectRemoteServiceNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectRemoteServiceNames.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import zipkin2.Call;
+import zipkin2.storage.cassandra.internal.call.AccumulateAllResults;
+import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_REMOTE_SERVICES;
+
+final class SelectRemoteServiceNames extends ResultSetFutureCall<ResultSet> {
+
+  static class Factory {
+    final Session session;
+    final PreparedStatement preparedStatement;
+    final AccumulateNamesAllResults accumulateNamesIntoSet = new AccumulateNamesAllResults();
+
+    Factory(Session session) {
+      this.session = session;
+      this.preparedStatement =
+          session.prepare(
+              QueryBuilder.select("remote_service")
+                  .from(TABLE_SERVICE_REMOTE_SERVICES)
+                  .where(QueryBuilder.eq("service", QueryBuilder.bindMarker("service")))
+                  .limit(QueryBuilder.bindMarker("limit_")));
+    }
+
+    Call<List<String>> create(String serviceName) {
+      if (serviceName == null || serviceName.isEmpty()) return Call.emptyList();
+      String service = checkNotNull(serviceName, "serviceName").toLowerCase();
+      return new SelectRemoteServiceNames(this, service).flatMap(accumulateNamesIntoSet);
+    }
+  }
+
+  final Factory factory;
+  final String service;
+
+  SelectRemoteServiceNames(Factory factory, String service) {
+    this.factory = factory;
+    this.service = service;
+  }
+
+  @Override
+  protected ResultSetFuture newFuture() {
+    return factory.session.executeAsync(factory.preparedStatement
+      .bind()
+      .setString("service", service)
+      .setInt("limit_", 1000)); // no one is ever going to browse so many span names
+  }
+
+  @Override public ResultSet map(ResultSet input) {
+    return input;
+  }
+
+  @Override
+  public String toString() {
+    return "SelectSpanNames{service=" + service + "}";
+  }
+
+  @Override
+  public SelectRemoteServiceNames clone() {
+    return new SelectRemoteServiceNames(factory, service);
+  }
+
+  static class AccumulateNamesAllResults extends AccumulateAllResults<List<String>> {
+    @Override
+    protected Supplier<List<String>> supplier() {
+      return ArrayList::new; // TODO: list might not be ok due to not distinct
+    }
+
+    @Override
+    protected BiConsumer<Row, List<String>> accumulator() {
+      return (row, list) -> {
+        String result = row.getString("remote_service");
+        if (!result.isEmpty()) list.add(result);
+      };
+    }
+
+    @Override
+    public String toString() {
+      return "AccumulateNamesAllResults{}";
+    }
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectServiceNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectServiceNames.java
@@ -16,15 +16,11 @@ package zipkin2.storage.cassandra;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
-import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 import zipkin2.Call;
-import zipkin2.storage.cassandra.internal.call.AccumulateAllResults;
+import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
 import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_SPANS;
@@ -33,8 +29,7 @@ final class SelectServiceNames extends ResultSetFutureCall<ResultSet> {
   static class Factory {
     final Session session;
     final PreparedStatement preparedStatement;
-    final AccumulateServicesAllResults accumulateServicesIntoSet =
-        new AccumulateServicesAllResults();
+    final DistinctSortedStrings services = new DistinctSortedStrings("service");
 
     Factory(Session session) {
       this.session = session;
@@ -43,7 +38,7 @@ final class SelectServiceNames extends ResultSetFutureCall<ResultSet> {
     }
 
     Call<List<String>> create() {
-      return new SelectServiceNames(this).flatMap(accumulateServicesIntoSet);
+      return new SelectServiceNames(this).flatMap(services);
     }
   }
 
@@ -53,8 +48,7 @@ final class SelectServiceNames extends ResultSetFutureCall<ResultSet> {
     this.factory = factory;
   }
 
-  @Override
-  protected ResultSetFuture newFuture() {
+  @Override protected ResultSetFuture newFuture() {
     return factory.session.executeAsync(factory.preparedStatement.bind());
   }
 
@@ -62,30 +56,11 @@ final class SelectServiceNames extends ResultSetFutureCall<ResultSet> {
     return input;
   }
 
-  @Override
-  public String toString() {
+  @Override public String toString() {
     return "SelectServiceNames{}";
   }
 
-  @Override
-  public SelectServiceNames clone() {
+  @Override public SelectServiceNames clone() {
     return new SelectServiceNames(factory);
-  }
-
-  static class AccumulateServicesAllResults extends AccumulateAllResults<List<String>> {
-    @Override
-    protected Supplier<List<String>> supplier() {
-      return ArrayList::new; // list is ok because it is distinct results
-    }
-
-    @Override
-    protected BiConsumer<Row, List<String>> accumulator() {
-      return (row, list) -> list.add(row.getString("service"));
-    }
-
-    @Override
-    public String toString() {
-      return "AccumulateServicesAllResults{}";
-    }
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
@@ -16,15 +16,11 @@ package zipkin2.storage.cassandra;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
-import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 import zipkin2.Call;
-import zipkin2.storage.cassandra.internal.call.AccumulateAllResults;
+import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -35,22 +31,21 @@ final class SelectSpanNames extends ResultSetFutureCall<ResultSet> {
   static class Factory {
     final Session session;
     final PreparedStatement preparedStatement;
-    final AccumulateNamesAllResults accumulateNamesIntoSet = new AccumulateNamesAllResults();
+    final DistinctSortedStrings spans = new DistinctSortedStrings("span");
 
     Factory(Session session) {
       this.session = session;
       this.preparedStatement =
-          session.prepare(
-              QueryBuilder.select("span")
-                  .from(TABLE_SERVICE_SPANS)
-                  .where(QueryBuilder.eq("service", QueryBuilder.bindMarker("service")))
-                  .limit(QueryBuilder.bindMarker("limit_")));
+        session.prepare(QueryBuilder.select("span")
+          .from(TABLE_SERVICE_SPANS)
+          .where(QueryBuilder.eq("service", QueryBuilder.bindMarker("service")))
+          .limit(QueryBuilder.bindMarker("limit_")));
     }
 
     Call<List<String>> create(String serviceName) {
       if (serviceName == null || serviceName.isEmpty()) return Call.emptyList();
       String service = checkNotNull(serviceName, "serviceName").toLowerCase();
-      return new SelectSpanNames(this, service).flatMap(accumulateNamesIntoSet);
+      return new SelectSpanNames(this, service).flatMap(spans);
     }
   }
 
@@ -62,10 +57,8 @@ final class SelectSpanNames extends ResultSetFutureCall<ResultSet> {
     this.service = service;
   }
 
-  @Override
-  protected ResultSetFuture newFuture() {
-    return factory.session.executeAsync(factory.preparedStatement
-      .bind()
+  @Override protected ResultSetFuture newFuture() {
+    return factory.session.executeAsync(factory.preparedStatement.bind()
       .setString("service", service)
       .setInt("limit_", 1000)); // no one is ever going to browse so many span names
   }
@@ -74,33 +67,11 @@ final class SelectSpanNames extends ResultSetFutureCall<ResultSet> {
     return input;
   }
 
-  @Override
-  public String toString() {
+  @Override public String toString() {
     return "SelectSpanNames{service=" + service + "}";
   }
 
-  @Override
-  public SelectSpanNames clone() {
+  @Override public SelectSpanNames clone() {
     return new SelectSpanNames(factory, service);
-  }
-
-  static class AccumulateNamesAllResults extends AccumulateAllResults<List<String>> {
-    @Override
-    protected Supplier<List<String>> supplier() {
-      return ArrayList::new; // TODO: list might not be ok due to not distinct
-    }
-
-    @Override
-    protected BiConsumer<Row, List<String>> accumulator() {
-      return (row, list) -> {
-        String result = row.getString("span");
-        if (!result.isEmpty()) list.add(result);
-      };
-    }
-
-    @Override
-    public String toString() {
-      return "AccumulateNamesAllResults{}";
-    }
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromServiceRemoteService.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromServiceRemoteService.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+import zipkin2.Call;
+import zipkin2.storage.cassandra.CassandraSpanStore.TimestampRange;
+import zipkin2.storage.cassandra.internal.call.AccumulateTraceIdTsUuid;
+import zipkin2.storage.cassandra.internal.call.AggregateIntoSet;
+import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
+
+import static zipkin2.storage.cassandra.Schema.TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE;
+
+final class SelectTraceIdsFromServiceRemoteService extends ResultSetFutureCall<ResultSet> {
+  @AutoValue abstract static class Input {
+    abstract String service();
+
+    abstract String remote_service();
+
+    abstract int bucket();
+
+    abstract UUID start_ts();
+
+    abstract UUID end_ts();
+
+    abstract int limit_();
+
+    Input withService(String service) {
+      return new AutoValue_SelectTraceIdsFromServiceRemoteService_Input(
+        service,
+        remote_service(),
+        bucket(),
+        start_ts(),
+        end_ts(),
+        limit_());
+    }
+  }
+
+  static class Factory {
+    final Session session;
+    final PreparedStatement preparedStatement;
+
+    Factory(Session session) {
+      this.session = session;
+      this.preparedStatement = session.prepare(QueryBuilder.select("ts", "trace_id")
+        .from(TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE)
+        .where(QueryBuilder.eq("service", QueryBuilder.bindMarker("service")))
+        .and(QueryBuilder.eq("remote_service", QueryBuilder.bindMarker("remote_service")))
+        .and(QueryBuilder.eq("bucket", QueryBuilder.bindMarker("bucket")))
+        .and(QueryBuilder.gte("ts", QueryBuilder.bindMarker("start_ts")))
+        .and(QueryBuilder.lte("ts", QueryBuilder.bindMarker("end_ts")))
+        .limit(QueryBuilder.bindMarker("limit_")));
+    }
+
+    Input newInput(
+      String serviceName,
+      String remoteServiceName,
+      int bucket,
+      TimestampRange timestampRange,
+      int limit) {
+      return new AutoValue_SelectTraceIdsFromServiceRemoteService_Input(
+        serviceName,
+        remoteServiceName,
+        bucket,
+        timestampRange.startUUID,
+        timestampRange.endUUID,
+        limit);
+    }
+
+    Call<Set<Entry<String, Long>>> newCall(List<Input> inputs) {
+      if (inputs.isEmpty()) return Call.create(Collections.emptySet());
+      if (inputs.size() == 1) return newCall(inputs.get(0));
+
+      List<Call<Set<Entry<String, Long>>>> bucketedTraceIdCalls = new ArrayList<>();
+      for (SelectTraceIdsFromServiceRemoteService.Input input : inputs) {
+        bucketedTraceIdCalls.add(newCall(input));
+      }
+      return new AggregateIntoSet<>(bucketedTraceIdCalls);
+    }
+
+    Call<Set<Entry<String, Long>>> newCall(Input input) {
+      return new SelectTraceIdsFromServiceRemoteService(this, preparedStatement, input)
+        .flatMap(new AccumulateTraceIdTsUuid());
+    }
+
+    /** Applies all deferred service names to all input templates */
+    FlatMapper<List<String>, Set<Entry<String, Long>>> newFlatMapper(List<Input> inputTemplates) {
+      return new FlatMapServicesToInputs(inputTemplates);
+    }
+
+    class FlatMapServicesToInputs implements FlatMapper<List<String>, Set<Entry<String, Long>>> {
+      final List<Input> inputTemplates;
+
+      FlatMapServicesToInputs(List<Input> inputTemplates) {
+        this.inputTemplates = inputTemplates;
+      }
+
+      @Override public Call<Set<Entry<String, Long>>> map(List<String> serviceNames) {
+        List<Call<Set<Entry<String, Long>>>> bucketedTraceIdCalls = new ArrayList<>();
+
+        for (String service : serviceNames) { // fan out every input for each service name
+          List<Input> scopedInputs = new ArrayList<>();
+          for (Input input : inputTemplates) {
+            scopedInputs.add(input.withService(service));
+          }
+          bucketedTraceIdCalls.add(newCall(scopedInputs));
+        }
+
+        if (bucketedTraceIdCalls.isEmpty()) return Call.create(Collections.emptySet());
+        if (bucketedTraceIdCalls.size() == 1) return bucketedTraceIdCalls.get(0);
+        return new AggregateIntoSet<>(bucketedTraceIdCalls);
+      }
+
+      @Override public String toString() {
+        return "FlatMapServicesToInputs{" + inputTemplates + "}";
+      }
+    }
+  }
+
+  final Factory factory;
+  final PreparedStatement preparedStatement;
+  final Input input;
+
+  SelectTraceIdsFromServiceRemoteService(Factory factory, PreparedStatement preparedStatement,
+    Input input) {
+    this.factory = factory;
+    this.preparedStatement = preparedStatement;
+    this.input = input;
+  }
+
+  @Override protected ResultSetFuture newFuture() {
+    Statement bound = preparedStatement.bind()
+      .setString("service", input.service())
+      .setString("remote_service", input.remote_service())
+      .setInt("bucket", input.bucket())
+      .setUUID("start_ts", input.start_ts())
+      .setUUID("end_ts", input.end_ts())
+      .setInt("limit_", input.limit_())
+      .setFetchSize(input.limit_());
+    return factory.session.executeAsync(bound);
+  }
+
+  @Override public ResultSet map(ResultSet input) {
+    return input;
+  }
+
+  @Override public String toString() {
+    return input.toString().replace("Input", "SelectTraceIdsFromServiceRemoteService");
+  }
+
+  @Override public SelectTraceIdsFromServiceRemoteService clone() {
+    return new SelectTraceIdsFromServiceRemoteService(factory, preparedStatement, input);
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromServiceRemoteService.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromServiceRemoteService.java
@@ -134,7 +134,11 @@ final class SelectTraceIdsFromServiceRemoteService extends ResultSetFutureCall<R
       }
 
       @Override public String toString() {
-        return "FlatMapServicesToInputs{" + inputTemplates + "}";
+        List<String> inputs = new ArrayList<>();
+        for (Input input : inputTemplates) {
+          inputs.add(input.toString().replace("Input", "SelectTraceIdsFromServiceRemoteService"));
+        }
+        return "FlatMapServicesToInputs{" + inputs + "}";
       }
     }
   }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromServiceSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectTraceIdsFromServiceSpan.java
@@ -158,8 +158,7 @@ final class SelectTraceIdsFromServiceSpan extends ResultSetFutureCall<ResultSet>
         this.inputTemplates = inputTemplates;
       }
 
-      @Override
-      public Call<Map<String, Long>> map(List<String> serviceNames) {
+      @Override public Call<Map<String, Long>> map(List<String> serviceNames) {
         List<Call<Map<String, Long>>> bucketedTraceIdCalls = new ArrayList<>();
 
         for (String service : serviceNames) { // fan out every input for each service name
@@ -175,9 +174,12 @@ final class SelectTraceIdsFromServiceSpan extends ResultSetFutureCall<ResultSet>
         return new AggregateIntoMap<>(bucketedTraceIdCalls);
       }
 
-      @Override
-      public String toString() {
-        return "FlatMapServicesToInputs{" + inputTemplates + "}";
+      @Override public String toString() {
+        List<String> inputs = new ArrayList<>();
+        for (Input input : inputTemplates) {
+          inputs.add(input.toString().replace("Input", "SelectTraceIdsFromServiceSpan"));
+        }
+        return "FlatMapServicesToInputs{" + inputs + "}";
       }
     }
   }
@@ -194,12 +196,10 @@ final class SelectTraceIdsFromServiceSpan extends ResultSetFutureCall<ResultSet>
 
   @Override
   protected ResultSetFuture newFuture() {
-    BoundStatement bound =
-        preparedStatement
-            .bind()
-            .setString("service", input.service())
-            .setString("span", input.span())
-            .setInt("bucket", input.bucket());
+    BoundStatement bound = preparedStatement.bind()
+      .setString("service", input.service())
+      .setString("span", input.span())
+      .setInt("bucket", input.bucket());
     if (input.start_duration() != null) {
       bound.setLong("start_duration", input.start_duration());
       bound.setLong("end_duration", input.end_duration());

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/AccumulateTraceIdTsUuid.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/AccumulateTraceIdTsUuid.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra.internal.call;
+
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.utils.UUIDs;
+import java.util.AbstractMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+public final class AccumulateTraceIdTsUuid
+  extends AccumulateAllResults<Set<Map.Entry<String, Long>>> {
+
+  @Override protected Supplier<Set<Map.Entry<String, Long>>> supplier() {
+    return LinkedHashSet::new; // because results are not distinct
+  }
+
+  @Override protected BiConsumer<Row, Set<Map.Entry<String, Long>>> accumulator() {
+    return (row, result) ->
+      result.add(
+        new AbstractMap.SimpleEntry<>(row.getString("trace_id"),
+          UUIDs.unixTimestamp(row.getUUID("ts"))));
+  }
+
+  @Override public String toString() {
+    return "AccumulateTraceIdTsUuid{}";
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/AccumulateTraceIdTsUuid.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/AccumulateTraceIdTsUuid.java
@@ -15,25 +15,21 @@ package zipkin2.storage.cassandra.internal.call;
 
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.utils.UUIDs;
-import java.util.AbstractMap;
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 public final class AccumulateTraceIdTsUuid
-  extends AccumulateAllResults<Set<Map.Entry<String, Long>>> {
+  extends AccumulateAllResults<Map<String, Long>> {
 
-  @Override protected Supplier<Set<Map.Entry<String, Long>>> supplier() {
-    return LinkedHashSet::new; // because results are not distinct
+  @Override protected Supplier<Map<String, Long>> supplier() {
+    return LinkedHashMap::new; // because results are not distinct
   }
 
-  @Override protected BiConsumer<Row, Set<Map.Entry<String, Long>>> accumulator() {
+  @Override protected BiConsumer<Row, Map<String, Long>> accumulator() {
     return (row, result) ->
-      result.add(
-        new AbstractMap.SimpleEntry<>(row.getString("trace_id"),
-          UUIDs.unixTimestamp(row.getUUID("ts"))));
+      result.put(row.getString("trace_id"), UUIDs.unixTimestamp(row.getUUID("ts")));
   }
 
   @Override public String toString() {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/AggregateIntoMap.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/AggregateIntoMap.java
@@ -13,30 +13,30 @@
  */
 package zipkin2.storage.cassandra.internal.call;
 
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import zipkin2.Call;
 import zipkin2.internal.AggregateCall;
 
-public final class AggregateIntoSet<T> extends AggregateCall<Set<T>, Set<T>> {
-  public AggregateIntoSet(List<Call<Set<T>>> calls) {
+public final class AggregateIntoMap<K, V> extends AggregateCall<Map<K, V>, Map<K, V>> {
+  public AggregateIntoMap(List<Call<Map<K, V>>> calls) {
     super(calls);
   }
 
-  @Override protected Set<T> newOutput() {
-    return new LinkedHashSet<>();
+  @Override protected Map<K, V> newOutput() {
+    return new LinkedHashMap<>();
   }
 
-  @Override protected void append(Set<T> input, Set<T> output) {
-    output.addAll(input);
+  @Override protected void append(Map<K, V> input, Map<K, V> output) {
+    output.putAll(input);
   }
 
-  @Override protected boolean isEmpty(Set<T> output) {
+  @Override protected boolean isEmpty(Map<K, V> output) {
     return output.isEmpty();
   }
 
-  @Override public AggregateIntoSet<T> clone() {
-    return new AggregateIntoSet<>(cloneCalls());
+  @Override public AggregateIntoMap<K, V> clone() {
+    return new AggregateIntoMap<>(cloneCalls());
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/DistinctSortedStrings.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/DistinctSortedStrings.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra.internal.call;
+
+import com.datastax.driver.core.Row;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class DistinctSortedStrings extends AccumulateAllResults<List<String>> {
+  final String columnName;
+
+  public DistinctSortedStrings(String columnName) {
+    if (columnName == null) throw new NullPointerException("columnName == null");
+    this.columnName = columnName;
+  }
+
+  @Override protected Supplier<List<String>> supplier() {
+    return ArrayList::new;
+  }
+
+  @Override protected Function<List<String>, List<String>> finisher() {
+    return SortDistinct.INSTANCE;
+  }
+
+  enum SortDistinct implements Function<List<String>, List<String>> {
+    INSTANCE;
+
+    @Override public List<String> apply(List<String> strings) {
+      Collections.sort(strings);
+      return new ArrayList<>(new LinkedHashSet<>(strings));
+    }
+  }
+
+  @Override protected BiConsumer<Row, List<String>> accumulator() {
+    return (row, list) -> {
+      String result = row.getString(columnName);
+      if (!result.isEmpty()) list.add(result);
+    };
+  }
+
+  @Override public String toString() {
+    return "DistinctSortedStrings{" + columnName + "}";
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/IntersectMaps.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/IntersectMaps.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra.internal.call;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import zipkin2.Call;
+import zipkin2.internal.AggregateCall;
+
+public final class IntersectMaps extends AggregateCall<Map<String, Long>, Map<String, Long>> {
+
+  public IntersectMaps(List<Call<Map<String, Long>>> calls) {
+    super(calls);
+  }
+
+  @Override protected Map<String, Long> newOutput() {
+    return new LinkedHashMap<>();
+  }
+
+  boolean firstInput = true;
+
+  @Override protected void append(Map<String, Long> input, Map<String, Long> output) {
+    if (firstInput) {
+      firstInput = false;
+      output.putAll(input);
+    } else {
+      output.keySet().retainAll(input.keySet());
+    }
+  }
+
+  @Override protected boolean isEmpty(Map<String, Long> output) {
+    return output.isEmpty();
+  }
+
+  @Override public IntersectMaps clone() {
+    return new IntersectMaps(cloneCalls());
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/IntersectMaps.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/IntersectMaps.java
@@ -14,26 +14,24 @@
 package zipkin2.storage.cassandra.internal.call;
 
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import zipkin2.Call;
 import zipkin2.internal.AggregateCall;
 
-public final class IntersectMaps extends AggregateCall<Map<String, Long>, Map<String, Long>> {
+public final class IntersectMaps<K, V> extends AggregateCall<Map<K, V>, Map<K, V>> {
 
-  public IntersectMaps(List<Call<Map<String, Long>>> calls) {
+  public IntersectMaps(List<Call<Map<K, V>>> calls) {
     super(calls);
   }
 
-  @Override protected Map<String, Long> newOutput() {
+  @Override protected Map<K, V> newOutput() {
     return new LinkedHashMap<>();
   }
 
   boolean firstInput = true;
 
-  @Override protected void append(Map<String, Long> input, Map<String, Long> output) {
+  @Override protected void append(Map<K, V> input, Map<K, V> output) {
     if (firstInput) {
       firstInput = false;
       output.putAll(input);
@@ -42,11 +40,11 @@ public final class IntersectMaps extends AggregateCall<Map<String, Long>, Map<St
     }
   }
 
-  @Override protected boolean isEmpty(Map<String, Long> output) {
+  @Override protected boolean isEmpty(Map<K, V> output) {
     return output.isEmpty();
   }
 
-  @Override public IntersectMaps clone() {
-    return new IntersectMaps(cloneCalls());
+  @Override public IntersectMaps<K, V> clone() {
+    return new IntersectMaps<>(cloneCalls());
   }
 }

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
@@ -31,6 +31,23 @@ CREATE TABLE IF NOT EXISTS zipkin2.trace_by_service_span (
 CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.trace_by_service_span (duration) USING 'org.apache.cassandra.index.sasi.SASIIndex'
    WITH OPTIONS = {'mode': 'PREFIX'};
 
+CREATE TABLE IF NOT EXISTS zipkin2.trace_by_service_remote_service (
+    service         text,             //-- service name
+    remote_service  text,             //-- remote servie name
+    bucket          int,              //-- time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1 day.
+    ts              timeuuid,         //-- start timestamp of the span, truncated to millisecond precision
+    trace_id        text,             //-- trace ID
+    PRIMARY KEY ((service, remote_service, bucket), ts)
+)
+   WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up a trace by a remote service. bucket column adds time bucketing to the partition key, values are microseconds rounded to a pre-configured interval (typically one day). ts column is start timestamp of the span as time-uuid, truncated to millisecond precision.';
+
 CREATE TABLE IF NOT EXISTS zipkin2.span_by_service (
     service text,
     span    text,

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
@@ -75,3 +75,17 @@ CREATE TABLE IF NOT EXISTS zipkin2.autocomplete_tags (
     AND dclocal_read_repair_chance = 0
     AND speculative_retry = '95percentile'
     AND comment = 'Secondary table for looking up tag key and values for a service';
+
+CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
+    service text,
+    remote_service text,
+    PRIMARY KEY (service, remote_service)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND caching = {'rows_per_partition': 'ALL'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up remote service names by a service name.';

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
@@ -1,5 +1,15 @@
 ALTER TABLE zipkin2.span ADD l_service text;
+CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.span (l_service) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {'mode': 'PREFIX'};
+
 ALTER TABLE zipkin2.span ADD annotation_query text; //-- can't do SASI on set<text>: ░-joined until CASSANDRA-11182
+DROP INDEX IF EXISTS zipkin2.span_annotation_query_idx;
+CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.span (annotation_query) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {
+    'mode': 'PREFIX',
+    'analyzed': 'true',
+    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.DelimiterAnalyzer',
+    'delimiter': '░'};
 
 CREATE TABLE IF NOT EXISTS zipkin2.trace_by_service_span (
     service       text,             //-- service name
@@ -18,6 +28,8 @@ CREATE TABLE IF NOT EXISTS zipkin2.trace_by_service_span (
     AND dclocal_read_repair_chance = 0
     AND speculative_retry = '95percentile'
     AND comment = 'Secondary table for looking up a trace by a service, or service and span. span column may be blank (when only looking up by service). bucket column adds time bucketing to the partition key, values are microseconds rounded to a pre-configured interval (typically one day). ts column is start timestamp of the span as time-uuid, truncated to millisecond precision. duration column is span duration, rounded up to tens of milliseconds (or hundredths of seconds)';
+CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.trace_by_service_span (duration) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {'mode': 'PREFIX'};
 
 CREATE TABLE IF NOT EXISTS zipkin2.span_by_service (
     service text,
@@ -35,7 +47,7 @@ CREATE TABLE IF NOT EXISTS zipkin2.span_by_service (
 
 CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
     service text,
-    remote_service    text,
+    remote_service text,
     PRIMARY KEY (service, remote_service)
 )
     WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
@@ -46,21 +58,6 @@ CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
     AND dclocal_read_repair_chance = 0
     AND speculative_retry = '95percentile'
     AND comment = 'Secondary table for looking up remote service names by a service name.';
-
-DROP INDEX IF EXISTS zipkin2.span_annotation_query_idx;
-
-CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.span (annotation_query) USING 'org.apache.cassandra.index.sasi.SASIIndex'
-   WITH OPTIONS = {
-    'mode': 'PREFIX',
-    'analyzed': 'true',
-    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.DelimiterAnalyzer',
-    'delimiter': '░'};
-
-CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.span (l_service) USING 'org.apache.cassandra.index.sasi.SASIIndex'
-   WITH OPTIONS = {'mode': 'PREFIX'};
-
-CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.trace_by_service_span (duration) USING 'org.apache.cassandra.index.sasi.SASIIndex'
-   WITH OPTIONS = {'mode': 'PREFIX'};
 
 CREATE TABLE IF NOT EXISTS zipkin2.autocomplete_tags (
     key     text,
@@ -75,17 +72,3 @@ CREATE TABLE IF NOT EXISTS zipkin2.autocomplete_tags (
     AND dclocal_read_repair_chance = 0
     AND speculative_retry = '95percentile'
     AND comment = 'Secondary table for looking up tag key and values for a service';
-
-CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
-    service text,
-    remote_service text,
-    PRIMARY KEY (service, remote_service)
-)
-    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
-    AND caching = {'rows_per_partition': 'ALL'}
-    AND default_time_to_live =  259200
-    AND gc_grace_seconds = 3600
-    AND read_repair_chance = 0
-    AND dclocal_read_repair_chance = 0
-    AND speculative_retry = '95percentile'
-    AND comment = 'Secondary table for looking up remote service names by a service name.';

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
@@ -33,6 +33,20 @@ CREATE TABLE IF NOT EXISTS zipkin2.span_by_service (
     AND speculative_retry = '95percentile'
     AND comment = 'Secondary table for looking up span names by a service name.';
 
+CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
+    service text,
+    remote_service    text,
+    PRIMARY KEY (service, remote_service)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND caching = {'rows_per_partition': 'ALL'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up remote service names by a service name.';
+
 DROP INDEX IF EXISTS zipkin2.span_annotation_query_idx;
 
 CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.span (annotation_query) USING 'org.apache.cassandra.index.sasi.SASIIndex'

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-indexes.cql
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS zipkin2.span_by_service (
     AND read_repair_chance = 0
     AND dclocal_read_repair_chance = 0
     AND speculative_retry = '95percentile'
-    AND comment = 'Secondary table for looking up span names by a service name.';
+    AND comment = 'Secondary table for looking up span names by a service name. To compensate for hot partitions, we deduplicate write client side, use LeveledCompactionStrategy with a low threshold and add row caching.';
 
 CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
     service text,
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
     AND read_repair_chance = 0
     AND dclocal_read_repair_chance = 0
     AND speculative_retry = '95percentile'
-    AND comment = 'Secondary table for looking up remote service names by a service name.';
+    AND comment = 'Secondary table for looking up remote service names by a service name. To compensate for hot partitions, we deduplicate write client side, use LeveledCompactionStrategy with a low threshold and add row caching.';
 
 CREATE TABLE IF NOT EXISTS zipkin2.autocomplete_tags (
     key     text,
@@ -88,4 +88,4 @@ CREATE TABLE IF NOT EXISTS zipkin2.autocomplete_tags (
     AND read_repair_chance = 0
     AND dclocal_read_repair_chance = 0
     AND speculative_retry = '95percentile'
-    AND comment = 'Secondary table for looking up tag key and values for a service';
+    AND comment = 'Secondary table for looking up span tag values for auto-complete purposes. To compensate for hot partitions, we deduplicate write client side, use LeveledCompactionStrategy with a low threshold and add row caching.';

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-upgrade-2.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-upgrade-2.cql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
+    service text,
+    remote_service text,
+    PRIMARY KEY (service, remote_service)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND caching = {'rows_per_partition': 'ALL'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up remote service names by a service name.';

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-upgrade-2.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema-upgrade-2.cql
@@ -11,3 +11,20 @@ CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
     AND dclocal_read_repair_chance = 0
     AND speculative_retry = '95percentile'
     AND comment = 'Secondary table for looking up remote service names by a service name.';
+
+CREATE TABLE IF NOT EXISTS zipkin2.trace_by_service_remote_service (
+    service         text,             //-- service name
+    remote_service  text,             //-- remote servie name
+    bucket          int,              //-- time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1 day.
+    ts              timeuuid,         //-- start timestamp of the span, truncated to millisecond precision
+    trace_id        text,             //-- trace ID
+    PRIMARY KEY ((service, remote_service, bucket), ts)
+)
+   WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up a trace by a remote service. bucket column adds time bucketing to the partition key, values are microseconds rounded to a pre-configured interval (typically one day). ts column is start timestamp of the span as time-uuid, truncated to millisecond precision.';

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema.cql
@@ -55,3 +55,31 @@ CREATE TABLE IF NOT EXISTS zipkin2.dependency (
     AND read_repair_chance = 0
     AND dclocal_read_repair_chance = 0
     AND comment = 'Holder for each days generation of zipkin2.DependencyLink';
+
+CREATE TABLE IF NOT EXISTS zipkin2.autocomplete_tags (
+    key     text,
+    value    text,
+    PRIMARY KEY (key, value)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND caching = {'rows_per_partition': 'ALL'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up tag key and values for a service';
+
+CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
+    service text,
+    remote_service text,
+    PRIMARY KEY (service, remote_service)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND caching = {'rows_per_partition': 'ALL'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up remote service names by a service name.';

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema.cql
@@ -55,31 +55,3 @@ CREATE TABLE IF NOT EXISTS zipkin2.dependency (
     AND read_repair_chance = 0
     AND dclocal_read_repair_chance = 0
     AND comment = 'Holder for each days generation of zipkin2.DependencyLink';
-
-CREATE TABLE IF NOT EXISTS zipkin2.autocomplete_tags (
-    key     text,
-    value    text,
-    PRIMARY KEY (key, value)
-)
-    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
-    AND caching = {'rows_per_partition': 'ALL'}
-    AND default_time_to_live =  259200
-    AND gc_grace_seconds = 3600
-    AND read_repair_chance = 0
-    AND dclocal_read_repair_chance = 0
-    AND speculative_retry = '95percentile'
-    AND comment = 'Secondary table for looking up tag key and values for a service';
-
-CREATE TABLE IF NOT EXISTS zipkin2.remote_service_by_service (
-    service text,
-    remote_service text,
-    PRIMARY KEY (service, remote_service)
-)
-    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
-    AND caching = {'rows_per_partition': 'ALL'}
-    AND default_time_to_live =  259200
-    AND gc_grace_seconds = 3600
-    AND read_repair_chance = 0
-    AND dclocal_read_repair_chance = 0
-    AND speculative_retry = '95percentile'
-    AND comment = 'Secondary table for looking up remote service names by a service name.';

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
@@ -108,16 +108,18 @@ public class CassandraSpanConsumerTest {
   }
 
   @Test
-  public void serviceSpanKeys_addsRemoteServiceName() {
+  public void serviceRemoteServiceKeys_addsRemoteServiceName() {
     Span span = spanWithoutAnnotationsOrTags.toBuilder().remoteEndpoint(BACKEND).build();
 
     Call<Void> call = consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
       .filteredOn(c -> c instanceof DeduplicatingVoidCallFactory.InvalidatingVoidCall)
-      .extracting("input.service", "input.span")
+      .extracting("input")
       .containsExactly(
-        tuple(BACKEND.serviceName(), span.name()), tuple(FRONTEND.serviceName(), span.name()));
+        InsertServiceSpan.Input.create(FRONTEND.serviceName(), span.name()),
+        InsertServiceRemoteService.Input.create(FRONTEND.serviceName(),BACKEND.serviceName() )
+      );
   }
 
   @Test

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
@@ -129,7 +129,7 @@ public class CassandraSpanConsumerTest {
     Call<Void> call = consumer.accept(singletonList(span));
 
     assertEnclosedCalls(call)
-      .filteredOn(c -> c instanceof DeduplicatingVoidCallFactory.InvalidatingVoidCall)
+      .filteredOn(c -> c instanceof InsertTraceByServiceSpan)
       .extracting("input.service", "input.span")
       .containsExactly(tuple(FRONTEND.serviceName(), ""));
   }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
@@ -42,7 +42,7 @@ public class CassandraSpanConsumerTest {
       .id("1")
       .name("get")
       .localEndpoint(FRONTEND)
-      .timestamp(1472470996199000L)
+      .timestamp(TODAY * 1000L)
       .duration(207000L)
       .build();
 
@@ -234,7 +234,7 @@ public class CassandraSpanConsumerTest {
     Span span =
       spanWithoutAnnotationsOrTags
         .toBuilder()
-        .addAnnotation(TODAY, "annotation")
+        .addAnnotation(TODAY * 1000L, "annotation")
         .putTag("foo", "bar")
         .duration(10000L)
         .build();
@@ -242,6 +242,13 @@ public class CassandraSpanConsumerTest {
     assertThat(consumer.accept(singletonList(span)))
       .extracting("input.annotation_query")
       .allSatisfy(q -> assertThat(q).isNull());
+  }
+
+  @Test public void doesntIndexWhenOnlyIncludesTimestamp() {
+    Span span = Span.newBuilder().traceId("a").id("1").timestamp(TODAY * 1000L).build();
+
+    assertThat(consumer.accept(singletonList(span)))
+      .isInstanceOf(ResultSetFutureCall.class);
   }
 
   static AbstractListAssert<?, List<? extends Call<Void>>, Call<Void>, ObjectAssert<Call<Void>>>

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -208,6 +208,25 @@ public class ITCassandraStorage {
     }
   }
 
+  public static class ITServiceAndSpanNames extends zipkin2.storage.ITServiceAndSpanNames {
+    @ClassRule public static CassandraStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    CassandraStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() {
+      dropKeyspace(backend.session(), keyspace(testName));
+    }
+  }
+
   public static class ITAutocompleteTags extends zipkin2.storage.ITAutocompleteTags {
     @ClassRule public static CassandraStorageRule backend = classRule();
     @Rule public TestName testName = new TestName();

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -17,7 +17,6 @@ import com.datastax.driver.core.Host;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -37,6 +36,7 @@ import zipkin2.TestObjects;
 import zipkin2.storage.QueryRequest;
 import zipkin2.storage.StorageComponent;
 
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.DAY;
@@ -305,7 +305,7 @@ public class ITCassandraStorage {
     while (true) {
       for (Host host : state.getConnectedHosts()) {
         if (state.getInFlightQueries(host) > 0) {
-          Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+          sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
           state = storage.session().getState();
           continue refresh;
         }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -85,12 +85,13 @@ public class ITCassandraStorage {
 
       // Index ends up containing more rows than services * trace count, and cannot be de-duped
       // in a server-side query.
+      int localServiceCount = storage().serviceAndSpanNames().getServiceNames().execute().size();
       assertThat(storage
         .session()
         .execute("SELECT COUNT(*) from trace_by_service_span")
         .one()
         .getLong(0))
-        .isGreaterThan(traceCount * store().getServiceNames().execute().size());
+        .isGreaterThan(traceCount * localServiceCount);
 
       // Implementation over-fetches on the index to allow the user to receive unsurprising results.
       QueryRequest request = requestBuilder()

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -18,9 +18,12 @@ import com.datastax.driver.core.Session;
 import java.net.InetSocketAddress;
 import org.junit.Test;
 import zipkin2.TestObjects;
+import zipkin2.storage.QueryRequest;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.DAY;
+import static zipkin2.TestObjects.TODAY;
 
 abstract class ITEnsureSchema {
 
@@ -102,6 +105,12 @@ abstract class ITEnsureSchema {
         .isEmpty(); // instead of an exception
       String serviceName = TestObjects.TRACE.get(0).localServiceName();
       assertThat(storage.serviceAndSpanNames().getRemoteServiceNames(serviceName).execute())
+        .isEmpty(); // instead of an exception
+      assertThat(storage.spanStore().getTraces(QueryRequest.newBuilder()
+        .endTs(TODAY)
+        .lookback(DAY)
+        .limit(10)
+        .remoteServiceName("foo").build()).execute())
         .isEmpty(); // instead of an exception
     }
   }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -19,6 +19,7 @@ import java.net.InetSocketAddress;
 import org.junit.Test;
 import zipkin2.TestObjects;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 abstract class ITEnsureSchema {
@@ -89,12 +90,19 @@ abstract class ITEnsureSchema {
     try (CassandraStorage storage = CassandraStorage.newBuilder()
       .contactPoints(contactPoint.getHostString() + ":" + contactPoint.getPort())
       .ensureSchema(false)
+      .autocompleteKeys(asList("environment"))
       .keyspace(keyspace()).build()) {
 
       storage.spanConsumer().accept(TestObjects.TRACE).execute();
 
       assertThat(storage.spanStore().getTrace(TestObjects.TRACE.get(0).traceId()).execute())
         .containsExactlyInAnyOrderElementsOf(TestObjects.TRACE);
+
+      assertThat(storage.autocompleteTags().getValues("environment").execute())
+        .isEmpty(); // instead of an exception
+      String serviceName = TestObjects.TRACE.get(0).localServiceName();
+      assertThat(storage.serviceAndSpanNames().getRemoteServiceNames(serviceName).execute())
+        .isEmpty(); // instead of an exception
     }
   }
 }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -57,7 +57,7 @@ abstract class ITEnsureSchema {
     assertThat(metadata.getTable("autocomplete_tags")).isNotNull();
   }
 
-  @Test public void upgradesOldSchema() {
+  @Test public void upgradesOldSchema_autocomplete() {
     Schema.applyCqlFile(keyspace(), session(), "/zipkin2-schema.cql");
     Schema.applyCqlFile(keyspace(), session(), "/zipkin2-schema-indexes-original.cql");
 
@@ -66,6 +66,18 @@ abstract class ITEnsureSchema {
     KeyspaceMetadata metadata = session().getCluster().getMetadata().getKeyspace(keyspace());
     assertThat(metadata).isNotNull();
     assertThat(Schema.hasUpgrade1_autocompleteTags(metadata)).isTrue();
+  }
+
+  @Test public void upgradesOldSchema_remoteService() {
+    Schema.applyCqlFile(keyspace(), session(), "/zipkin2-schema.cql");
+    Schema.applyCqlFile(keyspace(), session(), "/zipkin2-schema-indexes-original.cql");
+    Schema.applyCqlFile(keyspace(), session(), "/zipkin2-schema-upgrade-1.cql");
+
+    Schema.ensureExists(keyspace(), true, session());
+
+    KeyspaceMetadata metadata = session().getCluster().getMetadata().getKeyspace(keyspace());
+    assertThat(metadata).isNotNull();
+    assertThat(Schema.hasUpgrade2_remoteService(metadata)).isTrue();
   }
 
   /** This tests we don't accidentally rely on new indexes such as autocomplete tags */

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -110,8 +110,8 @@ abstract class ITEnsureSchema {
         .endTs(TODAY)
         .lookback(DAY)
         .limit(10)
-        .serviceName("frontend")
-        .remoteServiceName("backend").build()).execute())
+        .serviceName("invalid1")
+        .remoteServiceName("invalid2").build()).execute())
         .isEmpty(); // instead of an exception
     }
   }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -110,7 +110,8 @@ abstract class ITEnsureSchema {
         .endTs(TODAY)
         .lookback(DAY)
         .limit(10)
-        .remoteServiceName("foo").build()).execute())
+        .serviceName("frontend")
+        .remoteServiceName("backend").build()).execute())
         .isEmpty(); // instead of an exception
     }
   }

--- a/zipkin-storage/cassandra/src/test/resources/autocomplete_tags-stress.yaml
+++ b/zipkin-storage/cassandra/src/test/resources/autocomplete_tags-stress.yaml
@@ -10,63 +10,35 @@
 #    or implied. See the License for the specific language governing permissions and limitations under
 #    the License.
 #
-### Stress test for stress_zipkin2.span table
+###
+### Stress test for stress_zipkin2.autocomplete_tags table
 ###
 ### Stress testing is done using the `cassandra-stress` tool
 ###
 ### For example
 ###  cqlsh -f zipkin2-test-schema.cql
-###  cassandra-stress  user profile=span-stress.yaml ops\(insert=1\) no-warmup duration=1m  -rate threads=4 throttle=50/s
+###  cassandra-stress  user profile=autocomplete_tags-stress.yaml ops\(insert=1\) no-warmup duration=1m  -rate threads=4 throttle=50/s
 ###
 ### after a benchmark has been run with only writes, a mixed read-write benchmark can be run with
-###  cassandra-stress  user profile=span-stress.yaml ops\(insert=1,by_trace=1,by_trace_ts_id=1,by_annotation=1\)  duration=1m  -rate threads=4 throttle=50/s
+###  cassandra-stress  user profile=autocomplete_tags-stress.yaml ops\(insert=1,select=1,select_values=1\)  duration=1m  -rate threads=4 throttle=50/s
 
 # Keyspace Name
 keyspace: stress_zipkin2
 
 # Table name
-table: span
+table: autocomplete_tags
 
 
 ### Column Distribution Specifications ###
-#
 
 columnspec:
-  - name: trace_id
-    size: fixed(32)
-    population: uniform(1..10k)
+  - name: key
+    size: uniform(5..20)
+    population: uniform(1..5)
 
-  - name: ts_uuid
-    population: uniform(1..10k)
-
-  - name: id
-    size: fixed(32)
-    population: uniform(1..10k)
-
-  - name: ts
-    size: fixed(12)
-    population: uniform(1..10k)
-
-  - name: span
+  - name: value
     size: uniform(5..20)
     population: uniform(1..100)
-
-  - name: parent_id
-    size: uniform(5..20)
-    population: uniform(1..100)
-
-  - name: duration
-    size: fixed(12)
-    population: uniform(1..10k)
-
-  - name: l_service
-    size: uniform(5..20)
-    population: uniform(1..100)
-
-  - name: annotation_query
-    size: gaussian(50..500)
-    population: uniform(1..1k)
-
 
 
 ### Batch Ratio Distribution Specifications ###
@@ -81,12 +53,9 @@ insert:
 # A set of basic queries
 #
 queries:
-   by_trace:
-    cql: SELECT * FROM span WHERE trace_id = ?
+   select:
+    cql: SELECT DISTINCT key FROM autocomplete_tags
     fields: samerow
-   by_trace_ts_id:
-    cql: SELECT * FROM span WHERE trace_id = ? AND ts_uuid = ? AND id = ?
-    fields: samerow
-   by_annotation:
-    cql: SELECT trace_id, ts, id FROM span WHERE l_service = ? AND annotation_query LIKE ? ALLOW FILTERING
+   select_values:
+    cql: SELECT value FROM autocomplete_tags WHERE key = ? LIMIT 1000
     fields: samerow

--- a/zipkin-storage/cassandra/src/test/resources/remote_service_by_service-stress.yaml
+++ b/zipkin-storage/cassandra/src/test/resources/remote_service_by_service-stress.yaml
@@ -10,63 +10,35 @@
 #    or implied. See the License for the specific language governing permissions and limitations under
 #    the License.
 #
-### Stress test for stress_zipkin2.span table
+###
+### Stress test for stress_zipkin2.service_remote_service_index table
 ###
 ### Stress testing is done using the `cassandra-stress` tool
 ###
 ### For example
 ###  cqlsh -f zipkin2-test-schema.cql
-###  cassandra-stress  user profile=span-stress.yaml ops\(insert=1\) no-warmup duration=1m  -rate threads=4 throttle=50/s
+###  cassandra-stress  user profile=remote_service_by_service-stress.yaml ops\(insert=1\) no-warmup duration=1m  -rate threads=4 throttle=50/s
 ###
 ### after a benchmark has been run with only writes, a mixed read-write benchmark can be run with
-###  cassandra-stress  user profile=span-stress.yaml ops\(insert=1,by_trace=1,by_trace_ts_id=1,by_annotation=1\)  duration=1m  -rate threads=4 throttle=50/s
+###  cassandra-stress  user profile=remote_service_by_service-stress.yaml ops\(insert=1,select=1,select_remote_services=1\) duration=1m  -rate threads=4 throttle=50/s
 
 # Keyspace Name
 keyspace: stress_zipkin2
 
 # Table name
-table: span
+table: remote_service_by_service
 
 
 ### Column Distribution Specifications ###
-#
 
 columnspec:
-  - name: trace_id
-    size: fixed(32)
-    population: uniform(1..10k)
-
-  - name: ts_uuid
-    population: uniform(1..10k)
-
-  - name: id
-    size: fixed(32)
-    population: uniform(1..10k)
-
-  - name: ts
-    size: fixed(12)
-    population: uniform(1..10k)
-
-  - name: span
+  - name: service
     size: uniform(5..20)
     population: uniform(1..100)
 
-  - name: parent_id
+  - name: remote_service
     size: uniform(5..20)
     population: uniform(1..100)
-
-  - name: duration
-    size: fixed(12)
-    population: uniform(1..10k)
-
-  - name: l_service
-    size: uniform(5..20)
-    population: uniform(1..100)
-
-  - name: annotation_query
-    size: gaussian(50..500)
-    population: uniform(1..1k)
-
 
 
 ### Batch Ratio Distribution Specifications ###
@@ -81,12 +53,9 @@ insert:
 # A set of basic queries
 #
 queries:
-   by_trace:
-    cql: SELECT * FROM span WHERE trace_id = ?
+   select:
+    cql: SELECT DISTINCT service FROM remote_service_by_service
     fields: samerow
-   by_trace_ts_id:
-    cql: SELECT * FROM span WHERE trace_id = ? AND ts_uuid = ? AND id = ?
-    fields: samerow
-   by_annotation:
-    cql: SELECT trace_id, ts, id FROM span WHERE l_service = ? AND annotation_query LIKE ? ALLOW FILTERING
+   select_remote_services:
+    cql: SELECT remote_service FROM remote_service_by_service WHERE service = ? LIMIT 1000
     fields: samerow

--- a/zipkin-storage/cassandra/src/test/resources/span_by_service-stress.yaml
+++ b/zipkin-storage/cassandra/src/test/resources/span_by_service-stress.yaml
@@ -1,4 +1,4 @@
-#    Copyright 2015-2017 The OpenZipkin Authors
+#    Copyright 2015-2019 The OpenZipkin Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #    in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 #    the License.
 #
 ###
-### Stress test for stress_zipkin2.service_span_index table
+### Stress test for stress_zipkin2.span_by_service table
 ###
 ### Stress testing is done using the `cassandra-stress` tool
 ###
@@ -44,7 +44,7 @@ columnspec:
 ### Batch Ratio Distribution Specifications ###
 
 insert:
-  partitions: fixed(1)            # 1 pertition key at a time inserts to model a message being generated
+  partitions: fixed(1)            # 1 partition key at a time inserts to model a message being generated
   select:  fixed(1)/1000
   batchtype: UNLOGGED             # Unlogged batches
 

--- a/zipkin-storage/cassandra/src/test/resources/trace_by_service_remote_service-stress.yaml
+++ b/zipkin-storage/cassandra/src/test/resources/trace_by_service_remote_service-stress.yaml
@@ -10,63 +10,47 @@
 #    or implied. See the License for the specific language governing permissions and limitations under
 #    the License.
 #
-### Stress test for stress_zipkin2.span table
+###
+### Stress test for stress_zipkin2.trace_by_service_remote_service table
 ###
 ### Stress testing is done using the `cassandra-stress` tool
 ###
 ### For example
 ###  cqlsh -f zipkin2-test-schema.cql
-###  cassandra-stress  user profile=span-stress.yaml ops\(insert=1\) no-warmup duration=1m  -rate threads=4 throttle=50/s
+###  cassandra-stress  user profile=trace_by_service_remote_service-stress.yaml ops\(insert=1\) no-warmup duration=1m  -rate threads=4 throttle=50/s
 ###
 ### after a benchmark has been run with only writes, a mixed read-write benchmark can be run with
-###  cassandra-stress  user profile=span-stress.yaml ops\(insert=1,by_trace=1,by_trace_ts_id=1,by_annotation=1\)  duration=1m  -rate threads=4 throttle=50/s
+###  cassandra-stress  user profile=trace_by_service_remote_service-stress.yaml ops\(insert=1,select=1\)  duration=1m  -rate threads=4 throttle=50/s
 
 # Keyspace Name
 keyspace: stress_zipkin2
 
 # Table name
-table: span
+table: trace_by_service_remote_service
 
 
 ### Column Distribution Specifications ###
-#
 
 columnspec:
-  - name: trace_id
-    size: fixed(32)
-    population: uniform(1..10k)
+  - name: service
+    size: uniform(5..20)
+    population: uniform(1..100)
 
-  - name: ts_uuid
-    population: uniform(1..10k)
+  - name: remote_service
+    size: uniform(5..20)
+    population: uniform(1..100)
 
-  - name: id
-    size: fixed(32)
-    population: uniform(1..10k)
+  - name: bucket
+    size: fixed(12)
+    population: fixed(123456789012)
 
   - name: ts
     size: fixed(12)
     population: uniform(1..10k)
 
-  - name: span
-    size: uniform(5..20)
-    population: uniform(1..100)
-
-  - name: parent_id
-    size: uniform(5..20)
-    population: uniform(1..100)
-
-  - name: duration
-    size: fixed(12)
+  - name: trace_id
+    size: fixed(32)
     population: uniform(1..10k)
-
-  - name: l_service
-    size: uniform(5..20)
-    population: uniform(1..100)
-
-  - name: annotation_query
-    size: gaussian(50..500)
-    population: uniform(1..1k)
-
 
 
 ### Batch Ratio Distribution Specifications ###
@@ -81,12 +65,9 @@ insert:
 # A set of basic queries
 #
 queries:
-   by_trace:
-    cql: SELECT * FROM span WHERE trace_id = ?
+   select:
+    cql: SELECT * FROM trace_by_service_remote_service WHERE service = ? AND remote_service = ? AND bucket = ? LIMIT 1
     fields: samerow
-   by_trace_ts_id:
-    cql: SELECT * FROM span WHERE trace_id = ? AND ts_uuid = ? AND id = ?
-    fields: samerow
-   by_annotation:
-    cql: SELECT trace_id, ts, id FROM span WHERE l_service = ? AND annotation_query LIKE ? ALLOW FILTERING
-    fields: samerow
+
+# TODO: adrian doesn't know how to make a timestamp range query from test data
+# search by timestamp range

--- a/zipkin-storage/cassandra/src/test/resources/trace_by_service_span-stress.yaml
+++ b/zipkin-storage/cassandra/src/test/resources/trace_by_service_span-stress.yaml
@@ -1,4 +1,4 @@
-#    Copyright 2015-2017 The OpenZipkin Authors
+#    Copyright 2015-2019 The OpenZipkin Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 #    in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 #    the License.
 #
 ###
-### Stress test for stress_zipkin2.service_span_index table
+### Stress test for stress_zipkin2.trace_by_service_span table
 ###
 ### Stress testing is done using the `cassandra-stress` tool
 ###
@@ -61,7 +61,7 @@ columnspec:
 ### Batch Ratio Distribution Specifications ###
 
 insert:
-  partitions: fixed(1)            # 1 pertition key at a time inserts to model a message being generated
+  partitions: fixed(1)            # 1 partition key at a time inserts to model a message being generated
   select:  fixed(1)/1000
   batchtype: UNLOGGED             # Unlogged batches
 

--- a/zipkin-storage/cassandra/src/test/resources/zipkin2-test-schema.cql
+++ b/zipkin-storage/cassandra/src/test/resources/zipkin2-test-schema.cql
@@ -3,22 +3,37 @@ CREATE KEYSPACE IF NOT EXISTS stress_zipkin2 WITH replication = {'class': 'Simpl
 //-- same schema but remove all UDTs and collections (as cassandra-stress doesn't support them)
 
 CREATE TABLE IF NOT EXISTS stress_zipkin2.span (
-    trace_id            text,
+    trace_id            text, // when strictTraceId=false, only contains right-most 16 chars
     ts_uuid             timeuuid,
     id                  text,
-    ts                  bigint,
-    span                text,
+    trace_id_high       text, // when strictTraceId=false, contains left-most 16 chars if present
     parent_id           text,
+    kind                text,
+    span                text, // span.name
+    ts                  bigint,
     duration            bigint,
-    l_service           text,
     shared              boolean,
-    annotation_query    text, //-- can't do SASI on set<text>: comma-joined until CASSANDRA-11182
+    debug               boolean,
+    l_service           text,
+    annotation_query    text, //-- can't do SASI on set<text>: ░-joined until CASSANDRA-11182
     PRIMARY KEY (trace_id, ts_uuid, id)
 )
     WITH CLUSTERING ORDER BY (ts_uuid DESC)
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy', 'compaction_window_size': 10, 'compaction_window_unit': 'MINUTES'}
-    AND default_time_to_live =  604800;
-
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND default_time_to_live =  604800
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0.0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Primary table for holding trace data';
+CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin2.span (l_service) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {'mode': 'PREFIX'};
+CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin2.span (annotation_query) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {
+    'mode': 'PREFIX',
+    'analyzed': 'true',
+    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.DelimiterAnalyzer',
+    'delimiter': '░'};
 
 CREATE TABLE IF NOT EXISTS stress_zipkin2.trace_by_service_span (
     service       text,             //-- service name
@@ -26,12 +41,36 @@ CREATE TABLE IF NOT EXISTS stress_zipkin2.trace_by_service_span (
     bucket        int,              //-- time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1 day.
     ts            timeuuid,         //-- start timestamp of the span, truncated to millisecond precision
     trace_id      text,             //-- trace ID
-    duration      bigint,           //-- span duration, in microseconds
+    duration      bigint,           //-- span duration, in milliseconds
     PRIMARY KEY ((service, span, bucket), ts)
 )
    WITH CLUSTERING ORDER BY (ts DESC)
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy', 'compaction_window_size': 10, 'compaction_window_unit': 'MINUTES'}
-    AND default_time_to_live =  259200;
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up a trace by a service, or service and span. span column may be blank (when only looking up by service). bucket column adds time bucketing to the partition key, values are microseconds rounded to a pre-configured interval (typically one day). ts column is start timestamp of the span as time-uuid, truncated to millisecond precision. duration column is span duration, rounded up to tens of milliseconds (or hundredths of seconds)';
+CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin2.trace_by_service_span (duration) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+   WITH OPTIONS = {'mode': 'PREFIX'};
+
+CREATE TABLE IF NOT EXISTS stress_zipkin2.trace_by_service_remote_service (
+    service         text,             //-- service name
+    remote_service  text,             //-- remote servie name
+    bucket          int,              //-- time bucket, calculated as ts/interval (in microseconds), for some pre-configured interval like 1 day.
+    ts              timeuuid,         //-- start timestamp of the span, truncated to millisecond precision
+    trace_id        text,             //-- trace ID
+    PRIMARY KEY ((service, remote_service, bucket), ts)
+)
+   WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up a trace by a remote service. bucket column adds time bucketing to the partition key, values are microseconds rounded to a pre-configured interval (typically one day). ts column is start timestamp of the span as time-uuid, truncated to millisecond precision.';
 
 CREATE TABLE IF NOT EXISTS stress_zipkin2.span_by_service (
     service text,
@@ -39,18 +78,38 @@ CREATE TABLE IF NOT EXISTS stress_zipkin2.span_by_service (
     PRIMARY KEY (service, span)
 )
     WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
-    AND default_time_to_live =  259200;
+    AND caching = {'rows_per_partition': 'ALL'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up span names by a service name. To compensate for hot partitions, we deduplicate write client side, use LeveledCompactionStrategy with a low threshold and add row caching.';
 
-CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin2.span (annotation_query) USING 'org.apache.cassandra.index.sasi.SASIIndex'
-   WITH OPTIONS = {
-    'mode': 'PREFIX',
-    'analyzed': 'true',
-    'analyzer_class':'org.apache.cassandra.index.sasi.analyzer.DelimiterAnalyzer',
-    'delimiter': 'a'};
+CREATE TABLE IF NOT EXISTS stress_zipkin2.remote_service_by_service (
+    service text,
+    remote_service text,
+    PRIMARY KEY (service, remote_service)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND caching = {'rows_per_partition': 'ALL'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up remote service names by a service name. To compensate for hot partitions, we deduplicate write client side, use LeveledCompactionStrategy with a low threshold and add row caching.';
 
-CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin2.span (l_service) USING 'org.apache.cassandra.index.sasi.SASIIndex'
-   WITH OPTIONS = {'mode': 'PREFIX'};
-
-CREATE CUSTOM INDEX IF NOT EXISTS ON stress_zipkin2.trace_by_service_span (duration) USING 'org.apache.cassandra.index.sasi.SASIIndex'
-   WITH OPTIONS = {'mode': 'PREFIX'};
-
+CREATE TABLE IF NOT EXISTS stress_zipkin2.autocomplete_tags (
+    key     text,
+    value    text,
+    PRIMARY KEY (key, value)
+)
+    WITH compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'unchecked_tombstone_compaction': 'true', 'tombstone_threshold': '0.2'}
+    AND caching = {'rows_per_partition': 'ALL'}
+    AND default_time_to_live =  259200
+    AND gc_grace_seconds = 3600
+    AND read_repair_chance = 0
+    AND dclocal_read_repair_chance = 0
+    AND speculative_retry = '95percentile'
+    AND comment = 'Secondary table for looking up span tag values for auto-complete purposes. To compensate for hot partitions, we deduplicate write client side, use LeveledCompactionStrategy with a low threshold and add row caching.';

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
@@ -70,6 +70,10 @@ final class ElasticsearchSpanStore implements SpanStore, ServiceAndSpanNames {
       filters.addTerm("localEndpoint.serviceName", request.serviceName());
     }
 
+    if (request.remoteServiceName() != null) {
+      filters.addTerm("remoteEndpoint.serviceName", request.remoteServiceName());
+    }
+
     if (request.spanName() != null) {
       filters.addTerm("name", request.spanName());
     }

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -35,6 +35,7 @@ import zipkin2.elasticsearch.internal.client.HttpCall;
 import zipkin2.internal.Nullable;
 import zipkin2.internal.Platform;
 import zipkin2.storage.AutocompleteTags;
+import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
@@ -247,6 +248,11 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   public SpanStore spanStore() {
     ensureIndexTemplates();
     return new ElasticsearchSpanStore(this);
+  }
+
+  @Override
+  public ServiceAndSpanNames serviceAndSpanNames() {
+    return (ServiceAndSpanNames) spanStore();
   }
 
   @Override

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
@@ -98,6 +98,25 @@ public class ITElasticsearchStorageV2 {
     }
   }
 
+  public static class ITServiceAndSpanNames extends zipkin2.storage.ITServiceAndSpanNames {
+    @ClassRule public static ElasticsearchStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    ElasticsearchStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().index(index(testName)).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
+
   public static class ITAutocompleteTags extends zipkin2.storage.ITAutocompleteTags {
     @ClassRule public static ElasticsearchStorageRule backend = classRule();
     @Rule public TestName testName = new TestName();

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV2.java
@@ -52,10 +52,6 @@ public class ITElasticsearchStorageV2 {
       return storage;
     }
 
-    // we don't map this in elasticsearch
-    @Test @Ignore @Override public void getSpanNames_mapsNameToRemoteServiceName() {
-    }
-
     @Override @Test @Ignore("No consumer-side span deduplication") public void deduplicates() {
     }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
@@ -52,10 +52,6 @@ public class ITElasticsearchStorageV5 {
       return storage;
     }
 
-    // we don't map this in elasticsearch
-    @Test @Ignore @Override public void getSpanNames_mapsNameToRemoteServiceName() {
-    }
-
     @Override @Test @Ignore("No consumer-side span deduplication") public void deduplicates() {
     }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV5.java
@@ -99,6 +99,25 @@ public class ITElasticsearchStorageV5 {
     }
   }
 
+  public static class ITServiceAndSpanNames extends zipkin2.storage.ITServiceAndSpanNames {
+    @ClassRule public static ElasticsearchStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    ElasticsearchStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().index(index(testName)).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
+
   public static class ITAutocompleteTags extends zipkin2.storage.ITAutocompleteTags {
     @ClassRule public static ElasticsearchStorageRule backend = classRule();
     @Rule public TestName testName = new TestName();

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -52,10 +52,6 @@ public class ITElasticsearchStorageV6 {
       return storage;
     }
 
-    // we don't map this in elasticsearch
-    @Test @Ignore @Override public void getSpanNames_mapsNameToRemoteServiceName() {
-    }
-
     @Override @Test @Ignore("No consumer-side span deduplication") public void deduplicates() {
     }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -80,6 +80,25 @@ public class ITElasticsearchStorageV6 {
     }
   }
 
+  public static class ITServiceAndSpanNames extends zipkin2.storage.ITServiceAndSpanNames {
+    @ClassRule public static ElasticsearchStorageRule backend = classRule();
+    @Rule public TestName testName = new TestName();
+
+    ElasticsearchStorage storage;
+
+    @Before public void connect() {
+      storage = backend.computeStorageBuilder().index(index(testName)).build();
+    }
+
+    @Override protected StorageComponent storage() {
+      return storage;
+    }
+
+    @Before @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
+
   public static class ITAutocompleteTags extends zipkin2.storage.ITAutocompleteTags {
     @ClassRule public static ElasticsearchStorageRule backend = classRule();
     @Rule public TestName testName = new TestName();

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/HasRemoteServiceName.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/HasRemoteServiceName.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.mysql.v1;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import org.jooq.DSLContext;
+import org.jooq.exception.DataAccessException;
+
+import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinSpans.ZIPKIN_SPANS;
+
+final class HasRemoteServiceName {
+  static final Logger LOG = Logger.getLogger(HasRemoteServiceName.class.getName());
+  static final String MESSAGE =
+    "zipkin_spans.remote_service_name doesn't exist, so queries for remote service names will return empty.\n"
+      + "Execute: ALTER TABLE zipkin_spans ADD `remote_service_name` VARCHAR(255);\n"
+      + "ALTER TABLE zipkin_spans ADD INDEX `remote_service_name`;";
+
+  static boolean test(DataSource datasource, DSLContexts context) {
+    try (Connection conn = datasource.getConnection()) {
+      DSLContext dsl = context.get(conn);
+      dsl.select(ZIPKIN_SPANS.REMOTE_SERVICE_NAME).from(ZIPKIN_SPANS).limit(1).fetchAny();
+      return true;
+    } catch (DataAccessException e) {
+      if (e.sqlState().equals("42S22")) {
+        LOG.warning(MESSAGE);
+        return false;
+      }
+      problemReading(e);
+    } catch (SQLException | RuntimeException e) {
+      problemReading(e);
+    }
+    return false;
+  }
+
+  static void problemReading(Exception e) {
+    LOG.log(Level.WARNING, "problem reading zipkin_spans.remote_service_name", e);
+  }
+}

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/Schema.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -43,6 +43,7 @@ final class Schema {
   final boolean hasPreAggregatedDependencies;
   final boolean hasIpv6;
   final boolean hasErrorCount;
+  final boolean hasRemoteServiceName;
   final boolean strictTraceId;
 
   Schema(DataSource datasource, DSLContexts context, boolean strictTraceId) {
@@ -50,10 +51,12 @@ final class Schema {
     hasPreAggregatedDependencies = HasPreAggregatedDependencies.test(datasource, context);
     hasIpv6 = HasIpv6.test(datasource, context);
     hasErrorCount = HasErrorCount.test(datasource, context);
+    hasRemoteServiceName = HasRemoteServiceName.test(datasource, context);
     this.strictTraceId = strictTraceId;
 
     spanIdFields = list(ZIPKIN_SPANS.TRACE_ID_HIGH, ZIPKIN_SPANS.TRACE_ID);
     spanFields = list(ZIPKIN_SPANS.fields());
+    spanIdFields.remove(ZIPKIN_SPANS.REMOTE_SERVICE_NAME); // not used to recreate the span
     annotationFields = list(ZIPKIN_ANNOTATIONS.fields());
     dependencyLinkFields = list(ZIPKIN_DEPENDENCIES.fields());
     dependencyLinkerFields =

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectAnnotationServiceNames.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectAnnotationServiceNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,26 +15,29 @@ package zipkin2.storage.mysql.v1;
 
 import java.util.List;
 import java.util.function.Function;
+import org.jooq.Condition;
 import org.jooq.DSLContext;
+import zipkin2.v1.V1BinaryAnnotation;
 
 import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinAnnotations.ZIPKIN_ANNOTATIONS;
 
 final class SelectAnnotationServiceNames implements Function<DSLContext, List<String>> {
-  @Override
-  public List<String> apply(DSLContext context) {
+  @Override public List<String> apply(DSLContext context) {
     return context
-        .selectDistinct(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME)
-        .from(ZIPKIN_ANNOTATIONS)
-        .where(
-            ZIPKIN_ANNOTATIONS
-                .ENDPOINT_SERVICE_NAME
-                .isNotNull()
-                .and(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME.ne("")))
-        .fetch(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME);
+      .selectDistinct(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME)
+      .from(ZIPKIN_ANNOTATIONS)
+      .where(localServiceNameCondition())
+      .orderBy(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME)
+      .fetch(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME);
   }
 
-  @Override
-  public String toString() {
+  static Condition localServiceNameCondition() {
+    return ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME.isNotNull()
+      .and(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME.ne("")) // exclude address annotations
+      .and(ZIPKIN_ANNOTATIONS.A_TYPE.ne(V1BinaryAnnotation.TYPE_BOOLEAN));
+  }
+
+  @Override public String toString() {
     return "SelectAnnotationServiceNames{}";
   }
 }

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectRemoteServiceNames.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectRemoteServiceNames.java
@@ -21,11 +21,11 @@ import static zipkin2.storage.mysql.v1.SelectAnnotationServiceNames.localService
 import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinAnnotations.ZIPKIN_ANNOTATIONS;
 import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinSpans.ZIPKIN_SPANS;
 
-final class SelectSpanNames implements Function<DSLContext, List<String>> {
+final class SelectRemoteServiceNames implements Function<DSLContext, List<String>> {
   final Schema schema;
   final String serviceName;
 
-  SelectSpanNames(Schema schema, String serviceName) {
+  SelectRemoteServiceNames(Schema schema, String serviceName) {
     this.schema = schema;
     this.serviceName = serviceName;
   }
@@ -33,19 +33,19 @@ final class SelectSpanNames implements Function<DSLContext, List<String>> {
   @Override
   public List<String> apply(DSLContext context) {
     return context
-      .selectDistinct(ZIPKIN_SPANS.NAME)
+      .selectDistinct(ZIPKIN_SPANS.REMOTE_SERVICE_NAME)
       .from(ZIPKIN_SPANS)
       .join(ZIPKIN_ANNOTATIONS)
       .on(schema.joinCondition(ZIPKIN_ANNOTATIONS))
       .where(
         localServiceNameCondition().and(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME.eq(serviceName)))
-      .and(ZIPKIN_SPANS.NAME.notEqual(""))
-      .orderBy(ZIPKIN_SPANS.NAME)
-      .fetch(ZIPKIN_SPANS.NAME);
+      .and(ZIPKIN_SPANS.REMOTE_SERVICE_NAME.notEqual(""))
+      .orderBy(ZIPKIN_SPANS.REMOTE_SERVICE_NAME)
+      .fetch(ZIPKIN_SPANS.REMOTE_SERVICE_NAME);
   }
 
   @Override
   public String toString() {
-    return "SelectSpanNames{serviceName=" + serviceName + "}";
+    return "SelectRemoteServiceNames{serviceName=" + serviceName + "}";
   }
 }

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectSpansAndAnnotations.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectSpansAndAnnotations.java
@@ -67,6 +67,10 @@ abstract class SelectSpansAndAnnotations implements Function<DSLContext, List<Sp
     }
 
     SelectSpansAndAnnotations create(QueryRequest request) {
+      if (request.remoteServiceName() != null && !schema.hasRemoteServiceName) {
+        throw new IllegalArgumentException("remoteService=" + request.remoteServiceName()
+          + " unsupported due to missing column zipkin_spans.remote_service_name");
+      }
       return new SelectSpansAndAnnotations(schema) {
         @Override
         Condition traceIdCondition(DSLContext context) {

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/internal/generated/Indexes.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/internal/generated/Indexes.java
@@ -55,6 +55,7 @@ public class Indexes {
     public static final Index ZIPKIN_DEPENDENCIES_PRIMARY = Indexes0.ZIPKIN_DEPENDENCIES_PRIMARY;
     public static final Index ZIPKIN_SPANS_NAME = Indexes0.ZIPKIN_SPANS_NAME;
     public static final Index ZIPKIN_SPANS_PRIMARY = Indexes0.ZIPKIN_SPANS_PRIMARY;
+    public static final Index ZIPKIN_SPANS_REMOTE_SERVICE_NAME = Indexes0.ZIPKIN_SPANS_REMOTE_SERVICE_NAME;
     public static final Index ZIPKIN_SPANS_START_TS = Indexes0.ZIPKIN_SPANS_START_TS;
     public static final Index ZIPKIN_SPANS_TRACE_ID_HIGH = Indexes0.ZIPKIN_SPANS_TRACE_ID_HIGH;
 
@@ -73,6 +74,7 @@ public class Indexes {
         public static Index ZIPKIN_DEPENDENCIES_PRIMARY = Internal.createIndex("PRIMARY", ZipkinDependencies.ZIPKIN_DEPENDENCIES, new OrderField[] { ZipkinDependencies.ZIPKIN_DEPENDENCIES.DAY, ZipkinDependencies.ZIPKIN_DEPENDENCIES.PARENT, ZipkinDependencies.ZIPKIN_DEPENDENCIES.CHILD }, true);
         public static Index ZIPKIN_SPANS_NAME = Internal.createIndex("name", ZipkinSpans.ZIPKIN_SPANS, new OrderField[] { ZipkinSpans.ZIPKIN_SPANS.NAME }, false);
         public static Index ZIPKIN_SPANS_PRIMARY = Internal.createIndex("PRIMARY", ZipkinSpans.ZIPKIN_SPANS, new OrderField[] { ZipkinSpans.ZIPKIN_SPANS.TRACE_ID_HIGH, ZipkinSpans.ZIPKIN_SPANS.TRACE_ID, ZipkinSpans.ZIPKIN_SPANS.ID }, true);
+        public static Index ZIPKIN_SPANS_REMOTE_SERVICE_NAME = Internal.createIndex("remote_service_name", ZipkinSpans.ZIPKIN_SPANS, new OrderField[] { ZipkinSpans.ZIPKIN_SPANS.REMOTE_SERVICE_NAME }, false);
         public static Index ZIPKIN_SPANS_START_TS = Internal.createIndex("start_ts", ZipkinSpans.ZIPKIN_SPANS, new OrderField[] { ZipkinSpans.ZIPKIN_SPANS.START_TS }, false);
         public static Index ZIPKIN_SPANS_TRACE_ID_HIGH = Internal.createIndex("trace_id_high", ZipkinSpans.ZIPKIN_SPANS, new OrderField[] { ZipkinSpans.ZIPKIN_SPANS.TRACE_ID_HIGH, ZipkinSpans.ZIPKIN_SPANS.TRACE_ID }, false);
     }

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/internal/generated/tables/ZipkinSpans.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/internal/generated/tables/ZipkinSpans.java
@@ -52,7 +52,7 @@ import zipkin2.storage.mysql.v1.internal.generated.Zipkin;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class ZipkinSpans extends TableImpl<Record> {
 
-    private static final long serialVersionUID = -2037396969;
+    private static final long serialVersionUID = 530960242;
 
     /**
      * The reference instance of <code>zipkin.zipkin_spans</code>
@@ -86,6 +86,11 @@ public class ZipkinSpans extends TableImpl<Record> {
      * The column <code>zipkin.zipkin_spans.name</code>.
      */
     public final TableField<Record, String> NAME = createField("name", org.jooq.impl.SQLDataType.VARCHAR(255).nullable(false), this, "");
+
+    /**
+     * The column <code>zipkin.zipkin_spans.remote_service_name</code>.
+     */
+    public final TableField<Record, String> REMOTE_SERVICE_NAME = createField("remote_service_name", org.jooq.impl.SQLDataType.VARCHAR(255).defaultValue(org.jooq.impl.DSL.inline("NULL", org.jooq.impl.SQLDataType.VARCHAR)), this, "");
 
     /**
      * The column <code>zipkin.zipkin_spans.parent_id</code>.
@@ -153,7 +158,7 @@ public class ZipkinSpans extends TableImpl<Record> {
      */
     @Override
     public List<Index> getIndexes() {
-        return Arrays.<Index>asList(Indexes.ZIPKIN_SPANS_NAME, Indexes.ZIPKIN_SPANS_PRIMARY, Indexes.ZIPKIN_SPANS_START_TS, Indexes.ZIPKIN_SPANS_TRACE_ID_HIGH);
+        return Arrays.<Index>asList(Indexes.ZIPKIN_SPANS_NAME, Indexes.ZIPKIN_SPANS_PRIMARY, Indexes.ZIPKIN_SPANS_REMOTE_SERVICE_NAME, Indexes.ZIPKIN_SPANS_START_TS, Indexes.ZIPKIN_SPANS_TRACE_ID_HIGH);
     }
 
     /**

--- a/zipkin-storage/mysql-v1/src/main/resources/mysql.sql
+++ b/zipkin-storage/mysql-v1/src/main/resources/mysql.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS zipkin_spans (
   `trace_id` BIGINT NOT NULL,
   `id` BIGINT NOT NULL,
   `name` VARCHAR(255) NOT NULL,
+  `remote_service_name` VARCHAR(255),
   `parent_id` BIGINT,
   `debug` BIT(1),
   `start_ts` BIGINT COMMENT 'Span.timestamp(): epoch micros used for endTs query and to implement TTL',
@@ -12,6 +13,7 @@ CREATE TABLE IF NOT EXISTS zipkin_spans (
 
 ALTER TABLE zipkin_spans ADD INDEX(`trace_id_high`, `trace_id`) COMMENT 'for getTracesByIds';
 ALTER TABLE zipkin_spans ADD INDEX(`name`) COMMENT 'for getTraces and getSpanNames';
+ALTER TABLE zipkin_spans ADD INDEX(`remote_service_name`) COMMENT 'for getTraces and getRemoteServiceNames';
 ALTER TABLE zipkin_spans ADD INDEX(`start_ts`) COMMENT 'for getTraces ordering and range';
 
 CREATE TABLE IF NOT EXISTS zipkin_annotations (

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -120,6 +120,18 @@ public class ITMySQLStorage {
     }
   }
 
+  public static class ITServiceAndSpanNames extends zipkin2.storage.ITServiceAndSpanNames {
+    @ClassRule public static LazyMySQLStorage storage = classRule();
+
+    @Override protected StorageComponent storage() {
+      return storage.get();
+    }
+
+    @Override public void clear() {
+      storage.get().clear();
+    }
+  }
+
   public static class ITAutocompleteTags extends zipkin2.storage.ITAutocompleteTags {
     @ClassRule public static LazyMySQLStorage storage = classRule();
 

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/SchemaTest.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -109,5 +109,18 @@ public class SchemaTest {
         new DataAccessException(sqlException.getMessage(), sqlException));
 
     assertThat(schema.hasPreAggregatedDependencies).isFalse();
+  }
+
+  @Test
+  public void hasRemoteServiceName_falseWhenKnownSQLState() throws SQLException {
+    SQLSyntaxErrorException sqlException = new SQLSyntaxErrorException(
+      "Unknown column 'zipkin_spans.remote_serviceName' in 'field list'",
+      "42S22", 1054);
+
+    // cheats to lower mock count: this exception is really thrown during execution of the query
+    when(dataSource.getConnection()).thenThrow(
+      new DataAccessException(sqlException.getMessage(), sqlException));
+
+    assertThat(schema.hasRemoteServiceName).isFalse();
   }
 }

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLContainer.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLContainer.java
@@ -38,9 +38,9 @@ final class ZipkinMySQLContainer extends GenericContainer<ZipkinMySQLContainer> 
   @Override protected void containerIsStarting(InspectContainerResponse containerInfo) {
     try {
       dataSource = new MariaDbDataSource(
-          getContainerIpAddress(),
-          getMappedPort(getExposedPorts().get(0)),
-          "zipkin"
+        getContainerIpAddress(),
+        getMappedPort(getExposedPorts().get(0)),
+        "zipkin"
       );
       dataSource.setUser("zipkin");
       dataSource.setPassword("zipkin");
@@ -51,11 +51,11 @@ final class ZipkinMySQLContainer extends GenericContainer<ZipkinMySQLContainer> 
 
   @Override protected void containerIsStarted(InspectContainerResponse containerInfo) {
     String[] scripts = {
-        // Drop all previously created tables in zipkin.*
-        "drop_zipkin_tables.sql",
+      // Drop all previously created tables in zipkin.*
+      "drop_zipkin_tables.sql",
 
-        // Populate the schema
-        "mysql.sql"
+      // Populate the schema
+      "mysql.sql"
     };
 
     try (Connection connection = dataSource.getConnection()) {

--- a/zipkin/src/main/java/zipkin2/internal/AggregateCall.java
+++ b/zipkin/src/main/java/zipkin2/internal/AggregateCall.java
@@ -173,4 +173,8 @@ public abstract class AggregateCall<I, O> extends Call.Base<O> {
     }
     return result;
   }
+
+  @Override public String toString() {
+    return "AggregateCall{" + calls + "}";
+  }
 }

--- a/zipkin/src/main/java/zipkin2/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin2/storage/QueryRequest.java
@@ -22,7 +22,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import zipkin2.Annotation;
-import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.internal.Nullable;
 
@@ -39,8 +38,8 @@ import zipkin2.internal.Nullable;
  */
 public final class QueryRequest {
   /**
-   * When present, corresponds to the {@link Span#localEndpoint() local} {@link
-   * Endpoint#serviceName() service name} and constrains all other parameters.
+   * When present, corresponds to the {@link Span#localServiceName() local service name} and
+   * constrains all other parameters.
    *
    * @see ServiceAndSpanNames#getServiceNames()
    */
@@ -49,10 +48,10 @@ public final class QueryRequest {
   }
 
   /**
-   * When present, only include traces with this {@link Span#remoteEndpoint() remote} {@link
-   * Endpoint#serviceName() service name}.
+   * When present, only include traces with this {@link Span#remoteServiceName() remote service
+   * name}.
    *
-   * @see ServiceAndSpanNames#getRemoteServiceNames()
+   * @see ServiceAndSpanNames#getRemoteServiceNames(String)
    */
   @Nullable public String remoteServiceName() {
     return remoteServiceName;
@@ -243,6 +242,7 @@ public final class QueryRequest {
     public final QueryRequest build() {
       // coerce service and span names to lowercase
       if (serviceName != null) serviceName = serviceName.toLowerCase(Locale.ROOT);
+      if (remoteServiceName != null) remoteServiceName = remoteServiceName.toLowerCase(Locale.ROOT);
       if (spanName != null) spanName = spanName.toLowerCase(Locale.ROOT);
 
       // remove any accidental empty strings

--- a/zipkin/src/main/java/zipkin2/storage/ServiceAndSpanNames.java
+++ b/zipkin/src/main/java/zipkin2/storage/ServiceAndSpanNames.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.util.List;
+import zipkin2.Call;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+/**
+ * Provides autocomplete functionality by providing values for service and span names, usually
+ * derived from {@link SpanConsumer}.
+ */
+public interface ServiceAndSpanNames {
+
+  /**
+   * Retrieves all {@link Span#localEndpoint() local} {@link Endpoint#serviceName() service names},
+   * sorted lexicographically.
+   */
+  Call<List<String>> getServiceNames();
+
+  /**
+   * Retrieves all {@link Span#remoteEndpoint() remote} {@link Endpoint#serviceName() service names}
+   * recorded by a {@link Span#localEndpoint() service}, sorted lexicographically.
+   */
+  Call<List<String>> getRemoteServiceNames(String serviceName);
+
+  /**
+   * Retrieves all {@link Span#name() span names} recorded by a {@link Span#localEndpoint()
+   * service}, sorted lexicographically.
+   */
+  Call<List<String>> getSpanNames(String serviceName);
+}

--- a/zipkin/src/main/java/zipkin2/storage/SpanStore.java
+++ b/zipkin/src/main/java/zipkin2/storage/SpanStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -51,15 +51,19 @@ public interface SpanStore {
 
   /**
    * Retrieves all {@link Span#localEndpoint() local} and {@link Span#remoteEndpoint() remote}
-   * {@link Endpoint#serviceName service names}, sorted lexicographically.
+   * {@link Endpoint#serviceName() service names}, sorted lexicographically.
+   *
+   * @deprecated use {@link ServiceAndSpanNames#getServiceNames()}
    */
-  Call<List<String>> getServiceNames();
+  @Deprecated Call<List<String>> getServiceNames();
 
   /**
    * Retrieves all {@link Span#name() span names} recorded by a {@link Span#localEndpoint()
    * service}, sorted lexicographically.
+   *
+   * @deprecated use {@link ServiceAndSpanNames#getSpanNames(String)}
    */
-  Call<List<String>> getSpanNames(String serviceName);
+  @Deprecated Call<List<String>> getSpanNames(String serviceName);
 
   /**
    * Returns dependency links derived from spans in an interval contained by (endTs - lookback) or
@@ -77,9 +81,9 @@ public interface SpanStore {
    * <p>Spans are grouped by the right-most 16 characters of the trace ID. This ensures call counts
    * are not incremented twice due to one hop downgrading from 128 to 64-bit trace IDs.
    *
-   * @param endTs only return links from spans where {@link Span#timestamp} are at or before this
+   * @param endTs only return links from spans where {@link Span#timestamp()} are at or before this
    * time in epoch milliseconds.
-   * @param lookback only return links from spans where {@link Span#timestamp} are at or after
+   * @param lookback only return links from spans where {@link Span#timestamp()} are at or after
    * (endTs - lookback) in milliseconds.
    */
   Call<List<DependencyLink>> getDependencies(long endTs, long lookback);

--- a/zipkin/src/main/java/zipkin2/storage/StorageComponent.java
+++ b/zipkin/src/main/java/zipkin2/storage/StorageComponent.java
@@ -38,6 +38,31 @@ public abstract class StorageComponent extends Component {
       @Override public Call<List<String>> getValues(String key) {
         return Call.emptyList();
       }
+
+      @Override public String toString() {
+        return "EmptyAutocompleteTags{}";
+      }
+    };
+  }
+
+  public ServiceAndSpanNames serviceAndSpanNames() { // delegates to deprecated methods.
+    SpanStore delegate = spanStore();
+    return new ServiceAndSpanNames() {
+      @Override public Call<List<String>> getServiceNames() {
+        return delegate.getServiceNames();
+      }
+
+      @Override public Call<List<String>> getRemoteServiceNames(String serviceName) {
+        return Call.emptyList(); // incorrect for not yet ported 3rd party storage components.
+      }
+
+      @Override public Call<List<String>> getSpanNames(String serviceName) {
+        return delegate.getSpanNames(serviceName);
+      }
+
+      @Override public String toString() {
+        return "ServiceAndSpanNames{" + delegate + "}";
+      }
     };
   }
 
@@ -95,19 +120,21 @@ public abstract class StorageComponent extends Component {
      * The use case is typically to support 100% sampled data, or when traces are searched using
      * alternative means such as a logging index.
      *
-     * <p>Refer to implementation docs for the impact of this parameter. Operations that use indexes
+     * <p>Refer to implementation docs for the impact of this parameter. Operations that use
+     * indexes
      * should return empty as opposed to throwing an exception.
      */
     public abstract Builder searchEnabled(boolean searchEnabled);
 
     /**
-     * Autocomplete is used by the UI to suggest getValues for site-specific tags, such as environment
-     * names. The getKeys here would appear in {@link Span#tags() span tags}. Good choices for
-     * autocomplete are limited in cardinality for the same reasons as service and span names.
+     * Autocomplete is used by the UI to suggest getValues for site-specific tags, such as
+     * environment names. The getKeys here would appear in {@link Span#tags() span tags}. Good
+     * choices for autocomplete are limited in cardinality for the same reasons as service and span
+     * names.
      *
      * For example, "http.url" would be a bad choice for autocomplete, not just because it isn't
-     * site-specific (such as environment would be), but also as there are unlimited getValues due to
-     * factors such as unique ids in the path.
+     * site-specific (such as environment would be), but also as there are unlimited getValues due
+     * to factors such as unique ids in the path.
      *
      * @param keys controls the span values stored for auto-complete.
      */
@@ -122,8 +149,9 @@ public abstract class StorageComponent extends Component {
       return this;
     }
 
-    /** How many autocomplete key/value pairs to suppress at a time.  */
-    public Builder autocompleteCardinality(int autocompleteCardinality) { // not abstract as added later
+    /** How many autocomplete key/value pairs to suppress at a time. */
+    public Builder autocompleteCardinality(
+      int autocompleteCardinality) { // not abstract as added later
       Logger.getLogger(getClass().getName()).info("autocompleteCardinality not yet supported");
       return this;
     }

--- a/zipkin/src/test/java/zipkin2/storage/ITInMemoryStorage.java
+++ b/zipkin/src/test/java/zipkin2/storage/ITInMemoryStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -59,6 +59,18 @@ public class ITInMemoryStorage {
 
     @Override protected StorageComponent.Builder storageBuilder() {
       return InMemoryStorage.newBuilder();
+    }
+
+    @Override public void clear() {
+      // no need.. the test rule does this
+    }
+  }
+
+  public static class ITServiceAndSpanNames extends zipkin2.storage.ITServiceAndSpanNames {
+    InMemoryStorage storage = InMemoryStorage.newBuilder().build();
+
+    @Override protected InMemoryStorage storage() {
+      return storage;
     }
 
     @Override public void clear() {

--- a/zipkin/src/test/java/zipkin2/storage/ITSearchEnabledFalse.java
+++ b/zipkin/src/test/java/zipkin2/storage/ITSearchEnabledFalse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -38,6 +38,10 @@ public abstract class ITSearchEnabledFalse {
     return storage().spanStore();
   }
 
+  protected ServiceAndSpanNames names() {
+    return storage().serviceAndSpanNames();
+  }
+
   /** Clears store between tests. */
   @Before public abstract void clear() throws Exception;
 
@@ -64,16 +68,22 @@ public abstract class ITSearchEnabledFalse {
       .build()).execute()).isEmpty();
   }
 
-  @Test public void getSpanNames_isEmpty() throws Exception {
-    accept(CLIENT_SPAN);
-
-    assertThat(store().getSpanNames(CLIENT_SPAN.name()).execute()).isEmpty();
-  }
-
   @Test public void getServiceNames_isEmpty() throws Exception {
     accept(CLIENT_SPAN);
 
-    assertThat(store().getServiceNames().execute()).isEmpty();
+    assertThat(names().getServiceNames().execute()).isEmpty();
+  }
+
+  @Test public void getRemoteServiceNames_isEmpty() throws Exception {
+    accept(CLIENT_SPAN);
+
+    assertThat(names().getRemoteServiceNames(CLIENT_SPAN.localServiceName()).execute()).isEmpty();
+  }
+
+  @Test public void getSpanNames_isEmpty() throws Exception {
+    accept(CLIENT_SPAN);
+
+    assertThat(names().getSpanNames(CLIENT_SPAN.localServiceName()).execute()).isEmpty();
   }
 
   protected void accept(Span... spans) throws IOException {

--- a/zipkin/src/test/java/zipkin2/storage/ITServiceAndSpanNames.java
+++ b/zipkin/src/test/java/zipkin2/storage/ITServiceAndSpanNames.java
@@ -88,6 +88,14 @@ public abstract class ITServiceAndSpanNames {
       .containsExactlyInAnyOrderElementsOf(remoteServiceNames);
   }
 
+  /** Ensures the service name index returns distinct results */
+  @Test public void getRemoteServiceNames_dedupes() throws IOException {
+    for (int i = 0; i < 50; i++) accept(CLIENT_SPAN.toBuilder().id(i + 1).build());
+
+    assertThat(serviceAndSpanNames().getRemoteServiceNames("frontend").execute())
+      .containsExactly(CLIENT_SPAN.remoteServiceName());
+  }
+
   @Test public void getRemoteServiceNames_noRemoteServiceName() throws IOException {
     accept(Span.newBuilder().traceId("a").id("a").localEndpoint(FRONTEND).build());
 
@@ -106,7 +114,6 @@ public abstract class ITServiceAndSpanNames {
 
     assertThat(serviceAndSpanNames().getSpanNames(CLIENT_SPAN.remoteServiceName()).execute())
       .isEmpty();
-    ;
   }
 
   @Test public void getSpanNames() throws Exception {
@@ -133,6 +140,14 @@ public abstract class ITServiceAndSpanNames {
 
     assertThat(serviceAndSpanNames().getSpanNames("frontend").execute())
       .containsExactlyInAnyOrderElementsOf(spanNames);
+  }
+
+  /** Ensures the span name index returns distinct results */
+  @Test public void getSpanNames_dedupes() throws IOException {
+    for (int i = 0; i < 50; i++) accept(CLIENT_SPAN.toBuilder().id(i + 1).build());
+
+    assertThat(serviceAndSpanNames().getSpanNames("frontend").execute())
+      .containsExactly(CLIENT_SPAN.name());
   }
 
   @Test public void getSpanNames_noSpanName() throws IOException {

--- a/zipkin/src/test/java/zipkin2/storage/ITServiceAndSpanNames.java
+++ b/zipkin/src/test/java/zipkin2/storage/ITServiceAndSpanNames.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+import static zipkin2.TestObjects.FRONTEND;
+
+/**
+ * Base test for {@link ServiceAndSpanNames}.
+ *
+ * <p>Subtypes should create a connection to a real backend, even if that backend is in-process.
+ */
+public abstract class ITServiceAndSpanNames {
+
+  /** Should maintain state between multiple calls within a test. */
+  protected abstract StorageComponent storage();
+
+  protected ServiceAndSpanNames serviceAndSpanNames() {
+    return storage().serviceAndSpanNames();
+  }
+
+  /** Clears serviceAndSpanNames between tests. */
+  @Before public abstract void clear() throws Exception;
+
+  @Test public void getLocalServiceNames_includesLocalServiceName() throws Exception {
+    assertThat(serviceAndSpanNames().getServiceNames().execute())
+      .isEmpty();
+
+    accept(CLIENT_SPAN);
+
+    assertThat(serviceAndSpanNames().getServiceNames().execute())
+      .containsOnly("frontend");
+  }
+
+  @Test public void getLocalServiceNames_noServiceName() throws IOException {
+    accept(Span.newBuilder().traceId("a").id("a").build());
+
+    assertThat(serviceAndSpanNames().getServiceNames().execute()).isEmpty();
+  }
+
+  @Test public void getRemoteServiceNames() throws Exception {
+    assertThat(serviceAndSpanNames().getRemoteServiceNames("frontend").execute())
+      .isEmpty();
+
+    accept(CLIENT_SPAN);
+
+    assertThat(serviceAndSpanNames().getRemoteServiceNames("frontend" + 1).execute())
+      .isEmpty();
+
+    assertThat(serviceAndSpanNames().getRemoteServiceNames("frontend").execute())
+      .contains(CLIENT_SPAN.remoteServiceName());
+  }
+
+  @Test public void getRemoteServiceNames_allReturned() throws IOException {
+    // Assure a default store limit isn't hit by assuming if 50 are returned, all are returned
+    List<String> remoteServiceNames = new ArrayList<>();
+    for (int i = 0; i < 50; i++) {
+      String suffix = i < 10 ? "0" + i : String.valueOf(i);
+      accept(CLIENT_SPAN.toBuilder()
+        .id(i + 1)
+        .remoteEndpoint(Endpoint.newBuilder().serviceName("yak" + suffix).build())
+        .build());
+      remoteServiceNames.add("yak" + suffix);
+    }
+
+    assertThat(serviceAndSpanNames().getRemoteServiceNames("frontend").execute())
+      .containsExactlyInAnyOrderElementsOf(remoteServiceNames);
+  }
+
+  @Test public void getRemoteServiceNames_noRemoteServiceName() throws IOException {
+    accept(Span.newBuilder().traceId("a").id("a").localEndpoint(FRONTEND).build());
+
+    assertThat(serviceAndSpanNames().getRemoteServiceNames("frontend").execute()).isEmpty();
+  }
+
+  @Test public void getRemoteServiceNames_serviceNameGoesLowercase() throws IOException {
+    accept(CLIENT_SPAN);
+
+    assertThat(serviceAndSpanNames().getRemoteServiceNames("FrOnTeNd").execute())
+      .containsExactly(CLIENT_SPAN.remoteServiceName());
+  }
+
+  @Test public void getSpanNames_doesNotMapNameToRemoteServiceName() throws Exception {
+    accept(CLIENT_SPAN);
+
+    assertThat(serviceAndSpanNames().getSpanNames(CLIENT_SPAN.remoteServiceName()).execute())
+      .isEmpty();
+    ;
+  }
+
+  @Test public void getSpanNames() throws Exception {
+    assertThat(serviceAndSpanNames().getSpanNames("frontend").execute())
+      .isEmpty();
+
+    accept(CLIENT_SPAN);
+
+    assertThat(serviceAndSpanNames().getSpanNames("frontend" + 1).execute())
+      .isEmpty();
+
+    assertThat(serviceAndSpanNames().getSpanNames("frontend").execute())
+      .contains(CLIENT_SPAN.name());
+  }
+
+  @Test public void getSpanNames_allReturned() throws IOException {
+    // Assure a default store limit isn't hit by assuming if 50 are returned, all are returned
+    List<String> spanNames = new ArrayList<>();
+    for (int i = 0; i < 50; i++) {
+      String suffix = i < 10 ? "0" + i : String.valueOf(i);
+      accept(CLIENT_SPAN.toBuilder().id(i + 1).name("yak" + suffix).build());
+      spanNames.add("yak" + suffix);
+    }
+
+    assertThat(serviceAndSpanNames().getSpanNames("frontend").execute())
+      .containsExactlyInAnyOrderElementsOf(spanNames);
+  }
+
+  @Test public void getSpanNames_noSpanName() throws IOException {
+    accept(Span.newBuilder().traceId("a").id("a").localEndpoint(FRONTEND).build());
+
+    assertThat(serviceAndSpanNames().getSpanNames("frontend").execute()).isEmpty();
+  }
+
+  @Test public void getSpanNames_serviceNameGoesLowercase() throws IOException {
+    accept(CLIENT_SPAN);
+
+    assertThat(serviceAndSpanNames().getSpanNames("FrOnTeNd").execute()).containsExactly("get");
+  }
+
+  protected void accept(List<Span> spans) throws IOException {
+    storage().spanConsumer().accept(spans).execute();
+  }
+
+  protected void accept(Span... spans) throws IOException {
+    storage().spanConsumer().accept(asList(spans)).execute();
+  }
+}

--- a/zipkin/src/test/java/zipkin2/storage/ITSpanStore.java
+++ b/zipkin/src/test/java/zipkin2/storage/ITSpanStore.java
@@ -742,21 +742,6 @@ public abstract class ITSpanStore {
       .contains("frontend");
   }
 
-  @Test public void getServiceNames_includesRemoteServiceName() throws Exception {
-    accept(CLIENT_SPAN);
-
-    assertThat(store().getServiceNames().execute())
-      .contains(CLIENT_SPAN.remoteServiceName());
-  }
-
-  /** Our storage services aren't 100% consistent on this. we should reconsider at some point */
-  @Test public void getSpanNames_mapsNameToRemoteServiceName() throws Exception {
-    accept(CLIENT_SPAN);
-
-    assertThat(store().getSpanNames(CLIENT_SPAN.remoteServiceName()).execute())
-      .contains(CLIENT_SPAN.name());
-  }
-
   @Test public void getSpanNames() throws Exception {
     assertThat(store().getSpanNames("frontend").execute())
       .isEmpty();

--- a/zipkin/src/test/java/zipkin2/storage/ITSpanStore.java
+++ b/zipkin/src/test/java/zipkin2/storage/ITSpanStore.java
@@ -215,15 +215,24 @@ public abstract class ITSpanStore {
     accept(CLIENT_SPAN);
 
     assertThat(store().getTraces(requestBuilder()
+      .serviceName(CLIENT_SPAN.localServiceName())
       .remoteServiceName(CLIENT_SPAN.remoteServiceName() + 1)
       .build()).execute()).isEmpty();
 
     assertThat(store().getTraces(requestBuilder()
+      .serviceName(CLIENT_SPAN.localServiceName())
       .remoteServiceName(CLIENT_SPAN.remoteServiceName())
       .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
+  }
+
+  @Test public void getTraces_remoteServiceName_withoutServiceName() throws Exception {
+    accept(CLIENT_SPAN);
 
     assertThat(store().getTraces(requestBuilder()
-      .remoteServiceName("frontend")
+      .remoteServiceName(CLIENT_SPAN.remoteServiceName() + 1)
+      .build()).execute()).isEmpty();
+
+    assertThat(store().getTraces(requestBuilder()
       .remoteServiceName(CLIENT_SPAN.remoteServiceName())
       .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
   }
@@ -242,15 +251,24 @@ public abstract class ITSpanStore {
     accept(CLIENT_SPAN);
 
     assertThat(store().getTraces(requestBuilder()
+      .serviceName(CLIENT_SPAN.localServiceName())
       .spanName(CLIENT_SPAN.name() + 1)
       .build()).execute()).isEmpty();
 
     assertThat(store().getTraces(requestBuilder()
+      .serviceName(CLIENT_SPAN.localServiceName())
       .spanName(CLIENT_SPAN.name())
       .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
+  }
+
+  @Test public void getTraces_spanName_noServiceName() throws Exception {
+    accept(CLIENT_SPAN);
 
     assertThat(store().getTraces(requestBuilder()
-      .spanName("frontend")
+      .spanName(CLIENT_SPAN.name() + 1)
+      .build()).execute()).isEmpty();
+
+    assertThat(store().getTraces(requestBuilder()
       .spanName(CLIENT_SPAN.name())
       .build()).execute()).flatExtracting(l -> l).contains(CLIENT_SPAN);
   }

--- a/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
@@ -44,6 +44,16 @@ public class QueryRequestTest {
       .isNull();
   }
 
+  @Test public void remoteServiceNameCanBeNull() {
+    assertThat(queryBuilder.build().remoteServiceName())
+      .isNull();
+  }
+
+  @Test public void remoteServiceName_coercesEmptyToNull() {
+    assertThat(queryBuilder.remoteServiceName("").build().remoteServiceName())
+      .isNull();
+  }
+
   @Test public void spanName_coercesAllToNull() {
     assertThat(queryBuilder.spanName("all").build().spanName())
       .isNull();
@@ -200,6 +210,18 @@ public class QueryRequestTest {
       .isFalse();
 
     assertThat(request.test(asList(span.toBuilder().name("aloha").build())))
+      .isTrue();
+  }
+
+  @Test public void test_remoteServiceName() {
+    QueryRequest request = queryBuilder
+      .remoteServiceName("db")
+      .build();
+
+    assertThat(request.test(asList(span)))
+      .isFalse();
+
+    assertThat(request.test(asList(span.toBuilder().remoteEndpoint(Endpoint.newBuilder().serviceName("db").build()).build())))
       .isTrue();
   }
 


### PR DESCRIPTION
Especially mentioned in #1794, local and remote service names are undeniably serving different use cases, yet currently conflated in the api.

/services -> only local serviceNames
/remoteServices?serviceName=X -> new: only remote serviceNames for auto-complete
/spans?remoteServiceName=X -> new: to restore functionality @llinder mentioned

cc @openzipkin/ui @bulicekj 