### PR TITLE
Allows POST with content-type CORS config by default

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
@@ -92,7 +92,7 @@ public class ZipkinServerConfiguration implements WebMvcConfigurer {
       //
       // The reason is that our former CORS implementation accidentally allowed POST. People doing
       // browser-based tracing relied on this, so we can't remove it by default. In the future, we
-      // could split the collector's CORS policy into a different property, still allowing POST by
+      // could split the collector's CORS policy into a different property, still allowing POST
       // with content-type by default.
       .allowRequestMethods(HttpMethod.GET, HttpMethod.POST)
       .allowRequestHeaders(HttpHeaderNames.CONTENT_TYPE);


### PR DESCRIPTION
We missed a spot when porting our CORS config. We didn't realize that
before we switched to Armeria, that we allowed POST when we thought we
were controlling GET policy on our api endpoints.

This restores that access as we broke browser-based tracing.

Fixes #2486

Thanks @JonasVerhofste @trustin for the help!