### PR TITLE
Refactors index parsing of cassandra-v1 to make change easier to see

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CompositeIndexer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CompositeIndexer.java
@@ -13,7 +13,6 @@
  */
 package zipkin2.storage.cassandra.v1;
 
-import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheBuilderSpec;
@@ -22,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import zipkin2.Call;
+import zipkin2.Span;
 import zipkin2.v1.V1Span;
 
 final class CompositeIndexer {
@@ -41,10 +41,8 @@ final class CompositeIndexer {
             factory.create(new InsertTraceIdByAnnotation(bucketCount)));
   }
 
-  void index(List<V1Span> spans, List<Call<Void>> calls) {
-    for (Indexer optimizer : indexers) {
-      optimizer.index(spans, calls);
-    }
+  void index(Span span, List<Call<Void>> calls) {
+    for (Indexer indexer : indexers) indexer.index(span, calls);
   }
 
   public void clear() {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertAutocompleteValue.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertAutocompleteValue.java
@@ -24,7 +24,7 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DeduplicatingVoidCallFactory;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static zipkin2.storage.cassandra.v1.Tables.TABLE_AUTOCOMPLETE_TAGS;
+import static zipkin2.storage.cassandra.v1.Tables.AUTOCOMPLETE_TAGS;
 
 final class InsertAutocompleteValue extends ResultSetFutureCall<Void> {
 
@@ -35,7 +35,7 @@ final class InsertAutocompleteValue extends ResultSetFutureCall<Void> {
     Factory(CassandraStorage storage, int indexTtl) {
       super(storage.autocompleteTtl, storage.autocompleteCardinality);
       session = storage.session();
-      Insert insertQuery = QueryBuilder.insertInto(TABLE_AUTOCOMPLETE_TAGS)
+      Insert insertQuery = QueryBuilder.insertInto(AUTOCOMPLETE_TAGS)
         .value("key", QueryBuilder.bindMarker("key"))
         .value("value", QueryBuilder.bindMarker("value"));
       if (indexTtl > 0) insertQuery.using(QueryBuilder.ttl(indexTtl));

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTraceIdByAnnotation.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTraceIdByAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,7 +18,7 @@ import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import zipkin2.v1.V1Span;
+import zipkin2.Span;
 
 import static zipkin2.storage.cassandra.v1.CassandraUtil.annotationKeys;
 import static zipkin2.storage.cassandra.v1.CassandraUtil.toByteBuffer;
@@ -52,7 +52,7 @@ final class InsertTraceIdByAnnotation implements Indexer.IndexSupport {
   }
 
   @Override
-  public Set<String> partitionKeys(V1Span span) {
+  public Set<String> partitionKeys(Span span) {
     return annotationKeys(span);
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static zipkin2.storage.cassandra.v1.Tables.TABLE_AUTOCOMPLETE_TAGS;
+import static zipkin2.storage.cassandra.v1.Tables.AUTOCOMPLETE_TAGS;
 
 final class Schema {
   private static final Logger LOG = LoggerFactory.getLogger(Schema.class);
@@ -106,7 +106,7 @@ final class Schema {
   }
 
   static boolean hasUpgrade2_autocompleteTags(KeyspaceMetadata keyspaceMetadata) {
-    return keyspaceMetadata.getTable(TABLE_AUTOCOMPLETE_TAGS) != null;
+    return keyspaceMetadata.getTable(AUTOCOMPLETE_TAGS) != null;
   }
 
   static void applyCqlFile(String keyspace, Session session, String resource) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectAutocompleteValues.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectAutocompleteValues.java
@@ -27,7 +27,7 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.AccumulateAllResults;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static zipkin2.storage.cassandra.v1.Tables.TABLE_AUTOCOMPLETE_TAGS;
+import static zipkin2.storage.cassandra.v1.Tables.AUTOCOMPLETE_TAGS;
 
 final class SelectAutocompleteValues extends ResultSetFutureCall<ResultSet> {
   static class Factory {
@@ -39,7 +39,7 @@ final class SelectAutocompleteValues extends ResultSetFutureCall<ResultSet> {
       this.session = session;
       this.preparedStatement = session.prepare(
         QueryBuilder.select("value")
-          .from(TABLE_AUTOCOMPLETE_TAGS)
+          .from(AUTOCOMPLETE_TAGS)
           .where(QueryBuilder.eq("key", QueryBuilder.bindMarker("key")))
           .limit(QueryBuilder.bindMarker("limit_")));
       this.accumulateAutocompleteValues = new AccumulateAutocompleteValues();

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
@@ -72,7 +72,7 @@ abstract class ITSpanConsumer {
           .parentId(trace[0].id())
           .id(i + 1)
           .name(String.valueOf(i + 1))
-          .timestamp(trace[0].timestamp() + i * 1000) // child span timestamps happen 1 ms later
+          .timestamp(trace[0].timestampAsLong() + i * 1000) // child span timestamps happen 1 ms later
           .addAnnotation(trace[0].annotations().get(0).timestamp() + i * 1000, "bar")
           .build();
     }
@@ -105,7 +105,7 @@ abstract class ITSpanConsumer {
   static String getTagValue(CassandraStorage storage, String key) {
     return storage
       .session()
-      .execute("SELECT value from " + Tables.TABLE_AUTOCOMPLETE_TAGS + " WHERE key='environment'")
+      .execute("SELECT value from " + Tables.AUTOCOMPLETE_TAGS + " WHERE key='" + key + "'")
       .one()
       .getString(0);
   }
@@ -128,7 +128,7 @@ abstract class ITSpanConsumer {
         .build();
     accept(storage.spanConsumer(), trace);
 
-    assertThat(rowCount(Tables.TABLE_AUTOCOMPLETE_TAGS))
+    assertThat(rowCount(Tables.AUTOCOMPLETE_TAGS))
       .isGreaterThanOrEqualTo(1L);
 
     assertThat(getTagValue(storage, "environment")).isEqualTo("dev");

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/IndexerTest.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/IndexerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,28 +30,28 @@ public class IndexerTest {
 
     ImmutableSetMultimap<PartitionKeyToTraceId, Long> parsed = // intentionally shuffled
         ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800050L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800150L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800050L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 21), 1467676800150L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800125L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 21), 1467676800125L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800110L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "db", 20), 1467676800150L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800000L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800025L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "a"), 1467676800050L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "a"), 1467676800150L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", "a"), 1467676800050L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "b"), 1467676800150L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "a"), 1467676800125L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "b"), 1467676800125L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "a"), 1467676800110L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "db", "a"), 1467676800150L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", "a"), 1467676800000L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", "a"), 1467676800025L)
             .build();
 
     assertThat(Indexer.entriesThatIncreaseGap(sharedState, parsed))
         .hasSameEntriesAs(
             ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
-                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800050L)
-                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 20), 1467676800150L)
-                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 21), 1467676800125L)
-                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", 21), 1467676800150L)
-                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "db", 20), 1467676800150L)
-                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800000L)
-                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", 20), 1467676800050L)
+                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "a"), 1467676800050L)
+                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "a"), 1467676800150L)
+                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "b"), 1467676800125L)
+                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "b"), 1467676800150L)
+                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "db", "a"), 1467676800150L)
+                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", "a"), 1467676800000L)
+                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", "a"), 1467676800050L)
                 .build());
   }
 
@@ -69,19 +69,19 @@ public class IndexerTest {
     // first service index
     ImmutableSetMultimap<PartitionKeyToTraceId, Long> parsed =
         ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800050L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800110L)
-            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800125L)
-            .put(new PartitionKeyToTraceId(SERVICE_SPAN_NAME_INDEX, "app.foo", 20), 1467676800000L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", "a"), 1467676800050L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", "a"), 1467676800110L)
+            .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", "a"), 1467676800125L)
+            .put(new PartitionKeyToTraceId(SERVICE_SPAN_NAME_INDEX, "app.foo", "a"), 1467676800000L)
             .build();
 
     assertThat(Indexer.entriesThatIncreaseGap(sharedState, parsed))
         .hasSameEntriesAs(
             ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
-                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800050L)
-                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", 20), 1467676800125L)
+                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", "a"), 1467676800050L)
+                .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", "a"), 1467676800125L)
                 .put(
-                    new PartitionKeyToTraceId(SERVICE_SPAN_NAME_INDEX, "app.foo", 20),
+                    new PartitionKeyToTraceId(SERVICE_SPAN_NAME_INDEX, "app.foo", "a"),
                     1467676800000L)
                 .build());
   }


### PR DESCRIPTION
In #2484, we will stop indexing the remote service conflated with the
local service. This refactors the index parsing logic to allow that
change to be visible. This also corrects for some drift noticed while
refactoring.