### PR TITLE
Adds workaround for gzip compression regression

### DIFF
--- a/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/CompressionProperties.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/CompressionProperties.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.autoconfigure.ui;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.web.server.Compression;
+
+@ConfigurationProperties("server")
+class CompressionProperties {
+  public Compression getCompression() {
+    return compression;
+  }
+
+  public void setCompression(Compression compression) {
+    this.compression = compression;
+  }
+
+  private Compression compression;
+}

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin2/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -16,6 +16,7 @@ package zipkin2.autoconfigure.ui;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -27,6 +28,7 @@ import com.linecorp.armeria.server.ServerCacheControl;
 import com.linecorp.armeria.server.ServerCacheControlBuilder;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.encoding.HttpEncodingService;
 import com.linecorp.armeria.server.file.HttpFileBuilder;
 import com.linecorp.armeria.server.file.HttpFileServiceBuilder;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
@@ -35,20 +37,27 @@ import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.server.Compression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.Resource;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
 import static zipkin2.autoconfigure.ui.ZipkinUiProperties.DEFAULT_BASEPATH;
 
 /**
@@ -74,7 +83,7 @@ import static zipkin2.autoconfigure.ui.ZipkinUiProperties.DEFAULT_BASEPATH;
  * That's why hashed resource age can be 365 days.
  */
 @Configuration
-@EnableConfigurationProperties(ZipkinUiProperties.class)
+@EnableConfigurationProperties({ZipkinUiProperties.class, CompressionProperties.class})
 @ConditionalOnProperty(name = "zipkin.ui.enabled", matchIfMissing = true)
 class ZipkinUiAutoConfiguration {
   @Autowired
@@ -133,36 +142,44 @@ class ZipkinUiAutoConfiguration {
   }
 
   @Bean @Lazy ArmeriaServerConfigurator uiServerConfigurator(
+    CompressionProperties compressionProperties,
     IndexSwitchingService indexSwitchingService) throws IOException {
     ServerCacheControl maxAgeYear =
       new ServerCacheControlBuilder().maxAgeSeconds(TimeUnit.DAYS.toSeconds(365)).build();
     Service<HttpRequest, HttpResponse> uiFileService =
       HttpFileServiceBuilder.forClassPath("zipkin-ui").cacheControl(maxAgeYear).build()
-        .orElse(HttpFileServiceBuilder.forClassPath("zipkin-lens").cacheControl(maxAgeYear).build());
+        .orElse(
+          HttpFileServiceBuilder.forClassPath("zipkin-lens").cacheControl(maxAgeYear).build());
 
     byte[] config = new ObjectMapper().writeValueAsBytes(ui);
-
-    return sb -> sb
-      .service("/zipkin/config.json", HttpFileBuilder.of(HttpData.of(config))
+    return sb -> {
+      sb.service("/zipkin/config.json", HttpFileBuilder.of(HttpData.of(config))
         .cacheControl(new ServerCacheControlBuilder().maxAgeSeconds(600).build())
         .contentType(MediaType.JSON_UTF_8)
         .build()
-        .asService())
-      .service("/zipkin/index.html", indexSwitchingService)
+        .asService());
+
+      sb.serviceUnder("/zipkin/", uiFileService);
 
       // TODO This approach requires maintenance when new UI routes are added. Change to the following:
       // If the path is a a file w/an extension, treat normally.
       // Otherwise instead of returning 404, forward to the index.
       // See https://github.com/twitter/finatra/blob/458c6b639c3afb4e29873d123125eeeb2b02e2cd/http/src/main/scala/com/twitter/finatra/http/response/ResponseBuilder.scala#L321
-      .service("/zipkin/", indexSwitchingService)
-      .service("/zipkin/traces/{id}", indexSwitchingService)
-      .service("/zipkin/dependency", indexSwitchingService)
-      .service("/zipkin/traceViewer", indexSwitchingService)
+      sb.service("/zipkin/", indexSwitchingService)
+        .service("/zipkin/index.html", indexSwitchingService)
+        .service("/zipkin/traces/{id}", indexSwitchingService)
+        .service("/zipkin/dependency", indexSwitchingService)
+        .service("/zipkin/traceViewer", indexSwitchingService);
 
-      .service("/favicon.ico", new RedirectService(HttpStatus.FOUND, "/zipkin/favicon.ico"))
-      .service("/", new RedirectService(HttpStatus.FOUND, "/zipkin/"))
-      .service("/zipkin", new RedirectService(HttpStatus.FOUND, "/zipkin/"))
-      .serviceUnder("/zipkin/", uiFileService);
+      sb.service("/favicon.ico", new RedirectService(HttpStatus.FOUND, "/zipkin/favicon.ico"))
+        .service("/", new RedirectService(HttpStatus.FOUND, "/zipkin/"))
+        .service("/zipkin", new RedirectService(HttpStatus.FOUND, "/zipkin/"));
+
+      Compression compression = compressionProperties.getCompression();
+      if (compression.getEnabled()) {
+        sb.decorator(contentEncodingDecorator(compression));
+      }
+    };
   }
 
   static class IndexSwitchingService extends AbstractHttpService {
@@ -186,5 +203,39 @@ class ZipkinUiAutoConfiguration {
       }
       return legacyIndex.serve(ctx, req);
     }
+  }
+
+  // TEMPORARY: copy-pasta from com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactory
+  private static Function<Service<HttpRequest, HttpResponse>,
+    HttpEncodingService> contentEncodingDecorator(Compression compression) {
+    final Predicate<MediaType> encodableContentTypePredicate;
+    final String[] mimeTypes = compression.getMimeTypes();
+    if (mimeTypes == null || mimeTypes.length == 0) {
+      encodableContentTypePredicate = contentType -> true;
+    } else {
+      final List<MediaType> encodableContentTypes =
+        Arrays.stream(mimeTypes).map(MediaType::parse).collect(toList());
+      encodableContentTypePredicate = contentType ->
+        encodableContentTypes.stream().anyMatch(contentType::is);
+    }
+
+    final Predicate<HttpHeaders> encodableRequestHeadersPredicate;
+    final String[] excludedUserAgents = compression.getExcludedUserAgents();
+    if (excludedUserAgents == null || excludedUserAgents.length == 0) {
+      encodableRequestHeadersPredicate = headers -> true;
+    } else {
+      final List<Pattern> patterns =
+        Arrays.stream(excludedUserAgents).map(Pattern::compile).collect(toList());
+      encodableRequestHeadersPredicate = headers -> {
+        // No User-Agent header will be converted to an empty string.
+        final String userAgent = headers.get(HttpHeaderNames.USER_AGENT, "");
+        return patterns.stream().noneMatch(pattern -> pattern.matcher(userAgent).matches());
+      };
+    }
+
+    return delegate -> new HttpEncodingService(delegate,
+      encodableContentTypePredicate,
+      encodableRequestHeadersPredicate,
+      compression.getMinResponseSize().toBytes());
   }
 }

--- a/zipkin-autoconfigure/ui/src/test/java/zipkin2/autoconfigure/ui/ITZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/test/java/zipkin2/autoconfigure/ui/ITZipkinUiAutoConfiguration.java
@@ -84,8 +84,8 @@ public class ITZipkinUiAutoConfiguration {
         String etag = get(path).header("etag");
         assertThat(conditionalGet(path, etag).code())
           .isEqualTo(304);
-        assertThat(conditionalGet(path, "aargh").body().contentLength())
-          .isPositive();
+        assertThat(conditionalGet(path, "aargh").code())
+          .isEqualTo(200);
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }


### PR DESCRIPTION
It is costly to ship uncompressed json to browsers. This puts in a
stop-gap.

Thanks @timothybasanov for reporting

FYI @anuraaga @hyangtack we will remove this if addressed upstream

Fixes #2495