### PR TITLE
Matches path pattern of classic UI

### DIFF
--- a/zipkin-lens/src/components/GlobalSearch/index.js
+++ b/zipkin-lens/src/components/GlobalSearch/index.js
@@ -168,7 +168,7 @@ class GlobalSearch extends React.Component {
       limitCondition,
     );
     const location = {
-      pathname: '/zipkin',
+      pathname: '/zipkin/',
       search: queryParams,
     };
     history.push(location);


### PR DESCRIPTION
The current UI is anchored to trailing slash and if requests go to
zipkin without a trailing slash, there will be a redirect. This
redirect loses the query parameters of the search. Rather than write
a custom redirect handler that carries-over query parameters on
redirect, this matches the expected path and thus obviates a redirect
in the first place.