### PR TITLE
Fixes edge case in dependency resolution when ./mvnw test is used

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -90,6 +90,13 @@
           </execution>
         </executions>
       </plugin>
+      <!-- The benchmark test suite is not a valid dependency to others -->
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,13 @@
         <version>2.24.0</version>
       </dependency>
 
+      <!-- Internal classes used in SpanBytesDecoder.JSON_V[12] -->
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.8.5</version>
+      </dependency>
+
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>

--- a/zipkin-collector/core/pom.xml
+++ b/zipkin-collector/core/pom.xml
@@ -32,13 +32,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>

--- a/zipkin-collector/pom.xml
+++ b/zipkin-collector/pom.xml
@@ -47,11 +47,36 @@
       <artifactId>zipkin</artifactId>
     </dependency>
 
+    <!-- For test objects and integration tests -->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <!-- While gson is handled by shade, there's an edge case when ./mvnw test
+         is used in this multi-module build (ex via travis). This adds the dep
+         so that tests execute properly. Explanation below.
+
+         We shade the internal classes used in the test jar, and use optional
+         scope to prevent other modules from accidentally pulling in gson. This
+         works except that the test-jar when used here via ./mvnw test. Unlike
+         3rd party usage, which would resolve to zipkin2:zipkin's shaded dep,
+         ./mvnw test here will result in a project reference, and ignore the
+         gson dependency because it is set as optional. Note this doesn't occur
+         when ./mvnw install is used, only ./mvnw test. This may be a bug in
+         the way dependencies resolve, where some paths consider the shade
+         plugin and others don't.
+
+         This problem is actually more that we didn't initially create a -tests
+         jar, like we do in Brave. Before we release into apache, we should
+         remove the test-jar and make a zipkin-tests artifact instead, which
+         eliminates this edge case and follows recommended practice.
+      -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -56,13 +56,5 @@
       <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
-
 </project>

--- a/zipkin-collector/scribe/pom.xml
+++ b/zipkin-collector/scribe/pom.xml
@@ -87,12 +87,5 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/zipkin-junit/pom.xml
+++ b/zipkin-junit/pom.xml
@@ -62,5 +62,29 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <!-- While gson is handled by shade, there's an edge case when ./mvnw test
+         is used in this multi-module build (ex via travis). This adds the dep
+         so that tests execute properly. Explanation below.
+
+         We shade the internal classes used in the test jar, and use optional
+         scope to prevent other modules from accidentally pulling in gson. This
+         works except that the test-jar when used here via ./mvnw test. Unlike
+         3rd party usage, which would resolve to zipkin2:zipkin's shaded dep,
+         ./mvnw test here will result in a project reference, and ignore the
+         gson dependency because it is set as optional. Note this doesn't occur
+         when ./mvnw install is used, only ./mvnw test. This may be a bug in
+         the way dependencies resolve, where some paths consider the shade
+         plugin and others don't.
+
+         This problem is actually more that we didn't initially create a -tests
+         jar, like we do in Brave. Before we release into apache, we should
+         remove the test-jar and make a zipkin-tests artifact instead, which
+         eliminates this edge case and follows recommended practice.
+      -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -245,6 +245,30 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <!-- While gson is handled by shade, there's an edge case when ./mvnw test
+         is used in this multi-module build (ex via travis). This adds the dep
+         so that tests execute properly. Explanation below.
+
+         We shade the internal classes used in the test jar, and use optional
+         scope to prevent other modules from accidentally pulling in gson. This
+         works except that the test-jar when used here via ./mvnw test. Unlike
+         3rd party usage, which would resolve to zipkin2:zipkin's shaded dep,
+         ./mvnw test here will result in a project reference, and ignore the
+         gson dependency because it is set as optional. Note this doesn't occur
+         when ./mvnw install is used, only ./mvnw test. This may be a bug in
+         the way dependencies resolve, where some paths consider the shade
+         plugin and others don't.
+
+         This problem is actually more that we didn't initially create a -tests
+         jar, like we do in Brave. Before we release into apache, we should
+         remove the test-jar and make a zipkin-tests artifact instead, which
+         eliminates this edge case and follows recommended practice.
+      -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>

--- a/zipkin-storage/cassandra-v1/pom.xml
+++ b/zipkin-storage/cassandra-v1/pom.xml
@@ -56,15 +56,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- for integration tests -->
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
     <!-- To test nuance of load balancing behavior -->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -62,15 +62,6 @@
       <version>${cassandra-driver-core.version}</version>
     </dependency>
 
-    <!-- for integration tests -->
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
     <!-- To test nuance of load balancing behavior -->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -64,15 +64,6 @@
       <artifactId>moshi</artifactId>
     </dependency>
 
-    <!-- for TestObjects -->
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
     <!-- For HttpCallTest -->
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/zipkin-storage/mysql-v1/pom.xml
+++ b/zipkin-storage/mysql-v1/pom.xml
@@ -51,15 +51,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- for integration tests -->
-    <dependency>
-      <groupId>io.zipkin.zipkin2</groupId>
-      <artifactId>zipkin</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>

--- a/zipkin-storage/pom.xml
+++ b/zipkin-storage/pom.xml
@@ -40,6 +40,41 @@
     <module>elasticsearch</module>
   </modules>
 
+  <dependencies>
+    <!-- For test objects and integration tests -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <!-- While gson is handled by shade, there's an edge case when ./mvnw test
+         is used in this multi-module build (ex via travis). This adds the dep
+         so that tests execute properly. Explanation below.
+
+         We shade the internal classes used in the test jar, and use optional
+         scope to prevent other modules from accidentally pulling in gson. This
+         works except that the test-jar when used here via ./mvnw test. Unlike
+         3rd party usage, which would resolve to zipkin2:zipkin's shaded dep,
+         ./mvnw test here will result in a project reference, and ignore the
+         gson dependency because it is set as optional. Note this doesn't occur
+         when ./mvnw install is used, only ./mvnw test. This may be a bug in
+         the way dependencies resolve, where some paths consider the shade
+         plugin and others don't.
+
+         This problem is actually more that we didn't initially create a -tests
+         jar, like we do in Brave. Before we release into apache, we should
+         remove the test-jar and make a zipkin-tests artifact instead, which
+         eliminates this edge case and follows recommended practice.
+      -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <!-- disable retrolambda as we set language level to 1.8 -->

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.5</version>
       <!-- this dependency is shaded out -->
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
Detailed notes in the comments. Basically, there's some malpractice
that occurs when we use a test-jar instead of a main artifact named
`-tests`. This works around the dependency resolution bug until we
refactor that (likely before our first apache release).