### PR TITLE
Replaces fragile proto test setup with Square Wire

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
     </dependency>
+    <!-- for codec benchmarks -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.esotericsoftware.kryo</groupId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -69,19 +69,26 @@
       <artifactId>zipkin-server</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>com.squareup.wire</groupId>
+      <artifactId>wire-runtime</artifactId>
+      <version>${wire.version}</version>
+    </dependency>
     <dependency>
       <groupId>io.zipkin.proto3</groupId>
       <artifactId>zipkin-proto3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
     </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.squareup.wire</groupId>
+        <artifactId>wire-maven-plugin</artifactId>
+      </plugin>
       <!-- disable retrolambda as we allow language level 1.8 benchmark classes -->
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
@@ -104,27 +111,6 @@
         <configuration>
           <skip>true</skip>
         </configuration>
-      </plugin>
-      <!-- protobuf-maven-plugin cannot get proto definitions from dependencies, so we will -->
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>unpack-proto</id>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
-        <artifactId>protobuf-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>compile-proto</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>

--- a/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
@@ -74,12 +74,12 @@ public class CodecBenchmarks {
 
   /** manually implemented with json so not as slow as normal java */
   @Benchmark
-  public Span readClientSpan_java() {
+  public Span readClientSpan_kryo() {
     return kryo.readObject(new Input(zipkin2Serialized), Span.class);
   }
 
   @Benchmark
-  public byte[] writeClientSpan_java() {
+  public byte[] writeClientSpan_kryo() {
     Output output = new Output(zipkin2Serialized.length);
     kryo.writeObject(output, zipkin2);
     output.flush();
@@ -117,12 +117,12 @@ public class CodecBenchmarks {
   }
 
   @Benchmark
-  public byte[] writeClientSpan_json_legacy() {
+  public byte[] writeClientSpan_json_v1() {
     return SpanBytesEncoder.JSON_V1.encode(zipkin2);
   }
 
   @Benchmark
-  public byte[] writeTenClientSpans_json_legacy() {
+  public byte[] writeTenClientSpans_json_v1() {
     return SpanBytesEncoder.JSON_V1.encodeList(tenSpan2s);
   }
 
@@ -146,7 +146,7 @@ public class CodecBenchmarks {
   }
 
   @Benchmark
-  public zipkin2.proto3.Span readChineseSpan_proto3_protobuf() throws Exception {
+  public zipkin2.proto3.Span readChineseSpan_proto3_wire() throws Exception {
     return ADAPTER.decode(zipkin2Proto3Chinese);
   }
 

--- a/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import zipkin2.Span;
 
-import static zipkin2.proto3.Span.parseFrom;
+import static zipkin2.proto3.Span.ADAPTER;
 
 /**
  * The {@link SpanBytesEncoder bundled java codec} aims to be both small in size (i.e. does not
@@ -97,8 +97,8 @@ public class CodecBenchmarks {
   }
 
   @Benchmark
-  public zipkin2.proto3.Span readClientSpan_proto3_protobuf() throws Exception {
-    return parseFrom(zipkin2Proto3);
+  public zipkin2.proto3.Span readClientSpan_proto3_wire() throws Exception {
+    return ADAPTER.decode(zipkin2Proto3);
   }
 
   @Benchmark
@@ -147,7 +147,7 @@ public class CodecBenchmarks {
 
   @Benchmark
   public zipkin2.proto3.Span readChineseSpan_proto3_protobuf() throws Exception {
-    return parseFrom(zipkin2Proto3Chinese);
+    return ADAPTER.decode(zipkin2Proto3Chinese);
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
@@ -41,12 +41,15 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import zipkin2.Span;
 
-import static zipkin2.proto3.Span.ADAPTER;
-
 /**
  * The {@link SpanBytesEncoder bundled java codec} aims to be both small in size (i.e. does not
  * significantly increase the size of zipkin's jar), and efficient. It may not always be fastest,
  * but we should try to keep it competitive.
+ *
+ * <p>Note that the wire benchmarks use their structs, not ours. This will result in more efficient
+ * writes as there's no hex codec of IDs, stringifying of IPs etc. A later change could do that, but
+ * it likely still going to be more efficient than our dependency-free codec. This means in cases
+ * where extra dependencies are ok (such as our server), we could consider using wire.
  */
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 10, time = 1)
@@ -56,108 +59,133 @@ import static zipkin2.proto3.Span.ADAPTER;
 @State(Scope.Thread)
 @Threads(1)
 public class CodecBenchmarks {
-  static final byte[] zipkin2Json = read("/zipkin2-client.json");
-  static final Span zipkin2 = SpanBytesDecoder.JSON_V2.decodeOne(zipkin2Json);
-  static final byte[] zipkin2Proto3 = SpanBytesEncoder.PROTO3.encode(zipkin2);
-  static final List<Span> tenSpan2s = Collections.nCopies(10, zipkin2);
-  static final byte[] tenSpan2sJson = SpanBytesEncoder.JSON_V2.encodeList(tenSpan2s);
+  static final byte[] clientSpanJsonV2 = read("/zipkin2-client.json");
+  static final Span clientSpan = SpanBytesDecoder.JSON_V2.decodeOne(clientSpanJsonV2);
+  static final byte[] clientSpanProto3 = SpanBytesEncoder.PROTO3.encode(clientSpan);
+  static final zipkin2.proto3.Span clientSpan_wire;
+  static final List<Span> tenClientSpans = Collections.nCopies(10, clientSpan);
+  static final byte[] tenClientSpansJsonV2 = SpanBytesEncoder.JSON_V2.encodeList(tenClientSpans);
   static final Kryo kryo = new Kryo();
-  static final byte[] zipkin2Serialized;
+  static final byte[] clientSpanSerialized;
 
   static {
     kryo.register(Span.class, new JavaSerializer());
     Output output = new Output(4096);
-    kryo.writeObject(output, zipkin2);
+    kryo.writeObject(output, clientSpan);
     output.flush();
-    zipkin2Serialized = output.getBuffer();
+    clientSpanSerialized = output.getBuffer();
+    try {
+      clientSpan_wire = zipkin2.proto3.Span.ADAPTER.decode(clientSpanProto3);
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
   }
 
   /** manually implemented with json so not as slow as normal java */
   @Benchmark
   public Span readClientSpan_kryo() {
-    return kryo.readObject(new Input(zipkin2Serialized), Span.class);
+    return kryo.readObject(new Input(clientSpanSerialized), Span.class);
   }
 
   @Benchmark
   public byte[] writeClientSpan_kryo() {
-    Output output = new Output(zipkin2Serialized.length);
-    kryo.writeObject(output, zipkin2);
+    Output output = new Output(clientSpanSerialized.length);
+    kryo.writeObject(output, clientSpan);
     output.flush();
     return output.getBuffer();
   }
 
   @Benchmark
   public Span readClientSpan_json() {
-    return SpanBytesDecoder.JSON_V2.decodeOne(zipkin2Json);
+    return SpanBytesDecoder.JSON_V2.decodeOne(clientSpanJsonV2);
   }
 
   @Benchmark
   public Span readClientSpan_proto3() {
-    return SpanBytesDecoder.PROTO3.decodeOne(zipkin2Proto3);
+    return SpanBytesDecoder.PROTO3.decodeOne(clientSpanProto3);
   }
 
   @Benchmark
   public zipkin2.proto3.Span readClientSpan_proto3_wire() throws Exception {
-    return ADAPTER.decode(zipkin2Proto3);
+    return zipkin2.proto3.Span.ADAPTER.decode(clientSpanProto3);
   }
 
   @Benchmark
   public List<Span> readTenClientSpans_json() {
-    return SpanBytesDecoder.JSON_V2.decodeList(tenSpan2sJson);
+    return SpanBytesDecoder.JSON_V2.decodeList(tenClientSpansJsonV2);
   }
 
   @Benchmark
   public byte[] writeClientSpan_json() {
-    return SpanBytesEncoder.JSON_V2.encode(zipkin2);
+    return SpanBytesEncoder.JSON_V2.encode(clientSpan);
   }
 
   @Benchmark
   public byte[] writeTenClientSpans_json() {
-    return SpanBytesEncoder.JSON_V2.encodeList(tenSpan2s);
+    return SpanBytesEncoder.JSON_V2.encodeList(tenClientSpans);
   }
 
   @Benchmark
   public byte[] writeClientSpan_json_v1() {
-    return SpanBytesEncoder.JSON_V1.encode(zipkin2);
+    return SpanBytesEncoder.JSON_V1.encode(clientSpan);
   }
 
   @Benchmark
   public byte[] writeTenClientSpans_json_v1() {
-    return SpanBytesEncoder.JSON_V1.encodeList(tenSpan2s);
+    return SpanBytesEncoder.JSON_V1.encodeList(tenClientSpans);
   }
 
   @Benchmark
   public byte[] writeClientSpan_proto3() {
-    return SpanBytesEncoder.PROTO3.encode(zipkin2);
+    return SpanBytesEncoder.PROTO3.encode(clientSpan);
   }
 
-  static final byte[] zipkin2JsonChinese = read("/zipkin2-chinese.json");
-  static final Span zipkin2Chinese = SpanBytesDecoder.JSON_V2.decodeOne(zipkin2JsonChinese);
-  static final byte[] zipkin2Proto3Chinese = SpanBytesEncoder.PROTO3.encode(zipkin2Chinese);
+  @Benchmark
+  public byte[] writeClientSpan_proto3_wire() {
+    return clientSpan_wire.encode();
+  }
+
+  static final byte[] chineseSpanJsonV2 = read("/zipkin2-chinese.json");
+  static final Span chineseSpan = SpanBytesDecoder.JSON_V2.decodeOne(chineseSpanJsonV2);
+  static final zipkin2.proto3.Span chineseSpan_wire;
+  static final byte[] chineseSpanProto3 = SpanBytesEncoder.PROTO3.encode(chineseSpan);
+
+  static {
+    try {
+      chineseSpan_wire = zipkin2.proto3.Span.ADAPTER.decode(chineseSpanProto3);
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
 
   @Benchmark
   public Span readChineseSpan_json() {
-    return SpanBytesDecoder.JSON_V2.decodeOne(zipkin2JsonChinese);
+    return SpanBytesDecoder.JSON_V2.decodeOne(chineseSpanJsonV2);
   }
 
   @Benchmark
   public Span readChineseSpan_proto3() {
-    return SpanBytesDecoder.PROTO3.decodeOne(zipkin2Proto3Chinese);
+    return SpanBytesDecoder.PROTO3.decodeOne(chineseSpanProto3);
   }
 
   @Benchmark
   public zipkin2.proto3.Span readChineseSpan_proto3_wire() throws Exception {
-    return ADAPTER.decode(zipkin2Proto3Chinese);
+    return zipkin2.proto3.Span.ADAPTER.decode(chineseSpanProto3);
   }
 
   @Benchmark
   public byte[] writeChineseSpan_json() {
-    return SpanBytesEncoder.JSON_V2.encode(zipkin2Chinese);
+    return SpanBytesEncoder.JSON_V2.encode(chineseSpan);
   }
 
   @Benchmark
   public byte[] writeChineseSpan_proto3() {
-    return SpanBytesEncoder.PROTO3.encode(zipkin2Chinese);
+    return SpanBytesEncoder.PROTO3.encode(chineseSpan);
+  }
+
+  @Benchmark
+  public byte[] writeChineseSpan_proto3_wire() {
+    return chineseSpan_wire.encode();
   }
 
   // Convenience main entry-point

--- a/benchmarks/src/test/java/zipkin2/internal/Proto3CodecInteropTest.java
+++ b/benchmarks/src/test/java/zipkin2/internal/Proto3CodecInteropTest.java
@@ -141,14 +141,15 @@ public class Proto3CodecInteropTest {
 
   @Test public void span_sizeInBytes_matchesWire() {
     assertThat(SPAN.sizeInBytes(ZIPKIN_SPAN))
-      .isEqualTo(Span.ADAPTER.encodedSizeWithTag(SPAN.key, PROTO_SPAN));
+      .isEqualTo(Span.ADAPTER.encodedSizeWithTag(SPAN.fieldNumber, PROTO_SPAN));
   }
 
   @Test public void annotation_sizeInBytes_matchesWire() {
     zipkin2.Annotation zipkinAnnotation = ZIPKIN_SPAN.annotations().get(0);
 
     assertThat(ANNOTATION.sizeInBytes(zipkinAnnotation)).isEqualTo(
-      Annotation.ADAPTER.encodedSizeWithTag(ANNOTATION.key, PROTO_SPAN.annotations.get(0)));
+      Annotation.ADAPTER.encodedSizeWithTag(ANNOTATION.fieldNumber, PROTO_SPAN.annotations.get(0))
+    );
   }
 
   @Test public void annotation_write_matchesWire() {
@@ -178,11 +179,11 @@ public class Proto3CodecInteropTest {
 
   @Test public void endpoint_sizeInBytes_matchesWireEncodingWithTag() {
     assertThat(LOCAL_ENDPOINT.sizeInBytes(ZIPKIN_SPAN.localEndpoint())).isEqualTo(
-        Endpoint.ADAPTER.encodedSizeWithTag(LOCAL_ENDPOINT.key, PROTO_SPAN.local_endpoint)
+        Endpoint.ADAPTER.encodedSizeWithTag(LOCAL_ENDPOINT.fieldNumber, PROTO_SPAN.local_endpoint)
     );
 
     assertThat(REMOTE_ENDPOINT.sizeInBytes(ZIPKIN_SPAN.remoteEndpoint())).isEqualTo(
-      Endpoint.ADAPTER.encodedSizeWithTag(REMOTE_ENDPOINT.key, PROTO_SPAN.remote_endpoint)
+      Endpoint.ADAPTER.encodedSizeWithTag(REMOTE_ENDPOINT.fieldNumber, PROTO_SPAN.remote_endpoint)
     );
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -389,13 +389,6 @@
   </dependencies>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
-      </extension>
-    </extensions>
     <pluginManagement>
       <plugins>
         <!-- mvn -N io.takari:maven:wrapper generates the ./mvnw script -->

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,12 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <armeria.version>0.84.0</armeria.version>
-    <grpc.version>1.19.0</grpc.version>
-    <protobuf.version>3.7.0</protobuf.version>
-    <unpack-proto.directory>${project.build.directory}/test/proto</unpack-proto.directory>
     <!-- This is from armeria, but be careful to avoid >= v20 apis -->
     <guava.version>27.0.1-jre</guava.version>
+
+    <!-- only used for proto interop testing -->
+    <wire.version>3.0.0-alpha01</wire.version>
+    <unpack-proto.directory>${project.build.directory}/test/proto</unpack-proto.directory>
 
     <brave.version>5.6.3</brave.version>
     <cassandra-driver-core.version>3.7.1</cassandra-driver-core.version>
@@ -359,15 +360,16 @@
           </exclusion>
         </exclusions>
       </dependency>
+
       <dependency>
         <groupId>io.zipkin.proto3</groupId>
         <artifactId>zipkin-proto3</artifactId>
         <version>0.1.0</version>
       </dependency>
       <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java</artifactId>
-        <version>${protobuf.version}</version>
+        <groupId>com.squareup.wire</groupId>
+        <artifactId>wire-runtime</artifactId>
+        <version>${wire.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -519,11 +521,11 @@
           </executions>
         </plugin>
 
-        <!-- The below plugins compile google grpc proto stubs in the test tree -->
+        <!-- The below plugins compile protobuf stubs in the indicated source tree -->
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
           <executions>
-            <!-- protobuf-maven-plugin cannot get proto definitions from dependencies: this will -->
+            <!-- wire-maven-plugin cannot get proto definitions from dependencies: this will -->
             <execution>
               <id>unpack-proto</id>
               <phase>generate-sources</phase>
@@ -539,16 +541,23 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.xolstice.maven.plugins</groupId>
-          <artifactId>protobuf-maven-plugin</artifactId>
-          <version>0.6.1</version>
-          <configuration>
-            <protoSourceRoot>${project.build.directory}/main/proto</protoSourceRoot>
-            <protoTestSourceRoot>${project.build.directory}/test/proto</protoTestSourceRoot>
-            <protocArtifact>
-              com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
-            </protocArtifact>
-          </configuration>
+          <groupId>com.squareup.wire</groupId>
+          <artifactId>wire-maven-plugin</artifactId>
+          <version>${wire.version}</version>
+          <executions>
+            <execution>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>generate-sources</goal>
+              </goals>
+              <configuration>
+                <protoSourceDirectory>${unpack-proto.directory}</protoSourceDirectory>
+                <includes>
+                  <include>zipkin.proto3.*</include>
+                </includes>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Square Wire is a lot simpler setup, and it doesn't require installation
of binaries to compile proto files. This helps us and also anyone who
will be doing ASF source verification.

Fixes #2530