### PR TITLE
Tolerates empty POST requests with debug logging

### DIFF
--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -19,13 +19,9 @@ package zipkin2.server.internal;
 import com.linecorp.armeria.server.Server;
 import java.io.IOException;
 import java.util.List;
-import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import okhttp3.Response;
-import okio.Buffer;
-import okio.GzipSink;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +38,6 @@ import zipkin2.storage.InMemoryStorage;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.TODAY;
-import static zipkin2.TestObjects.UTF_8;
 
 @SpringBootTest(
   classes = ZipkinServer.class,
@@ -62,138 +57,23 @@ public class ITZipkinServer {
     storage.clear();
   }
 
-  @Test public void writeSpans_noContentTypeIsJson() throws Exception {
-    Response response = post("/api/v2/spans", SpanBytesEncoder.JSON_V2.encodeList(TRACE));
-
-    assertThat(response.code())
-      .isEqualTo(202);
-  }
-
-  @Test public void writeSpans_version2() throws Exception {
-    byte[] message = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
-
-    assertThat(post("/api/v2/spans", message).code())
-      .isEqualTo(202);
-
-    // sleep as the the storage operation is async
-    Thread.sleep(1500);
+  @Test public void getTrace() throws Exception {
+    storage.accept(TRACE).execute();
 
     Response response = get("/api/v2/trace/" + TRACE.get(0).traceId());
     assertThat(response.isSuccessful()).isTrue();
 
     assertThat(response.body().bytes())
-      .containsExactly(message);
+      .containsExactly(SpanBytesEncoder.JSON_V2.encodeList(TRACE));
   }
 
   @Test public void tracesQueryRequiresNoParameters() throws Exception {
-    byte[] message = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
-    post("/api/v2/spans", message);
-
+    storage.accept(TRACE).execute();
+    
     Response response = get("/api/v2/traces");
     assertThat(response.isSuccessful()).isTrue();
     assertThat(response.body().string())
-      .isEqualTo("[" + new String(message, UTF_8) + "]");
-  }
-
-  @Test public void writeSpans_malformedJsonIsBadRequest() throws Exception {
-    byte[] body = {'h', 'e', 'l', 'l', 'o'};
-
-    Response response = post("/api/v2/spans", body);
-    assertThat(response.code()).isEqualTo(400);
-    assertThat(response.body().string())
-      .startsWith("Expected a JSON_V2 encoded list\n");
-  }
-
-  @Test public void writeSpans_incorrectJsonFormatIsBadRequest_v1_v2() throws Exception {
-    byte[] message = SpanBytesEncoder.JSON_V1.encodeList(TRACE);
-
-    Response response = post("/api/v2/spans", message);
-    assertThat(response.code()).isEqualTo(400);
-    assertThat(response.body().string())
-      .startsWith("Expected a JSON_V2 encoded list, but received: JSON_V1\n");
-  }
-
-  @Test public void writeSpans_incorrectJsonFormatIsBadRequest_v2_v1() throws Exception {
-    byte[] message = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
-
-    Response response = post("/api/v1/spans", message);
-    assertThat(response.code()).isEqualTo(400);
-    assertThat(response.body().string())
-      .startsWith("Expected a JSON_V1 encoded list, but received: JSON_V2\n");
-  }
-
-  @Test public void writeSpans_ambiguousFormatOk() throws Exception {
-    byte[] message = SpanBytesEncoder.JSON_V2.encodeList(asList(
-      Span.newBuilder().traceId("1").id("1").name("test").build()
-    ));
-
-    assertThat(post("/api/v1/spans", message).code()).isEqualTo(202);
-    assertThat(post("/api/v2/spans", message).code()).isEqualTo(202);
-  }
-
-  @Test public void writeSpans_malformedGzipIsBadRequest() throws Exception {
-    byte[] body = {'h', 'e', 'l', 'l', 'o'};
-
-    Response response = client.newCall(new Request.Builder()
-      .url(url(server, "/api/v2/spans"))
-      .header("Content-Encoding", "gzip") // << gzip here, but the body isn't!
-      .post(RequestBody.create(null, body))
-      .build()).execute();
-
-    assertThat(response.code()).isEqualTo(400);
-    assertThat(response.body().string())
-      .startsWith("Cannot gunzip spans");
-  }
-
-  @Test public void writeSpans_contentTypeXThrift() throws Exception {
-    byte[] message = SpanBytesEncoder.THRIFT.encodeList(TRACE);
-
-    Response response = client.newCall(new Request.Builder()
-      .url(url(server, "/api/v1/spans"))
-      .post(RequestBody.create(MediaType.parse("application/x-thrift"), message))
-      .build()).execute();
-
-    assertThat(response.code())
-      .withFailMessage(response.body().string())
-      .isEqualTo(202);
-  }
-
-  @Test public void writeSpans_malformedThriftIsBadRequest() throws Exception {
-    byte[] body = {'h', 'e', 'l', 'l', 'o'};
-
-    Response response = client.newCall(new Request.Builder()
-      .url(url(server, "/api/v1/spans"))
-      .post(RequestBody.create(MediaType.parse("application/x-thrift"), body))
-      .build()).execute();
-
-    assertThat(response.code()).isEqualTo(400);
-    assertThat(response.body().string())
-      .endsWith("Expected a THRIFT encoded list\n");
-  }
-
-  @Test public void writeSpans_contentTypeXProtobuf() throws Exception {
-    byte[] message = SpanBytesEncoder.PROTO3.encodeList(TRACE);
-
-    Response response = client.newCall(new Request.Builder()
-      .url(url(server, "/api/v2/spans"))
-      .post(RequestBody.create(MediaType.parse("application/x-protobuf"), message))
-      .build()).execute();
-
-    assertThat(response.code())
-      .isEqualTo(202);
-  }
-
-  @Test public void writeSpans_malformedProto3IsBadRequest() throws Exception {
-    byte[] body = {'h', 'e', 'l', 'l', 'o'};
-
-    Response response = client.newCall(new Request.Builder()
-      .url(url(server, "/api/v2/spans"))
-      .post(RequestBody.create(MediaType.parse("application/x-protobuf"), body))
-      .build()).execute();
-
-    assertThat(response.code()).isEqualTo(400);
-    assertThat(response.body().string())
-      .startsWith("Expected a PROTO3 encoded list\n");
+      .isEqualTo("[" + SpanBytesEncoder.JSON_V2.encodeList(TRACE) + "]");
   }
 
   @Test public void v2WiresUp() throws Exception {
@@ -201,27 +81,8 @@ public class ITZipkinServer {
       .isTrue();
   }
 
-  @Test public void writeSpans_gzipEncoded() throws Exception {
-    byte[] message = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
-
-    Buffer sink = new Buffer();
-    GzipSink gzipSink = new GzipSink(sink);
-    gzipSink.write(new Buffer().write(message), message.length);
-    gzipSink.close();
-    byte[] gzippedBody = sink.readByteArray();
-
-    Response response = client.newCall(new Request.Builder()
-      .url(url(server, "/api/v2/spans"))
-      .header("Content-Encoding", "gzip")
-      .post(RequestBody.create(null, gzippedBody))
-      .build()).execute();
-
-    assertThat(response.isSuccessful());
-  }
-
   @Test public void doesntSetCacheControlOnNameEndpointsWhenLessThan4Services() throws Exception {
-    byte[] message = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
-    post("/api/v2/spans", message);
+    storage.accept(TRACE).execute();
 
     assertThat(get("/api/v2/services").header("Cache-Control"))
       .isNull();
@@ -246,12 +107,12 @@ public class ITZipkinServer {
   @Test public void setsCacheControlOnNameEndpointsWhenMoreThan3Services() throws Exception {
     List<String> services = asList("foo", "bar", "baz", "quz");
     for (int i = 0; i < services.size(); i++) {
-      post("/api/v2/spans", SpanBytesEncoder.JSON_V2.encodeList(asList(
+      storage.accept(asList(
         Span.newBuilder().traceId("a").id(i + 1).timestamp(TODAY).name("whopper")
           .localEndpoint(Endpoint.newBuilder().serviceName(services.get(i)).build())
           .remoteEndpoint(Endpoint.newBuilder().serviceName(services.get(i) + 1).build())
           .build()
-      )));
+      )).execute();
     }
 
     assertThat(get("/api/v2/services").header("Cache-Control"))
@@ -309,13 +170,6 @@ public class ITZipkinServer {
   private Response get(String path) throws IOException {
     return client.newCall(new Request.Builder()
       .url(url(server, path))
-      .build()).execute();
-  }
-
-  private Response post(String path, byte[] body) throws IOException {
-    return client.newCall(new Request.Builder()
-      .url(url(server, path))
-      .post(RequestBody.create(null, body))
       .build()).execute();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -38,6 +38,7 @@ import zipkin2.storage.InMemoryStorage;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.TODAY;
+import static zipkin2.TestObjects.UTF_8;
 
 @SpringBootTest(
   classes = ZipkinServer.class,
@@ -73,7 +74,7 @@ public class ITZipkinServer {
     Response response = get("/api/v2/traces");
     assertThat(response.isSuccessful()).isTrue();
     assertThat(response.body().string())
-      .isEqualTo("[" + SpanBytesEncoder.JSON_V2.encodeList(TRACE) + "]");
+      .isEqualTo("[" + new String(SpanBytesEncoder.JSON_V2.encodeList(TRACE), UTF_8) + "]");
   }
 
   @Test public void v2WiresUp() throws Exception {

--- a/zipkin-server/src/test/kotlin/zipkin2/server/internal/ITZipkinHttpCollector.kt
+++ b/zipkin-server/src/test/kotlin/zipkin2/server/internal/ITZipkinHttpCollector.kt
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zipkin2.server.internal
+
+import com.linecorp.armeria.server.Server
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import okio.Buffer
+import okio.GzipSink
+import org.assertj.core.api.Assert
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.junit4.SpringRunner
+import zipkin.server.ZipkinServer
+import zipkin2.Span
+import zipkin2.TestObjects.TRACE
+import zipkin2.codec.SpanBytesEncoder
+import zipkin2.storage.InMemoryStorage
+import java.io.IOException
+import java.util.Arrays.asList
+
+@SpringBootTest(classes = [ZipkinServer::class],
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  properties = ["spring.config.name=zipkin-server"])
+@RunWith(SpringRunner::class)
+class ITZipkinHttpCollector {
+  @Autowired lateinit var storage: InMemoryStorage
+  @Autowired lateinit var server: Server
+
+  var client = OkHttpClient.Builder().followRedirects(true).build()
+
+  @Before fun init() {
+    storage.clear()
+  }
+
+  @Test @Throws(IOException::class)
+  fun noContentTypeIsJsonV2() {
+    val response = post("/api/v2/spans", SpanBytesEncoder.JSON_V2.encodeList(TRACE))
+
+    assertThat(response.code())
+      .isEqualTo(202)
+
+    assertThat(storage.traces).containsExactly(TRACE);
+  }
+
+  @Test @Throws(IOException::class)
+  fun jsonV2() {
+    val body = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
+    val response = client.newCall(Request.Builder()
+      .url(url(server, "/api/v2/spans"))
+      .post(RequestBody.create(MediaType.parse("application/json"), body))
+      .build()).execute()
+
+    assertThat(response.code())
+      .isEqualTo(202)
+
+    assertThat(storage.traces).containsExactly(TRACE);
+  }
+
+  @Test @Throws(IOException::class)
+  fun jsonV2_accidentallySentV1Format() {
+    val message = SpanBytesEncoder.JSON_V1.encodeList(TRACE)
+
+    val response = post("/api/v2/spans", message)
+    assertThat(response.code()).isEqualTo(400)
+    assertThat(response.body()!!.string())
+      .startsWith("Expected a JSON_V2 encoded list, but received: JSON_V1\n")
+  }
+
+  @Test @Throws(IOException::class)
+  fun jsonV1_accidentallySentV2Format() {
+    val message = SpanBytesEncoder.JSON_V2.encodeList(TRACE)
+
+    val response = post("/api/v1/spans", message)
+    assertThat(response.code()).isEqualTo(400)
+    assertThat(response.body()!!.string())
+      .startsWith("Expected a JSON_V1 encoded list, but received: JSON_V2\n")
+  }
+
+  @Test @Throws(IOException::class)
+  fun ambiguousFormatOk() {
+    val message = SpanBytesEncoder.JSON_V2.encodeList(asList(
+      Span.newBuilder().traceId("1").id("1").name("test").build()
+    ))
+
+    assertThat(post("/api/v1/spans", message).code()).isEqualTo(202)
+    assertThat(post("/api/v2/spans", message).code()).isEqualTo(202)
+  }
+
+  @Test @Throws(IOException::class)
+  fun emptyIsOk() {
+    assertOnAllEndpoints(byteArrayOf()) { response: Response,
+      path: String, contentType: String, encoding: String ->
+      assertThat(response.isSuccessful)
+        .withFailMessage("$path $contentType $encoding failed")
+        .isTrue()
+    }
+  }
+
+  @Test @Throws(IOException::class)
+  fun malformedNotOk() {
+    assertOnAllEndpoints(byteArrayOf(1, 2, 3, 4)) { response: Response,
+      path: String, contentType: String, encoding: String ->
+      assertThat(response.code()).isEqualTo(400)
+
+      if (encoding == "identity") {
+        assertThat(response.body()!!.string())
+          .withFailMessage("$path $contentType $encoding failed")
+          .contains("Expected a ", " encoded list\n")
+      } else {
+        assertThat(response.body()!!.string())
+          .withFailMessage("$path $contentType $encoding failed")
+          .contains("Cannot gunzip spans")
+      }
+    }
+  }
+
+  fun assertOnAllEndpoints(
+    body: ByteArray,
+    assertion: (Response, String, String, String) -> Assert<*, *>
+  ) {
+    listOf(
+      Pair("/api/v2/spans", "application/json"),
+      Pair("/api/v2/spans", "application/x-protobuf"),
+      Pair("/api/v1/spans", "application/json"),
+      Pair("/api/v1/spans", "application/x-thrift")
+    ).forEach {
+      val (path, contentType) = it
+      for (encoding in listOf("identity", "gzip")) {
+        val response = client.newCall(Request.Builder()
+          .url(url(server, path))
+          .header("Content-Encoding", encoding)
+          .post(RequestBody.create(MediaType.get(contentType), body))
+          .build()).execute()
+
+        assertion(response, path, contentType, encoding)
+      }
+    }
+  }
+
+  @Test @Throws(IOException::class)
+  fun contentTypeXThrift() {
+    val message = SpanBytesEncoder.THRIFT.encodeList(TRACE)
+
+    val response = client.newCall(Request.Builder()
+      .url(url(server, "/api/v1/spans"))
+      .post(RequestBody.create(MediaType.parse("application/x-thrift"), message))
+      .build()).execute()
+
+    assertThat(response.code())
+      .withFailMessage(response.body()!!.string())
+      .isEqualTo(202)
+  }
+
+  @Test @Throws(IOException::class)
+  fun contentTypeXProtobuf() {
+    val message = SpanBytesEncoder.PROTO3.encodeList(TRACE)
+
+    val response = client.newCall(Request.Builder()
+      .url(url(server, "/api/v2/spans"))
+      .post(RequestBody.create(MediaType.parse("application/x-protobuf"), message))
+      .build()).execute()
+
+    assertThat(response.code())
+      .isEqualTo(202)
+  }
+
+  @Test @Throws(IOException::class)
+  fun gzipEncoded() {
+    val message = SpanBytesEncoder.JSON_V2.encodeList(TRACE)
+    val gzippedBody = gzip(message)
+
+    val response = client.newCall(Request.Builder()
+      .url(url(server, "/api/v2/spans"))
+      .header("Content-Encoding", "gzip")
+      .post(RequestBody.create(null, gzippedBody))
+      .build()).execute()
+
+    assertThat(response.isSuccessful)
+  }
+
+  fun gzip(message: ByteArray): ByteArray {
+    val sink = Buffer()
+    val gzipSink = GzipSink(sink)
+    gzipSink.write(Buffer().write(message), message.size.toLong())
+    gzipSink.close()
+    val gzippedBody = sink.readByteArray()
+    return gzippedBody
+  }
+
+  @Throws(IOException::class)
+  fun get(path: String): Response {
+    return client.newCall(Request.Builder()
+      .url(url(server, path))
+      .build()).execute()
+  }
+
+  @Throws(IOException::class)
+  fun post(path: String, body: ByteArray): Response {
+    return client.newCall(Request.Builder()
+      .url(url(server, path))
+      .post(RequestBody.create(null, body))
+      .build()).execute()
+  }
+
+  fun url(server: Server, path: String): String {
+    return "http://localhost:" + server.activePort().get().localAddress().port + path
+  }
+}

--- a/zipkin/src/test/java/zipkin2/codec/SpanBytesDecoderTest.java
+++ b/zipkin/src/test/java/zipkin2/codec/SpanBytesDecoderTest.java
@@ -40,6 +40,34 @@ public class SpanBytesDecoderTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
+  @Test public void emptyListOk_JSON_V1() {
+    assertThat(SpanBytesDecoder.JSON_V1.decodeList(new byte[0]))
+      .isEmpty(); // instead of throwing an exception
+    assertThat(SpanBytesDecoder.JSON_V1.decodeList(new byte[] {'[', ']'}))
+      .isEmpty(); // instead of throwing an exception
+  }
+
+  @Test public void emptyListOk_JSON_V2() {
+    assertThat(SpanBytesDecoder.JSON_V2.decodeList(new byte[0]))
+      .isEmpty(); // instead of throwing an exception
+    assertThat(SpanBytesDecoder.JSON_V2.decodeList(new byte[] {'[', ']'}))
+      .isEmpty(); // instead of throwing an exception
+  }
+
+  @Test public void emptyListOk_PROTO3() {
+    assertThat(SpanBytesDecoder.PROTO3.decodeList(new byte[0]))
+      .isEmpty(); // instead of throwing an exception
+  }
+
+  @Test public void emptyListOk_THRIFT() {
+    assertThat(SpanBytesDecoder.THRIFT.decodeList(new byte[0]))
+      .isEmpty(); // instead of throwing an exception
+
+    byte[] emptyListLiteral = {12 /* TYPE_STRUCT */, 0, 0, 0, 0 /* zero length */};
+    assertThat(SpanBytesDecoder.THRIFT.decodeList(emptyListLiteral))
+      .isEmpty(); // instead of throwing an exception
+  }
+
   @Test public void spanRoundTrip_JSON_V2() {
     assertThat(SpanBytesDecoder.JSON_V2.decodeOne(SpanBytesEncoder.JSON_V2.encode(span)))
       .isEqualTo(span);


### PR DESCRIPTION
This backfills tests to show that our normal codec library is ok with
empty data. What's different, is this doesn't fail on POST when there
are empty messages. Instead, if debug logging is enabled, we say which
IP and user agent posted it.

See https://github.com/apache/incubator-zipkin-reporter-java/issues/138