### PR TITLE
Cleans up poor parent names

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.zipkin</groupId>
-  <artifactId>parent</artifactId>
+  <artifactId>zipkin-parent</artifactId>
   <version>2.13.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 

--- a/zipkin-autoconfigure/collector-kafka08/pom.xml
+++ b/zipkin-autoconfigure/collector-kafka08/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>zipkin-autoconfigure</artifactId>
+    <artifactId>zipkin-autoconfigure-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/zipkin-autoconfigure/collector-scribe/pom.xml
+++ b/zipkin-autoconfigure/collector-scribe/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>zipkin-autoconfigure</artifactId>
+    <artifactId>zipkin-autoconfigure-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/zipkin-autoconfigure/pom.xml
+++ b/zipkin-autoconfigure/pom.xml
@@ -22,11 +22,11 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-autoconfigure</artifactId>
+  <artifactId>zipkin-autoconfigure-parent</artifactId>
   <name>Auto Configuration</name>
   <packaging>pom</packaging>
 

--- a/zipkin-collector/pom.xml
+++ b/zipkin-collector/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/zipkin-junit/pom.xml
+++ b/zipkin-junit/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/zipkin-server/src/it/minimal-dependencies/pom.xml
+++ b/zipkin-server/src/it/minimal-dependencies/pom.xml
@@ -24,7 +24,7 @@
 
   <parent>
     <groupId>@project.groupId@</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>@project.version@</version>
     <relativePath>../../../..</relativePath>
   </parent>

--- a/zipkin-storage/pom.xml
+++ b/zipkin-storage/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/zipkin-tests/pom.xml
+++ b/zipkin-tests/pom.xml
@@ -24,7 +24,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/zipkin-ui/pom.xml
+++ b/zipkin-ui/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>org.apache.zipkin</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <version>2.13.0-SNAPSHOT</version>
   </parent>
 


### PR DESCRIPTION
We never fixed our parent names for the root and autoconfigure projects,
due to not wanting to change things already released. Since we are
moving to a different group ID, now is the perfect time to avoid
creating a file named "parent.jar"

Note: zipkin-collector and zipkin-storage parent poms were named correctly!