### PR TITLE
Scopes retrolambda to the core library

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -107,16 +107,6 @@
         <groupId>com.squareup.wire</groupId>
         <artifactId>wire-maven-plugin</artifactId>
       </plugin>
-      <!-- disable retrolambda as we allow language level 1.8 benchmark classes -->
-      <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
       <!-- The benchmark test suite is not a valid dependency to others -->
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -527,24 +527,6 @@
           </configuration>
         </plugin>
 
-        <plugin>
-          <groupId>net.orfjackal.retrolambda</groupId>
-          <artifactId>retrolambda-maven-plugin</artifactId>
-          <version>2.5.6</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>process-main</goal>
-              </goals>
-              <configuration>
-                <target>${main.java.version}</target>
-                <fork>true</fork>
-                <quiet>true</quiet>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-
         <!-- The below plugins compile protobuf stubs in the indicated source tree -->
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
@@ -590,12 +572,8 @@
     </pluginManagement>
 
     <plugins>
-      <!-- Explicitly disable when using java version 1.8+ or not using java -->
-      <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-      </plugin>
-
+      <!-- Top-level to ensure our server can use JDK 1.8
+             (by checking we don't accidentally use later apis) -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>

--- a/zipkin-autoconfigure/pom.xml
+++ b/zipkin-autoconfigure/pom.xml
@@ -57,16 +57,6 @@
 
   <build>
     <plugins>
-      <!-- disable retrolambda as zipkin-server is language level 1.8 -->
-      <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <configuration>

--- a/zipkin-collector/pom.xml
+++ b/zipkin-collector/pom.xml
@@ -62,16 +62,6 @@
 
   <build>
     <plugins>
-      <!-- disable retrolambda as zipkin-server is language level 1.8 -->
-      <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <configuration>

--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -97,16 +97,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- disable retrolambda as this module doesn't include Java -->
-      <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -453,16 +453,6 @@
           <executable>true</executable>
         </configuration>
       </plugin>
-      <!-- disable retrolambda since this module uses java 8 types -->
-      <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <configuration>

--- a/zipkin-storage/pom.xml
+++ b/zipkin-storage/pom.xml
@@ -61,16 +61,6 @@
 
   <build>
     <plugins>
-      <!-- disable retrolambda as we set language level to 1.8 -->
-      <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <configuration>

--- a/zipkin-tests/pom.xml
+++ b/zipkin-tests/pom.xml
@@ -61,15 +61,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <configuration>
           <skip>false</skip>

--- a/zipkin-ui/pom.xml
+++ b/zipkin-ui/pom.xml
@@ -98,16 +98,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- disable retrolambda as this module doesn't include Java -->
-      <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -90,6 +90,24 @@
           </instructions>
         </configuration>
       </plugin>
+      <!-- Rewrites bytecode back down to java 1.6 -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <version>2.5.6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>process-main</goal>
+            </goals>
+            <configuration>
+              <target>${main.java.version}</target>
+              <fork>true</fork>
+              <quiet>true</quiet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- Use of gson is internal only -->
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
All other libraries use Java 1.8 or aren't Java. Scoping retrolambda
to the core jar speeds up the build.