### PR TITLE
Simplifies Elasticsearch index template when strict trace ID is enabled

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/IndexTemplates.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/IndexTemplates.java
@@ -26,24 +26,19 @@ abstract class IndexTemplates {
 
   abstract float version();
 
+  abstract char indexTypeDelimiter();
+
   abstract String span();
 
   abstract String dependency();
 
   abstract String autocomplete();
 
-  /**
-   * This returns a delimiter based on what's supported by the Elasticsearch version.
-   *
-   * <p>See https://github.com/openzipkin/zipkin/issues/2219
-   */
-  char indexTypeDelimiter() {
-    return version() < 7 ? ':' : '-';
-  }
-
   @AutoValue.Builder
   interface Builder {
     Builder version(float version);
+
+    Builder indexTypeDelimiter(char indexTypeDelimiter);
 
     Builder span(String span);
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/TestResponses.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/TestResponses.java
@@ -16,8 +16,8 @@
  */
 package zipkin2.elasticsearch;
 
-public final class TestResponses {
-  public static final String SERVICE_NAMES =
+final class TestResponses {
+  static final String SERVICE_NAMES =
       "{\n"
           + "  \"took\": 4,\n"
           + "  \"timed_out\": false,\n"
@@ -61,7 +61,7 @@ public final class TestResponses {
           + "  }\n"
           + "}";
 
-  public static final String SPAN_NAMES =
+  static final String SPAN_NAMES =
       "{\n"
           + "  \"took\": 1,\n"
           + "  \"timed_out\": false,\n"
@@ -93,7 +93,7 @@ public final class TestResponses {
           + "  }\n"
           + "}";
 
-      public static final String AUTOCOMPLETE_VALUES = "{\n"
+      static final String AUTOCOMPLETE_VALUES = "{\n"
         + "  \"took\": 12,\n"
         + "  \"timed_out\": false,\n"
         + "  \"_shards\": {\n"

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
@@ -149,7 +149,7 @@ public class VersionSpecificTemplatesTest {
       .withFailMessage("Starting at v7.x, we delimit index and type with hyphen")
       .contains("\"index_patterns\": \"zipkin-autocomplete-*\"");
     assertThat(template.autocomplete())
-      .withFailMessage("7.x does not support the key index.mapper.dynamic")
+      //.withFailMessage("7.x does not support the key index.mapper.dynamic")
       .doesNotContain("\"index.mapper.dynamic\": false");
   }
 
@@ -173,5 +173,25 @@ public class VersionSpecificTemplatesTest {
         + "      }\n"
         + "    }\n"
         + "  }");
+  }
+
+  @Test public void strictTraceId_doesNotIncludeAnalysisSection() throws Exception {
+    es.enqueue(VERSION_RESPONSE_6);
+
+    IndexTemplates template = new VersionSpecificTemplates(storage).get(storage.http());
+
+    assertThat(template.span()).doesNotContain("analysis");
+  }
+
+  @Test public void strictTraceId_false_includesAnalysisForMixedLengthTraceId() throws Exception {
+    storage = ElasticsearchStorage.newBuilder().hosts(storage.hostsSupplier().get())
+      .strictTraceId(false)
+      .build();
+
+    es.enqueue(VERSION_RESPONSE_6);
+
+    IndexTemplates template = new VersionSpecificTemplates(storage).get(storage.http());
+
+    assertThat(template.span()).contains("analysis");
   }
 }

--- a/zipkin/src/main/java/zipkin2/storage/StorageComponent.java
+++ b/zipkin/src/main/java/zipkin2/storage/StorageComponent.java
@@ -111,8 +111,8 @@ public abstract class StorageComponent extends Component {
      * there is overhead associated with indexing spans both by 64 and 128-bit trace IDs. When a
      * site has finished upgrading to 128-bit trace IDs, they should enable this setting.
      *
-     * <p>See https://github.com/openzipkin/b3-propagation/issues/6 for the status of known open
-     * source libraries on 128-bit trace identifiers.
+     * <p>See https://github.com/apache/incubator-zipkin-b3-propagation/issues/6 for the status of
+     * known open source libraries on 128-bit trace identifiers.
      */
     public abstract Builder strictTraceId(boolean strictTraceId);
 


### PR DESCRIPTION
By default, we use strict trace IDs. This removes the analysis section
of the index template when that's the case, simplifying it.