### PR TITLE
Conditionally wraps in Elasticsearch index template based on version

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanConsumer.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanConsumer.java
@@ -87,9 +87,8 @@ class ElasticsearchSpanConsumer implements SpanConsumer { // not final for testi
       } else {
         // guessTimestamp is made for determining the span's authoritative timestamp. When choosing
         // the index bucket, any annotation is better than using current time.
-        for (int i = 0, length = span.annotations().size(); i < length; i++) {
-          indexTimestamp = span.annotations().get(i).timestamp() / 1000;
-          break;
+        if (!span.annotations().isEmpty()) {
+          indexTimestamp = span.annotations().get(0).timestamp() / 1000;
         }
         if (indexTimestamp == 0L) indexTimestamp = System.currentTimeMillis();
       }

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -342,7 +342,7 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   @Memoized // since we don't want overlapping calls to apply the index templates
   IndexTemplates ensureIndexTemplates() {
     try {
-      IndexTemplates templates = new VersionSpecificTemplates(this).get(http());
+      IndexTemplates templates = new VersionSpecificTemplates(this).get();
       HttpCall.Factory http = http();
       ensureIndexTemplate(http, buildUrl(http, templates, SPAN), templates.span());
       ensureIndexTemplate(http, buildUrl(http, templates, DEPENDENCY), templates.dependency());
@@ -355,8 +355,6 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
 
   HttpUrl buildUrl(HttpCall.Factory http, IndexTemplates templates, String type) {
     HttpUrl.Builder builder = http.baseUrl.newBuilder("_template");
-    // ES 7.x defaults include_type_name to false https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_literal_include_type_name_literal_now_defaults_to_literal_false_literal
-    if (templates.version() >= 7) builder.addQueryParameter("include_type_name", "true");
     String indexPrefix = indexNameFormatter().index() + templates.indexTypeDelimiter();
     return builder.addPathSegment(indexPrefix + type + "_template").build();
   }

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/HttpBulkIndexer.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/HttpBulkIndexer.java
@@ -36,6 +36,7 @@ public final class HttpBulkIndexer {
   static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
 
   final String tag;
+  final boolean shouldAddType;
   final HttpCall.Factory http;
   final String pipeline;
   final boolean waitForRefresh;
@@ -45,6 +46,7 @@ public final class HttpBulkIndexer {
 
   public HttpBulkIndexer(String tag, ElasticsearchStorage es) {
     this.tag = tag;
+    shouldAddType = es.version() < 7.0f;
     http = es.http();
     pipeline = es.pipeline();
     waitForRefresh = es.flushOnWrites();
@@ -74,8 +76,8 @@ public final class HttpBulkIndexer {
 
   void writeIndexMetadata(String index, String typeName, @Nullable String id) {
     body.writeUtf8("{\"index\":{\"_index\":\"").writeUtf8(index).writeByte('"');
-    // the _type parameter is needed for Elasticsearch <6.x
-    body.writeUtf8(",\"_type\":\"").writeUtf8(typeName).writeByte('"');
+    // the _type parameter is needed for Elasticsearch < 6.x
+    if (shouldAddType) body.writeUtf8(",\"_type\":\"").writeUtf8(typeName).writeByte('"');
     if (id != null) {
       body.writeUtf8(",\"_id\":\"").writeUtf8(jsonEscape(id).toString()).writeByte('"');
     }


### PR DESCRIPTION
Elasticsearch 7.x no longer wraps mappings by top-level type. They have
a compatibility mode, but it complicates secondary templates as noticed
by @chefky

> For my custom index issue in elasticsearch 7.0 -- I figured it out, but I think it does have an implication with the code. You are still creating the index template with the mapping type, which ElasticSearch has deprecated in 7.0. When I do a 'GET /_template/zipkin-span_template', the mapping type 'span' is removed, and so my updated version did not include the mapping type. I can only get it to work by including the mapping type 'span' in my updated index template, but I have to append 'includeTypeName=true' in the URL, which then results in a message from ElasticSearch indicating that this is deprecated and that they will not support this in the next major version. Do you also use 'includeTypeName=true' when creating the span index template in ElasticSearch? Because I tried to edit the source code to remove the mapping type, but I was getting this error: "Malformed [mappings] section for type [dynamic_templates], should include an inner object describing the mapping". I was able to replicate it in the Kibana dev tool if I explicitly pass in includeTypeName=true and omit the mapping type in my json.

This addresses the issue depending on the version of Elasticsearch in
use.

Fixes #2559