### PR TITLE
annotation query parsing improvements

### DIFF
--- a/zipkin/src/main/java/zipkin2/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin2/storage/QueryRequest.java
@@ -186,7 +186,8 @@ public final class QueryRequest {
     }
 
     /**
-     * Corresponds to query parameter "annotationQuery". Ex. "http.method=GET and error"
+     * Corresponds to query parameter "annotationQuery". Ex. "http.method=GET and error". Parameter keys and values are
+     * trimmed.
      *
      * @see QueryRequest#annotationQueryString()
      */
@@ -196,9 +197,12 @@ public final class QueryRequest {
       for (String ann : annotationQuery.split(" and ", 100)) {
         int idx = ann.indexOf('=');
         if (idx == -1) {
-          map.put(ann.trim(), "");
+          // put the annotation only if there is no key present already, prevents overriding more specific tags
+          map.putIfAbsent(ann.trim(), "");
         } else {
+          // tag
           String[] keyValue = ann.split("=", 2);
+          // tags are put regardless, i.e. last tag wins
           map.put(ann.substring(0, idx).trim(), keyValue.length < 2 ? "" : ann.substring(idx + 1).trim());
         }
       }

--- a/zipkin/src/main/java/zipkin2/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin2/storage/QueryRequest.java
@@ -196,10 +196,10 @@ public final class QueryRequest {
       for (String ann : annotationQuery.split(" and ", 100)) {
         int idx = ann.indexOf('=');
         if (idx == -1) {
-          map.put(ann, "");
+          map.put(ann.trim(), "");
         } else {
           String[] keyValue = ann.split("=", 2);
-          map.put(ann.substring(0, idx), keyValue.length < 2 ? "" : ann.substring(idx + 1));
+          map.put(ann.substring(0, idx).trim(), keyValue.length < 2 ? "" : ann.substring(idx + 1).trim());
         }
       }
       return annotationQuery(map);

--- a/zipkin/src/main/java/zipkin2/storage/QueryRequest.java
+++ b/zipkin/src/main/java/zipkin2/storage/QueryRequest.java
@@ -198,7 +198,8 @@ public final class QueryRequest {
         int idx = ann.indexOf('=');
         if (idx == -1) {
           // put the annotation only if there is no key present already, prevents overriding more specific tags
-          map.putIfAbsent(ann.trim(), "");
+          ann = ann.trim();
+          if (!map.containsKey(ann)) map.put(ann, "");
         } else {
           // tag
           String[] keyValue = ann.split("=", 2);

--- a/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
@@ -100,7 +100,7 @@ public class QueryRequestTest {
     // when a parameter is specified both as a tag and annotation, the tag wins because it's considered to be more
     // specific
     assertThat(queryBuilder.parseAnnotationQuery("a=123 and a").annotationQuery).containsOnly(entry("a", "123"));
-    assertThat(queryBuilder.parseAnnotationQuery("a=123 and a").annotationQuery).containsOnly(entry("a", "123"));
+    assertThat(queryBuilder.parseAnnotationQuery("a and a=123").annotationQuery).containsOnly(entry("a", "123"));
     // also last tag wins
     assertThat(queryBuilder.parseAnnotationQuery("a=123 and a=456").annotationQuery).containsOnly(entry("a", "456"));
     assertThat(queryBuilder.parseAnnotationQuery("a and a=123 and a=456").annotationQuery).containsOnly(entry("a", "456"));

--- a/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
@@ -96,6 +96,16 @@ public class QueryRequestTest {
       .containsOnly(entry("L O L", ""), entry("http.path", "/a"));
   }
 
+  @Test public void annotationQueryParameterSpecificity() {
+    // when a parameter is specified both as a tag and annotation, the tag wins because it's considered to be more
+    // specific
+    assertThat(queryBuilder.parseAnnotationQuery("a=123 and a").annotationQuery).containsOnly(entry("a", "123"));
+    assertThat(queryBuilder.parseAnnotationQuery("a=123 and a").annotationQuery).containsOnly(entry("a", "123"));
+    // also last tag wins
+    assertThat(queryBuilder.parseAnnotationQuery("a=123 and a=456").annotationQuery).containsOnly(entry("a", "456"));
+    assertThat(queryBuilder.parseAnnotationQuery("a and a=123 and a=456").annotationQuery).containsOnly(entry("a", "456"));
+  }
+
   @Test public void endTsMustBePositive() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("endTs <= 0");

--- a/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
@@ -18,7 +18,6 @@ package zipkin2.storage;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/QueryRequestTest.java
@@ -91,9 +91,6 @@ public class QueryRequestTest {
       .containsOnly(entry("L O L", ""), entry("http.path", "/a"));
     assertThat(queryBuilder.parseAnnotationQuery("bar =123 and L O L and http.path = /a and A B C").annotationQuery)
       .containsOnly(entry("L O L", ""), entry("http.path", "/a"), entry("bar", "123"), entry("A B C", ""));
-    // border case, L O L as a tag and annotation, seems that the annotation takes precedence
-    assertThat(queryBuilder.parseAnnotationQuery("L O L=123 and L O L and http.path = /a").annotationQuery)
-      .containsOnly(entry("L O L", ""), entry("http.path", "/a"));
   }
 
   @Test public void annotationQueryParameterSpecificity() {


### PR DESCRIPTION
- whitespace is trimmed from annotation query parameters
- when both an annotation and tag are specified with the same key, (ie `foo and foo=bar`) the tag now wins because it's considered to be more specific. Previously last one in the query would win.