### PR TITLE
Benchmark bytes / bytebuffer, protobuf vs zipkin vs wire.

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -70,6 +70,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.7.1</version>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-server</artifactId>
       <version>${project.version}</version>
@@ -144,6 +150,8 @@
             <configuration combine.self="override">
               <!-- instead of javac-with-errorprone -->
               <compilerId>javac</compilerId>
+              <source>1.8</source>
+              <target>1.8</target>
               <!-- scrub errorprone compiler args -->
               <compilerArgs />
             </configuration>

--- a/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
@@ -54,17 +54,14 @@ public class ProtoCodecBenchmarks {
   static final byte[] clientSpanJsonV2 = read("/zipkin2-client.json");
   static final Span clientSpan = SpanBytesDecoder.JSON_V2.decodeOne(clientSpanJsonV2);
 
-  @Param({"1", "10", "100", "1000", "10000"})
-  public int num;
+  // Assume a message is 1000 spans (which is a high number for as this is per-node-second)
+  static final List<Span> spans = Collections.nCopies(1000, clientSpan);
+  static final byte[] encodedBytes = SpanBytesEncoder.PROTO3.encodeList(spans);
 
-  private byte[] encodedBytes;
   private ByteBuf encodedBuf;
 
   @Setup
   public void setup() {
-    List<Span> spans = Collections.nCopies(num, clientSpan);
-    encodedBytes = SpanBytesEncoder.PROTO3.encodeList(spans);
-
     encodedBuf = PooledByteBufAllocator.DEFAULT.buffer(encodedBytes.length);
     encodedBuf.writeBytes(encodedBytes);
   }
@@ -109,7 +106,6 @@ public class ProtoCodecBenchmarks {
     Options opt = new OptionsBuilder()
       .include(".*" + ProtoCodecBenchmarks.class.getSimpleName() + ".*bytebuffer_")
       .addProfiler("gc")
-      .param("num", "10000")
       .build();
 
     new Runner(opt).run();

--- a/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package zipkin2.codec;
 
 import com.google.common.io.Resources;
@@ -69,20 +85,9 @@ public class ProtoCodecBenchmarks {
   }
 
   @Benchmark
-  public List<Span> bytes_copy_protobufDecoder() {
-    return ProtobufSpanDecoder.decodeList(ByteBufUtil.getBytes(encodedBuf));
-  }
-
-  @Benchmark
-  public List<Span> bytes_wireDecoder() throws IOException {
+  public List<Span> bytes_wireDecoder() {
     return WireSpanDecoder.decodeList(encodedBytes);
   }
-
-  @Benchmark
-  public List<Span> bytes_copy_wireDecoder() throws IOException {
-    return WireSpanDecoder.decodeList(ByteBufUtil.getBytes(encodedBuf));
-  }
-
 
   @Benchmark
   public List<Span> bytebuffer_zipkinDecoder() {
@@ -102,7 +107,7 @@ public class ProtoCodecBenchmarks {
   // Convenience main entry-point
   public static void main(String[] args) throws Exception {
     Options opt = new OptionsBuilder()
-      .include(".*" + ProtoCodecBenchmarks.class.getSimpleName() + ".*bytes_")
+      .include(".*" + ProtoCodecBenchmarks.class.getSimpleName() + ".*bytebuffer_")
       .addProfiler("gc")
       .param("num", "10000")
       .build();

--- a/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
@@ -1,0 +1,110 @@
+package zipkin2.codec;
+
+import com.google.common.io.Resources;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import okio.ByteString;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin2.Span;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Threads(1)
+public class ProtoCodecBenchmarks {
+
+  static final byte[] clientSpanJsonV2 = read("/zipkin2-client.json");
+  static final Span clientSpan = SpanBytesDecoder.JSON_V2.decodeOne(clientSpanJsonV2);
+
+  @Param({"1", "10", "100", "1000", "10000"})
+  public int num;
+
+  private byte[] encodedBytes;
+  private ByteBuf encodedBuf;
+
+  @Setup
+  public void setup() {
+    List<Span> spans = Collections.nCopies(num, clientSpan);
+    encodedBytes = SpanBytesEncoder.PROTO3.encodeList(spans);
+
+    encodedBuf = PooledByteBufAllocator.DEFAULT.buffer(encodedBytes.length);
+    encodedBuf.writeBytes(encodedBytes);
+  }
+
+  @TearDown
+  public void tearDown() {
+    encodedBuf.release();
+  }
+
+  @Benchmark
+  public List<Span> bytes_zipkinDecoder() {
+    return SpanBytesDecoder.PROTO3.decodeList(encodedBytes);
+  }
+
+  @Benchmark
+  public List<Span> bytes_protobufDecoder() {
+    return ProtobufSpanDecoder.decodeList(encodedBytes);
+  }
+
+  @Benchmark
+  public List<zipkin2.proto3.Span> bytes_wireDecoder() throws IOException {
+    return zipkin2.proto3.Span.ADAPTER.asRepeated().decode(encodedBytes);
+  }
+
+
+  @Benchmark
+  public List<Span> bytebuffer_zipkinDecoder() {
+    return SpanBytesDecoder.PROTO3.decodeList(ByteBufUtil.getBytes(encodedBuf));
+  }
+
+  @Benchmark
+  public List<Span> bytebuffer_protobufDecoder() {
+    return ProtobufSpanDecoder.decodeList(encodedBuf.nioBuffer());
+  }
+
+  @Benchmark
+  public List<zipkin2.proto3.Span> bytebuffer_wireDecoder() throws IOException {
+    return zipkin2.proto3.Span.ADAPTER.asRepeated().decode(ByteString.of(encodedBuf.nioBuffer()));
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+      .include(".*" + ProtoCodecBenchmarks.class.getSimpleName())
+      .build();
+
+    new Runner(opt).run();
+  }
+
+  static byte[] read(String resource) {
+    try {
+      return Resources.toByteArray(Resources.getResource(CodecBenchmarks.class, resource));
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/benchmarks/src/main/java/zipkin2/codec/ProtobufSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtobufSpanDecoder.java
@@ -1,0 +1,285 @@
+package zipkin2.codec;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.WireFormat;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+import static java.util.logging.Level.FINE;
+
+public class ProtobufSpanDecoder {
+  static final Logger LOG = Logger.getLogger(ProtobufSpanDecoder.class.getName());
+
+  // map<string,string> in proto is a special field with key, value
+  static final int MAP_KEY_KEY = (1 << 3) | WireFormat.WIRETYPE_LENGTH_DELIMITED;
+  static final int MAP_VALUE_KEY = (2 << 3) | WireFormat.WIRETYPE_LENGTH_DELIMITED;
+
+  static boolean decodeTag(CodedInputStream input, Span.Builder span) throws IOException {
+    // now, we are in the tag fields
+    String key = null, value = ""; // empty tags allowed
+
+    boolean done = false;
+    while (!done) {
+      int tag = input.readTag();
+      switch (tag) {
+        case 0:
+          done = true;
+          break;
+        case MAP_KEY_KEY: {
+          key = input.readStringRequireUtf8();
+          break;
+        }
+        case MAP_VALUE_KEY: {
+          value = input.readStringRequireUtf8();
+          break;
+        }
+        default: {
+          logAndSkip(input, tag);
+          break;
+        }
+      }
+    }
+
+    if (key == null) return false;
+    span.putTag(key, value);
+    return true;
+  }
+
+  static boolean decodeAnnotation(CodedInputStream input, Span.Builder span) throws IOException {
+    long timestamp = 0L;
+    String value = null;
+
+    boolean done = false;
+    while (!done) {
+      int tag = input.readTag();
+      switch (tag) {
+        case 0:
+          done = true;
+          break;
+        case 9: {
+          timestamp = input.readFixed64();
+          break;
+        }
+        case 18: {
+          java.lang.String s = input.readStringRequireUtf8();
+          value = s;
+          break;
+        }
+        default: {
+          logAndSkip(input, tag);
+          break;
+        }
+      }
+    }
+
+    if (timestamp == 0L || value == null) return false;
+    span.addAnnotation(timestamp, value);
+    return true;
+  }
+
+  private static Endpoint decodeEndpoint(CodedInputStream input) throws IOException {
+    Endpoint.Builder endpoint = Endpoint.newBuilder();
+
+    boolean done = false;
+    while (!done) {
+      int tag = input.readTag();
+      switch (tag) {
+        case 0:
+          done = true;
+          break;
+        case 10: {
+          java.lang.String s = input.readStringRequireUtf8();
+          endpoint.serviceName(s);
+          break;
+        }
+        case 18:
+        case 26: {
+          endpoint.parseIp(input.readByteArray());
+          break;
+        }
+        case 32: {
+          endpoint.port(input.readInt32());
+          break;
+        }
+        default: {
+          logAndSkip(input, tag);
+          break;
+        }
+      }
+    }
+    return endpoint.build();
+  }
+
+  public static Span decodeOne(CodedInputStream input) throws IOException {
+    Span.Builder span = Span.newBuilder();
+
+    boolean done = false;
+    while (!done) {
+      int tag = input.readTag();
+      switch (tag) {
+        case 0:
+          done = true;
+          break;
+        case 10: {
+          span.traceId(readHexString(input));
+          break;
+        }
+        case 18: {
+          span.parentId(readHexString(input));
+          break;
+        }
+        case 26: {
+          span.id(readHexString(input));
+          break;
+        }
+        case 32: {
+          int kind = input.readEnum();
+          if (kind == 0) break;
+          if (kind > Span.Kind.values().length) break;
+          span.kind(Span.Kind.values()[kind - 1]);
+          break;
+        }
+        case 42: {
+          java.lang.String name = input.readStringRequireUtf8();
+          span.name(name);
+          break;
+        }
+        case 49: {
+          span.timestamp(input.readFixed64());
+          break;
+        }
+        case 56: {
+          span.duration(input.readUInt64());
+          break;
+        }
+        case 66: {
+          int length = input.readRawVarint32();
+          int oldLimit = input.pushLimit(length);
+
+          span.localEndpoint(decodeEndpoint(input));
+
+          input.checkLastTagWas(0);
+          input.popLimit(oldLimit);
+          break;
+        }
+        case 74: {
+          int length = input.readRawVarint32();
+          int oldLimit = input.pushLimit(length);
+
+          span.remoteEndpoint(decodeEndpoint(input));
+
+          input.checkLastTagWas(0);
+          input.popLimit(oldLimit);
+          break;
+        }
+        case 82: {
+          int length = input.readRawVarint32();
+          int oldLimit = input.pushLimit(length);
+
+          decodeAnnotation(input, span);
+
+          input.checkLastTagWas(0);
+          input.popLimit(oldLimit);
+          break;
+        }
+        case 90: {
+          int length = input.readRawVarint32();
+          int oldLimit = input.pushLimit(length);
+
+          decodeTag(input, span);
+
+          input.checkLastTagWas(0);
+          input.popLimit(oldLimit);
+          break;
+        }
+        case 96: {
+          span.debug(input.readBool());
+          break;
+        }
+        case 104: {
+          span.shared(input.readBool());
+          break;
+        }
+        default: {
+          logAndSkip(input, tag);
+          break;
+        }
+      }
+    }
+
+    return span.build();
+  }
+
+  public static List<Span> decodeList(byte[] spans) {
+    return decodeList(CodedInputStream.newInstance(spans));
+  }
+
+  public static List<Span> decodeList(ByteBuffer spans) {
+    return decodeList(CodedInputStream.newInstance(spans));
+  }
+
+  public static List<Span> decodeList(CodedInputStream input) {
+    ArrayList<Span> spans = new ArrayList<>();
+
+    try {
+      boolean done = false;
+      while (!done) {
+        int tag = input.readTag();
+        switch (tag) {
+          case 0:
+            done = true;
+            break;
+          case 10:
+            int length = input.readRawVarint32();
+            int oldLimit = input.pushLimit(length);
+            spans.add(decodeOne(input));
+            input.checkLastTagWas(0);
+            input.popLimit(oldLimit);
+            break;
+          default: {
+            logAndSkip(input, tag);
+            break;
+          }
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return spans;
+  }
+
+  static final char[] HEX_DIGITS =
+    {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+  private static String readHexString(CodedInputStream input) throws IOException {
+    int size = input.readRawVarint32();
+
+    char[] result = new char[size * 2];
+
+    for (int i = 0; i < result.length; i += 2) {
+      byte b = input.readRawByte();
+      result[i] = HEX_DIGITS[(b >> 4) & 0xf];
+      result[i + 1] = HEX_DIGITS[b & 0xf];
+    }
+
+    return new String(result);
+  }
+
+
+
+  static void logAndSkip(CodedInputStream input, int tag) throws IOException {
+    int nextWireType = WireFormat.getTagWireType(tag);
+    if (LOG.isLoggable(FINE)) {
+      int nextFieldNumber = WireFormat.getTagFieldNumber(tag);
+      LOG.fine(String.format("Skipping field: byte=%s, fieldNumber=%s, wireType=%s",
+        input.getTotalBytesRead(), nextFieldNumber, nextWireType));
+    }
+    input.skipField(tag);
+  }
+}


### PR DESCRIPTION
For #2435 

This is just a hacky set of code to compare performance of decoding `ByteBuffer` and `byte[]`. I used the protobuf library mainly since it has native decoders for each type so is easiest to compare. Naturally zipkin's `Buffer` could be updated to act on `ByteBuffer` directly to avoid this, though I'm not sure it'd be faster since protobuf uses `Unsafe` when it can. wire does especially poorly with `ByteBuffer` it seems, since it just copies it into a `byte[]` but doesn't have netty's unsafe optimizations like `ByteBufUtil.getBytes` would have.

As expected, wire is especially fast in time here, probably because it doesn't do hex decoding - it's nowhere near an apple comparison and mainly for reference. Otherwise, `byte[]` seems to be a bit faster, which isn't unexpected given the JVM is optimized for it, but the difference is mainly in the noise throughout. This could possibly be considered enough reason to switch to `ByteBuffer` though as given similar parsing time, `ByteBuffer` version is a bit better since it generates no garbage and could potentially reduce GC.

```
Benchmark                                        (num)  Mode  Cnt    Score    Error  Units
ProtoCodecBenchmarks.bytebuffer_protobufDecoder      1  avgt   15      1.267 ±   0.014  us/op
ProtoCodecBenchmarks.bytebuffer_protobufDecoder     10  avgt   15     12.244 ±   0.165  us/op
ProtoCodecBenchmarks.bytebuffer_protobufDecoder    100  avgt   15    121.105 ±   1.388  us/op
ProtoCodecBenchmarks.bytebuffer_protobufDecoder   1000  avgt   15   1209.171 ±  18.580  us/op
ProtoCodecBenchmarks.bytebuffer_protobufDecoder  10000  avgt   15  12839.910 ± 771.469  us/op
ProtoCodecBenchmarks.bytebuffer_wireDecoder          1  avgt   15      0.214 ±   0.018  us/op
ProtoCodecBenchmarks.bytebuffer_wireDecoder         10  avgt   15      0.969 ±   0.064  us/op
ProtoCodecBenchmarks.bytebuffer_wireDecoder        100  avgt   15      8.317 ±   0.600  us/op
ProtoCodecBenchmarks.bytebuffer_wireDecoder       1000  avgt   15     90.706 ±   2.031  us/op
ProtoCodecBenchmarks.bytebuffer_wireDecoder      10000  avgt   15   1039.518 ±  65.438  us/op
ProtoCodecBenchmarks.bytebuffer_zipkinDecoder        1  avgt   15      1.389 ±   0.049  us/op
ProtoCodecBenchmarks.bytebuffer_zipkinDecoder       10  avgt   15     13.393 ±   0.802  us/op
ProtoCodecBenchmarks.bytebuffer_zipkinDecoder      100  avgt   15    111.140 ±   2.660  us/op
ProtoCodecBenchmarks.bytebuffer_zipkinDecoder     1000  avgt   15   1234.412 ± 106.794  us/op
ProtoCodecBenchmarks.bytebuffer_zipkinDecoder    10000  avgt   15  11658.781 ± 694.221  us/op
ProtoCodecBenchmarks.bytes_protobufDecoder           1  avgt   15      1.143 ±   0.031  us/op
ProtoCodecBenchmarks.bytes_protobufDecoder          10  avgt   15     11.733 ±   0.545  us/op
ProtoCodecBenchmarks.bytes_protobufDecoder         100  avgt   15    122.660 ±   7.020  us/op
ProtoCodecBenchmarks.bytes_protobufDecoder        1000  avgt   15   1287.893 ±  41.410  us/op
ProtoCodecBenchmarks.bytes_protobufDecoder       10000  avgt   15  11838.844 ± 184.314  us/op
ProtoCodecBenchmarks.bytes_wireDecoder               1  avgt   15      0.136 ±   0.005  us/op
ProtoCodecBenchmarks.bytes_wireDecoder              10  avgt   15      0.598 ±   0.024  us/op
ProtoCodecBenchmarks.bytes_wireDecoder             100  avgt   15      5.603 ±   0.113  us/op
ProtoCodecBenchmarks.bytes_wireDecoder            1000  avgt   15     67.543 ±   1.314  us/op
ProtoCodecBenchmarks.bytes_wireDecoder           10000  avgt   15    775.430 ±  72.922  us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder             1  avgt   15      1.132 ±   0.061  us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder            10  avgt   15     10.942 ±   0.225  us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder           100  avgt   15    117.941 ±   8.454  us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder          1000  avgt   15   1279.525 ±  73.367  us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder         10000  avgt   15  12400.006 ± 469.528  us/op
```