### PR TITLE
Reuse char[] buffer when decoding hex fields.

### DIFF
--- a/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
@@ -30,7 +30,6 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -104,7 +103,7 @@ public class ProtoCodecBenchmarks {
   // Convenience main entry-point
   public static void main(String[] args) throws Exception {
     Options opt = new OptionsBuilder()
-      .include(".*" + ProtoCodecBenchmarks.class.getSimpleName() + ".*bytebuffer_")
+      .include(".*" + ProtoCodecBenchmarks.class.getSimpleName() + ".*bytes_zipkin.*")
       .addProfiler("gc")
       .build();
 

--- a/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
@@ -103,7 +103,7 @@ public class ProtoCodecBenchmarks {
   // Convenience main entry-point
   public static void main(String[] args) throws Exception {
     Options opt = new OptionsBuilder()
-      .include(".*" + ProtoCodecBenchmarks.class.getSimpleName() + ".*bytes_zipkin.*")
+      .include(".*" + ProtoCodecBenchmarks.class.getSimpleName() + ".*bytes_zipkin")
       .addProfiler("gc")
       .build();
 

--- a/benchmarks/src/main/java/zipkin2/codec/ProtobufSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtobufSpanDecoder.java
@@ -269,18 +269,31 @@ public class ProtobufSpanDecoder {
   static final char[] HEX_DIGITS =
     {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
+  // Reuse the buffer for decoding into hex since it's immediately copied into a String.
+  static final ThreadLocal<char[]> THIRTY_TWO_CHARS = new ThreadLocal<char[]>() {
+    @Override protected char[] initialValue() {
+      return new char[32];
+    }
+  };
+
   private static String readHexString(CodedInputStream input) throws IOException {
     int size = input.readRawVarint32();
+    int length = size * 2;
 
-    char[] result = new char[size * 2];
+    // All our hex fields are at most 32 characters.
+    if (length > 32) {
+      throw new AssertionError("hex field greater than 32 chars long: " + length);
+    }
 
-    for (int i = 0; i < result.length; i += 2) {
+    char[] result = THIRTY_TWO_CHARS.get();
+
+    for (int i = 0; i < length; i += 2) {
       byte b = input.readRawByte();
       result[i] = HEX_DIGITS[(b >> 4) & 0xf];
       result[i + 1] = HEX_DIGITS[b & 0xf];
     }
 
-    return new String(result);
+    return new String(result, 0, length);
   }
 
   static void logAndSkip(CodedInputStream input, int tag) throws IOException {

--- a/benchmarks/src/main/java/zipkin2/codec/ProtobufSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtobufSpanDecoder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import zipkin2.Endpoint;
 import zipkin2.Span;
+import zipkin2.internal.Platform;
 
 public class ProtobufSpanDecoder {
   static final Logger LOG = Logger.getLogger(ProtobufSpanDecoder.class.getName());
@@ -269,13 +270,6 @@ public class ProtobufSpanDecoder {
   static final char[] HEX_DIGITS =
     {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
-  // Reuse the buffer for decoding into hex since it's immediately copied into a String.
-  static final ThreadLocal<char[]> THIRTY_TWO_CHARS = new ThreadLocal<char[]>() {
-    @Override protected char[] initialValue() {
-      return new char[32];
-    }
-  };
-
   private static String readHexString(CodedInputStream input) throws IOException {
     int size = input.readRawVarint32();
     int length = size * 2;
@@ -285,7 +279,7 @@ public class ProtobufSpanDecoder {
       throw new AssertionError("hex field greater than 32 chars long: " + length);
     }
 
-    char[] result = THIRTY_TWO_CHARS.get();
+    char[] result = Platform.get().idBuffer();
 
     for (int i = 0; i < length; i += 2) {
       byte b = input.readRawByte();

--- a/benchmarks/src/main/java/zipkin2/codec/WireSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/WireSpanDecoder.java
@@ -29,6 +29,7 @@ import okio.Buffer;
 import okio.ByteString;
 import zipkin2.Endpoint;
 import zipkin2.Span;
+import zipkin2.internal.Platform;
 
 public class WireSpanDecoder {
   static final Logger LOG = Logger.getLogger(WireSpanDecoder.class.getName());
@@ -300,7 +301,7 @@ public class WireSpanDecoder {
       throw new AssertionError("hex field greater than 32 chars long: " + length);
     }
 
-    char[] result = THIRTY_TWO_CHARS.get();
+    char[] result = Platform.get().idBuffer();
 
     for (int i = 0; i < bytes.size(); i ++) {
       byte b = bytes.getByte(i);

--- a/benchmarks/src/main/java/zipkin2/codec/WireSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/WireSpanDecoder.java
@@ -284,13 +284,6 @@ public class WireSpanDecoder {
   static final char[] HEX_DIGITS =
     {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
-  // Reuse the buffer for decoding into hex since it's immediately copied into a String.
-  static final ThreadLocal<char[]> THIRTY_TWO_CHARS = new ThreadLocal<char[]>() {
-    @Override protected char[] initialValue() {
-      return new char[32];
-    }
-  };
-
   // https://github.com/square/wire/issues/958
   private static String readHexString(ProtoReader input) throws IOException {
     ByteString bytes = input.readBytes();

--- a/benchmarks/src/main/java/zipkin2/codec/WireSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/WireSpanDecoder.java
@@ -290,6 +290,7 @@ public class WireSpanDecoder {
     }
   };
 
+  // https://github.com/square/wire/issues/958
   private static String readHexString(ProtoReader input) throws IOException {
     ByteString bytes = input.readBytes();
     int length = bytes.size() * 2;

--- a/zipkin/src/main/java/zipkin2/internal/Platform.java
+++ b/zipkin/src/main/java/zipkin2/internal/Platform.java
@@ -27,7 +27,23 @@ import org.jvnet.animal_sniffer.IgnoreJRERequirement;
 public abstract class Platform {
   private static final Platform PLATFORM = findPlatform();
 
+  private static final ThreadLocal<char[]> ID_BUFFER = new ThreadLocal<>();
+
   Platform() {
+  }
+
+  /**
+   * Returns a {@link ThreadLocal} reused {@code char[]} for use when decoding bytes into a hex
+   * string. The buffer should be immediately copied into a {@link String} after decoding within the
+   * same method.
+   */
+  public char[] idBuffer() {
+    char[] idBuffer = ID_BUFFER.get();
+    if (idBuffer == null) {
+      idBuffer = new char[32];
+      ID_BUFFER.set(idBuffer);
+    }
+    return idBuffer;
   }
 
   public RuntimeException uncheckedIOException(IOException e) {

--- a/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
@@ -205,7 +205,7 @@ final class Proto3Fields {
 
       // All our hex fields are at most 32 characters.
       if (length > 32) {
-        throw new AssertionError("hex field greater than 32 chars long: " + length);
+        throw new IllegalArgumentException("hex field greater than 32 chars long: " + length);
       }
 
       char[] result = getThirtyTwoChars();

--- a/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
@@ -164,18 +164,6 @@ final class Proto3Fields {
     static final char[] HEX_DIGITS =
       {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
-    // Reuse the buffer for decoding into hex since it's immediately copied into a String.
-    static final ThreadLocal<char[]> THIRTY_TWO_CHARS = new ThreadLocal<>();
-
-    static char[] getThirtyTwoChars() {
-      char[] charBuffer = THIRTY_TWO_CHARS.get();
-      if (charBuffer == null) {
-        charBuffer = new char[32];
-        THIRTY_TWO_CHARS.set(charBuffer);
-      }
-      return charBuffer;
-    }
-
     HexField(int key) {
       super(key);
     }
@@ -208,7 +196,7 @@ final class Proto3Fields {
         throw new IllegalArgumentException("hex field greater than 32 chars long: " + length);
       }
 
-      char[] result = getThirtyTwoChars();
+      char[] result = Platform.get().idBuffer();
 
       for (int i = 0; i < length; i += 2) {
         byte b = buffer.readByte();

--- a/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
@@ -165,11 +165,16 @@ final class Proto3Fields {
       {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
     // Reuse the buffer for decoding into hex since it's immediately copied into a String.
-    static final ThreadLocal<char[]> THIRTY_TWO_CHARS = new ThreadLocal<char[]>() {
-      @Override protected char[] initialValue() {
-        return new char[32];
+    static final ThreadLocal<char[]> THIRTY_TWO_CHARS = new ThreadLocal<>();
+
+    static char[] getThirtyTwoChars() {
+      char[] charBuffer = THIRTY_TWO_CHARS.get();
+      if (charBuffer == null) {
+        charBuffer = new char[32];
+        THIRTY_TWO_CHARS.set(charBuffer);
       }
-    };
+      return charBuffer;
+    }
 
     HexField(int key) {
       super(key);
@@ -203,7 +208,7 @@ final class Proto3Fields {
         throw new AssertionError("hex field greater than 32 chars long: " + length);
       }
 
-      char[] result = THIRTY_TWO_CHARS.get();
+      char[] result = getThirtyTwoChars();
 
       for (int i = 0; i < length; i += 2) {
         byte b = buffer.readByte();


### PR DESCRIPTION
Very low hanging fruit to cut out a bit of time and lots of allocation from proto decoding across the board.

After
```

Benchmark                                                                    Mode    Cnt        Score        Error   Units
ProtoCodecBenchmarks.bytes_zipkinDecoder                                   sample  13944     1075.996 ±      5.424   us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.00         sample             946.176                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.50         sample            1035.264                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.90         sample            1206.272                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.95         sample            1300.480                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.99         sample            1905.971                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.999        sample            2646.241                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.9999       sample            9064.374                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p1.00         sample           12173.312                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate                    sample     15     1127.734 ±     19.652  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate.norm               sample     15  1911162.365 ±     18.035    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space           sample     15     1129.688 ±     63.861  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space.norm      sample     15  1914777.841 ± 110248.824    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen              sample     15        1.437 ±      0.248  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen.norm         sample     15     2432.063 ±    404.121    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space       sample     15        1.287 ±      0.326  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space.norm  sample     15     2184.517 ±    582.806    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.count                         sample     15      117.000               counts
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.time                          sample     15      110.000                   ms
```

Before
```
Benchmark                                                                    Mode    Cnt        Score        Error   Units
ProtoCodecBenchmarks.bytes_zipkinDecoder                                   sample  13504     1110.811 ±      5.541   us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.00         sample             942.080                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.50         sample            1060.864                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.90         sample            1269.760                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.95         sample            1376.256                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.99         sample            2080.154                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.999        sample            2699.264                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.9999       sample            5006.438                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p1.00         sample            5652.480                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate                    sample     15     1192.757 ±     75.891  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate.norm               sample     15  2087164.817 ±     22.574    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space           sample     15     1189.685 ±     95.704  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space.norm      sample     15  2081750.627 ± 103259.490    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen              sample     15        1.142 ±      0.611  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen.norm         sample     15     2024.829 ±   1101.138    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space       sample     15        1.553 ±      0.581  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space.norm  sample     15     2735.052 ±   1038.158    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.count                         sample     15      116.000               counts
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.time                          sample     15      110.000                   ms
```