### PR TITLE
Remove array copy when decoding UTF-8 field.

### DIFF
--- a/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
@@ -30,7 +30,6 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -104,7 +103,7 @@ public class ProtoCodecBenchmarks {
   // Convenience main entry-point
   public static void main(String[] args) throws Exception {
     Options opt = new OptionsBuilder()
-      .include(".*" + ProtoCodecBenchmarks.class.getSimpleName() + ".*bytebuffer_")
+      .include(".*" + ProtoCodecBenchmarks.class.getSimpleName() + ".*bytes_zipkin")
       .addProfiler("gc")
       .build();
 

--- a/benchmarks/src/main/java/zipkin2/internal/BufferBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/internal/BufferBenchmarks.java
@@ -59,7 +59,7 @@ public class BufferBenchmarks {
   @Benchmark public byte[] writeUtf8_chinese() {
     Buffer bufferUtf8 = Buffer.allocate(CHINESE_UTF8_SIZE);
     bufferUtf8.writeUtf8(CHINESE_UTF8);
-    return bufferUtf8.toByteArray();
+    return bufferUtf8.toByteArrayUnsafe();
   }
 
   @Benchmark public ByteBuffer writeUtf8_chinese_jdk() {

--- a/benchmarks/src/test/java/zipkin2/internal/Proto3CodecInteropTest.java
+++ b/benchmarks/src/test/java/zipkin2/internal/Proto3CodecInteropTest.java
@@ -159,7 +159,7 @@ public class Proto3CodecInteropTest {
     Buffer zipkinBytes = Buffer.allocate(ANNOTATION.sizeInBytes(zipkinAnnotation));
     ANNOTATION.write(zipkinBytes, zipkinAnnotation);
 
-    assertThat(zipkinBytes.toByteArray())
+    assertThat(zipkinBytes.toByteArrayUnsafe())
       .containsExactly(wireSpan.encode());
   }
 
@@ -192,7 +192,7 @@ public class Proto3CodecInteropTest {
     LOCAL_ENDPOINT.write(zipkinBytes, ZIPKIN_SPAN.localEndpoint());
     Span wireSpan = new Span.Builder().local_endpoint(PROTO_SPAN.local_endpoint).build();
 
-    assertThat(zipkinBytes.toByteArray())
+    assertThat(zipkinBytes.toByteArrayUnsafe())
       .containsExactly(wireSpan.encode());
   }
 
@@ -201,7 +201,7 @@ public class Proto3CodecInteropTest {
     REMOTE_ENDPOINT.write(zipkinBytes, ZIPKIN_SPAN.remoteEndpoint());
     Span wireSpan = new Span.Builder().remote_endpoint(PROTO_SPAN.remote_endpoint).build();
 
-    assertThat(zipkinBytes.toByteArray())
+    assertThat(zipkinBytes.toByteArrayUnsafe())
       .containsExactly(wireSpan.encode());
   }
 
@@ -220,7 +220,7 @@ public class Proto3CodecInteropTest {
     field.write(zipkinBytes, entry);
 
     Span oneField = new Span.Builder().tags(singletonMap(entry.key, entry.value)).build();
-    assertThat(zipkinBytes.toByteArray())
+    assertThat(zipkinBytes.toByteArrayUnsafe())
       .containsExactly(oneField.encode());
   }
 
@@ -231,7 +231,7 @@ public class Proto3CodecInteropTest {
     field.write(zipkinBytes, entry);
 
     Span oneField = new Span.Builder().tags(singletonMap(entry.key, entry.value)).build();
-    assertThat(zipkinBytes.toByteArray())
+    assertThat(zipkinBytes.toByteArrayUnsafe())
       .containsExactly(oneField.encode());
   }
 

--- a/zipkin/src/main/java/zipkin2/internal/Buffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/Buffer.java
@@ -337,7 +337,7 @@ public abstract class Buffer {
 
   public abstract int pos();
 
-  public abstract byte[] toByteArray();
+  public abstract byte[] toByteArrayUnsafe();
 
   public interface Writer<T> {
     int sizeInBytes(T value);

--- a/zipkin/src/main/java/zipkin2/internal/ByteArrayBuffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/ByteArrayBuffer.java
@@ -95,7 +95,7 @@ final class ByteArrayBuffer extends Buffer {
     return pos;
   }
 
-  @Override public byte[] toByteArray() {
+  @Override public byte[] toByteArrayUnsafe() {
     // assert pos == buf.length;
     return buf;
   }

--- a/zipkin/src/main/java/zipkin2/internal/Dependencies.java
+++ b/zipkin/src/main/java/zipkin2/internal/Dependencies.java
@@ -78,7 +78,7 @@ public final class Dependencies {
   public ByteBuffer toThrift() {
     Buffer buffer = Buffer.allocate(sizeInBytes());
     write(buffer);
-    return ByteBuffer.wrap(buffer.toByteArray());
+    return ByteBuffer.wrap(buffer.toByteArrayUnsafe());
   }
 
   int sizeInBytes() {

--- a/zipkin/src/main/java/zipkin2/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin2/internal/JsonCodec.java
@@ -173,7 +173,7 @@ public final class JsonCodec {
     try {
       writer.write(value, b);
     } catch (RuntimeException e) {
-      byte[] bytes = b.toByteArray();
+      byte[] bytes = b.toByteArrayUnsafe();
       int lengthWritten = bytes.length;
       for (int i = 0; i < bytes.length; i++) {
         if (bytes[i] == 0) {
@@ -203,14 +203,14 @@ public final class JsonCodec {
           written);
       throw Platform.get().assertionError(message, e);
     }
-    return b.toByteArray();
+    return b.toByteArrayUnsafe();
   }
 
   public static <T> byte[] writeList(Buffer.Writer<T> writer, List<T> value) {
     if (value.isEmpty()) return new byte[] {'[', ']'};
     Buffer result = Buffer.allocate(sizeInBytes(writer, value));
     writeList(writer, value, result);
-    return result.toByteArray();
+    return result.toByteArrayUnsafe();
   }
 
   public static <T> int writeList(Buffer.Writer<T> writer, List<T> value, byte[] out, int pos) {

--- a/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
@@ -216,7 +216,9 @@ final class Proto3Fields {
     }
 
     @Override String readValue(Buffer buffer, int length) {
-      return new String(buffer.readByteArray(length), UTF_8);
+      String result = new String(buffer.toByteArrayUnsafe(), buffer.pos(), length, UTF_8);
+      buffer.skip(length);
+      return result;
     }
   }
 

--- a/zipkin/src/main/java/zipkin2/internal/Proto3SpanWriter.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3SpanWriter.java
@@ -55,14 +55,14 @@ final class Proto3SpanWriter implements Buffer.Writer<Span> {
     for (int i = 0; i < lengthOfSpans; i++) {
       writeSpan(spans.get(i), sizeOfValues[i], result);
     }
-    return result.toByteArray();
+    return result.toByteArrayUnsafe();
   }
 
   byte[] write(Span onlySpan) {
     int sizeOfValue = SPAN.sizeOfValue(onlySpan);
     Buffer result = Buffer.allocate(sizeOfLengthDelimitedField(sizeOfValue));
     writeSpan(onlySpan, sizeOfValue, result);
-    return result.toByteArray();
+    return result.toByteArrayUnsafe();
   }
 
   // prevents resizing twice

--- a/zipkin/src/main/java/zipkin2/internal/V1SpanWriter.java
+++ b/zipkin/src/main/java/zipkin2/internal/V1SpanWriter.java
@@ -195,7 +195,7 @@ public final class V1SpanWriter implements Buffer.Writer<V1Span> {
     if (localEndpoint == null) return null;
     Buffer buffer = Buffer.allocate(endpointSizeInBytes(localEndpoint, true));
     V2SpanWriter.writeEndpoint(localEndpoint, buffer, true);
-    return buffer.toByteArray();
+    return buffer.toByteArrayUnsafe();
   }
 
   static int binaryAnnotationSizeInBytes(String key, String value, int endpointSize) {

--- a/zipkin/src/main/java/zipkin2/internal/V1ThriftSpanWriter.java
+++ b/zipkin/src/main/java/zipkin2/internal/V1ThriftSpanWriter.java
@@ -172,13 +172,13 @@ public final class V1ThriftSpanWriter implements Buffer.Writer<Span> {
 
     Buffer result = Buffer.allocate(ThriftCodec.listSizeInBytes(this, spans));
     ThriftCodec.writeList(this, spans, result);
-    return result.toByteArray();
+    return result.toByteArrayUnsafe();
   }
 
   public byte[] write(Span onlySpan) {
     Buffer result = Buffer.allocate(sizeInBytes(onlySpan));
     write(onlySpan, result);
-    return result.toByteArray();
+    return result.toByteArrayUnsafe();
   }
 
   public int writeList(List<Span> spans, byte[] out, int pos) {
@@ -195,7 +195,7 @@ public final class V1ThriftSpanWriter implements Buffer.Writer<Span> {
     if (localEndpoint == null) return null;
     Buffer buffer = Buffer.allocate(ThriftEndpointCodec.sizeInBytes(localEndpoint));
     ThriftEndpointCodec.write(localEndpoint, buffer);
-    return buffer.toByteArray();
+    return buffer.toByteArrayUnsafe();
   }
 
   static class ThriftAnnotationWriter {

--- a/zipkin/src/test/java/zipkin2/internal/BufferTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/BufferTest.java
@@ -51,7 +51,7 @@ public class BufferTest {
 
       Buffer buffer = Buffer.allocate(3);
       buffer.writeUtf8(test);
-      assertThat(buffer.toByteArray())
+      assertThat(buffer.toByteArrayUnsafe())
         .containsExactly('a', '?', 'c');
     }
   }
@@ -66,7 +66,7 @@ public class BufferTest {
 
     Buffer buffer = Buffer.allocate(5);
     buffer.writeUtf8(test);
-    assertThat(new String(buffer.toByteArray(), UTF_8))
+    assertThat(new String(buffer.toByteArrayUnsafe(), UTF_8))
       .isEqualTo("\uD83C\uDC00?");
   }
 
@@ -80,7 +80,7 @@ public class BufferTest {
 
     Buffer buffer = Buffer.allocate(6);
     buffer.writeUtf8(test);
-    assertThat(new String(buffer.toByteArray(), UTF_8))
+    assertThat(new String(buffer.toByteArrayUnsafe(), UTF_8))
       .isEqualTo("\uD83C\uDC00?c");
   }
 
@@ -97,7 +97,7 @@ public class BufferTest {
 
       Buffer bufferUtf8 = Buffer.allocate(encodedSize);
       bufferUtf8.writeUtf8(string);
-      assertThat(new String(bufferUtf8.toByteArray(), UTF_8))
+      assertThat(new String(bufferUtf8.toByteArrayUnsafe(), UTF_8))
         .isEqualTo(string);
     }
   }
@@ -110,12 +110,12 @@ public class BufferTest {
 
     Buffer bufferAscii = Buffer.allocate(encodedSize);
     bufferAscii.writeAscii(ascii);
-    assertThat(new String(bufferAscii.toByteArray(), "US-ASCII"))
+    assertThat(new String(bufferAscii.toByteArrayUnsafe(), "US-ASCII"))
       .isEqualTo(ascii);
 
     Buffer bufferUtf8 = Buffer.allocate(encodedSize);
     bufferUtf8.writeUtf8(ascii);
-    assertThat(new String(bufferUtf8.toByteArray(), "US-ASCII"))
+    assertThat(new String(bufferUtf8.toByteArrayUnsafe(), "US-ASCII"))
       .isEqualTo(ascii);
   }
 
@@ -127,7 +127,7 @@ public class BufferTest {
 
     Buffer buffer = Buffer.allocate(emojiBytes.length);
     buffer.writeUtf8(emoji);
-    assertThat(buffer.toByteArray())
+    assertThat(buffer.toByteArrayUnsafe())
       .isEqualTo(emojiBytes);
   }
 
@@ -145,7 +145,7 @@ public class BufferTest {
   static String writeAscii(long v) {
     Buffer buffer = Buffer.allocate(Buffer.asciiSizeInBytes(v));
     buffer.writeAscii(v);
-    return new String(buffer.toByteArray(), UTF_8);
+    return new String(buffer.toByteArrayUnsafe(), UTF_8);
   }
 
   // Test creating Buffer for a long string
@@ -157,7 +157,7 @@ public class BufferTest {
     String string = stringBuffer.toString();
     Buffer buffer = Buffer.allocate(string.length());
     buffer.writeAscii(string);
-    assertThat(new String(buffer.toByteArray(), "US-ASCII")).isEqualTo(string);
+    assertThat(new String(buffer.toByteArrayUnsafe(), "US-ASCII")).isEqualTo(string);
   }
 
   @Test public void unsignedVarintSize_32_largest() {
@@ -181,7 +181,7 @@ public class BufferTest {
       byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
       byteBuffer.putLong(number);
 
-      assertThat(buffer.toByteArray())
+      assertThat(buffer.toByteArrayUnsafe())
         .containsExactly(byteBuffer.array());
     }
   }
@@ -193,7 +193,7 @@ public class BufferTest {
     Buffer buffer = Buffer.allocate(Buffer.varintSizeInBytes(number));
     buffer.writeVarint(number);
 
-    assertThat(buffer.toByteArray())
+    assertThat(buffer.toByteArrayUnsafe())
       .containsExactly(0b1010_1100, 0b0000_0010);
   }
 
@@ -204,7 +204,7 @@ public class BufferTest {
     Buffer buffer = Buffer.allocate(Buffer.varintSizeInBytes(number));
     buffer.writeVarint(number);
 
-    assertThat(buffer.toByteArray())
+    assertThat(buffer.toByteArrayUnsafe())
       .containsExactly(0b1010_1100, 0b0000_0010);
   }
 
@@ -213,21 +213,21 @@ public class BufferTest {
     Buffer buffer = Buffer.allocate(Buffer.varintSizeInBytes(80));
     buffer.writeVarint(80);
 
-    assertThat(buffer.toByteArray())
+    assertThat(buffer.toByteArrayUnsafe())
       .containsExactly(0b0101_0000);
 
     // largest value to not require more than 2 bytes (14 bits set)
     buffer = Buffer.allocate(Buffer.varintSizeInBytes(16383));
     buffer.writeVarint(16383);
 
-    assertThat(buffer.toByteArray())
+    assertThat(buffer.toByteArrayUnsafe())
       .containsExactly(0b1111_1111, 0b0111_1111);
 
     // worst case is a byte longer than fixed 16
     buffer = Buffer.allocate(Buffer.varintSizeInBytes(65535));
     buffer.writeVarint(65535);
 
-    assertThat(buffer.toByteArray())
+    assertThat(buffer.toByteArrayUnsafe())
       .containsExactly(0b1111_1111, 0b1111_1111, 0b0000_0011);
 
     // most bits
@@ -235,7 +235,7 @@ public class BufferTest {
     buffer.writeVarint(0xFFFFFFFF);
 
     // we have a total of 32 bits encoded
-    assertThat(buffer.toByteArray())
+    assertThat(buffer.toByteArrayUnsafe())
       .containsExactly(0b1111_1111, 0b1111_1111, 0b1111_1111, 0b1111_1111, 0b0000_1111);
   }
 

--- a/zipkin/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
@@ -59,9 +59,9 @@ public class Proto3SpanWriterTest {
   }
 
   @Test public void writeList_offset_startsWithSpanKeyAndLengthPrefix() {
-    writer.writeList(asList(CLIENT_SPAN, CLIENT_SPAN), buf.toByteArray(), 0);
+    writer.writeList(asList(CLIENT_SPAN, CLIENT_SPAN), buf.toByteArrayUnsafe(), 0);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
       .startsWith((byte) 10, SPAN.sizeOfValue(CLIENT_SPAN));
   }
 }

--- a/zipkin/src/test/java/zipkin2/internal/Proto3ZipkinFieldsTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/Proto3ZipkinFieldsTest.java
@@ -79,14 +79,14 @@ public class Proto3ZipkinFieldsTest {
   @Test public void span_write_startsWithFieldInListOfSpans() {
     SPAN.write(buf, spanBuilder().build());
 
-    assertThat(buf.toByteArray()).startsWith(
+    assertThat(buf.toByteArrayUnsafe()).startsWith(
       0b00001010 /* span key */, 20 /* bytes for length of the span */
     );
   }
 
   @Test public void span_write_writesIds() {
     SPAN.write(buf, spanBuilder().build());
-    assertThat(buf.toByteArray()).startsWith(
+    assertThat(buf.toByteArrayUnsafe()).startsWith(
       0b00001010 /* span key */, 20 /* bytes for length of the span */,
       0b00001010 /* trace ID key */, 8 /* bytes for 64-bit trace ID */,
       0, 0, 0, 0, 0, 0, 0, 1, // hex trace ID
@@ -154,7 +154,7 @@ public class Proto3ZipkinFieldsTest {
 
   @Test public void span_write_kind() {
     SPAN.write(buf, spanBuilder().kind(Span.Kind.PRODUCER).build());
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
       .contains(0b0100000, atIndex(22)) // (field_number << 3) | wire_type = 4 << 3 | 0
       .contains(0b0000011, atIndex(23)); // producer's index is 3
   }
@@ -163,12 +163,12 @@ public class Proto3ZipkinFieldsTest {
     assertRoundTrip(spanBuilder().kind(Span.Kind.CONSUMER).build());
 
     buf.reset();
-    buf.toByteArray()[23] = (byte) (Span.Kind.values().length + 1); // undefined kind
+    buf.toByteArrayUnsafe()[23] = (byte) (Span.Kind.values().length + 1); // undefined kind
     assertThat(SPAN.read(buf))
       .isEqualTo(spanBuilder().build()); // skips undefined kind instead of dying
 
     buf.reset();
-    buf.toByteArray()[23] = 0; // serialized zero
+    buf.toByteArrayUnsafe()[23] = 0; // serialized zero
     assertThat(SPAN.read(buf))
       .isEqualTo(spanBuilder().build());
   }
@@ -176,7 +176,7 @@ public class Proto3ZipkinFieldsTest {
   @Test public void span_write_debug() {
     SPAN.write(buf, CLIENT_SPAN.toBuilder().debug(true).build());
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
       .contains(0b01100000, atIndex(buf.pos() - 2)) // (field_number << 3) | wire_type = 12 << 3 | 0
       .contains(1, atIndex(buf.pos() - 1)); // true
   }
@@ -184,7 +184,7 @@ public class Proto3ZipkinFieldsTest {
   @Test public void span_write_shared() {
     SPAN.write(buf, CLIENT_SPAN.toBuilder().kind(Span.Kind.SERVER).shared(true).build());
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
       .contains(0b01101000, atIndex(buf.pos() - 2)) // (field_number << 3) | wire_type = 13 << 3 | 0
       .contains(1, atIndex(buf.pos() - 1)); // true
   }

--- a/zipkin/src/test/java/zipkin2/internal/V1JsonSpanWriterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/V1JsonSpanWriterTest.java
@@ -65,7 +65,7 @@ public class V1JsonSpanWriterTest {
   }
 
   void writesCoreAnnotations(String begin, String end) throws UnsupportedEncodingException {
-    String json = new String(buf.toByteArray(), "UTF-8");
+    String json = new String(buf.toByteArrayUnsafe(), "UTF-8");
 
     assertThat(json)
         .contains("{\"timestamp\":" + CLIENT_SPAN.timestamp() + ",\"value\":\"" + begin + "\"");
@@ -107,7 +107,7 @@ public class V1JsonSpanWriterTest {
   }
 
   void writesCoreSendAnnotations(String begin) throws UnsupportedEncodingException {
-    String json = new String(buf.toByteArray(), "UTF-8");
+    String json = new String(buf.toByteArrayUnsafe(), "UTF-8");
 
     assertThat(json)
         .contains("{\"timestamp\":" + CLIENT_SPAN.timestamp() + ",\"value\":\"" + begin + "\"");
@@ -142,7 +142,7 @@ public class V1JsonSpanWriterTest {
   }
 
   void writesAddressBinaryAnnotation(String address) throws UnsupportedEncodingException {
-    String json = new String(buf.toByteArray(), "UTF-8");
+    String json = new String(buf.toByteArrayUnsafe(), "UTF-8");
 
     assertThat(json).contains("{\"key\":\"" + address + "\",\"value\":true,\"endpoint\":");
   }
@@ -151,7 +151,7 @@ public class V1JsonSpanWriterTest {
   public void writes128BitTraceId() throws UnsupportedEncodingException {
     writer.write(CLIENT_SPAN, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
         .startsWith("{\"traceId\":\"" + CLIENT_SPAN.traceId() + "\"");
   }
 
@@ -159,7 +159,7 @@ public class V1JsonSpanWriterTest {
   public void annotationsHaveEndpoints() throws IOException {
     writer.write(CLIENT_SPAN, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
         .contains(
             "\"value\":\"foo\",\"endpoint\":{\"serviceName\":\"frontend\",\"ipv4\":\"127.0.0.1\"}");
   }
@@ -168,7 +168,7 @@ public class V1JsonSpanWriterTest {
   public void writesTimestampAndDuration() throws IOException {
     writer.write(CLIENT_SPAN, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
         .contains(
             "\"timestamp\":" + CLIENT_SPAN.timestamp() + ",\"duration\":" + CLIENT_SPAN.duration());
   }
@@ -177,7 +177,7 @@ public class V1JsonSpanWriterTest {
   public void skipsTimestampAndDuration_shared() throws IOException {
     writer.write(CLIENT_SPAN.toBuilder().kind(Span.Kind.SERVER).shared(true).build(), buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
         .doesNotContain(
             "\"timestamp\":" + CLIENT_SPAN.timestamp() + ",\"duration\":" + CLIENT_SPAN.duration());
   }
@@ -193,7 +193,7 @@ public class V1JsonSpanWriterTest {
 
     writer.write(span, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8")).contains("\"name\":\"\"");
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8")).contains("\"name\":\"\"");
   }
 
   @Test
@@ -206,7 +206,7 @@ public class V1JsonSpanWriterTest {
 
     writer.write(span, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
         .contains("\"value\":\"foo\",\"endpoint\":{\"serviceName\":\"\",\"ipv4\":\"127.0.0.1\"}");
   }
 
@@ -214,7 +214,7 @@ public class V1JsonSpanWriterTest {
   public void tagsAreBinaryAnnotations() throws IOException {
     writer.write(CLIENT_SPAN, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
         .contains(
             "\"binaryAnnotations\":["
                 + "{\"key\":\"clnt/finagle.version\",\"value\":\"6.45.0\",\"endpoint\":{\"serviceName\":\"frontend\",\"ipv4\":\"127.0.0.1\"}},"

--- a/zipkin/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
@@ -47,7 +47,7 @@ public class V1ThriftSpanWriterTest {
   public void init() {
     Buffer endpointBuffer = Buffer.allocate(ThriftEndpointCodec.sizeInBytes(endpoint));
     ThriftEndpointCodec.write(endpoint, endpointBuffer);
-    endpointBytes = endpointBuffer.toByteArray();
+    endpointBytes = endpointBuffer.toByteArrayUnsafe();
   }
 
 
@@ -57,7 +57,7 @@ public class V1ThriftSpanWriterTest {
     Endpoint endpoint = Endpoint.newBuilder().ip("127.0.0.1").port(63840).build();
     Buffer endpointBuffer = Buffer.allocate(ThriftEndpointCodec.sizeInBytes(endpoint));
     ThriftEndpointCodec.write(endpoint, endpointBuffer);
-    byte[] buff = endpointBuffer.toByteArray();
+    byte[] buff = endpointBuffer.toByteArrayUnsafe();
 
     assertThat(buff)
       .containsSequence(TYPE_I32, 0, 1, 127, 0, 0, 1) // ipv4
@@ -103,9 +103,9 @@ public class V1ThriftSpanWriterTest {
 
   @Test
   public void writeList_offset_startsWithListPrefix() {
-    writer.writeList(asList(span, span), buf.toByteArray(), 1);
+    writer.writeList(asList(span, span), buf.toByteArrayUnsafe(), 1);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .startsWith( // member type of the list and an integer with the count
             0, TYPE_STRUCT, 0, 0, 0, 2);
   }
@@ -117,7 +117,7 @@ public class V1ThriftSpanWriterTest {
     Buffer buf2 = Buffer.allocate(2048);
     writer.write(span, buf2);
 
-    assertThat(buf.toByteArray()).containsExactly(buf.toByteArray());
+    assertThat(buf.toByteArrayUnsafe()).containsExactly(buf.toByteArrayUnsafe());
   }
 
   @Test
@@ -144,7 +144,7 @@ public class V1ThriftSpanWriterTest {
     span = span.toBuilder().kind(kind).timestamp(5).duration(10).build();
     writer.write(span, buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(TYPE_LIST, 0, 6, TYPE_STRUCT, 0, 0, 0, 2) // two annotations
         .containsSequence(TYPE_I64, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5) // timestamp
         .containsSequence(TYPE_STRING, 0, 2, 0, 0, 0, 2, begin.charAt(0), begin.charAt(1))
@@ -176,7 +176,7 @@ public class V1ThriftSpanWriterTest {
     span = span.toBuilder().kind(kind).timestamp(5).build();
     writer.write(span, buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(TYPE_LIST, 0, 6, TYPE_STRUCT, 0, 0, 0, 1) // one annotation
         .containsSequence(TYPE_I64, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5) // timestamp
         .containsSequence(TYPE_STRING, 0, 2, 0, 0, 0, 2, begin.charAt(0), begin.charAt(1));
@@ -205,7 +205,7 @@ public class V1ThriftSpanWriterTest {
   void writesAddressBinaryAnnotation(Span.Kind kind, String addr) {
     writer.write(span.toBuilder().kind(kind).remoteEndpoint(endpoint).build(), buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(TYPE_LIST, 0, 8, TYPE_STRUCT, 0, 0, 0, 1) // one binary annotation
         .containsSequence(TYPE_STRING, 0, 1, 0, 0, 0, 2, addr.charAt(0), addr.charAt(1)) // key
         .containsSequence(TYPE_STRING, 0, 2, 0, 0, 0, 1, 1) // value
@@ -217,7 +217,7 @@ public class V1ThriftSpanWriterTest {
   public void annotationsHaveEndpoints() {
     writer.write(span.toBuilder().localEndpoint(endpoint).addAnnotation(5, "foo").build(), buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(TYPE_LIST, 0, 6, TYPE_STRUCT, 0, 0, 0, 1) // one annotation
         .containsSequence(TYPE_I64, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5) // timestamp
         .containsSequence(TYPE_STRING, 0, 2, 0, 0, 0, 3, 'f', 'o', 'o') // value
@@ -228,7 +228,7 @@ public class V1ThriftSpanWriterTest {
   public void writesTimestampAndDuration() {
     writer.write(span.toBuilder().timestamp(5).duration(10).build(), buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(TYPE_I64, 0, 10, 0, 0, 0, 0, 0, 0, 0, 5) // timestamp
         .containsSequence(TYPE_I64, 0, 11, 0, 0, 0, 0, 0, 0, 0, 10); // duration
   }
@@ -240,7 +240,7 @@ public class V1ThriftSpanWriterTest {
     Buffer buf2 = Buffer.allocate(2048);
     writer.write(span.toBuilder().kind(SERVER).build(), buf2);
 
-    assertThat(buf.toByteArray()).containsExactly(buf.toByteArray());
+    assertThat(buf.toByteArrayUnsafe()).containsExactly(buf.toByteArrayUnsafe());
   }
 
   @Test
@@ -249,7 +249,7 @@ public class V1ThriftSpanWriterTest {
 
     writer.write(span, buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(
             ThriftField.TYPE_STRING, 0, 3, 0, 0, 0, 0); // name (empty is 32 zero bits)
   }
@@ -258,7 +258,7 @@ public class V1ThriftSpanWriterTest {
   public void writesTraceAndSpanIds() {
     writer.write(span, buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .startsWith(TYPE_I64, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1) // trace ID
         .containsSequence(TYPE_I64, 0, 4, 0, 0, 0, 0, 0, 0, 0, 2); // ID
   }
@@ -269,7 +269,7 @@ public class V1ThriftSpanWriterTest {
         Span.newBuilder().traceId("00000000000000010000000000000002").parentId("3").id("4").build(),
         buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .startsWith(TYPE_I64, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2) // trace ID
         .containsSequence(TYPE_I64, 0, 12, 0, 0, 0, 0, 0, 0, 0, 1) // trace ID high
         .containsSequence(TYPE_I64, 0, 5, 0, 0, 0, 0, 0, 0, 0, 3); // parent ID
@@ -282,7 +282,7 @@ public class V1ThriftSpanWriterTest {
 
     writer.write(span, buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(TYPE_LIST, 0, 6, TYPE_STRUCT, 0, 0, 0, 0) // empty annotations
         .containsSequence(TYPE_LIST, 0, 8, TYPE_STRUCT, 0, 0, 0, 0); // empty binary annotations
   }
@@ -293,7 +293,7 @@ public class V1ThriftSpanWriterTest {
 
     writer.write(span, buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(TYPE_LIST, 0, 8, TYPE_STRUCT, 0, 0, 0, 1) // one binary annotation
         .containsSequence(TYPE_STRING, 0, 1, 0, 0, 0, 2, 'l', 'c') // key
         .containsSequence(TYPE_STRING, 0, 2, 0, 0, 0, 0) // empty value
@@ -311,7 +311,7 @@ public class V1ThriftSpanWriterTest {
 
     writer.write(span, buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(
             ThriftField.TYPE_STRING, 0, 3, 0, 0, 0, 0); // serviceName (empty is 32 zero bits)
   }
@@ -323,14 +323,14 @@ public class V1ThriftSpanWriterTest {
 
     writer.write(span, buf);
 
-    assertThat(buf.toByteArray()).containsSequence(ThriftField.TYPE_BOOL, 0);
+    assertThat(buf.toByteArrayUnsafe()).containsSequence(ThriftField.TYPE_BOOL, 0);
   }
 
   @Test
   public void tagsAreBinaryAnnotations() {
     writer.write(span.toBuilder().putTag("foo", "bar").build(), buf);
 
-    assertThat(buf.toByteArray())
+    assertThat(buf.toByteArrayUnsafe())
         .containsSequence(TYPE_LIST, 0, 8, TYPE_STRUCT, 0, 0, 0, 1) // one binary annotation
         .containsSequence(TYPE_STRING, 0, 1, 0, 0, 0, 3, 'f', 'o', 'o') // key
         .containsSequence(TYPE_STRING, 0, 2, 0, 0, 0, 3, 'b', 'a', 'r') // value

--- a/zipkin/src/test/java/zipkin2/internal/V2SpanWriterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/V2SpanWriterTest.java
@@ -43,14 +43,14 @@ public class V2SpanWriterTest {
   @Test public void writes128BitTraceId() throws UnsupportedEncodingException {
     writer.write(CLIENT_SPAN, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
       .startsWith("{\"traceId\":\"" + CLIENT_SPAN.traceId() + "\"");
   }
 
   @Test public void writesAnnotationWithoutEndpoint() throws IOException {
     writer.write(CLIENT_SPAN, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
       .contains("{\"timestamp\":" + (TODAY + 100) * 1000L + ",\"value\":\"foo\"}");
   }
 
@@ -63,7 +63,7 @@ public class V2SpanWriterTest {
 
     writer.write(span, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
       .doesNotContain("name");
   }
 
@@ -74,14 +74,14 @@ public class V2SpanWriterTest {
 
     writer.write(span, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
       .contains("\"localEndpoint\":{\"ipv4\":\"127.0.0.1\"}");
   }
 
   @Test public void tagsAreAMap() throws IOException {
     writer.write(CLIENT_SPAN, buf);
 
-    assertThat(new String(buf.toByteArray(), "UTF-8"))
+    assertThat(new String(buf.toByteArrayUnsafe(), "UTF-8"))
       .contains("\"tags\":{\"clnt/finagle.version\":\"6.45.0\",\"http.path\":\"/api\"}");
   }
 }


### PR DESCRIPTION
In the benchmark, this affects 7 fields instead of 3, so actually has a larger impact than #2582 (this PR does not include that one).

Also renamed `toByteArray` to include `Unsafe` since it is.

After
```
Benchmark                                                                    Mode    Cnt        Score        Error   Units
ProtoCodecBenchmarks.bytes_zipkinDecoder                                   sample  14048     1068.003 ±      5.292   us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.00         sample             919.552                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.50         sample            1010.688                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.90         sample            1212.416                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.95         sample            1347.584                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.99         sample            2002.944                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.999        sample            2506.351                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.9999       sample            4236.627                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p1.00         sample            4530.176                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate                    sample     15     1097.823 ±     29.917  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate.norm               sample     15  1847161.027 ±     18.455    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space           sample     15     1110.072 ±     85.859  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space.norm      sample     15  1866332.749 ± 107577.650    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen              sample     15        0.803 ±      0.645  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen.norm         sample     15     1350.408 ±   1090.177    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space       sample     15        0.488 ±      0.628  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space.norm  sample     15      808.818 ±   1034.386    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.count                         sample     15      116.000               counts
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.time                          sample     15      103.000                   ms
```

Before
```
Benchmark                                                                    Mode    Cnt        Score        Error   Units
ProtoCodecBenchmarks.bytes_zipkinDecoder                                   sample  13504     1110.811 ±      5.541   us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.00         sample             942.080                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.50         sample            1060.864                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.90         sample            1269.760                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.95         sample            1376.256                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.99         sample            2080.154                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.999        sample            2699.264                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.9999       sample            5006.438                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p1.00         sample            5652.480                us/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate                    sample     15     1192.757 ±     75.891  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate.norm               sample     15  2087164.817 ±     22.574    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space           sample     15     1189.685 ±     95.704  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space.norm      sample     15  2081750.627 ± 103259.490    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen              sample     15        1.142 ±      0.611  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen.norm         sample     15     2024.829 ±   1101.138    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space       sample     15        1.553 ±      0.581  MB/sec
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space.norm  sample     15     2735.052 ±   1038.158    B/op
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.count                         sample     15      116.000               counts
ProtoCodecBenchmarks.bytes_zipkinDecoder:·gc.time                          sample     15      110.000                   ms
```