### PR TITLE
Update Build Status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin)
-[![Build Status](https://img.shields.io/jenkins/s/https/builds.apache.org/job/incubator-zipkin.svg)](https://builds.apache.org/blue/organizations/jenkins/incubator-zipkin)
+[![Build Status](https://builds.apache.org/view/Z/view/Zipkin/job/GH-incubator-zipkin/job/incubator-zipkin/job/master/badge/icon)](https://builds.apache.org/view/Z/view/Zipkin/job/GH-incubator-zipkin/job/incubator-zipkin/job/master/)
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.zipkin/zipkin-server.svg)](https://search.maven.org/search?q=g:org.apache.zipkin%20AND%20a:zipkin-server)
 
 # zipkin


### PR DESCRIPTION
I spent ~10 minutes trying to get img.shields.io in there and failed; feel free to update the badge to use it if it's preferred (even though we don't seem to be actually using it for anything other than a simple proxy in this scenario?)