### PR TITLE
Consolidates buffers and generally improves string decoding

### DIFF
--- a/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
@@ -16,10 +16,6 @@
  */
 package zipkin2.codec;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
-import com.esotericsoftware.kryo.serializers.JavaSerializer;
 import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.util.Collections;
@@ -61,137 +57,112 @@ import zipkin2.Span;
 public class CodecBenchmarks {
   static final byte[] clientSpanJsonV2 = read("/zipkin2-client.json");
   static final Span clientSpan = SpanBytesDecoder.JSON_V2.decodeOne(clientSpanJsonV2);
+  static final byte[] clientSpanJsonV1 = SpanBytesEncoder.JSON_V1.encode(clientSpan);
   static final byte[] clientSpanProto3 = SpanBytesEncoder.PROTO3.encode(clientSpan);
-  static final zipkin2.proto3.Span clientSpan_wire;
+  static final byte[] clientSpanThrift = SpanBytesEncoder.THRIFT.encode(clientSpan);
   static final List<Span> tenClientSpans = Collections.nCopies(10, clientSpan);
   static final byte[] tenClientSpansJsonV2 = SpanBytesEncoder.JSON_V2.encodeList(tenClientSpans);
-  static final Kryo kryo = new Kryo();
-  static final byte[] clientSpanSerialized;
 
-  static {
-    kryo.register(Span.class, new JavaSerializer());
-    Output output = new Output(4096);
-    kryo.writeObject(output, clientSpan);
-    output.flush();
-    clientSpanSerialized = output.getBuffer();
-    try {
-      clientSpan_wire = zipkin2.proto3.Span.ADAPTER.decode(clientSpanProto3);
-    } catch (IOException e) {
-      throw new AssertionError(e);
-    }
-  }
-
-  /** manually implemented with json so not as slow as normal java */
   @Benchmark
-  public Span readClientSpan_kryo() {
-    return kryo.readObject(new Input(clientSpanSerialized), Span.class);
+  public Span readClientSpan_JSON_V1() {
+    return SpanBytesDecoder.JSON_V1.decodeOne(clientSpanJsonV1);
   }
 
   @Benchmark
-  public byte[] writeClientSpan_kryo() {
-    Output output = new Output(clientSpanSerialized.length);
-    kryo.writeObject(output, clientSpan);
-    output.flush();
-    return output.getBuffer();
-  }
-
-  @Benchmark
-  public Span readClientSpan_json() {
+  public Span readClientSpan_JSON_V2() {
     return SpanBytesDecoder.JSON_V2.decodeOne(clientSpanJsonV2);
   }
 
   @Benchmark
-  public Span readClientSpan_proto3() {
+  public Span readClientSpan_PROTO3() {
     return SpanBytesDecoder.PROTO3.decodeOne(clientSpanProto3);
   }
 
   @Benchmark
-  public zipkin2.proto3.Span readClientSpan_proto3_wire() throws Exception {
-    return zipkin2.proto3.Span.ADAPTER.decode(clientSpanProto3);
+  public Span readClientSpan_THRIFT() {
+    return SpanBytesDecoder.THRIFT.decodeOne(clientSpanThrift);
   }
 
   @Benchmark
-  public List<Span> readTenClientSpans_json() {
-    return SpanBytesDecoder.JSON_V2.decodeList(tenClientSpansJsonV2);
-  }
-
-  @Benchmark
-  public byte[] writeClientSpan_json() {
+  public byte[] writeClientSpan_JSON_V2() {
     return SpanBytesEncoder.JSON_V2.encode(clientSpan);
   }
 
   @Benchmark
-  public byte[] writeTenClientSpans_json() {
-    return SpanBytesEncoder.JSON_V2.encodeList(tenClientSpans);
-  }
-
-  @Benchmark
-  public byte[] writeClientSpan_json_v1() {
+  public byte[] writeClientSpan_JSON_V1() {
     return SpanBytesEncoder.JSON_V1.encode(clientSpan);
   }
 
   @Benchmark
-  public byte[] writeTenClientSpans_json_v1() {
-    return SpanBytesEncoder.JSON_V1.encodeList(tenClientSpans);
-  }
-
-  @Benchmark
-  public byte[] writeClientSpan_proto3() {
+  public byte[] writeClientSpan_PROTO3() {
     return SpanBytesEncoder.PROTO3.encode(clientSpan);
   }
 
   @Benchmark
-  public byte[] writeClientSpan_proto3_wire() {
-    return clientSpan_wire.encode();
+  public byte[] writeClientSpan_THRIFT() {
+    return SpanBytesEncoder.THRIFT.encode(clientSpan);
+  }
+
+  @Benchmark
+  public List<Span> readTenClientSpans_JSON_V2() {
+    return SpanBytesDecoder.JSON_V2.decodeList(tenClientSpansJsonV2);
+  }
+
+  @Benchmark
+  public byte[] writeTenClientSpans_JSON_V2() {
+    return SpanBytesEncoder.JSON_V2.encodeList(tenClientSpans);
   }
 
   static final byte[] chineseSpanJsonV2 = read("/zipkin2-chinese.json");
   static final Span chineseSpan = SpanBytesDecoder.JSON_V2.decodeOne(chineseSpanJsonV2);
-  static final zipkin2.proto3.Span chineseSpan_wire;
   static final byte[] chineseSpanProto3 = SpanBytesEncoder.PROTO3.encode(chineseSpan);
+  static final byte[] chineseSpanJsonV1 = SpanBytesEncoder.JSON_V1.encode(chineseSpan);
+  static final byte[] chineseSpanThrift = SpanBytesEncoder.THRIFT.encode(chineseSpan);
 
-  static {
-    try {
-      chineseSpan_wire = zipkin2.proto3.Span.ADAPTER.decode(chineseSpanProto3);
-    } catch (IOException e) {
-      throw new AssertionError(e);
-    }
+  @Benchmark
+  public Span readChineseSpan_JSON_V1() {
+    return SpanBytesDecoder.JSON_V1.decodeOne(chineseSpanJsonV1);
   }
 
   @Benchmark
-  public Span readChineseSpan_json() {
+  public Span readChineseSpan_JSON_V2() {
     return SpanBytesDecoder.JSON_V2.decodeOne(chineseSpanJsonV2);
   }
 
   @Benchmark
-  public Span readChineseSpan_proto3() {
+  public Span readChineseSpan_PROTO3() {
     return SpanBytesDecoder.PROTO3.decodeOne(chineseSpanProto3);
   }
 
   @Benchmark
-  public zipkin2.proto3.Span readChineseSpan_proto3_wire() throws Exception {
-    return zipkin2.proto3.Span.ADAPTER.decode(chineseSpanProto3);
+  public Span readChineseSpan_THRIFT() {
+    return SpanBytesDecoder.THRIFT.decodeOne(chineseSpanThrift);
   }
 
   @Benchmark
-  public byte[] writeChineseSpan_json() {
+  public byte[] writeChineseSpan_JSON_V2() {
     return SpanBytesEncoder.JSON_V2.encode(chineseSpan);
   }
 
   @Benchmark
-  public byte[] writeChineseSpan_proto3() {
+  public byte[] writeChineseSpan_JSON_V1() {
+    return SpanBytesEncoder.JSON_V1.encode(chineseSpan);
+  }
+
+  @Benchmark
+  public byte[] writeChineseSpan_PROTO3() {
     return SpanBytesEncoder.PROTO3.encode(chineseSpan);
   }
 
   @Benchmark
-  public byte[] writeChineseSpan_proto3_wire() {
-    return chineseSpan_wire.encode();
+  public byte[] writeChineseSpan_THRIFT() {
+    return SpanBytesEncoder.THRIFT.encode(chineseSpan);
   }
 
   // Convenience main entry-point
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-      .include(".*" + CodecBenchmarks.class.getSimpleName())
+      .include(".*" + CodecBenchmarks.class.getSimpleName() +".*read.*Span_.*")
       .addProfiler("gc")
       .build();
 

--- a/benchmarks/src/main/java/zipkin2/codec/ProtobufSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtobufSpanDecoder.java
@@ -279,7 +279,7 @@ public class ProtobufSpanDecoder {
       throw new AssertionError("hex field greater than 32 chars long: " + length);
     }
 
-    char[] result = Platform.get().idBuffer();
+    char[] result = Platform.shortStringBuffer();
 
     for (int i = 0; i < length; i += 2) {
       byte b = input.readRawByte();

--- a/benchmarks/src/main/java/zipkin2/codec/WireSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/WireSpanDecoder.java
@@ -294,7 +294,7 @@ public class WireSpanDecoder {
       throw new AssertionError("hex field greater than 32 chars long: " + length);
     }
 
-    char[] result = Platform.get().idBuffer();
+    char[] result = Platform.shortStringBuffer();
 
     for (int i = 0; i < bytes.size(); i ++) {
       byte b = bytes.getByte(i);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanConsumer.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanConsumer.java
@@ -31,7 +31,7 @@ import zipkin2.storage.SpanConsumer;
 
 import static zipkin2.elasticsearch.ElasticsearchAutocompleteTags.AUTOCOMPLETE;
 import static zipkin2.elasticsearch.ElasticsearchSpanStore.SPAN;
-import static zipkin2.elasticsearch.internal.BulkCallBuilder.INDEX_CHARS_LIMIT;
+import static zipkin2.internal.Platform.SHORT_STRING_LENGTH;
 
 class ElasticsearchSpanConsumer implements SpanConsumer { // not final for testing
 
@@ -107,7 +107,7 @@ class ElasticsearchSpanConsumer implements SpanConsumer { // not final for testi
       String idx = consumer.formatTypeAndTimestampForInsert(AUTOCOMPLETE, indexTimestamp);
       for (Map.Entry<String, String> tag : span.tags().entrySet()) {
         int length = tag.getKey().length() + tag.getValue().length() + 1;
-        if (length > INDEX_CHARS_LIMIT) continue;
+        if (length > SHORT_STRING_LENGTH) continue;
 
         // If the autocomplete whitelist doesn't contain the key, skip storing its value
         if (!consumer.autocompleteKeys.contains(tag.getKey())) continue;

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
@@ -26,6 +26,7 @@ import static zipkin2.elasticsearch.ElasticsearchAutocompleteTags.AUTOCOMPLETE;
 import static zipkin2.elasticsearch.ElasticsearchSpanStore.DEPENDENCY;
 import static zipkin2.elasticsearch.ElasticsearchSpanStore.SPAN;
 import static zipkin2.elasticsearch.internal.JsonReaders.enterPath;
+import static zipkin2.internal.Platform.SHORT_STRING_LENGTH;
 
 /** Returns a version-specific span and dependency index template */
 final class VersionSpecificTemplates {
@@ -109,7 +110,8 @@ final class VersionSpecificTemplates {
         + "      {\n"
         + "        \"strings\": {\n"
         + "          \"mapping\": {\n"
-        + "            \"type\": \"keyword\",\"norms\": false, \"ignore_above\": 256\n"
+        + "            \"type\": \"keyword\",\"norms\": false,"
+        + " \"ignore_above\": " + SHORT_STRING_LENGTH + "\n"
         + "          },\n"
         + "          \"match_mapping_type\": \"string\",\n"
         + "          \"match\": \"*\"\n"

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/BulkCallBuilder.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/BulkCallBuilder.java
@@ -35,7 +35,6 @@ import zipkin2.elasticsearch.internal.client.HttpCall;
 // See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
 // exposed to re-use for testing writes of dependency links
 public final class BulkCallBuilder {
-  public static final int INDEX_CHARS_LIMIT = 256;
   static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
 
   final String tag;

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/BulkIndexWriter.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/BulkIndexWriter.java
@@ -28,7 +28,7 @@ import zipkin2.Annotation;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 
-import static zipkin2.elasticsearch.internal.BulkCallBuilder.INDEX_CHARS_LIMIT;
+import static zipkin2.internal.Platform.SHORT_STRING_LENGTH;
 
 public abstract class BulkIndexWriter<T> {
 
@@ -163,12 +163,12 @@ public abstract class BulkIndexWriter<T> {
       writer.name("_q");
       writer.beginArray();
       for (Annotation a : span.annotations()) {
-        if (a.value().length() > INDEX_CHARS_LIMIT) continue;
+        if (a.value().length() > SHORT_STRING_LENGTH) continue;
         writer.value(a.value());
       }
       for (Map.Entry<String, String> tag : span.tags().entrySet()) {
         int length = tag.getKey().length() + tag.getValue().length() + 1;
-        if (length > INDEX_CHARS_LIMIT) continue;
+        if (length > SHORT_STRING_LENGTH) continue;
         writer.value(tag.getKey()); // search is possible by key alone
         writer.value(tag.getKey() + "=" + tag.getValue());
       }

--- a/zipkin/src/main/java/zipkin2/Endpoint.java
+++ b/zipkin/src/main/java/zipkin2/Endpoint.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.Locale;
 import zipkin2.internal.Nullable;
+import zipkin2.internal.Platform;
 
 import static zipkin2.internal.UnsafeBuffer.HEX_DIGITS;
 
@@ -198,7 +199,7 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
     }
 
     static String writeIpV4(byte[] ipBytes) {
-      char[] buf = ipBuffer();
+      char[] buf = Platform.shortStringBuffer();
       int pos = 0;
       pos = writeBackwards(ipBytes[0] & 0xff, pos, buf);
       buf[pos++] = '.';
@@ -368,20 +369,9 @@ public final class Endpoint implements Serializable { // for Spark and Flink job
     return (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F');
   }
 
-  static final ThreadLocal<char[]> IP_BUFFER = new ThreadLocal<>();
-
-  static char[] ipBuffer() {
-    char[] ipBuffer = IP_BUFFER.get();
-    if (ipBuffer == null) {
-      ipBuffer = new char[39]; // maximum length of encoded ipv6
-      IP_BUFFER.set(ipBuffer);
-    }
-    return ipBuffer;
-  }
-
   static String writeIpV6(byte[] ipv6) {
     int pos = 0;
-    char[] buf = ipBuffer();
+    char[] buf = Platform.shortStringBuffer();
 
     // Compress the longest string of zeros
     int zeroCompressionIndex = -1;

--- a/zipkin/src/main/java/zipkin2/Span.java
+++ b/zipkin/src/main/java/zipkin2/Span.java
@@ -416,7 +416,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
      */
     public Builder traceId(long high, long low) {
       if (high == 0L && low == 0L) throw new IllegalArgumentException("empty trace ID");
-      char[] data = Platform.get().idBuffer();
+      char[] data = Platform.shortStringBuffer();
       int pos = 0;
       if (high != 0L) {
         writeHexLong(data, pos, high);
@@ -660,7 +660,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
   }
 
   static String padLeft(String id, int desiredLength) {
-    char[] data = Platform.get().idBuffer();
+    char[] data = Platform.shortStringBuffer();
     int i = 0, length = id.length(), offset = desiredLength - length;
     for (; i < offset; i++) data[i] = '0';
     for (int j = 0; j < length; j++) data[i++] = id.charAt(j);
@@ -668,7 +668,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
   }
 
   static String toLowerHex(long v) {
-    char[] data = Platform.get().idBuffer();
+    char[] data = Platform.shortStringBuffer();
     writeHexLong(data, 0, v);
     return new String(data, 0, 16);
   }

--- a/zipkin/src/main/java/zipkin2/internal/Platform.java
+++ b/zipkin/src/main/java/zipkin2/internal/Platform.java
@@ -27,23 +27,25 @@ import org.jvnet.animal_sniffer.IgnoreJRERequirement;
 public abstract class Platform {
   private static final Platform PLATFORM = findPlatform();
 
-  private static final ThreadLocal<char[]> ID_BUFFER = new ThreadLocal<>();
-
   Platform() {
   }
 
+  static final ThreadLocal<char[]> SHORT_STRING_BUFFER = new ThreadLocal<>();
+  /** Maximum character length constraint of most names, IP literals and IDs. */
+  public static final int SHORT_STRING_LENGTH = 256;
+
   /**
-   * Returns a {@link ThreadLocal} reused {@code char[]} for use when decoding bytes into a hex
-   * string. The buffer should be immediately copied into a {@link String} after decoding within the
-   * same method.
+   * Returns a {@link ThreadLocal} reused {@code char[]} for use when decoding bytes into hex, IP
+   * literals, or {@link #SHORT_STRING_LENGTH short strings}. The buffer must never be leaked
+   * outside the method. Most will {@link String#String(char[], int, int) copy it into a string}.
    */
-  public char[] idBuffer() {
-    char[] idBuffer = ID_BUFFER.get();
-    if (idBuffer == null) {
-      idBuffer = new char[32];
-      ID_BUFFER.set(idBuffer);
+  public static char[] shortStringBuffer() {
+    char[] shortStringBuffer = SHORT_STRING_BUFFER.get();
+    if (shortStringBuffer == null) {
+      shortStringBuffer = new char[SHORT_STRING_LENGTH];
+      SHORT_STRING_BUFFER.set(shortStringBuffer);
     }
-    return idBuffer;
+    return shortStringBuffer;
   }
 
   public RuntimeException uncheckedIOException(IOException e) {

--- a/zipkin/src/main/java/zipkin2/internal/Proto3Codec.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Codec.java
@@ -52,13 +52,17 @@ public final class Proto3Codec {
       if (span == null) return false;
       out.add(span);
       return true;
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       throw exceptionReading("Span", e);
     }
   }
 
   public static @Nullable Span readOne(byte[] bytes) {
-    return SPAN.read(UnsafeBuffer.wrap(bytes, 0));
+    try {
+      return SPAN.read(UnsafeBuffer.wrap(bytes, 0));
+    } catch (RuntimeException e) {
+      throw exceptionReading("Span", e);
+    }
   }
 
   public static boolean readList(byte[] bytes, Collection<Span> out) {
@@ -71,7 +75,7 @@ public final class Proto3Codec {
         if (span == null) return false;
         out.add(span);
       }
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       throw exceptionReading("List<Span>", e);
     }
     return true;

--- a/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
@@ -124,13 +124,18 @@ final class Proto3Fields {
      * is returned when the length prefix is zero.
      */
     final T readLengthPrefixAndValue(UnsafeBuffer b) {
-      int length = readLengthPrefix(b);
+      int length = guardLength(b);
       if (length == 0) return null;
       return readValue(b, length);
     }
 
-    final int readLengthPrefix(UnsafeBuffer b) {
-      return b.readVarint32();
+    final int guardLength(UnsafeBuffer buffer) {
+      int length = buffer.readVarint32();
+      if (length > buffer.remaining()) {
+        throw new IllegalArgumentException(
+          "Truncated: length " + length + " > bytes remaining " + buffer.remaining());
+      }
+      return length;
     }
 
     abstract int sizeOfValue(T value);

--- a/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Fields.java
@@ -124,18 +124,9 @@ final class Proto3Fields {
      * is returned when the length prefix is zero.
      */
     final T readLengthPrefixAndValue(UnsafeBuffer b) {
-      int length = guardLength(b);
+      int length = b.readVarint32();
       if (length == 0) return null;
       return readValue(b, length);
-    }
-
-    final int guardLength(UnsafeBuffer buffer) {
-      int length = buffer.readVarint32();
-      if (length > buffer.remaining()) {
-        throw new IllegalArgumentException(
-          "Truncated: length " + length + " > bytes remaining " + buffer.remaining());
-      }
-      return length;
     }
 
     abstract int sizeOfValue(T value);

--- a/zipkin/src/main/java/zipkin2/internal/Proto3ZipkinFields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3ZipkinFields.java
@@ -139,7 +139,7 @@ final class Proto3ZipkinFields {
     }
 
     @Override boolean readLengthPrefixAndValue(UnsafeBuffer b, Span.Builder builder) {
-      int length = readLengthPrefix(b);
+      int length = guardLength(b);
       if (length == 0) return false;
       int endPos = b.pos() + length;
 
@@ -187,7 +187,7 @@ final class Proto3ZipkinFields {
     }
 
     @Override boolean readLengthPrefixAndValue(UnsafeBuffer b, Span.Builder builder) {
-      int length = readLengthPrefix(b);
+      int length = guardLength(b);
       if (length == 0) return false;
       int endPos = b.pos() + length;
 

--- a/zipkin/src/main/java/zipkin2/internal/Proto3ZipkinFields.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3ZipkinFields.java
@@ -139,7 +139,7 @@ final class Proto3ZipkinFields {
     }
 
     @Override boolean readLengthPrefixAndValue(UnsafeBuffer b, Span.Builder builder) {
-      int length = guardLength(b);
+      int length = b.readVarint32();
       if (length == 0) return false;
       int endPos = b.pos() + length;
 
@@ -187,7 +187,7 @@ final class Proto3ZipkinFields {
     }
 
     @Override boolean readLengthPrefixAndValue(UnsafeBuffer b, Span.Builder builder) {
-      int length = guardLength(b);
+      int length = b.readVarint32();
       if (length == 0) return false;
       int endPos = b.pos() + length;
 
@@ -315,6 +315,7 @@ final class Proto3ZipkinFields {
     }
 
     @Override Span readValue(UnsafeBuffer buffer, int length) {
+      buffer.require(length); // more convenient to check up-front vs partially read
       int endPos = buffer.pos() + length;
 
       // now, we are in the span fields

--- a/zipkin/src/main/java/zipkin2/internal/ThriftEndpointCodec.java
+++ b/zipkin/src/main/java/zipkin2/internal/ThriftEndpointCodec.java
@@ -19,6 +19,7 @@ package zipkin2.internal;
 import java.nio.ByteBuffer;
 import zipkin2.Endpoint;
 
+import static zipkin2.internal.ThriftCodec.guardLength;
 import static zipkin2.internal.ThriftCodec.skip;
 import static zipkin2.internal.ThriftField.TYPE_I16;
 import static zipkin2.internal.ThriftField.TYPE_I32;
@@ -41,6 +42,7 @@ final class ThriftEndpointCodec {
       if (thriftField.type == TYPE_STOP) break;
 
       if (thriftField.isEqualTo(IPV4)) {
+        guardLength(bytes, 4);
         int ipv4 = bytes.getInt();
         if (ipv4 != 0) {
           result.parseIp( // allocation is ok here as Endpoint.ipv4Bytes would anyway
@@ -52,6 +54,7 @@ final class ThriftEndpointCodec {
             });
         }
       } else if (thriftField.isEqualTo(PORT)) {
+        guardLength(bytes, 2);
         result.port(bytes.getShort() & 0xFFFF);
       } else if (thriftField.isEqualTo(SERVICE_NAME)) {
         result.serviceName(ThriftCodec.readUtf8(bytes));

--- a/zipkin/src/main/java/zipkin2/internal/UnsafeBuffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/UnsafeBuffer.java
@@ -105,7 +105,7 @@ public final class UnsafeBuffer {
   }
 
   // Speculatively assume all 7-bit ASCII characters.. common in normal tags and names
-  static String maybeDecodeShortAsciiString(byte[] buf, int offset, int length) {
+  @Nullable static String maybeDecodeShortAsciiString(byte[] buf, int offset, int length) {
     if (length == 0) return ""; // ex error tag with no value
     if (length > Platform.SHORT_STRING_LENGTH) return null;
     char[] buffer = Platform.shortStringBuffer();
@@ -124,7 +124,7 @@ public final class UnsafeBuffer {
     }
 
     require(length);
-    char[] result = Platform.get().shortStringBuffer();
+    char[] result = Platform.shortStringBuffer();
 
     int hexLength = length * 2;
     for (int i = 0; i < hexLength; i += 2) {

--- a/zipkin/src/main/java/zipkin2/internal/UnsafeBuffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/UnsafeBuffer.java
@@ -99,7 +99,7 @@ public final class UnsafeBuffer {
   String readUtf8(int length) {
     require(length);
     String result = maybeDecodeShortAsciiString(buf, pos, length);
-    if (result == null) new String(buf, pos, length, UTF_8);
+    if (result == null) result = new String(buf, pos, length, UTF_8);
     pos += length;
     return result;
   }

--- a/zipkin/src/main/java/zipkin2/internal/UnsafeBuffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/UnsafeBuffer.java
@@ -98,9 +98,23 @@ public final class UnsafeBuffer {
 
   String readUtf8(int length) {
     require(length);
-    String result = new String(buf, pos, length, UTF_8);
+    String result = maybeDecodeShortAsciiString(buf, pos, length);
+    if (result == null) new String(buf, pos, length, UTF_8);
     pos += length;
     return result;
+  }
+
+  // Speculatively assume all 7-bit ASCII characters.. common in normal tags and names
+  static String maybeDecodeShortAsciiString(byte[] buf, int offset, int length) {
+    if (length == 0) return ""; // ex error tag with no value
+    if (length > Platform.SHORT_STRING_LENGTH) return null;
+    char[] buffer = Platform.shortStringBuffer();
+    for (int i = 0; i < length; i++) {
+      byte b = buf[offset + i];
+      if ((b & 0x80) != 0) return null; // Not 7-bit ASCII character
+      buffer[i] = (char) b;
+    }
+    return new String(buffer, 0, length);
   }
 
   String readBytesAsHex(int length) {
@@ -110,7 +124,7 @@ public final class UnsafeBuffer {
     }
 
     require(length);
-    char[] result = Platform.get().idBuffer();
+    char[] result = Platform.get().shortStringBuffer();
 
     int hexLength = length * 2;
     for (int i = 0; i < hexLength; i += 2) {

--- a/zipkin/src/test/java/zipkin2/internal/Proto3FieldsTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/Proto3FieldsTest.java
@@ -179,7 +179,7 @@ public class Proto3FieldsTest {
     buf.reset();
     buf.skip(1); // skip the key
 
-    assertThat(field.guardLength(buf))
+    assertThat(buf.readVarint32())
       .isEqualTo(10);
   }
 

--- a/zipkin/src/test/java/zipkin2/internal/Proto3FieldsTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/Proto3FieldsTest.java
@@ -179,7 +179,7 @@ public class Proto3FieldsTest {
     buf.reset();
     buf.skip(1); // skip the key
 
-    assertThat(field.readLengthPrefix(buf))
+    assertThat(field.guardLength(buf))
       .isEqualTo(10);
   }
 


### PR DESCRIPTION
This consolidates buffers used for string decoding in binary protocols and uses them in thrift and proto. It also special cases to get better parsing performance than 3rd party codec libraries

before
```
CodecBenchmarks.readChineseSpan_PROTO3:readChineseSpan_PROTO3·p0.99       sample              3.036             us/op
CodecBenchmarks.readChineseSpan_PROTO3:·gc.alloc.rate.norm                sample      15   2328.293 ±   0.024    B/op
CodecBenchmarks.readChineseSpan_THRIFT:readChineseSpan_THRIFT·p0.99       sample              8.192             us/op
CodecBenchmarks.readChineseSpan_THRIFT:·gc.alloc.rate.norm                sample      15   6464.752 ±   0.078    B/op
CodecBenchmarks.readClientSpan_PROTO3:readClientSpan_PROTO3·p0.99         sample              2.248             us/op
CodecBenchmarks.readClientSpan_PROTO3:·gc.alloc.rate.norm                 sample      15   2104.260 ±   0.023    B/op
CodecBenchmarks.readClientSpan_THRIFT:readClientSpan_THRIFT·p0.99         sample             12.176             us/op
CodecBenchmarks.readClientSpan_THRIFT:·gc.alloc.rate.norm                 sample      15   6184.692 ±  12.531    B/op
```

after
```
CodecBenchmarks.readChineseSpan_PROTO3:readChineseSpan_PROTO3·p0.99       sample              2.316             us/op
CodecBenchmarks.readChineseSpan_PROTO3:·gc.alloc.rate.norm                sample      15   2032.257 ±   0.025    B/op
CodecBenchmarks.readChineseSpan_THRIFT:readChineseSpan_THRIFT·p0.99       sample              7.511             us/op
CodecBenchmarks.readChineseSpan_THRIFT:·gc.alloc.rate.norm                sample      15   5461.857 ±  41.728    B/op
CodecBenchmarks.readClientSpan_PROTO3:readClientSpan_PROTO3·p0.99         sample              1.936             us/op
CodecBenchmarks.readClientSpan_PROTO3:·gc.alloc.rate.norm                 sample      15   1744.273 ±   0.015    B/op
CodecBenchmarks.readClientSpan_THRIFT:readClientSpan_THRIFT·p0.99         sample              7.472             us/op
CodecBenchmarks.readClientSpan_THRIFT:·gc.alloc.rate.norm                 sample      15   4920.538 ± 187.788    B/op
```