### PR TITLE
Let Java copy arrays which it can sometimes do faster than manual loops.

### DIFF
--- a/benchmarks/src/main/java/zipkin2/SpanBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/SpanBenchmarks.java
@@ -143,6 +143,26 @@ public class SpanBenchmarks {
     return output.getBuffer();
   }
 
+  @Benchmark
+  public String padLeft_1Char() {
+    return Span.padLeft("1", 16);
+  }
+
+  @Benchmark
+  public String padLeft_15Chars() {
+    return Span.padLeft("123456789012345", 16);
+  }
+
+  @Benchmark
+  public String padLeft_17Chars() {
+    return Span.padLeft("12345678901234567", 32);
+  }
+
+  @Benchmark
+  public String padLeft_31Chars() {
+    return Span.padLeft("1234567890123456789012345678901", 32);
+  }
+
   // Convenience main entry-point
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()

--- a/zipkin/src/main/java/zipkin2/Span.java
+++ b/zipkin/src/main/java/zipkin2/Span.java
@@ -659,11 +659,21 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     }
   }
 
+  static final String THIRTY_TWO_ZEROS;
+  static {
+    char[] zeros = new char[32];
+    Arrays.fill(zeros, '0');
+    THIRTY_TWO_ZEROS = new String(zeros);
+  }
+
   static String padLeft(String id, int desiredLength) {
+    int length = id.length();
+    int numZeros = desiredLength - length;
+
     char[] data = Platform.shortStringBuffer();
-    int i = 0, length = id.length(), offset = desiredLength - length;
-    for (; i < offset; i++) data[i] = '0';
-    for (int j = 0; j < length; j++) data[i++] = id.charAt(j);
+    THIRTY_TWO_ZEROS.getChars(0, numZeros, data, 0);
+    id.getChars(0, length, data, numZeros);
+
     return new String(data, 0, desiredLength);
   }
 


### PR DESCRIPTION
Very small difference but figured it doesn't hurt. At the very least, should be less bytecode.

Before
```
Benchmark                                                      Mode      Cnt     Score     Error   Units
SpanBenchmarks.padLeft_15Chars                               sample   701905     0.091 ±   0.013   us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.00         sample                ≈ 0             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.50         sample              0.100             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.90         sample              0.100             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.95         sample              0.100             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.99         sample              0.200             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.999        sample              2.900             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.9999       sample             19.776             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p1.00         sample           1028.096             us/op
SpanBenchmarks.padLeft_15Chars:·gc.alloc.rate                sample       15  1701.950 ±  50.450  MB/sec
SpanBenchmarks.padLeft_15Chars:·gc.alloc.rate.norm           sample       15    56.008 ±   0.001    B/op
SpanBenchmarks.padLeft_15Chars:·gc.churn.G1_Eden_Space       sample       15  1701.868 ±  97.354  MB/sec
SpanBenchmarks.padLeft_15Chars:·gc.churn.G1_Eden_Space.norm  sample       15    55.999 ±   2.559    B/op
SpanBenchmarks.padLeft_15Chars:·gc.churn.G1_Old_Gen          sample       15     0.006 ±   0.004  MB/sec
SpanBenchmarks.padLeft_15Chars:·gc.churn.G1_Old_Gen.norm     sample       15    ≈ 10⁻⁴              B/op
SpanBenchmarks.padLeft_15Chars:·gc.count                     sample       15   166.000            counts
SpanBenchmarks.padLeft_15Chars:·gc.time                      sample       15   104.000                ms
SpanBenchmarks.padLeft_17Chars                               sample   877723     0.092 ±   0.008   us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.00         sample                ≈ 0             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.50         sample              0.100             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.90         sample              0.100             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.95         sample              0.100             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.99         sample              0.200             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.999        sample              2.700             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.9999       sample             18.636             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p1.00         sample           1232.896             us/op
SpanBenchmarks.padLeft_17Chars:·gc.alloc.rate                sample       15  1878.518 ±  49.474  MB/sec
SpanBenchmarks.padLeft_17Chars:·gc.alloc.rate.norm           sample       15    72.010 ±   0.001    B/op
SpanBenchmarks.padLeft_17Chars:·gc.churn.G1_Eden_Space       sample       15  1879.248 ±  85.320  MB/sec
SpanBenchmarks.padLeft_17Chars:·gc.churn.G1_Eden_Space.norm  sample       15    72.037 ±   2.660    B/op
SpanBenchmarks.padLeft_17Chars:·gc.churn.G1_Old_Gen          sample       15     0.005 ±   0.002  MB/sec
SpanBenchmarks.padLeft_17Chars:·gc.churn.G1_Old_Gen.norm     sample       15    ≈ 10⁻⁴              B/op
SpanBenchmarks.padLeft_17Chars:·gc.count                     sample       15   161.000            counts
SpanBenchmarks.padLeft_17Chars:·gc.time                      sample       15   103.000                ms
SpanBenchmarks.padLeft_1Char                                 sample  1081477     0.066 ±   0.008   us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.00             sample                ≈ 0             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.50             sample              0.100             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.90             sample              0.100             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.95             sample              0.100             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.99             sample              0.101             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.999            sample              1.400             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.9999           sample             16.992             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p1.00             sample           2146.304             us/op
SpanBenchmarks.padLeft_1Char:·gc.alloc.rate                  sample       15  2623.244 ±  71.575  MB/sec
SpanBenchmarks.padLeft_1Char:·gc.alloc.rate.norm             sample       15    56.005 ±   0.001    B/op
SpanBenchmarks.padLeft_1Char:·gc.churn.G1_Eden_Space         sample       15  2625.438 ± 169.930  MB/sec
SpanBenchmarks.padLeft_1Char:·gc.churn.G1_Eden_Space.norm    sample       15    56.047 ±   3.237    B/op
SpanBenchmarks.padLeft_1Char:·gc.churn.G1_Old_Gen            sample       15     0.005 ±   0.003  MB/sec
SpanBenchmarks.padLeft_1Char:·gc.churn.G1_Old_Gen.norm       sample       15    ≈ 10⁻⁴              B/op
SpanBenchmarks.padLeft_1Char:·gc.count                       sample       15   153.000            counts
SpanBenchmarks.padLeft_1Char:·gc.time                        sample       15   114.000                ms
SpanBenchmarks.padLeft_31Chars                               sample   884336     0.090 ±   0.005   us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.00         sample                ≈ 0             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.50         sample              0.100             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.90         sample              0.100             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.95         sample              0.100             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.99         sample              0.200             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.999        sample              2.596             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.9999       sample             17.846             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p1.00         sample            917.504             us/op
SpanBenchmarks.padLeft_31Chars:·gc.alloc.rate                sample       15  1846.067 ± 754.068  MB/sec
SpanBenchmarks.padLeft_31Chars:·gc.alloc.rate.norm           sample       15    72.011 ±   0.003    B/op
SpanBenchmarks.padLeft_31Chars:·gc.churn.G1_Eden_Space       sample       15  1856.717 ± 776.381  MB/sec
SpanBenchmarks.padLeft_31Chars:·gc.churn.G1_Eden_Space.norm  sample       15    72.248 ±   2.679    B/op
SpanBenchmarks.padLeft_31Chars:·gc.churn.G1_Old_Gen          sample       15     0.007 ±   0.004  MB/sec
SpanBenchmarks.padLeft_31Chars:·gc.churn.G1_Old_Gen.norm     sample       15    ≈ 10⁻⁴              B/op
SpanBenchmarks.padLeft_31Chars:·gc.count                     sample       15   155.000            counts
SpanBenchmarks.padLeft_31Chars:·gc.time                      sample       15   101.000                ms
```

After
```
Benchmark                                                      Mode      Cnt     Score     Error   Units
SpanBenchmarks.padLeft_15Chars                               sample  1033106     0.067 ±   0.007   us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.00         sample                ≈ 0             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.50         sample              0.100             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.90         sample              0.100             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.95         sample              0.100             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.99         sample              0.101             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.999        sample              1.600             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p0.9999       sample             17.316             us/op
SpanBenchmarks.padLeft_15Chars:padLeft_15Chars·p1.00         sample           1056.768             us/op
SpanBenchmarks.padLeft_15Chars:·gc.alloc.rate                sample       15  2504.974 ± 103.821  MB/sec
SpanBenchmarks.padLeft_15Chars:·gc.alloc.rate.norm           sample       15    56.005 ±   0.001    B/op
SpanBenchmarks.padLeft_15Chars:·gc.churn.G1_Eden_Space       sample       15  2494.559 ± 140.684  MB/sec
SpanBenchmarks.padLeft_15Chars:·gc.churn.G1_Eden_Space.norm  sample       15    55.781 ±   2.332    B/op
SpanBenchmarks.padLeft_15Chars:·gc.churn.G1_Old_Gen          sample       15     0.005 ±   0.004  MB/sec
SpanBenchmarks.padLeft_15Chars:·gc.churn.G1_Old_Gen.norm     sample       15    ≈ 10⁻⁴              B/op
SpanBenchmarks.padLeft_15Chars:·gc.count                     sample       15   142.000            counts
SpanBenchmarks.padLeft_15Chars:·gc.time                      sample       15   105.000                ms
SpanBenchmarks.padLeft_17Chars                               sample   937017     0.073 ±   0.008   us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.00         sample                ≈ 0             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.50         sample              0.100             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.90         sample              0.100             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.95         sample              0.100             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.99         sample              0.200             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.999        sample              2.000             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p0.9999       sample             17.696             us/op
SpanBenchmarks.padLeft_17Chars:padLeft_17Chars·p1.00         sample           1161.216             us/op
SpanBenchmarks.padLeft_17Chars:·gc.alloc.rate                sample       15  2921.212 ± 136.130  MB/sec
SpanBenchmarks.padLeft_17Chars:·gc.alloc.rate.norm           sample       15    72.006 ±   0.001    B/op
SpanBenchmarks.padLeft_17Chars:·gc.churn.G1_Eden_Space       sample       15  2928.819 ± 210.943  MB/sec
SpanBenchmarks.padLeft_17Chars:·gc.churn.G1_Eden_Space.norm  sample       15    72.200 ±   4.118    B/op
SpanBenchmarks.padLeft_17Chars:·gc.churn.G1_Old_Gen          sample       15     0.005 ±   0.003  MB/sec
SpanBenchmarks.padLeft_17Chars:·gc.churn.G1_Old_Gen.norm     sample       15    ≈ 10⁻⁴              B/op
SpanBenchmarks.padLeft_17Chars:·gc.count                     sample       15   140.000            counts
SpanBenchmarks.padLeft_17Chars:·gc.time                      sample       15   111.000                ms
SpanBenchmarks.padLeft_1Char                                 sample  1014978     0.070 ±   0.007   us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.00             sample                ≈ 0             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.50             sample              0.100             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.90             sample              0.100             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.95             sample              0.100             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.99             sample              0.101             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.999            sample              1.700             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p0.9999           sample             17.600             us/op
SpanBenchmarks.padLeft_1Char:padLeft_1Char·p1.00             sample            995.328             us/op
SpanBenchmarks.padLeft_1Char:·gc.alloc.rate                  sample       15  2460.997 ± 185.566  MB/sec
SpanBenchmarks.padLeft_1Char:·gc.alloc.rate.norm             sample       15    56.006 ±   0.001    B/op
SpanBenchmarks.padLeft_1Char:·gc.churn.G1_Eden_Space         sample       15  2471.890 ± 222.055  MB/sec
SpanBenchmarks.padLeft_1Char:·gc.churn.G1_Eden_Space.norm    sample       15    56.235 ±   2.282    B/op
SpanBenchmarks.padLeft_1Char:·gc.churn.G1_Old_Gen            sample       15     0.006 ±   0.003  MB/sec
SpanBenchmarks.padLeft_1Char:·gc.churn.G1_Old_Gen.norm       sample       15    ≈ 10⁻⁴              B/op
SpanBenchmarks.padLeft_1Char:·gc.count                       sample       15   183.000            counts
SpanBenchmarks.padLeft_1Char:·gc.time                        sample       15   130.000                ms
SpanBenchmarks.padLeft_31Chars                               sample   927592     0.069 ±   0.006   us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.00         sample                ≈ 0             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.50         sample              0.100             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.90         sample              0.100             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.95         sample              0.100             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.99         sample              0.101             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.999        sample              1.800             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p0.9999       sample             15.815             us/op
SpanBenchmarks.padLeft_31Chars:padLeft_31Chars·p1.00         sample            963.584             us/op
SpanBenchmarks.padLeft_31Chars:·gc.alloc.rate                sample       15  2892.091 ±  91.278  MB/sec
SpanBenchmarks.padLeft_31Chars:·gc.alloc.rate.norm           sample       15    72.006 ±   0.001    B/op
SpanBenchmarks.padLeft_31Chars:·gc.churn.G1_Eden_Space       sample       15  2908.182 ± 185.541  MB/sec
SpanBenchmarks.padLeft_31Chars:·gc.churn.G1_Eden_Space.norm  sample       15    72.392 ±   3.791    B/op
SpanBenchmarks.padLeft_31Chars:·gc.churn.G1_Old_Gen          sample       15     0.006 ±   0.004  MB/sec
SpanBenchmarks.padLeft_31Chars:·gc.churn.G1_Old_Gen.norm     sample       15    ≈ 10⁻⁴              B/op
SpanBenchmarks.padLeft_31Chars:·gc.count                     sample       15   160.000            counts
SpanBenchmarks.padLeft_31Chars:·gc.time                      sample       15   119.000                ms
```