### PR TITLE
Add benchmark of jackson span decoder.

### DIFF
--- a/benchmarks/src/main/java/zipkin2/codec/JacksonSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/JacksonSpanDecoder.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package zipkin2.codec;
 
 import com.fasterxml.jackson.core.JsonFactory;

--- a/benchmarks/src/main/java/zipkin2/codec/JacksonSpanDecoder.java
+++ b/benchmarks/src/main/java/zipkin2/codec/JacksonSpanDecoder.java
@@ -1,0 +1,227 @@
+package zipkin2.codec;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import zipkin2.Annotation;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.internal.ReadBuffer;
+
+public final class JacksonSpanDecoder {
+
+  static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+  public static List<Span> decodeList(byte[] spans) {
+    try {
+      return decodeList(JSON_FACTORY.createParser(spans));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static List<Span> decodeList(ByteBuffer spans) {
+    try {
+      return decodeList(JSON_FACTORY.createParser(ReadBuffer.wrapUnsafe(spans)));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static Span decodeOne(byte[] span) {
+    try {
+      return decodeOne(JSON_FACTORY.createParser(span));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static Span decodeOne(ByteBuffer span) {
+    try {
+      return decodeOne(JSON_FACTORY.createParser(ReadBuffer.wrapUnsafe(span)));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  static List<Span> decodeList(JsonParser jsonParser) {
+    List<Span> out = new ArrayList<>();
+
+    try {
+      if (jsonParser.nextToken() != JsonToken.START_ARRAY) {
+        throw new IOException("Not a valid JSON array, start token: " + jsonParser.currentToken());
+      }
+
+      while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
+        out.add(parseSpan(jsonParser));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    return out;
+  }
+
+  static Span decodeOne(JsonParser jsonParser) {
+    try {
+      if (!jsonParser.hasCurrentToken()) {
+        jsonParser.nextToken();
+      }
+      return parseSpan(jsonParser);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  static Span parseSpan(JsonParser jsonParser) throws IOException {
+    if (!jsonParser.isExpectedStartObjectToken()) {
+      throw new IOException("Not a valid JSON object, start token: " +
+        jsonParser.currentToken());
+    }
+
+    Span.Builder result = Span.newBuilder();
+
+    while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+      String fieldName = jsonParser.currentName();
+      JsonToken value = jsonParser.nextToken();
+      if (value == JsonToken.VALUE_NULL) {
+        continue;
+      }
+      switch (fieldName) {
+        case "traceId":
+          result.traceId(jsonParser.getValueAsString());
+          break;
+        case "parentId":
+          result.parentId(jsonParser.getValueAsString());
+          break;
+        case "id":
+          result.id(jsonParser.getValueAsString());
+          break;
+        case "kind":
+          result.kind(Span.Kind.valueOf(jsonParser.getValueAsString()));
+          break;
+        case "name":
+          result.name(jsonParser.getValueAsString());
+          break;
+        case "timestamp":
+          result.timestamp(jsonParser.getValueAsLong());
+          break;
+        case "duration":
+          result.duration(jsonParser.getValueAsLong());
+          break;
+        case "localEndpoint":
+          result.localEndpoint(parseEndpoint(jsonParser));
+          break;
+        case "remoteEndpoint":
+          result.remoteEndpoint(parseEndpoint(jsonParser));
+          break;
+        case "annotations":
+          if (!jsonParser.isExpectedStartArrayToken()) {
+            throw new IOException("Invalid span, expecting annotations array start, got: " +
+              value);
+          }
+          while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
+            Annotation a = parseAnnotation(jsonParser);
+            result.addAnnotation(a.timestamp(), a.value());
+          }
+          break;
+        case "tags":
+          if (value != JsonToken.START_OBJECT) {
+            throw new IOException("Invalid span, expecting tags object, got: " + value);
+          }
+          while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+            result.putTag(jsonParser.currentName(), jsonParser.nextTextValue());
+          }
+          break;
+        case "debug":
+          result.debug(jsonParser.getBooleanValue());
+          break;
+        case "shared":
+          result.shared(jsonParser.getBooleanValue());
+          break;
+        default:
+          jsonParser.skipChildren();
+      }
+    }
+
+    return result.build();
+  }
+
+  static Endpoint parseEndpoint(JsonParser jsonParser) throws IOException {
+    if (!jsonParser.isExpectedStartObjectToken()) {
+      throw new IOException("Not a valid JSON object, start token: " +
+        jsonParser.currentToken());
+    }
+
+    String serviceName = null, ipv4 = null, ipv6 = null;
+    int port = 0;
+
+    while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+      String fieldName = jsonParser.currentName();
+      JsonToken value = jsonParser.nextToken();
+      if (value == JsonToken.VALUE_NULL) {
+        continue;
+      }
+
+      switch (fieldName) {
+        case "serviceName":
+          serviceName = jsonParser.getValueAsString();
+          break;
+        case "ipv4":
+          ipv4 = jsonParser.getValueAsString();
+          break;
+        case "ipv6":
+          ipv6 = jsonParser.getValueAsString();
+          break;
+        case "port":
+          port = jsonParser.getValueAsInt();
+          break;
+        default:
+          jsonParser.skipChildren();
+      }
+    }
+
+    if (serviceName == null && ipv4 == null && ipv6 == null && port == 0) return null;
+    return Endpoint.newBuilder()
+      .serviceName(serviceName)
+      .ip(ipv4)
+      .ip(ipv6)
+      .port(port)
+      .build();
+  }
+
+  static Annotation parseAnnotation(JsonParser jsonParser) throws IOException {
+    if (!jsonParser.isExpectedStartObjectToken()) {
+      throw new IOException("Not a valid JSON object, start token: " +
+        jsonParser.currentToken());
+    }
+
+    long timestamp = 0;
+    String value = null;
+
+    while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+      String fieldName = jsonParser.currentName();
+
+      switch (fieldName) {
+        case "timestamp":
+          timestamp = jsonParser.getValueAsLong();
+          break;
+        case "value":
+          value = jsonParser.getValueAsString();
+          break;
+        default:
+          jsonParser.skipChildren();
+      }
+    }
+
+    if (timestamp == 0 || value == null) {
+      throw new IllegalStateException("Incomplete annotation at " + jsonParser.currentToken());
+    }
+    return Annotation.create(timestamp, value);
+  }
+}

--- a/benchmarks/src/main/java/zipkin2/codec/JsonCodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/JsonCodecBenchmarks.java
@@ -68,12 +68,20 @@ public class JsonCodecBenchmarks {
     encodedBuf.release();
   }
 
+  @Benchmark public List<Span> bytes_jacksonDecoder() {
+    return JacksonSpanDecoder.decodeList(encodedBytes);
+  }
+
   @Benchmark public List<Span> bytes_moshiDecoder() {
     return MOSHI.decodeList(encodedBytes);
   }
 
   @Benchmark public List<Span> bytes_zipkinDecoder() {
     return SpanBytesDecoder.JSON_V2.decodeList(encodedBytes);
+  }
+
+  @Benchmark public List<Span> bytebuffer_jacksonDecoder() {
+    return JacksonSpanDecoder.decodeList(encodedBuf.nioBuffer());
   }
 
   @Benchmark public List<Span> bytebuffer_moshiDecoder() {
@@ -87,7 +95,7 @@ public class JsonCodecBenchmarks {
   // Convenience main entry-point
   public static void main(String[] args) throws Exception {
     Options opt = new OptionsBuilder()
-      .include(".*" + JsonCodecBenchmarks.class.getSimpleName())
+      .include(".*" + JsonCodecBenchmarks.class.getSimpleName() + ".*")
       .addProfiler("gc")
       .build();
 


### PR DESCRIPTION
Figured it's worth comparing. Jackson does seem to be quite a bit faster, which fits with my experience comparing gson and jackson for protobuf json serialization.

```
Benchmark                                                                          Mode   Cnt        Score        Error   Units
JsonCodecBenchmarks.bytebuffer_jacksonDecoder                                    sample  5901     2544.586 ±     12.446   us/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:bytebuffer_jacksonDecoder·p0.00    sample           2265.088                us/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:bytebuffer_jacksonDecoder·p0.50    sample           2482.176                us/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:bytebuffer_jacksonDecoder·p0.90    sample           2805.760                us/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:bytebuffer_jacksonDecoder·p0.95    sample           2977.792                us/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:bytebuffer_jacksonDecoder·p0.99    sample           3890.954                us/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:bytebuffer_jacksonDecoder·p0.999   sample           5007.720                us/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:bytebuffer_jacksonDecoder·p0.9999  sample           6234.112                us/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:bytebuffer_jacksonDecoder·p1.00    sample           6234.112                us/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.alloc.rate                     sample    15      485.928 ±     11.010  MB/sec
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.alloc.rate.norm                sample    15  1947212.928 ±  54268.319    B/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.churn.G1_Eden_Space            sample    15      474.709 ±     41.802  MB/sec
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.churn.G1_Eden_Space.norm       sample    15  1902536.334 ± 174257.340    B/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.churn.G1_Old_Gen               sample    15        0.522 ±      0.229  MB/sec
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.churn.G1_Old_Gen.norm          sample    15     2081.496 ±    900.600    B/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.churn.G1_Survivor_Space        sample    15        0.710 ±      0.422  MB/sec
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.churn.G1_Survivor_Space.norm   sample    15     2845.078 ±   1710.011    B/op
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.count                          sample    15       63.000               counts
JsonCodecBenchmarks.bytebuffer_jacksonDecoder:·gc.time                           sample    15       59.000                   ms
JsonCodecBenchmarks.bytebuffer_moshiDecoder                                      sample  3622     4149.591 ±     23.637   us/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:bytebuffer_moshiDecoder·p0.00        sample           3538.944                us/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:bytebuffer_moshiDecoder·p0.50        sample           4083.712                us/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:bytebuffer_moshiDecoder·p0.90        sample           4579.328                us/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:bytebuffer_moshiDecoder·p0.95        sample           4800.512                us/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:bytebuffer_moshiDecoder·p0.99        sample           5726.863                us/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:bytebuffer_moshiDecoder·p0.999       sample           7977.124                us/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:bytebuffer_moshiDecoder·p0.9999      sample          10633.216                us/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:bytebuffer_moshiDecoder·p1.00        sample          10633.216                us/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.alloc.rate                       sample    15      475.416 ±     22.444  MB/sec
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.alloc.rate.norm                  sample    15  3105210.609 ±     90.856    B/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.churn.G1_Eden_Space              sample    15      481.880 ±     36.226  MB/sec
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.churn.G1_Eden_Space.norm         sample    15  3147773.994 ± 201647.808    B/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.churn.G1_Old_Gen                 sample    15        0.362 ±      0.278  MB/sec
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.churn.G1_Old_Gen.norm            sample    15     2371.526 ±   1847.100    B/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.churn.G1_Survivor_Space          sample    15        0.355 ±      0.367  MB/sec
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.churn.G1_Survivor_Space.norm     sample    15     2297.098 ±   2382.129    B/op
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.count                            sample    15       68.000               counts
JsonCodecBenchmarks.bytebuffer_moshiDecoder:·gc.time                             sample    15       62.000                   ms
JsonCodecBenchmarks.bytebuffer_zipkinDecoder                                     sample  4316     3480.430 ±     19.196   us/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:bytebuffer_zipkinDecoder·p0.00      sample           3084.288                us/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:bytebuffer_zipkinDecoder·p0.50      sample           3387.392                us/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:bytebuffer_zipkinDecoder·p0.90      sample           3825.664                us/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:bytebuffer_zipkinDecoder·p0.95      sample           4027.597                us/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:bytebuffer_zipkinDecoder·p0.99      sample           4951.982                us/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:bytebuffer_zipkinDecoder·p0.999     sample           6742.819                us/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:bytebuffer_zipkinDecoder·p0.9999    sample          12369.920                us/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:bytebuffer_zipkinDecoder·p1.00      sample          12369.920                us/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.alloc.rate                      sample    15      526.684 ±     10.409  MB/sec
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.alloc.rate.norm                 sample    15  2885357.205 ±  29202.870    B/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.churn.G1_Eden_Space             sample    15      531.141 ±     56.507  MB/sec
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.churn.G1_Eden_Space.norm        sample    15  2909782.493 ± 305111.674    B/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.churn.G1_Old_Gen                sample    15        0.559 ±      0.244  MB/sec
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.churn.G1_Old_Gen.norm           sample    15     3056.974 ±   1313.696    B/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.churn.G1_Survivor_Space         sample    15        0.754 ±      0.593  MB/sec
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.churn.G1_Survivor_Space.norm    sample    15     4131.131 ±   3233.971    B/op
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.count                           sample    15       75.000               counts
JsonCodecBenchmarks.bytebuffer_zipkinDecoder:·gc.time                            sample    15       75.000                   ms
JsonCodecBenchmarks.bytes_jacksonDecoder                                         sample  5923     2535.539 ±     15.459   us/op
JsonCodecBenchmarks.bytes_jacksonDecoder:bytes_jacksonDecoder·p0.00              sample           2232.320                us/op
JsonCodecBenchmarks.bytes_jacksonDecoder:bytes_jacksonDecoder·p0.50              sample           2461.696                us/op
JsonCodecBenchmarks.bytes_jacksonDecoder:bytes_jacksonDecoder·p0.90              sample           2793.472                us/op
JsonCodecBenchmarks.bytes_jacksonDecoder:bytes_jacksonDecoder·p0.95              sample           3006.464                us/op
JsonCodecBenchmarks.bytes_jacksonDecoder:bytes_jacksonDecoder·p0.99              sample           3869.737                us/op
JsonCodecBenchmarks.bytes_jacksonDecoder:bytes_jacksonDecoder·p0.999             sample           6267.011                us/op
JsonCodecBenchmarks.bytes_jacksonDecoder:bytes_jacksonDecoder·p0.9999            sample          15925.248                us/op
JsonCodecBenchmarks.bytes_jacksonDecoder:bytes_jacksonDecoder·p1.00              sample          15925.248                us/op
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.alloc.rate                          sample    15      494.354 ±      9.378  MB/sec
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.alloc.rate.norm                     sample    15  1973729.248 ±     52.341    B/op
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.churn.G1_Eden_Space                 sample    15      497.189 ±     41.667  MB/sec
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.churn.G1_Eden_Space.norm            sample    15  1985573.255 ± 170232.613    B/op
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.churn.G1_Old_Gen                    sample    15        0.487 ±      0.338  MB/sec
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.churn.G1_Old_Gen.norm               sample    15     1935.626 ±   1341.708    B/op
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.churn.G1_Survivor_Space             sample    15        0.310 ±      0.367  MB/sec
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.churn.G1_Survivor_Space.norm        sample    15     1249.878 ±   1478.821    B/op
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.count                               sample    15       70.000               counts
JsonCodecBenchmarks.bytes_jacksonDecoder:·gc.time                                sample    15       70.000                   ms
JsonCodecBenchmarks.bytes_moshiDecoder                                           sample  3418     4399.938 ±     35.054   us/op
JsonCodecBenchmarks.bytes_moshiDecoder:bytes_moshiDecoder·p0.00                  sample           3588.096                us/op
JsonCodecBenchmarks.bytes_moshiDecoder:bytes_moshiDecoder·p0.50                  sample           4374.528                us/op
JsonCodecBenchmarks.bytes_moshiDecoder:bytes_moshiDecoder·p0.90                  sample           4825.088                us/op
JsonCodecBenchmarks.bytes_moshiDecoder:bytes_moshiDecoder·p0.95                  sample           5169.562                us/op
JsonCodecBenchmarks.bytes_moshiDecoder:bytes_moshiDecoder·p0.99                  sample           7517.143                us/op
JsonCodecBenchmarks.bytes_moshiDecoder:bytes_moshiDecoder·p0.999                 sample           9332.654                us/op
JsonCodecBenchmarks.bytes_moshiDecoder:bytes_moshiDecoder·p0.9999                sample          11091.968                us/op
JsonCodecBenchmarks.bytes_moshiDecoder:bytes_moshiDecoder·p1.00                  sample          11091.968                us/op
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.alloc.rate                            sample    15      513.047 ±     34.288  MB/sec
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.alloc.rate.norm                       sample    15  3552581.606 ±  29222.197    B/op
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.churn.G1_Eden_Space                   sample    15      521.506 ±     56.109  MB/sec
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.churn.G1_Eden_Space.norm              sample    15  3611983.639 ± 309826.684    B/op
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.churn.G1_Old_Gen                      sample    15        0.384 ±      0.341  MB/sec
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.churn.G1_Old_Gen.norm                 sample    15     2653.762 ±   2449.685    B/op
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.churn.G1_Survivor_Space               sample    15        0.664 ±      0.710  MB/sec
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.churn.G1_Survivor_Space.norm          sample    15     4617.205 ±   5086.783    B/op
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.count                                 sample    15       69.000               counts
JsonCodecBenchmarks.bytes_moshiDecoder:·gc.time                                  sample    15       58.000                   ms
JsonCodecBenchmarks.bytes_zipkinDecoder                                          sample  3747     4012.987 ±     26.430   us/op
JsonCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.00                sample           3317.760                us/op
JsonCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.50                sample           3985.408                us/op
JsonCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.90                sample           4251.648                us/op
JsonCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.95                sample           4800.512                us/op
JsonCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.99                sample           6500.516                us/op
JsonCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.999               sample           7707.001                us/op
JsonCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p0.9999              sample           8355.840                us/op
JsonCodecBenchmarks.bytes_zipkinDecoder:bytes_zipkinDecoder·p1.00                sample           8355.840                us/op
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate                           sample    15      459.039 ±     11.709  MB/sec
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.alloc.rate.norm                      sample    15  2898592.404 ±  12521.738    B/op
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space                  sample    15      460.318 ±     53.819  MB/sec
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Eden_Space.norm             sample    15  2910512.906 ± 370418.450    B/op
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen                     sample    15        0.682 ±      0.388  MB/sec
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Old_Gen.norm                sample    15     4328.483 ±   2484.072    B/op
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space              sample    15        0.576 ±      0.592  MB/sec
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.churn.G1_Survivor_Space.norm         sample    15     3643.936 ±   3786.948    B/op
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.count                                sample    15       65.000               counts
JsonCodecBenchmarks.bytes_zipkinDecoder:·gc.time                                 sample    15       64.000                   ms
```