### PR TITLE
Uses legacy packaging of classic UI until it can be deleted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
   <modules>
     <module>zipkin</module>
     <module>zipkin-tests</module>
-    <module>zipkin-ui</module>
     <module>zipkin-lens</module>
     <module>zipkin-junit</module>
     <module>benchmarks</module>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -108,12 +108,13 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- Static content for the web UI -->
+    <!-- Static content for the Classic UI -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin-ui</artifactId>
-      <version>${project.version}</version>
+      <version>2.12.10</version>
     </dependency>
+    <!-- Static content for the Lens UI -->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-lens</artifactId>


### PR DESCRIPTION
This frees us of the responsibility of building the old UI in every run.
This also allows us to delete the old codebase, solving some ASF
bookkeeping concerns.