### PR TITLE
Fix traceViewer bug that after loading JSON screen is busted

### DIFF
--- a/zipkin-lens/src/components/App/App.jsx
+++ b/zipkin-lens/src/components/App/App.jsx
@@ -55,7 +55,7 @@ class App extends React.Component {
             <Route
               exact
               path="/zipkin/traceViewer"
-              render={TraceViewerContainer}
+              component={TraceViewerContainer}
             />
           </Layout>
         </BrowserRouter>


### PR DESCRIPTION
Related: #2600 