### PR TITLE
Handle exceptions without message.

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
@@ -241,12 +241,12 @@ final class BodyIsExceptionMessage implements ExceptionHandlerFunction {
   public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
     ZipkinHttpCollector.metrics.incrementMessagesDropped();
 
-    LOGGER.warn("Unexpected error handling request.", cause);
-
     String message = cause.getMessage() != null ? cause.getMessage() : "";
     if (cause instanceof IllegalArgumentException) {
       return HttpResponse.of(BAD_REQUEST, MediaType.ANY_TEXT_TYPE, message);
     } else {
+      LOGGER.warn("Unexpected error handling request.", cause);
+
       return HttpResponse.of(INTERNAL_SERVER_ERROR, MediaType.ANY_TEXT_TYPE, message);
     }
   }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
@@ -235,13 +235,19 @@ final class UnzippingBytesRequestConverter {
 
 final class BodyIsExceptionMessage implements ExceptionHandlerFunction {
 
+  static final Logger LOGGER = LogManager.getLogger();
+
   @Override
   public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
     ZipkinHttpCollector.metrics.incrementMessagesDropped();
+
+    LOGGER.warn("Unexpected error handling request.", cause);
+
+    String message = cause.getMessage() != null ? cause.getMessage() : "";
     if (cause instanceof IllegalArgumentException) {
-      return HttpResponse.of(BAD_REQUEST, MediaType.ANY_TEXT_TYPE, cause.getMessage());
+      return HttpResponse.of(BAD_REQUEST, MediaType.ANY_TEXT_TYPE, message);
     } else {
-      return HttpResponse.of(INTERNAL_SERVER_ERROR, MediaType.ANY_TEXT_TYPE, cause.getMessage());
+      return HttpResponse.of(INTERNAL_SERVER_ERROR, MediaType.ANY_TEXT_TYPE, message);
     }
   }
 


### PR DESCRIPTION
While this doesn't address the root issue in #2609 it is needed to prevent a proper exception being turned into a NPE.