### PR TITLE
Fix ThrottledStorageComponent not passing through health check

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHealthIndicator.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHealthIndicator.java
@@ -27,7 +27,7 @@ final class ZipkinHealthIndicator extends CompositeHealthIndicator {
   }
 
   void addComponent(Component component) {
-    String healthName = component.name();
+    String healthName = component.toString();
     addHealthIndicator(healthName, new ComponentHealthIndicator(component));
   }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHealthIndicator.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHealthIndicator.java
@@ -27,8 +27,7 @@ final class ZipkinHealthIndicator extends CompositeHealthIndicator {
   }
 
   void addComponent(Component component) {
-    String healthName = component.getClass().getSimpleName();
-    healthName = healthName.replace("AutoValue_", "");
+    String healthName = component.name();
     addHealthIndicator(healthName, new ComponentHealthIndicator(component));
   }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import zipkin2.Call;
+import zipkin2.CheckResult;
 import zipkin2.Span;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
@@ -95,6 +96,14 @@ public final class ThrottledStorageComponent extends StorageComponent {
   @Override public void close() throws IOException {
     executor.shutdownNow();
     delegate.close();
+  }
+
+  @Override public CheckResult check() {
+    return delegate.check();
+  }
+
+  @Override public String name() {
+    return "Throttled(" + delegate.name() + ")";
   }
 
   @Override public String toString() {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
@@ -102,12 +102,8 @@ public final class ThrottledStorageComponent extends StorageComponent {
     return delegate.check();
   }
 
-  @Override public String name() {
-    return "Throttled(" + delegate.name() + ")";
-  }
-
   @Override public String toString() {
-    return "Throttled(" + delegate + ")";
+    return "Throttled(" + delegate.toString() + ")";
   }
 
   static final class ThrottledSpanConsumer implements SpanConsumer {

--- a/zipkin-server/src/test/kotlin/zipkin2/server/internal/throttle/ThrottledStorageComponentTest.kt
+++ b/zipkin-server/src/test/kotlin/zipkin2/server/internal/throttle/ThrottledStorageComponentTest.kt
@@ -16,7 +16,9 @@ package zipkin2.server.internal.throttle
 import com.linecorp.armeria.common.metric.NoopMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.Mockito.*
 import zipkin2.storage.InMemoryStorage
+import zipkin2.storage.StorageComponent
 
 class ThrottledStorageComponentTest {
   val delegate = InMemoryStorage.newBuilder().build()
@@ -44,5 +46,16 @@ class ThrottledStorageComponentTest {
   @Test fun niceToString() {
     assertThat(ThrottledStorageComponent(delegate, registry, 1, 2, 1))
       .hasToString("Throttled(InMemoryStorage{traceCount=0})");
+  }
+
+  @Test fun delegatesCheck() {
+    val mock = mock(StorageComponent::class.java)
+    ThrottledStorageComponent(mock, registry, 1, 2, 1).check()
+    verify(mock, times(1)).check()
+  }
+
+  @Test fun wrapsName() {
+    assertThat(ThrottledStorageComponent(delegate, registry, 1, 2, 1).name())
+      .isEqualTo("Throttled(InMemoryStorage)")
   }
 }

--- a/zipkin-server/src/test/kotlin/zipkin2/server/internal/throttle/ThrottledStorageComponentTest.kt
+++ b/zipkin-server/src/test/kotlin/zipkin2/server/internal/throttle/ThrottledStorageComponentTest.kt
@@ -16,7 +16,9 @@ package zipkin2.server.internal.throttle
 import com.linecorp.armeria.common.metric.NoopMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import zipkin2.storage.InMemoryStorage
 import zipkin2.storage.StorageComponent
 
@@ -45,17 +47,12 @@ class ThrottledStorageComponentTest {
 
   @Test fun niceToString() {
     assertThat(ThrottledStorageComponent(delegate, registry, 1, 2, 1))
-      .hasToString("Throttled(InMemoryStorage{traceCount=0})");
+      .hasToString("Throttled(InMemoryStorage{traceCount=0})")
   }
 
   @Test fun delegatesCheck() {
     val mock = mock(StorageComponent::class.java)
     ThrottledStorageComponent(mock, registry, 1, 2, 1).check()
     verify(mock, times(1)).check()
-  }
-
-  @Test fun wrapsName() {
-    assertThat(ThrottledStorageComponent(delegate, registry, 1, 2, 1).name())
-      .isEqualTo("Throttled(InMemoryStorage)")
   }
 }

--- a/zipkin/src/main/java/zipkin2/Component.java
+++ b/zipkin/src/main/java/zipkin2/Component.java
@@ -38,6 +38,11 @@ public abstract class Component implements Closeable {
     return CheckResult.OK;
   }
 
+  public String name() {
+    String name = this.getClass().getSimpleName();
+    return name.replace("AutoValue_", "");
+  }
+
   /**
    * Closes any network resources created implicitly by the component.
    *

--- a/zipkin/src/main/java/zipkin2/Component.java
+++ b/zipkin/src/main/java/zipkin2/Component.java
@@ -38,11 +38,6 @@ public abstract class Component implements Closeable {
     return CheckResult.OK;
   }
 
-  public String name() {
-    String name = this.getClass().getSimpleName();
-    return name.replace("AutoValue_", "");
-  }
-
   /**
    * Closes any network resources created implicitly by the component.
    *


### PR DESCRIPTION
When using the ThrottledStorageComponent the health check (/actuator/health) always reports "UP" even when the backing storage component is in a bad state.

This change passes through the check from the delegate. I also formalized the name of components so that instead of reporting on the "ThrottledStorageComponent" in the health endpoint, you will get a more useful name such as "Throttled(ElasticsearchStorage)". 