### PR TITLE
Makes RabbitMQ connect exceptions visible

### DIFF
--- a/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
@@ -21,6 +21,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -169,8 +170,11 @@ public final class RabbitMQCollector extends CollectorComponent {
                 ? builder.connectionFactory.newConnection()
                 : builder.connectionFactory.newConnection(builder.addresses);
         declareQueueIfMissing(connection);
-      } catch (IOException | TimeoutException e) {
-        throw new IllegalStateException("Unable to establish connection to RabbitMQ server", e);
+      } catch (IOException e) {
+        throw new UncheckedIOException(
+          "Unable to establish connection to RabbitMQ server: " + e.getMessage(), e);
+      } catch (TimeoutException e) {
+        throw new RuntimeException("Timeout establishing connection to RabbitMQ server: " + e.getMessage(), e);
       }
       Collector collector = builder.delegate.build();
       CollectorMetrics metrics = builder.metrics;

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/ITRabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/ITRabbitMQCollector.java
@@ -15,6 +15,7 @@ package zipkin2.collector.rabbitmq;
 
 import com.rabbitmq.client.Channel;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -60,8 +61,8 @@ public class ITRabbitMQCollector {
     String notRabbitMqAddress = "localhost:80";
     try (RabbitMQCollector collector =
         builder().addresses(Collections.singletonList(notRabbitMqAddress)).build()) {
-      thrown.expect(IllegalStateException.class);
-      thrown.expectMessage("Unable to establish connection to RabbitMQ server");
+      thrown.expect(UncheckedIOException.class);
+      thrown.expectMessage("Unable to establish connection to RabbitMQ server: Connection refused");
       collector.start();
     }
   }


### PR DESCRIPTION
cc @thanhct who noticed the exception before this is useless.

To try this change, you can use jitpack https://jitpack.io/#openzipkin/zipkin

ex.
```bash
TAG=most-exceptionally-yours-SNAPSHOT
curl -sSL https://jitpack.io/com/github/openzipkin/zipkin/zipkin-server/${TAG}/zipkin-server-${TAG}-exec.jar > zipkin.jar
# now java -jar zipkin.jar etc
```