### PR TITLE
Bumps to latest, notably Armeria

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.7.1</version>
+      <version>3.8.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,30 +48,30 @@
 
     <main.basedir>${project.basedir}</main.basedir>
 
-    <armeria.version>0.87.0</armeria.version>
+    <armeria.version>0.88.0</armeria.version>
     <!-- This should only be used in tests, and be careful to avoid >= v20 apis -->
-    <guava.version>27.1-jre</guava.version>
+    <guava.version>28.0-jre</guava.version>
 
     <!-- only used for proto interop testing -->
     <wire.version>3.0.0-alpha01</wire.version>
     <unpack-proto.directory>${project.build.directory}/test/proto</unpack-proto.directory>
 
-    <brave.version>5.6.5</brave.version>
+    <brave.version>5.6.6</brave.version>
     <cassandra-driver-core.version>3.7.1</cassandra-driver-core.version>
     <okhttp.version>3.14.2</okhttp.version>
     <okio.version>1.17.4</okio.version>
     <jooq.version>3.11.11</jooq.version>
-    <micrometer.version>1.1.4</micrometer.version>
-    <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
+    <micrometer.version>1.2.0</micrometer.version>
+    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
 
          MariaDB has a friendlier license, LGPL, which is less scary in audits.
     -->
-    <mariadb-java-client.version>2.4.1</mariadb-java-client.version>
+    <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
     <!-- Java 8 dep, which is ok as zipkin-mysql is Java 8 anyway -->
     <HikariCP.version>3.3.1</HikariCP.version>
-    <log4j.version>2.11.2</log4j.version>
+    <log4j.version>2.12.0</log4j.version>
 
     <junit.version>4.12</junit.version>
     <powermock.version>2.0.2</powermock.version>
@@ -84,7 +84,7 @@
     <testcontainers.version>1.11.3</testcontainers.version>
 
     <auto-value.version>1.6.5</auto-value.version>
-    <animal-sniffer-maven-plugin.version>1.17</animal-sniffer-maven-plugin.version>
+    <animal-sniffer-maven-plugin.version>1.18</animal-sniffer-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
@@ -681,6 +681,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
+                  <!-- don't JDK 12 until https://github.com/google/error-prone/issues/1106 -->
                   <version>[1.8,12)</version>
                 </requireJavaVersion>
               </rules>

--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <amqp-client.version>4.11.0</amqp-client.version>
+    <amqp-client.version>4.11.1</amqp-client.version>
   </properties>
 
   <dependencies>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -30,7 +30,7 @@
     <main.basedir>${project.basedir}/..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
-    <kotlin.version>1.3.31</kotlin.version>
+    <kotlin.version>1.3.40</kotlin.version>
     <maven-invoker-plugin.version>3.2.0</maven-invoker-plugin.version>
     <proto.generatedSourceDirectory>${project.build.directory}/generated-test-sources/wire</proto.generatedSourceDirectory>
   </properties>
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>com.linecorp.armeria</groupId>
-      <artifactId>armeria-zipkin</artifactId>
+      <artifactId>armeria-brave</artifactId>
     </dependency>
     <dependency>
       <groupId>com.linecorp.armeria</groupId>


### PR DESCRIPTION
Testing with `SELF_TRACING_ENABLED=true STORAGE_TYPE=elasticsearch java -jar zipkin.jar` and clicking around.. I got this in the console which might not be new. I didn't go back and check prior


```
2019-07-02 20:34:57.169  WARN 57190 --- [ender@7af707e0}] .a.c.b.RequestContextCurrentTraceContext : Attempted to propagate trace context, but no request context available. Did you forget to use RequestContext.contextAwareExecutor() or RequestContext.makeContextAware()?

com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext$LogRequestContextWarningOnce$NoRequestContextException: null
	at com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext$LogRequestContextWarningOnce$ClassLoaderHack.<clinit>(RequestContextCurrentTraceContext.java:266) [armeria-brave-0.88.0.jar!/:?]
	at com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext$LogRequestContextWarningOnce.get(RequestContextCurrentTraceContext.java:254) [armeria-brave-0.88.0.jar!/:?]
	at com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext$LogRequestContextWarningOnce.get(RequestContextCurrentTraceContext.java:247) [armeria-brave-0.88.0.jar!/:?]
	at com.linecorp.armeria.common.RequestContext.mapCurrent(RequestContext.java:108) [armeria-0.88.0.jar!/:?]
	at com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext.getRequestContextOrWarnOnce(RequestContextCurrentTraceContext.java:232) [armeria-brave-0.88.0.jar!/:?]
	at com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext.get(RequestContextCurrentTraceContext.java:143) [armeria-brave-0.88.0.jar!/:?]
	at brave.Tracer.currentSpan(Tracer.java:440) [brave-5.6.6.jar!/:?]
	at zipkin2.server.internal.elasticsearch.ZipkinElasticsearchStorageAutoConfiguration$TracingOkHttpClientBuilderEnhancer$1.intercept(ZipkinElasticsearchStorageAutoConfiguration.java:139) [classes!/:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) [okhttp-3.14.2.jar!/:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) [okhttp-3.14.2.jar!/:?]
	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:221) [okhttp-3.14.2.jar!/:?]
	at okhttp3.RealCall.execute(RealCall.java:81) [okhttp-3.14.2.jar!/:?]
	at zipkin2.elasticsearch.internal.client.HttpCall.doExecute(HttpCall.java:78) [zipkin-storage-elasticsearch-2.14.3-SNAPSHOT.jar!/:?]
	at zipkin2.Call$Base.execute(Call.java:379) [zipkin-2.14.3-SNAPSHOT.jar!/:?]
	at zipkin2.elasticsearch.VersionSpecificTemplates.getVersion(VersionSpecificTemplates.java:222) [zipkin-storage-elasticsearch-2.14.3-SNAPSHOT.jar!/:?]
	at zipkin2.elasticsearch.VersionSpecificTemplates.get(VersionSpecificTemplates.java:188) [zipkin-storage-elasticsearch-2.14.3-SNAPSHOT.jar!/:?]
	at zipkin2.elasticsearch.ElasticsearchStorage.ensureIndexTemplates(ElasticsearchStorage.java:342) [zipkin-storage-elasticsearch-2.14.3-SNAPSHOT.jar!/:?]
	at zipkin2.elasticsearch.AutoValue_ElasticsearchStorage.ensureIndexTemplates(AutoValue_ElasticsearchStorage.java:29) [zipkin-storage-elasticsearch-2.14.3-SNAPSHOT.jar!/:?]
	at zipkin2.elasticsearch.ElasticsearchStorage.spanConsumer(ElasticsearchStorage.java:270) [zipkin-storage-elasticsearch-2.14.3-SNAPSHOT.jar!/:?]
	at zipkin2.server.internal.brave.TracingStorageComponent.spanConsumer(TracingStorageComponent.java:49) [classes!/:?]
	at zipkin2.storage.StorageComponent$$FastClassBySpringCGLIB$$37dbd580.invoke(<generated>) [zipkin-2.14.3-SNAPSHOT.jar!/:?]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) [spring-core-5.1.8.RELEASE.jar!/:5.1.8.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:684) [spring-aop-5.1.8.RELEASE.jar!/:5.1.8.RELEASE]
	at zipkin2.storage.StorageComponent$$EnhancerBySpringCGLIB$$2354a631.spanConsumer(<generated>) [zipkin-2.14.3-SNAPSHOT.jar!/:?]
	at zipkin2.server.internal.brave.TracingConfiguration$LocalSender.sendSpans(TracingConfiguration.java:144) [classes!/:?]
	at zipkin2.reporter.AsyncReporter$BoundedAsyncReporter.flush(AsyncReporter.java:286) [zipkin-reporter-2.8.4.jar!/:?]
	at zipkin2.reporter.AsyncReporter$Builder$1.run(AsyncReporter.java:190) [zipkin-reporter-2.8.4.jar!/:?]
```