### PR TITLE
Takes care to not load any types that refer to new ones

### DIFF
--- a/zipkin/src/main/java/zipkin2/internal/Platform.java
+++ b/zipkin/src/main/java/zipkin2/internal/Platform.java
@@ -61,47 +61,33 @@ public abstract class Platform {
 
   /** Attempt to match the host runtime to a capable Platform implementation. */
   static Platform findPlatform() {
-    Platform jre8 = Jre8.buildIfSupported();
+    // Find JRE 8 new types
+    try {
+      Class.forName("java.io.UncheckedIOException");
+      return new Jre8(); // intentionally doesn't not access the type prior to the above guard
+    } catch (ClassNotFoundException e) {
+      // pre JRE 8
+    }
 
-    if (jre8 != null) return jre8;
-
-    Platform jre7 = Jre7.buildIfSupported();
-
-    if (jre7 != null) return jre7;
+    // Find JRE 7 new types
+    try {
+      Class.forName("java.util.concurrent.ThreadLocalRandom");
+      return new Jre7(); // intentionally doesn't not access the type prior to the above guard
+    } catch (ClassNotFoundException e) {
+      // pre JRE 7
+    }
 
     // compatible with JRE 6
     return Jre6.build();
   }
 
   static final class Jre8 extends Jre7 {
-    static Jre8 buildIfSupported() {
-      // Find JRE 8 new types
-      try {
-        Class.forName("java.io.UncheckedIOException");
-        return new Jre8();
-      } catch (ClassNotFoundException e) {
-        // pre JRE 8
-      }
-      return null;
-    }
-
     @IgnoreJRERequirement @Override public RuntimeException uncheckedIOException(IOException e) {
       return new java.io.UncheckedIOException(e);
     }
   }
 
   static class Jre7 extends Platform {
-    static Jre7 buildIfSupported() {
-      // Find JRE 7 new types
-      try {
-        Class.forName("java.util.concurrent.ThreadLocalRandom");
-        return new Jre7();
-      } catch (ClassNotFoundException e) {
-        // pre JRE 7
-      }
-      return null;
-    }
-
     @IgnoreJRERequirement @Override
     public AssertionError assertionError(String message, Throwable cause) {
       return new AssertionError(message, cause);


### PR DESCRIPTION
An odd thing happened while testing JRE 7, which I suspect had to do
with the Jre8 variant using a new type in its bytecode. This changes
to not access a type that compiles with new classes until the guard
passes.

Example exception:
```
java.lang.NoClassDefFoundError: java/io/UncheckedIOException
    at zipkin2.internal.Platform.findPlatform (Platform.java:64)
    at zipkin2.internal.Platform.<clinit> (Platform.java:25)
    at zipkin2.Endpoint.writeIpV6 (Endpoint.java:371)
    at zipkin2.Endpoint$Builder.parseIp (Endpoint.java:256)
    at zipkin2.Endpoint$Builder.ip (Endpoint.java:227)
    at brave.internal.handler.MutableSpanConverter.convert (MutableSpanConverter.java:63)
    at brave.internal.handler.ZipkinFinishedSpanHandler.handle (ZipkinFinishedSpanHandler.java:43)
    at brave.internal.handler.FinishedSpanHandlers$NoopAwareFinishedSpan.handle (FinishedSpanHandlers.java:65)
    at brave.RealSpan.finish (RealSpan.java:151)
    at brave.RealSpan.finish (RealSpan.java:143)
    at brave.http.HttpHandler.finishInNullScope (HttpHandler.java:67)
    at brave.http.HttpHandler.handleFinish (HttpHandler.java:59)
    at brave.http.HttpServerHandler.handleSend (HttpServerHandler.java:116)
    at brave.servlet.TracingFilter.doFilter (TracingFilter.java:108)
    at brave.spring.webmvc.DelegatingTracingFilter.doFilter (DelegatingTracingFilter.java:47)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter (ServletHandler.java:1288)
    at org.eclipse.jetty.servlet.ServletHandler.doHandle (ServletHandler.java:443)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle (ScopedHandler.java:137)
    at org.eclipse.jetty.security.SecurityHandler.handle (SecurityHandler.java:556)
    at org.eclipse.jetty.server.session.SessionHandler.doHandle (SessionHandler.java:227)
    at org.eclipse.jetty.server.handler.ContextHandler.doHandle (ContextHandler.java:1044)
    at org.eclipse.jetty.servlet.ServletHandler.doScope (ServletHandler.java:372)
    at org.eclipse.jetty.server.session.SessionHandler.doScope (SessionHandler.java:189)
    at org.eclipse.jetty.server.handler.ContextHandler.doScope (ContextHandler.java:978)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle (ScopedHandler.java:135)
    at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle (ContextHandlerCollection.java:255)
    at org.eclipse.jetty.server.handler.HandlerCollection.handle (HandlerCollection.java:154)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle (HandlerWrapper.java:116)
    at org.eclipse.jetty.server.Server.handle (Server.java:369)
    at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest (AbstractHttpConnection.java:486)
    at org.eclipse.jetty.server.AbstractHttpConnection.headerComplete (AbstractHttpConnection.java:933)
    at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete (AbstractHttpConnection.java:995)
    at org.eclipse.jetty.http.HttpParser.parseNext (HttpParser.java:644)
    at org.eclipse.jetty.http.HttpParser.parseAvailable (HttpParser.java:235)
    at org.eclipse.jetty.server.AsyncHttpConnection.handle (AsyncHttpConnection.java:82)
    at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle (SelectChannelEndPoint.java:667)
    at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run (SelectChannelEndPoint.java:52)
    at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob (QueuedThreadPool.java:608)
    at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run (QueuedThreadPool.java:543)
    at java.lang.Thread.run (Thread.java:745)
Caused by: java.lang.ClassNotFoundException: java.io.UncheckedIOException
    at java.net.URLClassLoader$1.run (URLClassLoader.java:366)
    at java.net.URLClassLoader$1.run (URLClassLoader.java:355)
    at java.security.AccessController.doPrivileged (Native Method)
    at java.net.URLClassLoader.findClass (URLClassLoader.java:354)
```