### PR TITLE
Fix bugs that fetching traces with old conditions

### DIFF
--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
@@ -12,7 +12,7 @@
  * the License.
  */
 import PropTypes from 'prop-types';
-import React, { useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { withRouter } from 'react-router';
 import moment from 'moment';
@@ -175,15 +175,20 @@ const DiscoverPage = ({ history, location }) => {
     history,
   ]);
 
-  const handleKeyDown = (event) => {
+  const handleKeyDown = useCallback((event) => {
     if (document.activeElement.tagName === 'BODY' && event.key === 'Enter') {
-      findTraces();
+      findData();
     }
-  };
+  }, [findData]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   useMount(() => {
-    window.addEventListener('keydown', handleKeyDown);
-
     // When mounted, parse a query parameter of a browser's address bar
     // and retrieve initial conditions, and setup these conditions as redux state.
     const queryParams = queryString.parse(location.search);

--- a/zipkin-lens/src/components/GlobalSearch/GlobalSearch.jsx
+++ b/zipkin-lens/src/components/GlobalSearch/GlobalSearch.jsx
@@ -21,7 +21,6 @@ import Button from '@material-ui/core/Button';
 import GlobalSearchConditionList from './GlobalSearchConditionList';
 import LimitCondition from './conditions/LimitCondition';
 import LookbackCondition from './conditions/LookbackCondition';
-import { useUnmount } from '../../hooks';
 
 const useStyles = makeStyles({
   findButton: {
@@ -40,14 +39,6 @@ const propTypes = {
 
 const GlobalSearch = ({ findData }) => {
   const classes = useStyles();
-
-  const handleKeyDown = (event) => {
-    if (document.activeElement.tagName === 'BODY' && event.key === 'Enter') {
-      findData();
-    }
-  };
-
-  useUnmount(() => document.removeEventListener('keydown', handleKeyDown));
 
   return (
     <Box


### PR DESCRIPTION
## Summary

After adding conditions in search bar and pushing enter key, I noticed that the conditions were not applied to parameters of the fetching.
This PR fixes this.

### Before

ServiceName condition is not added to the address bar of browser after pushing enter key.

![before](https://user-images.githubusercontent.com/19551419/61162902-af118c00-a545-11e9-92e2-07669e8ffb74.gif)

### After

ServiceName condition is added.

![after](https://user-images.githubusercontent.com/19551419/61162927-d700ef80-a545-11e9-86ac-0ae008442d69.gif)

## Content

* Fix the above bug.
* Remove unnecessary statements.
* Optimize a bit (use useCallback to handleKeyDown).