### PR TITLE
Fix an bug that can not scroll on the Trace page

### DIFF
--- a/zipkin-lens/src/components/App/Layout.jsx
+++ b/zipkin-lens/src/components/App/Layout.jsx
@@ -36,7 +36,7 @@ const Layout = ({ children }) => (
       width="100%"
       pl={3}
       pr={3}
-      overflow="hidden"
+      overflow="auto"
     >
       {children}
     </Box>


### PR DESCRIPTION
This is a little bug.

Before

![before-scroll](https://user-images.githubusercontent.com/19551419/61168473-a80c6d00-a589-11e9-9dcb-5556e8be4a96.gif)

After

![after-scroll](https://user-images.githubusercontent.com/19551419/61168476-b064a800-a589-11e9-89b1-5756d744df12.gif)
