### PR TITLE
Prunes single-span traces after the fact until we can control http sampling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <wire.version>3.0.0-alpha01</wire.version>
     <unpack-proto.directory>${project.build.directory}/test/proto</unpack-proto.directory>
 
-    <brave.version>5.6.6</brave.version>
+    <brave.version>5.6.8</brave.version>
     <cassandra-driver-core.version>3.7.1</cassandra-driver-core.version>
     <okhttp.version>3.14.2</okhttp.version>
     <okio.version>1.17.4</okio.version>

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageAutoConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageAutoConfiguration.java
@@ -152,10 +152,11 @@ public class ZipkinElasticsearchStorageAutoConfiguration {
     return result.build();
   }
 
-  @Bean @Qualifier(QUALIFIER) @ConditionalOnSelfTracing Consumer<HttpClientBuilder>
-  elasticsearchTracing(Optional<Tracing> tracing) {
+  @Bean @Qualifier(QUALIFIER) @ConditionalOnSelfTracing
+  Consumer<HttpClientBuilder> elasticsearchTracing(Optional<Tracing> tracing) {
     if (!tracing.isPresent()) {
-      return client -> {};
+      return client -> {
+      };
     }
     return client -> client.decorator(BraveClient.newDecorator(tracing.get(), "elasticsearch"));
   }


### PR DESCRIPTION
This helps ensure self-tracing isn't overrun with static assets.


Example that shows it works:
<img width="1011" alt="Screenshot 2019-07-14 at 9 31 08 AM" src="https://user-images.githubusercontent.com/64215/61177884-8e673600-a61a-11e9-9b35-4172f141473d.png">

from
```bash
$ SELF_TRACING_ENABLED=true STORAGE_THROTTLE_ENABLED=true STORAGE_TYPE=elasticsearch java -jar ./zipkin-server/target/zipkin-server-*exec.jar
```


See https://github.com/line/armeria/issues/1223