### PR TITLE
Close Cassandra storage during integration tests.

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
@@ -145,10 +145,10 @@ final class CassandraSpanConsumer implements SpanConsumer {
   /** Clears any caches */
   @VisibleForTesting
   void clear() {
-    insertServiceName.clear();
+    if (insertServiceName != null) insertServiceName.clear();
     if (insertRemoteServiceName != null) insertRemoteServiceName.clear();
-    insertSpanName.clear();
-    indexer.clear();
+    if (insertSpanName != null) insertSpanName.clear();
+    if (indexer != null) indexer.clear();
     if (insertAutocompleteValue != null) insertAutocompleteValue.clear();
   }
 

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -22,6 +22,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -59,6 +60,10 @@ public class ITCassandraStorage {
 
     @Before public void connect() {
       storage = backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
+    }
+
+    @After public void disconnect() {
+      storage.close();
     }
 
     @Override protected StorageComponent storage() {
@@ -180,6 +185,10 @@ public class ITCassandraStorage {
         backend.computeStorageBuilder().keyspace(keyspace(testName)).searchEnabled(false).build();
     }
 
+    @After public void disconnect() {
+      storage.close();
+    }
+
     @Override protected StorageComponent storage() {
       return storage;
     }
@@ -200,6 +209,10 @@ public class ITCassandraStorage {
         backend.computeStorageBuilder().keyspace(keyspace(testName)).strictTraceId(false).build();
     }
 
+    @After public void disconnect() {
+      storage.close();
+    }
+
     @Override protected StorageComponent storage() {
       return storage;
     }
@@ -217,6 +230,10 @@ public class ITCassandraStorage {
 
     @Before public void connect() {
       storage = backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
+    }
+
+    @After public void disconnect() {
+      storage.close();
     }
 
     @Override protected StorageComponent storage() {
@@ -249,6 +266,10 @@ public class ITCassandraStorage {
 
     @Before public void connect() {
       storage = backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
+    }
+
+    @After public void disconnect() {
+      storage.close();
     }
 
     @Override protected StorageComponent storage() {

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
@@ -14,6 +14,7 @@
 package zipkin2.storage.cassandra.v1;
 
 import java.io.IOException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin2.Span;
@@ -31,6 +32,10 @@ abstract class ITSpanConsumer {
   @Before
   public void connect() {
     storage = storageBuilder().autocompleteKeys(asList("environment")).keyspace(keyspace()).build();
+  }
+
+  @After public void disconnect() {
+    storage.close();
   }
 
   abstract CassandraStorage.Builder storageBuilder();

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -22,6 +22,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -60,6 +61,10 @@ public class ITCassandraStorage {
 
     @Before public void connect() {
       storage = backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
+    }
+
+    @After public void disconnect() {
+      storage.close();
     }
 
     @Override protected StorageComponent storage() {
@@ -157,6 +162,10 @@ public class ITCassandraStorage {
         backend.computeStorageBuilder().keyspace(keyspace(testName)).searchEnabled(false).build();
     }
 
+    @After public void disconnect() {
+      storage.close();
+    }
+
     @Test public void doesntCreateIndexes() {
       KeyspaceMetadata metadata =
         storage.session().getCluster().getMetadata().getKeyspace(keyspace(testName));
@@ -185,6 +194,10 @@ public class ITCassandraStorage {
         backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
       storage =
         backend.computeStorageBuilder().keyspace(keyspace(testName)).strictTraceId(false).build();
+    }
+
+    @After public void disconnect() {
+      storage.close();
     }
 
     /** Ensures we can still lookup fully 128-bit traces when strict trace ID id disabled */
@@ -219,6 +232,10 @@ public class ITCassandraStorage {
       storage = backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
     }
 
+    @After public void disconnect() {
+      storage.close();
+    }
+
     @Override protected StorageComponent storage() {
       return storage;
     }
@@ -249,6 +266,10 @@ public class ITCassandraStorage {
 
     @Before public void connect() {
       storage = backend.computeStorageBuilder().keyspace(keyspace(testName)).build();
+    }
+
+    @After public void disconnect() {
+      storage.close();
     }
 
     @Override protected StorageComponent storage() {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
@@ -15,6 +15,7 @@ package zipkin2.storage.cassandra;
 
 import java.io.IOException;
 import java.util.stream.IntStream;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin2.Span;
@@ -32,6 +33,10 @@ abstract class ITSpanConsumer {
 
   @Before public void connect() {
     storage = storageBuilder().autocompleteKeys(asList("environment")).keyspace(keyspace()).build();
+  }
+
+  @After public void disconnect() {
+    storage.close();
   }
 
   abstract CassandraStorage.Builder storageBuilder();

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
@@ -14,8 +14,10 @@
 package zipkin2.storage;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.List;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin2.Span;
@@ -34,6 +36,14 @@ public abstract class ITAutocompleteTags {
 
   @Before public void before() {
     storage = storageBuilder().autocompleteKeys(asList("http.host")).build();
+  }
+
+  @After public void after() {
+    try {
+      storage.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   protected abstract StorageComponent.Builder storageBuilder();


### PR DESCRIPTION
Don't expect a huge difference in test time or anything but seems like a good idea not to leak sessions if nothing else than as principle.