### PR TITLE
Await endpoints in check, not httpClient

### DIFF
--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -253,7 +253,7 @@ public class ITCassandraStorage {
       return backend.computeStorageBuilder().keyspace(keyspace(testName));
     }
 
-    @Before @Override public void clear() {
+    @Override public void clear() {
       dropKeyspace(backend.session(), keyspace(testName));
     }
   }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -253,7 +253,7 @@ public class ITCassandraStorage {
       return backend.computeStorageBuilder().keyspace(keyspace(testName));
     }
 
-    @Before @Override public void clear() {
+    @Override public void clear() {
       dropKeyspace(backend.session(), keyspace(testName));
     }
   }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -16,6 +16,7 @@ package zipkin2.elasticsearch.integration;
 import java.io.IOException;
 import java.util.List;
 import org.junit.AfterClass;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -23,6 +24,7 @@ import org.junit.Rule;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import zipkin2.CheckResult;
 import zipkin2.Span;
 import zipkin2.elasticsearch.ElasticsearchStorage;
 import zipkin2.elasticsearch.InternalForTests;
@@ -45,6 +47,10 @@ public class ITElasticsearchStorageV6 {
 
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test").build();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {
@@ -68,6 +74,10 @@ public class ITElasticsearchStorageV6 {
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test")
         .searchEnabled(false).build();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {
@@ -90,6 +100,10 @@ public class ITElasticsearchStorageV6 {
 
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test").build();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {
@@ -125,6 +139,10 @@ public class ITElasticsearchStorageV6 {
 
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test").strictTraceId(false).build();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {
@@ -147,6 +165,10 @@ public class ITElasticsearchStorageV6 {
 
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test").build();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -127,7 +127,7 @@ public class ITElasticsearchStorageV6 {
       return backend.computeStorageBuilder().index(index(testName));
     }
 
-    @Before @Override public void clear() throws IOException {
+    @Override public void clear() throws IOException {
       ((ElasticsearchStorage) storage).clear();
     }
   }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
@@ -16,6 +16,7 @@ package zipkin2.elasticsearch.integration;
 import java.io.IOException;
 import java.util.List;
 import org.junit.AfterClass;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -23,6 +24,7 @@ import org.junit.Rule;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import zipkin2.CheckResult;
 import zipkin2.Span;
 import zipkin2.elasticsearch.ElasticsearchStorage;
 import zipkin2.elasticsearch.InternalForTests;
@@ -45,7 +47,10 @@ public class ITElasticsearchStorageV7 {
 
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test").build();
-      storage.check();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {
@@ -69,6 +74,10 @@ public class ITElasticsearchStorageV7 {
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test")
         .searchEnabled(false).build();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {
@@ -91,6 +100,10 @@ public class ITElasticsearchStorageV7 {
 
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test").build();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {
@@ -126,6 +139,10 @@ public class ITElasticsearchStorageV7 {
 
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test").strictTraceId(false).build();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {
@@ -148,6 +165,10 @@ public class ITElasticsearchStorageV7 {
 
     @BeforeClass public static void connect() {
       storage = backend.computeStorageBuilder().index("zipkin-test").build();
+      CheckResult check = storage.check();
+      if (!check.ok()) {
+        throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      }
     }
 
     @Override protected StorageComponent storage() {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
@@ -127,7 +127,7 @@ public class ITElasticsearchStorageV7 {
       return backend.computeStorageBuilder().index(index(testName));
     }
 
-    @Before @Override public void clear() throws IOException {
+    @Override public void clear() throws IOException {
       ((ElasticsearchStorage) storage).clear();
     }
   }

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jooq.DSLContext;
 import org.jooq.Query;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -139,7 +138,7 @@ public class ITMySQLStorage {
       return storage.computeStorageBuilder();
     }
 
-    @Before @Override public void clear() {
+    @Override public void clear() {
       storage.get().clear();
     }
   }

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
@@ -16,8 +16,10 @@ package zipkin2.storage;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin2.CheckResult;
 import zipkin2.Span;
 import zipkin2.TestObjects;
 
@@ -34,6 +36,10 @@ public abstract class ITAutocompleteTags {
 
   @Before public void before() {
     storage = storageBuilder().autocompleteKeys(asList("http.host")).build();
+    CheckResult check = storage.check();
+    if (!check.ok()) {
+      throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+    }
   }
 
   protected abstract StorageComponent.Builder storageBuilder();

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
@@ -44,7 +44,8 @@ public abstract class ITAutocompleteTags {
     }
   }
 
-  @After public void after() {
+  @After public void after() throws Exception {
+    clear();
     try {
       storage.close();
     } catch (IOException e) {
@@ -55,7 +56,7 @@ public abstract class ITAutocompleteTags {
   protected abstract StorageComponent.Builder storageBuilder();
 
   /** Clears store between tests. */
-  @Before public abstract void clear() throws Exception;
+  public abstract void clear() throws Exception;
 
   @Test public void Should_not_store_when_key_not_in_autocompleteTags() throws IOException {
     accept(TestObjects.LOTS_OF_SPANS[0].toBuilder()


### PR DESCRIPTION
Noticed that some non-integration tests were slow waiting and failing on the initial endpoints because they don't have real ones. It was dubious to be waiting in the method that creates an object anyways, so I moved it to `check` which seems like the right spot. Reduced the timeout to use the configured one too.

Also apply some cleanups mentioned in #2653 