### PR TITLE
Fix ReadBuffer when wrapping an array at an offset.

### DIFF
--- a/zipkin/src/main/java/zipkin2/internal/ReadBuffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/ReadBuffer.java
@@ -27,8 +27,7 @@ public abstract class ReadBuffer extends InputStream {
   public static ReadBuffer wrapUnsafe(ByteBuffer buffer) {
     if (buffer.hasArray()) {
       int offset = buffer.arrayOffset() + buffer.position();
-      int limit = offset + buffer.remaining();
-      return wrap(buffer.array(), offset, limit);
+      return wrap(buffer.array(), offset, buffer.remaining());
     }
     return buffer.order() == ByteOrder.BIG_ENDIAN
       ? new BigEndianByteBuffer(buffer)
@@ -39,8 +38,8 @@ public abstract class ReadBuffer extends InputStream {
     return wrap(bytes, 0, bytes.length);
   }
 
-  public static ReadBuffer wrap(byte[] bytes, int pos, int limit) {
-    return new ReadBuffer.Array(bytes, pos, limit);
+  public static ReadBuffer wrap(byte[] bytes, int pos, int length) {
+    return new ReadBuffer.Array(bytes, pos, length);
   }
 
   static final class BigEndianByteBuffer extends Buff {
@@ -153,11 +152,11 @@ public abstract class ReadBuffer extends InputStream {
 
   static final class Array extends ReadBuffer {
     final byte[] buf;
-    int offset, length;
+    int arrayOffset, offset, length;
 
     Array(byte[] buf, int offset, int length) {
       this.buf = buf;
-      this.offset = offset;
+      this.arrayOffset = this.offset = offset;
       this.length = length;
     }
 
@@ -233,7 +232,7 @@ public abstract class ReadBuffer extends InputStream {
     }
 
     @Override public int pos() {
-      return offset;
+      return offset - arrayOffset;
     }
 
     @Override public long skip(long maxCount) {
@@ -243,7 +242,7 @@ public abstract class ReadBuffer extends InputStream {
     }
 
     @Override public int available() {
-      return length - offset;
+      return length - (offset - arrayOffset);
     }
   }
 

--- a/zipkin/src/test/java/zipkin2/codec/SpanBytesDecoderTest.java
+++ b/zipkin/src/test/java/zipkin2/codec/SpanBytesDecoderTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.codec;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -186,6 +187,34 @@ public class SpanBytesDecoderTest {
     byte[] message = SpanBytesEncoder.PROTO3.encodeList(TRACE);
 
     assertThat(SpanBytesDecoder.PROTO3.decodeList(message)).isEqualTo(TRACE);
+  }
+
+  @Test
+  public void traceRoundTrip_PROTO3_directBuffer() {
+    byte[] message = SpanBytesEncoder.PROTO3.encodeList(TRACE);
+    ByteBuffer buf = ByteBuffer.allocateDirect(message.length);
+    buf.put(message);
+    buf.flip();
+
+    assertThat(SpanBytesDecoder.PROTO3.decodeList(buf)).isEqualTo(TRACE);
+  }
+
+  @Test
+  public void traceRoundTrip_PROTO3_heapBuffer() {
+    byte[] message = SpanBytesEncoder.PROTO3.encodeList(TRACE);
+    ByteBuffer buf = ByteBuffer.wrap(message);
+
+    assertThat(SpanBytesDecoder.PROTO3.decodeList(buf)).isEqualTo(TRACE);
+  }
+
+  @Test
+  public void traceRoundTrip_PROTO3_heapBufferOffset() {
+    byte[] message = SpanBytesEncoder.PROTO3.encodeList(TRACE);
+    byte[] array = new byte[message.length + 4 + 5];
+    System.arraycopy(message, 0, array, 4, message.length);
+    ByteBuffer buf = ByteBuffer.wrap(array, 4, message.length);
+
+    assertThat(SpanBytesDecoder.PROTO3.decodeList(buf)).isEqualTo(TRACE);
   }
 
   @Test public void spansRoundTrip_JSON_V2() {

--- a/zipkin/src/test/java/zipkin2/internal/Proto3FieldsTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/Proto3FieldsTest.java
@@ -139,7 +139,7 @@ public class Proto3FieldsTest {
     VarintField field = new VarintField(128 << 3 | WIRETYPE_VARINT);
     field.write(buf, 0xffffffffffffffffL);
 
-    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length);
+    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length - 1);
     skipValue(readBuffer, WIRETYPE_VARINT);
   }
 
@@ -147,7 +147,7 @@ public class Proto3FieldsTest {
     Utf8Field field = new Utf8Field(128 << 3 | WIRETYPE_LENGTH_DELIMITED);
     field.write(buf, "订单维护服务");
 
-    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length);
+    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length - 1);
     skipValue(readBuffer, WIRETYPE_LENGTH_DELIMITED);
   }
 
@@ -155,7 +155,7 @@ public class Proto3FieldsTest {
     Fixed64Field field = new Fixed64Field(128 << 3 | WIRETYPE_FIXED64);
     field.write(buf, 0xffffffffffffffffL);
 
-    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length);
+    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length - 1);
     skipValue(readBuffer, WIRETYPE_FIXED64);
   }
 
@@ -167,7 +167,7 @@ public class Proto3FieldsTest {
     buf.writeByte(0xff);
     buf.writeByte(0xff);
 
-    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length);
+    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length - 1);
     skipValue(readBuffer, WIRETYPE_FIXED32);
   }
 
@@ -175,7 +175,7 @@ public class Proto3FieldsTest {
     BytesField field = new BytesField(128 << 3 | WIRETYPE_LENGTH_DELIMITED);
     field.write(buf, new byte[10]);
 
-    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length);
+    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length - 1);
     assertThat(readBuffer.readVarint32())
       .isEqualTo(10);
   }
@@ -197,7 +197,7 @@ public class Proto3FieldsTest {
     Fixed64Field field = new Fixed64Field(128 << 3 | WIRETYPE_FIXED64);
     field.write(buf, 0xffffffffffffffffL);
 
-    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length);
+    ReadBuffer readBuffer = ReadBuffer.wrap(bytes, 1 /* skip the key */, bytes.length - 1);
     assertThat(field.readValue(readBuffer))
       .isEqualTo(0xffffffffffffffffL);
   }

--- a/zipkin/src/test/java/zipkin2/internal/ReadBufferTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/ReadBufferTest.java
@@ -29,6 +29,14 @@ public class ReadBufferTest {
     assertThat(readBuffer.readUtf8(readBuffer.available()))
       .isEqualTo("love");
   }
+  @Test public void byteBuffer_arrayOffset() {
+    ByteBuffer buf = ByteBuffer.wrap("glove".getBytes(UTF_8), 1, 4);
+    ReadBuffer readBuffer = ReadBuffer.wrapUnsafe(buf.slice());
+    assertThat(readBuffer.pos()).isEqualTo(0);
+    assertThat(readBuffer.available()).isEqualTo(4);
+    assertThat(readBuffer.readUtf8(readBuffer.available()))
+      .isEqualTo("love");
+  }
 
   @Test public void readVarint32() {
     assertReadVarint32(0);


### PR DESCRIPTION
Hmm - this is really broken.

The issue only happens with gzipped requests, where unzipping moves the content from direct memory to pooled heap buffers. Presumably its triggered by larger requests since the sender only gzips past some threshold though I didn't verify that behavior.

The problem came by mixing limit and length in the code. When wrapping in Java, it's more conventional to use length, so I made the APIs consistently use length.

Fixes #2662