### PR TITLE
Cleans up some Elasticsearch configuration prior to release

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -162,7 +162,7 @@ These settings can be used to help tune the rate at which Zipkin flushes data to
 
     * `STORAGE_THROTTLE_ENABLED`: Enables throttling
     * `STORAGE_THROTTLE_MIN_CONCURRENCY`: Minimum number of Threads to use for writing to storage.
-    * `STORAGE_THROTTLE_MAX_CONCURRENCY`: Maximum number of Threads to use for writing to storage.  In order to avoid configuration drift, this value may override other, storage-specific values such as Elasticsearch's `ES_MAX_REQUESTS`.
+    * `STORAGE_THROTTLE_MAX_CONCURRENCY`: Maximum number of Threads to use for writing to storage.
     * `STORAGE_THROTTLE_MAX_QUEUE_SIZE`: How many messages to buffer while all Threads are writing data before abandoning a message (0 = no buffering).
 
 As this feature is experimental, it is not recommended to run this in production environments.
@@ -202,8 +202,6 @@ The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
     * `ES_PIPELINE`: Indicates the ingest pipeline used before spans are indexed. No default.
     * `ES_TIMEOUT`: Controls the connect, read and write socket timeouts (in milliseconds) for
                     Elasticsearch Api. Defaults to 10000 (10 seconds)
-    * `ES_MAX_REQUESTS`: Only valid when the transport is http. Sets maximum in-flight requests from
-                         this process to any Elasticsearch host. Defaults to 64.
     * `ES_INDEX`: The index prefix to use when generating daily index names. Defaults to zipkin.
     * `ES_DATE_SEPARATOR`: The date separator to use when generating daily index names. Defaults to '-'.
     * `ES_INDEX_SHARDS`: The number of shards to split the index into. Each shard and its replicas

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -129,7 +129,6 @@ zipkin:
       # host is left unset intentionally, to defer the decision
       hosts: ${ES_HOSTS:}
       pipeline: ${ES_PIPELINE:}
-      max-requests: ${ES_MAX_REQUESTS:64}
       timeout: ${ES_TIMEOUT:10000}
       index: ${ES_INDEX:zipkin}
       date-separator: ${ES_DATE_SEPARATOR:-}
@@ -138,7 +137,6 @@ zipkin:
       username: ${ES_USERNAME:}
       password: ${ES_PASSWORD:}
       http-logging: ${ES_HTTP_LOGGING:}
-      legacy-reads-enabled: ${ES_LEGACY_READS_ENABLED:true}
     mysql:
       jdbc-url: ${MYSQL_JDBC_URL:}
       host: ${MYSQL_HOST:localhost}

--- a/zipkin-server/src/test/java/zipkin2/elasticsearch/ZipkinElasticsearchStorageAutoConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/elasticsearch/ZipkinElasticsearchStorageAutoConfigurationTest.java
@@ -94,18 +94,6 @@ public class ZipkinElasticsearchStorageAutoConfigurationTest {
     assertThat(es().pipeline()).isEqualTo("zipkin");
   }
 
-  @Test public void configuresMaxRequests() {
-    TestPropertyValues.of(
-      "zipkin.storage.type:elasticsearch",
-      "zipkin.storage.elasticsearch.hosts:http://host1:9200",
-      "zipkin.storage.elasticsearch.max-requests:200")
-      .applyTo(context);
-    Access.registerElasticsearchHttp(context);
-    context.refresh();
-
-    assertThat(es().maxRequests()).isEqualTo(200);
-  }
-
   /** This helps ensure old setups don't break (provided they have http port 9200 open) */
   @Test public void coersesPort9300To9200() {
     TestPropertyValues.of(

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -88,7 +88,6 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
       .clientFactoryCustomizer(unused -> {
       })
       .hosts(Collections.singletonList("http://localhost:9200"))
-      .maxRequests(64)
       .strictTraceId(true)
       .searchEnabled(true)
       .index("zipkin")
@@ -143,15 +142,6 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
      * value is only read once.
      */
     public abstract Builder hostsSupplier(HostsSupplier hosts);
-
-    /**
-     * Sets maximum in-flight requests from this process to any Elasticsearch host. Defaults to 64
-     *
-     * <p>A backlog is not permitted. Once this number of requests are in-flight, future requests
-     * will drop until we are under maxRequests again. This allows the server to remain up during a
-     * traffic surge.
-     */
-    public abstract Builder maxRequests(int maxRequests);
 
     /**
      * Only valid when the destination is Elasticsearch 5.x. Indicates the ingest pipeline used
@@ -249,12 +239,9 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
 
   public abstract HostsSupplier hostsSupplier();
 
-  @Nullable
-  public abstract String pipeline();
+  @Nullable public abstract String pipeline();
 
   public abstract boolean flushOnWrites();
-
-  public abstract int maxRequests();
 
   public abstract boolean strictTraceId();
 
@@ -529,7 +516,7 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
 
   @Memoized // hosts resolution might imply a network call, and we might make a new client instance
   public HttpCall.Factory http() {
-    return new HttpCall.Factory(httpClient(), maxRequests());
+    return new HttpCall.Factory(httpClient());
   }
 
   ElasticsearchStorage() {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
@@ -57,11 +57,10 @@ public class HttpCallTest {
   HttpCall.Factory http;
 
   @Before public void setUp() {
-    http = new HttpCall.Factory(HttpClient.of(server.httpUri("/")), Integer.MAX_VALUE);
+    http = new HttpCall.Factory(HttpClient.of(server.httpUri("/")));
   }
 
-  @Test
-  public void propagatesOnDispatcherThreadWhenFatal() throws Exception {
+  @Test public void propagatesOnDispatcherThreadWhenFatal() throws Exception {
     MOCK_RESPONSE.set(SUCCESS_RESPONSE);
 
     final LinkedBlockingQueue<Object> q = new LinkedBlockingQueue<>();
@@ -88,8 +87,7 @@ public class HttpCallTest {
     }
   }
 
-  @Test
-  public void executionException_conversionException() throws Exception {
+  @Test public void executionException_conversionException() throws Exception {
     MOCK_RESPONSE.set(SUCCESS_RESPONSE);
 
     Call<?> call = http.newCall(REQUEST, b -> {
@@ -104,8 +102,7 @@ public class HttpCallTest {
     }
   }
 
-  @Test
-  public void cloned() throws Exception {
+  @Test public void cloned() throws Exception {
     MOCK_RESPONSE.set(SUCCESS_RESPONSE);
 
     Call<?> call = http.newCall(REQUEST, b -> null);
@@ -123,8 +120,7 @@ public class HttpCallTest {
     call.clone().execute();
   }
 
-  @Test
-  public void executionException_httpFailure() throws Exception {
+  @Test public void executionException_httpFailure() throws Exception {
     MOCK_RESPONSE.set(AggregatedHttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR));
 
     Call<?> call = http.newCall(REQUEST, b -> null);

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchCallFactoryTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchCallFactoryTest.java
@@ -22,15 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SearchCallFactoryTest {
 
-  @Mock
-  private HttpClient httpClient;
+  @Mock HttpClient httpClient;
 
-  SearchCallFactory client =
-    new SearchCallFactory(new HttpCall.Factory(httpClient, 0));
+  SearchCallFactory client = new SearchCallFactory(new HttpCall.Factory(httpClient));
 
   /** Declaring queries alphabetically helps simplify amazon signature logic */
-  @Test
-  public void lenientSearchOrdersQueryAlphabetically() {
+  @Test public void lenientSearchOrdersQueryAlphabetically() {
     assertThat(client.lenientSearch(asList("zipkin:span-2016-10-01"), null))
         .endsWith("/_search?allow_no_indices=true&expand_wildcards=open&ignore_unavailable=true");
   }


### PR DESCRIPTION
Notably `ES_MAX_REQUESTS` is unusable in real life, so this removes
support as we've changed other things anyway. This also exposes the
`HostsSupplier` so that zipkin-aws can use it in case of static urls.