### PR TITLE
Fix LookbackCondition's warning

### DIFF
--- a/zipkin-lens/src/components/GlobalSearch/conditions/LookbackCondition.jsx
+++ b/zipkin-lens/src/components/GlobalSearch/conditions/LookbackCondition.jsx
@@ -45,6 +45,7 @@ const lookbackOptions = [
   { value: 'custom', label: 'Custom' },
 ];
 
+// Create a map like { '1m': '1 Minute', '5m': '5 Minutes', ... }
 const lookbackOptionMap = lookbackOptions.reduce((acc, cur) => {
   acc[cur.value] = cur.label;
   return acc;
@@ -145,14 +146,15 @@ const LookbackCondition = () => {
   const renderMenuItems = (lookbackOption) => {
     if (lookbackOption.value === 'more') {
       return (
-        <MenuItem onClick={handleMoreClick} key={lookbackCondition.value}>
+        <MenuItem onClick={handleMoreClick} key={lookbackOption.value}>
           {lookbackOption.label}
         </MenuItem>
       );
     }
+
     return (
       <MenuItem
-        key={lookbackCondition.value}
+        key={lookbackOption.value}
         onClick={() => {
           setMenuAnchor(null);
           dispatch(setLookbackCondition({
@@ -205,7 +207,7 @@ const LookbackCondition = () => {
         open={Boolean(menuAnchor)}
         onClose={handleMenuClose}
       >
-        { lookbackMenuOptions.map(renderMenuItems) }
+        {lookbackMenuOptions.map(renderMenuItems)}
       </Menu>
       <Dialog open={isModalOpen} onClose={handleModalClose}>
         <DialogTitle>


### PR DESCRIPTION
Because I mistakenly set key props to MenuItem component, the following warning has happened.

```
react-dom.development.js?61bb:506 Warning: Encountered two children with the same key, `.$1h`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
    in ul (created by ForwardRef(List))
    in ForwardRef(List) (created by WithStyles(ForwardRef(List)))
    in WithStyles(ForwardRef(List)) (created by ForwardRef(MenuList))
    in ForwardRef(MenuList) (created by ForwardRef(Menu))
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by Transition)
    in Transition (created by ForwardRef(Grow))
    in ForwardRef(Grow) (created by WithTheme(ForwardRef(Grow)))
    in WithTheme(ForwardRef(Grow)) (created by TrapFocus)
    in TrapFocus (created by Modal)
    in div (created by Modal)
    in ForwardRef(Portal) (created by Modal)
    in Modal (created by ForwardRef(Modal))
    in ForwardRef(Modal) (created by WithTheme(ForwardRef(Modal)))
    in WithTheme(ForwardRef(Modal)) (created by ForwardRef(Popover))
    in ForwardRef(Popover) (created by WithStyles(ForwardRef(Popover)))
    in WithStyles(ForwardRef(Popover)) (created by ForwardRef(Menu))
    in ForwardRef(Menu) (created by WithStyles(ForwardRef(Menu)))
    in WithStyles(ForwardRef(Menu)) (created by LookbackCondition)
    in div (created by Styled(MuiBox))
    in Styled(MuiBox) (created by LookbackCondition)
    in LookbackCondition (created by GlobalSearch)
    in div (created by Styled(MuiBox))
    in Styled(MuiBox) (created by GlobalSearch)
    in GlobalSearch (created by Context.Consumer)
    in withRouter(GlobalSearch) (created by DiscoverPage)
    in DiscoverPage (created by Context.Consumer)
    in withRouter(DiscoverPage) (created by Context.Consumer)
    in Route (created by App)
    in main (created by Styled(MuiBox))
    in Styled(MuiBox) (created by Layout)
    in div (created by Styled(MuiBox))
    in Styled(MuiBox) (created by Layout)
    in Layout (created by App)
    in Router (created by BrowserRouter)
    in BrowserRouter (created by App)
    in Provider (created by App)
    in ThemeProvider (created by App)
    in MuiPickersUtilsProvider (created by App)
    in App
```

This PR fixes this.