### PR TITLE
Run span accepting logic on blocking executor.

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinGrpcCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinGrpcCollector.java
@@ -70,6 +70,8 @@ final class ZipkinGrpcCollector {
         CompletableFutureCallback result = new CompletableFutureCallback();
         List<Span> spans = SpanBytesDecoder.PROTO3.decodeList(bytes.nioBuffer());
 
+        // collector.accept might block so need to move off the event loop. We make sure the
+        // callback is context aware to continue the trace.
         ServiceRequestContext.mapCurrent(
           ctx -> ctx.makeContextAware(ctx.blockingTaskExecutor()),
           CommonPools::blockingTaskExecutor).execute(() -> collector.accept(spans, result));

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
@@ -159,7 +159,8 @@ public class ZipkinHttpCollector {
           return null;
         }
 
-        // collector.accept might block so need to move off the event loop
+        // collector.accept might block so need to move off the event loop. We make sure the
+        // callback is context aware to continue the trace.
         ctx.blockingTaskExecutor().execute(ctx.makeContextAware(() -> {
           // UnzippingBytesRequestConverter handles incrementing message and bytes
           collector.accept(spans, result);

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
@@ -159,9 +159,7 @@ public class ZipkinHttpCollector {
           return null;
         }
 
-        // collector.accept looks like an async API, but currently some of our storage
-        // implementations run blocking logic during processing of the async method. For now, we
-        // move to the blocking executor.
+        // collector.accept might block so need to move off the event loop
         ctx.blockingTaskExecutor().execute(ctx.makeContextAware(() -> {
           // UnzippingBytesRequestConverter handles incrementing message and bytes
           collector.accept(spans, result);

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
@@ -154,30 +154,6 @@ public class ZipkinServerConfiguration implements WebMvcConfigurer {
   }
 
   @Configuration
-  static class StorageComponentEagerInitializer implements BeanPostProcessor {
-
-    @Override
-    public Object postProcessBeforeInitialization(Object bean, String beanName) {
-      return bean;
-    }
-
-    @Override
-    public Object postProcessAfterInitialization(Object bean, String beanName) {
-      if (bean instanceof StorageComponent) {
-        // These provide asynchronous APIs, however some storage implementations like Elasticsearch
-        // and Cassandra will run blocking logic in their constructors, which is not allowed for
-        // asynchronous APIs. We go ahead and eagerly initialize them to run the initialization
-        // logic in advance.
-        StorageComponent storage = (StorageComponent) bean;
-        storage.autocompleteTags();
-        storage.spanConsumer();
-        storage.spanStore();
-      }
-      return bean;
-    }
-  }
-
-  @Configuration
   @ConditionalOnSelfTracing
   static class TracingStorageComponentEnhancer implements BeanPostProcessor {
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -263,6 +263,7 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   public abstract int namesLookback();
 
   @Override
+  @Memoized // Memoized to reduce garbage as this is effectively a singleton.
   public SpanStore spanStore() {
     ensureIndexTemplates();
     return new ElasticsearchSpanStore(this);
@@ -274,12 +275,14 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   }
 
   @Override
+  @Memoized // Memoized to reduce garbage as this is effectively a singleton.
   public AutocompleteTags autocompleteTags() {
     ensureIndexTemplates();
     return new ElasticsearchAutocompleteTags(this);
   }
 
   @Override
+  @Memoized // Memoized to reduce garbage as this is effectively a singleton.
   public SpanConsumer spanConsumer() {
     ensureIndexTemplates();
     return new ElasticsearchSpanConsumer(this);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -263,7 +263,6 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   public abstract int namesLookback();
 
   @Override
-  @Memoized // Memoized to reduce garbage as this is effectively a singleton.
   public SpanStore spanStore() {
     ensureIndexTemplates();
     return new ElasticsearchSpanStore(this);
@@ -275,14 +274,12 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   }
 
   @Override
-  @Memoized // Memoized to reduce garbage as this is effectively a singleton.
   public AutocompleteTags autocompleteTags() {
     ensureIndexTemplates();
     return new ElasticsearchAutocompleteTags(this);
   }
 
   @Override
-  @Memoized // Memoized to reduce garbage as this is effectively a singleton.
   public SpanConsumer spanConsumer() {
     ensureIndexTemplates();
     return new ElasticsearchSpanConsumer(this);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
@@ -94,9 +94,10 @@ public final class HttpCall<V> extends Call.Base<V> {
   }
 
   @Override protected V doExecute() throws IOException {
+    // TODO: testme
     for (EventExecutor eventLoop : httpClient.factory().eventLoopGroup()) {
       if (eventLoop.inEventLoop()) {
-        throw new IllegalStateException("Attempting to make a blocking request from an event loop. "
+        throw new RuntimeException("Attempting to make a blocking request from an event loop. "
           + "Either use doEnqueue() or run this in a separate thread.");
       }
     }


### PR DESCRIPTION
Our storage components expose asynchronous APIs, but this is somewhat deceptive since some of their parts run blocking logic in constructors which isn't allowed. We currently are not using event loops properly during the time the server gets ready but it's ok since the blocking calls eventually complete and aren't ever made again. Switching to Armeria client for ES though means that the blocking call itself also needs to use the event loop, and if a server and client call get assigned to the same event loop, the thread hangs forever.

This has the span accepting logic run on a blocking executor thread. It's a bit more overhead, but shouldn't be too bad.

I also found a trick in the cassandra client library for preventing accidentally deadlocking like this.