### PR TITLE
Enlists load related errors from cassandra in storage throttling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <unpack-proto.directory>${project.build.directory}/test/proto</unpack-proto.directory>
 
     <brave.version>5.6.9</brave.version>
-    <cassandra-driver-core.version>3.7.1</cassandra-driver-core.version>
+    <cassandra-driver-core.version>3.7.2</cassandra-driver-core.version>
     <okhttp.version>3.14.2</okhttp.version>
     <okio.version>1.17.4</okio.version>
     <jooq.version>3.11.11</jooq.version>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -251,7 +251,7 @@
     <dependency>
       <groupId>com.netflix.concurrency-limits</groupId>
       <artifactId>concurrency-limits-core</artifactId>
-      <version>0.3.2</version>
+      <version>0.3.6</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/call/ResultSetFutureCallTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/call/ResultSetFutureCallTest.java
@@ -14,10 +14,16 @@
 package zipkin2.storage.cassandra.internal.call;
 
 import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.exceptions.BusyConnectionException;
+import com.datastax.driver.core.exceptions.BusyPoolException;
+import com.datastax.driver.core.exceptions.QueryConsistencyException;
+import java.net.InetSocketAddress;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import org.junit.Test;
 import zipkin2.Callback;
 
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.JdkFutureAdapters.listenInPoolThread;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
@@ -81,5 +87,24 @@ public class ResultSetFutureCallTest {
     // ensure the callback received the exception
     verify(callback).onError(any(IllegalArgumentException.class));
     verifyNoMoreInteractions(callback);
+  }
+
+  // below are load related exceptions which should result in a backoff of storage requests
+  @Test(expected = RejectedExecutionException.class)
+  public void getUninterruptibly_wrapsBusyPoolException() {
+    InetSocketAddress sa = InetSocketAddress.createUnresolved("host", 9402);
+    ResultSetFutureCall.getUninterruptibly(immediateFailedFuture(new BusyPoolException(sa, 100)));
+  }
+
+  @Test(expected = RejectedExecutionException.class)
+  public void getUninterruptibly_wrapsBusyConnectionException() {
+    InetSocketAddress sa = InetSocketAddress.createUnresolved("host", 9402);
+    ResultSetFutureCall.getUninterruptibly(immediateFailedFuture(new BusyConnectionException(sa)));
+  }
+
+  @Test(expected = RejectedExecutionException.class)
+  public void getUninterruptibly_wrapsQueryConsistencyException() {
+    ResultSetFutureCall.getUninterruptibly(
+      immediateFailedFuture(mock(QueryConsistencyException.class)));
   }
 }


### PR DESCRIPTION
This classifies the following exception trees as possibly recoverable.
The storage throttling feature should back off when encountered.

* BusyPoolException
* BusyConnectionException
* QueryConsistencyException

cc @openzipkin/cassandra @Logic-32 