### PR TITLE
Translate UnprocessedRequestException to RejectedExecutionException.

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import zipkin2.CheckResult;
@@ -257,7 +256,6 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
         HttpMethod.GET, "/_cluster/health/" + index);
       return http.newCall(request, READ_STATUS, "get-cluster-health").execute();
     } catch (IOException | RuntimeException e) {
-      if (e instanceof CompletionException) return CheckResult.failed(e.getCause());
       return CheckResult.failed(e);
     }
   }

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
@@ -172,6 +172,8 @@ public final class HttpCall<V> extends Call.Base<V> {
     responseFuture = responseFuture.exceptionally(t -> {
       if (t instanceof UnprocessedRequestException) {
         Throwable cause = t.getCause();
+        // Go ahead and reduce the output in logs since this is usually a configuration or
+        // infrastructure issue and the Armeria stack trace won't help debugging that.
         Exceptions.clearTrace(cause);
         throw new RejectedExecutionException("Rejected execution: " + cause.getMessage(), cause);
       } else {

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
@@ -16,6 +16,7 @@ package zipkin2.elasticsearch.internal.client;
 import com.fasterxml.jackson.core.JsonParser;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
@@ -23,6 +24,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
@@ -33,6 +35,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
 import zipkin2.Call;
 import zipkin2.Callback;
 
@@ -158,6 +161,16 @@ public final class HttpCall<V> extends Call.Base<V> {
         ctx -> response.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()),
         // This should never be used in practice since the module runs in an Armeria server.
         response::aggregate);
+    responseFuture = responseFuture.exceptionally(t -> {
+      if (t instanceof UnprocessedRequestException) {
+        Throwable cause = t.getCause();
+        Exceptions.clearTrace(cause);
+        throw new RejectedExecutionException("Could not process request.", cause);
+      } else {
+        Exceptions.throwUnsafely(t);
+      }
+      return null;
+    });
     this.responseFuture = responseFuture;
     return responseFuture;
   }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/HttpCallTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/HttpCallTest.java
@@ -231,7 +231,7 @@ public class HttpCallTest {
 
     assertThatThrownBy(() -> http.newCall(REQUEST, BodyConverters.NULL, "test").execute())
       .isInstanceOf(RejectedExecutionException.class)
-      .hasMessageContaining("No endpoints");
+      .hasMessage("Rejected execution: No endpoints");
   }
 
   // TODO(adriancole): Find a home for this generic conversion between Call and Java 8.


### PR DESCRIPTION
Also unwrap `CompletionException`

Fixes #2714 

Log message looks like

```
2019-07-31 15:43:17.433  WARN 18272 --- [cking-tasks-1-3] c.l.a.i.a.DefaultExceptionHandler        : [id: 0x124a5aa0, L:/0:0:0:0:0:0:0:1:9411 - R:/0:0:0:0:0:0:0:1:51877][h1c://desktop-6rdo32o:9411/zipkin/api/v2/services#GET] Unhandled exception from an annotated service:

java.util.concurrent.RejectedExecutionException: Could not process request.
	at zipkin2.elasticsearch.internal.client.HttpCall.lambda$sendRequest$3(HttpCall.java:168) ~[classes/:?]
	at java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:986) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:970) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at com.linecorp.armeria.common.HttpMessageAggregator.fail(HttpMessageAggregator.java:146) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.HttpMessageAggregator.onError(HttpMessageAggregator.java:60) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.stream.AbstractStreamMessage$CloseEvent.notifySubscriber(AbstractStreamMessage.java:370) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberOfCloseEvent(DefaultStreamMessage.java:194) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.handleCloseEvent(DefaultStreamMessage.java:363) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber0(DefaultStreamMessage.java:306) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.doRequest(DefaultStreamMessage.java:181) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.request(DefaultStreamMessage.java:166) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.stream.AbstractStreamMessage$SubscriptionImpl.request(AbstractStreamMessage.java:309) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.HttpMessageAggregator.onSubscribe(HttpMessageAggregator.java:55) ~[armeria-0.89.0.jar:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.lambda$subscribe$0(DefaultStreamMessage.java:124) ~[armeria-0.89.0.jar:?]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) ~[netty-common-4.1.38.Final.jar:4.1.38.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:416) ~[netty-common-4.1.38.Final.jar:4.1.38.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:515) ~[netty-transport-4.1.38.Final.jar:4.1.38.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:918) ~[netty-common-4.1.38.Final.jar:4.1.38.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.38.Final.jar:4.1.38.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.38.Final.jar:4.1.38.Final]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: com.linecorp.armeria.client.endpoint.EndpointGroupException: com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup@12c75a76 is empty
```