### PR TITLE
Add support for health-checking ES client.

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
@@ -15,11 +15,13 @@ package zipkin2.server.internal.elasticsearch;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
 import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 import com.linecorp.armeria.client.endpoint.healthcheck.HttpHealthCheckedEndpointGroup;
 import com.linecorp.armeria.client.endpoint.healthcheck.HttpHealthCheckedEndpointGroupBuilder;
+import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.SessionProtocol;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -31,14 +33,18 @@ final class LazyHttpClientImpl implements LazyHttpClient {
   final HttpClientFactory factory;
   final SessionProtocol protocol;
   final Supplier<EndpointGroup> configuredEndpoints;
+  final ZipkinElasticsearchStorageProperties.HealthCheck healthCheck;
+  final int timeoutMillis;
 
   volatile HttpClient result;
 
   LazyHttpClientImpl(HttpClientFactory factory, SessionProtocol protocol,
-    Supplier<EndpointGroup> configuredEndpoints) {
+    Supplier<EndpointGroup> configuredEndpoints, ZipkinElasticsearchStorageProperties es) {
     this.factory = factory;
     this.protocol = protocol;
     this.configuredEndpoints = configuredEndpoints;
+    this.healthCheck = es.getHealthCheck();
+    timeoutMillis = es.getTimeout();
   }
 
   @Override public void close() {
@@ -67,28 +73,47 @@ final class LazyHttpClientImpl implements LazyHttpClient {
       return endpointGroup.endpoints().get(0);
     }
 
+    if (endpointGroup instanceof DynamicEndpointGroup) {
+      try {
+        // Since we aren't holding up server startup, or sitting on the event loop, it is ok to
+        // block. The alternative is round-robin, which could be unlucky and hit a bad node first.
+        //
+        // We are blocking up to the connection timeout which should be enough time for any DNS
+        // resolution that hasn't happened yet to finish.
+        ((DynamicEndpointGroup) endpointGroup)
+          .awaitInitialEndpoints(timeoutMillis, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        // We'll try again next time around.
+        throw new IllegalStateException("couldn't connect any of " + endpointGroup.endpoints(), e);
+      }
+    }
+
+    if (healthCheck.isEnabled()) endpointGroup = decorateHealthCheck(endpointGroup);
+
     // TODO: why must we do this instead of using direct type references.
-    // The static factory is concerning.
+    // The static factory is concerning. https://github.com/line/armeria/issues/1084
     EndpointGroupRegistry.register("elasticsearch", endpointGroup, ROUND_ROBIN);
     return Endpoint.ofGroup("elasticsearch");
   }
 
-  // Unused code until we can get to a point of stability. This must become optional if we add it.
+  // Enables health-checking of an endpoint group, so we only send requests to endpoints that are
+  // up.
   HttpHealthCheckedEndpointGroup decorateHealthCheck(EndpointGroup endpointGroup) {
     HttpHealthCheckedEndpointGroup healthChecked =
       new HttpHealthCheckedEndpointGroupBuilder(endpointGroup, "/_cluster/health")
         .protocol(protocol)
         .clientFactory(factory.delegate)
         .withClientOptions(factory::configureOptionsExceptLogging)
+        .retryBackoff(Backoff.fixed(healthCheck.getInterval().toMillis()))
         .build();
 
     // Since we aren't holding up server startup, or sitting on the event loop, it is ok to block.
     // The alternative is round-robin, which could be unlucky and hit a bad node first.
     //
-    // We are blocking a second as this should be enough time for a health check to respond
-    // TODO: I don't know if this is enough time considering amazon and it is really too fragile
+    // We are blocking up to the connection timeout which should be enough time for a health check
+    // to respond.
     try {
-      healthChecked.awaitInitialEndpoints(1, TimeUnit.SECONDS);
+      healthChecked.awaitInitialEndpoints(timeoutMillis, TimeUnit.MILLISECONDS);
     } catch (Exception e) {
       healthChecked.close(); // we'll recreate it the next time around.
       throw new IllegalStateException("couldn't connect any of " + endpointGroup.endpoints(), e);

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
@@ -95,7 +95,7 @@ public class ZipkinElasticsearchStorageConfiguration {
     @Value("${zipkin.storage.autocomplete-ttl:3600000}") int autocompleteTtl,
     @Value("${zipkin.storage.autocomplete-cardinality:20000}") int autocompleteCardinality) {
     ElasticsearchStorage.Builder builder = es
-      .toBuilder(new LazyHttpClientImpl(esHttpClientFactory, protocol, initialEndpoints))
+      .toBuilder(new LazyHttpClientImpl(esHttpClientFactory, protocol, initialEndpoints, es))
       .namesLookback(namesLookback)
       .strictTraceId(strictTraceId)
       .searchEnabled(searchEnabled)

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -15,8 +15,10 @@ package zipkin2.server.internal.elasticsearch;
 
 import java.io.Serializable;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.logging.Logger;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
 import zipkin2.elasticsearch.ElasticsearchStorage;
 import zipkin2.elasticsearch.ElasticsearchStorage.LazyHttpClient;
 
@@ -41,6 +43,7 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
     private boolean enabled = true;
 
     /** The time to wait between sending health check requests. */
+    @DurationUnit(ChronoUnit.MILLIS)
     private Duration interval = Duration.ofSeconds(3);
 
     public boolean isEnabled() {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -36,7 +36,7 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
   /**
    * Configures the health-checking of endpoints by the Elasticsearch client.
    */
-  static class HealthCheck {
+  public static class HealthCheck {
     /** Indicates health checking is enabled. */
     private boolean enabled = true;
 
@@ -87,7 +87,7 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
 
   private Integer maxRequests; // unused
 
-  private HealthCheck healthCheck;
+  private HealthCheck healthCheck = new HealthCheck();
 
   public String getPipeline() {
     return pipeline;

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -14,6 +14,7 @@
 package zipkin2.server.internal.elasticsearch;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.logging.Logger;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin2.elasticsearch.ElasticsearchStorage;
@@ -30,6 +31,33 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
     BASIC,
     HEADERS,
     BODY
+  }
+
+  /**
+   * Configures the health-checking of endpoints by the Elasticsearch client.
+   */
+  static class HealthCheck {
+    /** Indicates health checking is enabled. */
+    private boolean enabled = true;
+
+    /** The time to wait between sending health check requests. */
+    private Duration interval = Duration.ofSeconds(3);
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public Duration getInterval() {
+      return interval;
+    }
+
+    public void setInterval(Duration interval) {
+      this.interval = interval;
+    }
   }
 
   static final Logger log = Logger.getLogger(ZipkinElasticsearchStorageProperties.class.getName());
@@ -58,6 +86,8 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
   private Integer timeout = 10_000;
 
   private Integer maxRequests; // unused
+
+  private HealthCheck healthCheck;
 
   public String getPipeline() {
     return pipeline;
@@ -149,6 +179,15 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
 
   public void setTimeout(Integer timeout) {
     this.timeout = timeout;
+  }
+
+  public HealthCheck getHealthCheck() {
+    return healthCheck;
+  }
+
+  public void setHealthCheck(
+    HealthCheck healthCheck) {
+    this.healthCheck = healthCheck;
   }
 
   public ElasticsearchStorage.Builder toBuilder(LazyHttpClient httpClient) {

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -137,6 +137,9 @@ zipkin:
       username: ${ES_USERNAME:}
       password: ${ES_PASSWORD:}
       http-logging: ${ES_HTTP_LOGGING:}
+      health-check:
+        enabled: ${ES_HEALTH_CHECK_ENABLED:true}
+        interval: ${ES_HEALTH_CHECK_INTERVAL:3s}
     mysql:
       jdbc-url: ${MYSQL_JDBC_URL:}
       host: ${MYSQL_HOST:localhost}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchAuth.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchAuth.java
@@ -36,7 +36,7 @@ import org.springframework.context.annotation.Configuration;
 import zipkin2.elasticsearch.ElasticsearchStorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static zipkin2.server.internal.elasticsearch.ITElasticsearchHealthCheck.YELLOW_RESPONSE;
+import static zipkin2.server.internal.elasticsearch.TestResponses.YELLOW_RESPONSE;
 import static zipkin2.server.internal.elasticsearch.ZipkinElasticsearchStorageConfiguration.QUALIFIER;
 
 public class ITElasticsearchAuth {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchClientInitialization.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchClientInitialization.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.elasticsearch;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin2.CheckResult;
+import zipkin2.elasticsearch.ElasticsearchStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITElasticsearchClientInitialization {
+
+  AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+  /**
+   * This blocks for less than the timeout of 2 second to prove we defer i/o until first use
+   * of the storage component.
+   */
+  @Test(timeout = 1900L) public void defersIOUntilFirstUse() throws IOException {
+    TestPropertyValues.of(
+      "spring.config.name=zipkin-server",
+      "zipkin.storage.type:elasticsearch",
+      "zipkin.storage.elasticsearch.timeout:2000",
+      "zipkin.storage.elasticsearch.hosts:127.0.0.1:1234,127.0.0.1:5678")
+      .applyTo(context);
+    context.register(
+      PropertyPlaceholderAutoConfiguration.class,
+      ZipkinElasticsearchStorageConfiguration.class);
+    context.refresh();
+
+    context.getBean(ElasticsearchStorage.class).close();
+  }
+
+  /** blocking a little is ok, but blocking forever is not. */
+  @Test(timeout = 3000L) public void doesntHangWhenAllDown() throws IOException {
+    TestPropertyValues.of(
+      "spring.config.name=zipkin-server",
+      "zipkin.storage.type:elasticsearch",
+      "zipkin.storage.elasticsearch.timeout:1000",
+      "zipkin.storage.elasticsearch.hosts:127.0.0.1:1234,127.0.0.1:5678")
+      .applyTo(context);
+    context.register(
+      PropertyPlaceholderAutoConfiguration.class,
+      ZipkinElasticsearchStorageConfiguration.class);
+    context.refresh();
+
+    try (ElasticsearchStorage storage = context.getBean(ElasticsearchStorage.class)) {
+      CheckResult result = storage.check();
+      assertThat(result.ok()).isFalse();
+    }
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
@@ -83,14 +83,14 @@ public class ITElasticsearchHealthCheck {
   }
 
   /**
-   * This blocks for less than the timeout of 1 second to prove we defer i/o until first use
+   * This blocks for less than the timeout of 2 second to prove we defer i/o until first use
    * of the storage component.
    */
-  @Test(timeout = 950L) public void defersIOUntilFirstUse() throws IOException {
+  @Test(timeout = 1900L) public void defersIOUntilFirstUse() throws IOException {
     TestPropertyValues.of(
       "spring.config.name=zipkin-server",
       "zipkin.storage.type:elasticsearch",
-      "zipkin.storage.elasticsearch.timeout:1000",
+      "zipkin.storage.elasticsearch.timeout:2000",
       "zipkin.storage.elasticsearch.hosts:127.0.0.1:1234,127.0.0.1:5678")
       .applyTo(context);
     context.register(

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
@@ -83,13 +83,14 @@ public class ITElasticsearchHealthCheck {
   }
 
   /**
-   * This blocks for less than the ready timeout of 1 second to prove we defer i/o until first use
+   * This blocks for less than the timeout of 1 second to prove we defer i/o until first use
    * of the storage component.
    */
   @Test(timeout = 950L) public void defersIOUntilFirstUse() throws IOException {
     TestPropertyValues.of(
       "spring.config.name=zipkin-server",
       "zipkin.storage.type:elasticsearch",
+      "zipkin.storage.elasticsearch.timeout:1000",
       "zipkin.storage.elasticsearch.hosts:127.0.0.1:1234,127.0.0.1:5678")
       .applyTo(context);
     context.register(

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchSelfTracing.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchSelfTracing.java
@@ -29,7 +29,7 @@ import zipkin2.elasticsearch.ElasticsearchStorage;
 import zipkin2.server.internal.brave.TracingConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static zipkin2.server.internal.elasticsearch.ITElasticsearchHealthCheck.YELLOW_RESPONSE;
+import static zipkin2.server.internal.elasticsearch.TestResponses.YELLOW_RESPONSE;
 
 public class ITElasticsearchSelfTracing {
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/TestResponses.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/TestResponses.java
@@ -1,0 +1,47 @@
+package zipkin2.server.internal.elasticsearch;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+
+import static com.linecorp.armeria.common.HttpStatus.OK;
+import static com.linecorp.armeria.common.MediaType.JSON;
+
+final class TestResponses {
+  static final AggregatedHttpResponse YELLOW_RESPONSE = AggregatedHttpResponse.of(OK, JSON,
+    "{\n"
+      + "  \"cluster_name\": \"CollectorDBCluster\",\n"
+      + "  \"status\": \"yellow\",\n"
+      + "  \"timed_out\": false,\n"
+      + "  \"number_of_nodes\": 1,\n"
+      + "  \"number_of_data_nodes\": 1,\n"
+      + "  \"active_primary_shards\": 5,\n"
+      + "  \"active_shards\": 5,\n"
+      + "  \"relocating_shards\": 0,\n"
+      + "  \"initializing_shards\": 0,\n"
+      + "  \"unassigned_shards\": 5,\n"
+      + "  \"delayed_unassigned_shards\": 0,\n"
+      + "  \"number_of_pending_tasks\": 0,\n"
+      + "  \"number_of_in_flight_fetch\": 0,\n"
+      + "  \"task_max_waiting_in_queue_millis\": 0,\n"
+      + "  \"active_shards_percent_as_number\": 50\n"
+      + "}\n");
+  static final AggregatedHttpResponse GREEN_RESPONSE = AggregatedHttpResponse.of(OK, JSON,
+    "{\n"
+      + "  \"cluster_name\": \"CollectorDBCluster\",\n"
+      + "  \"status\": \"green\",\n"
+      + "  \"timed_out\": false,\n"
+      + "  \"number_of_nodes\": 1,\n"
+      + "  \"number_of_data_nodes\": 1,\n"
+      + "  \"active_primary_shards\": 5,\n"
+      + "  \"active_shards\": 5,\n"
+      + "  \"relocating_shards\": 0,\n"
+      + "  \"initializing_shards\": 0,\n"
+      + "  \"unassigned_shards\": 5,\n"
+      + "  \"delayed_unassigned_shards\": 0,\n"
+      + "  \"number_of_pending_tasks\": 0,\n"
+      + "  \"number_of_in_flight_fetch\": 0,\n"
+      + "  \"task_max_waiting_in_queue_millis\": 0,\n"
+      + "  \"active_shards_percent_as_number\": 50\n"
+      + "}\n");
+
+  private TestResponses() {}
+}


### PR DESCRIPTION
By default, health-check is enabled with a check interval of 3 seconds. This allows the client to skip nodes that do not return a successful health check. When health-check is disabled, no check requests will be made, but if a node becomes unusable it will still have requests sent to it as part of the round-robin.

Renamed a test named health check since it didn't seem to be testing health check, but I needed to :P
Also raised the timeout on `defersIOUntilFirstUse`, on my computer I couldn't get it to pass on master either.

Fixes #2720