### PR TITLE
Allows throttling to re-use 3rd party exceptions as opposed to wrapping

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
@@ -28,6 +28,7 @@ import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
 import zipkin2.storage.cassandra.internal.call.DeduplicatingVoidCallFactory;
+import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -369,6 +370,10 @@ public class CassandraStorage extends StorageComponent { // not final for mockin
       }
     }
     return spanConsumer;
+  }
+
+  @Override public boolean isOverCapacity(Throwable e) {
+    return ResultSetFutureCall.isOverCapacity(e);
   }
 
   @Override public final String toString() {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/HttpCallTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/HttpCallTest.java
@@ -225,7 +225,6 @@ public class HttpCallTest {
   @Test public void unprocessedRequest() {
     MOCK_RESPONSE.set(SUCCESS_RESPONSE);
 
-    AtomicReference<RequestLog> log = new AtomicReference<>();
     http = new HttpCall.Factory(new HttpClientBuilder(server.httpUri("/"))
       .decorator((client, ctx, req) -> {
         throw new UnprocessedRequestException("Could not process request.",

--- a/zipkin/src/main/java/zipkin2/storage/ForwardingStorageComponent.java
+++ b/zipkin/src/main/java/zipkin2/storage/ForwardingStorageComponent.java
@@ -58,6 +58,10 @@ public abstract class ForwardingStorageComponent extends StorageComponent {
     return delegate().check();
   }
 
+  @Override public boolean isOverCapacity(Throwable e) {
+    return delegate().isOverCapacity(e);
+  }
+
   @Override public void close() throws IOException {
     delegate().close();
   }

--- a/zipkin/src/test/java/zipkin2/storage/ForwardingStorageComponentTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/ForwardingStorageComponentTest.java
@@ -15,6 +15,7 @@ package zipkin2.storage;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Test;
@@ -65,6 +66,15 @@ public class ForwardingStorageComponentTest {
     assertThat(forwarder.check()).isEqualTo(down);
 
     verify(delegate).check();
+  }
+
+  @Test public void delegatesIsOverCapacity() {
+    Exception wayOver = new RejectedExecutionException();
+    when(delegate.isOverCapacity(wayOver)).thenReturn(true);
+
+    assertThat(forwarder.isOverCapacity(wayOver)).isEqualTo(true);
+
+    verify(delegate).isOverCapacity(wayOver);
   }
 
   @Test public void delegatesClose() throws IOException {


### PR DESCRIPTION
While re-wrapping exceptions can still make sense (ex to trim huge stack
traces), re-wrapping only to fit `RejectedExecutionException` can be
counter-productive and result in debates about naming that don't need to
be debated.

This adds `StorageComponent.isOvercapacity(Throwable)` to make
classification more flexible.

Fixes #2721