### PR TITLE
Use unique attribute key.

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
@@ -38,7 +38,6 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import zipkin2.elasticsearch.ElasticsearchStorage;
-import zipkin2.elasticsearch.internal.client.HttpCall;
 import zipkin2.server.internal.ConditionalOnSelfTracing;
 import zipkin2.storage.StorageComponent;
 
@@ -134,8 +133,8 @@ public class ZipkinElasticsearchStorageConfiguration {
 
     return client -> {
       client.decorator((delegate, ctx, req) -> {
-        if (ctx.hasAttr(HttpCall.NAME)) { // override the span name if set
-          spanCustomizer.name(ctx.attr(HttpCall.NAME).get());
+        if (ctx.hasAttr(ElasticsearchStorage.CUSTOM_HTTP_SPAN_NAME)) { // override the span name if set
+          spanCustomizer.name(ctx.attr(ElasticsearchStorage.CUSTOM_HTTP_SPAN_NAME).get());
         }
         return delegate.execute(ctx, req);
       });

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -21,6 +21,7 @@ import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
+import io.netty.util.AttributeKey;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
@@ -51,6 +52,21 @@ import static zipkin2.elasticsearch.internal.JsonSerializers.JSON_FACTORY;
 
 @AutoValue
 public abstract class ElasticsearchStorage extends zipkin2.storage.StorageComponent {
+
+  /**
+   * Use with something like <pre>{@code
+   *
+   * try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> ctx.attr(
+   *   ElasticsearchStorage.CUSTOM_HTTP_SPAN_NAME).set("custom-name")) {
+   *   httpClient.execute(request).aggregate().join();
+   * }
+   *
+   * }</pre>
+   *
+   * <p>Only made public for use from zipkin-aws for annotating the domain endpoint request.
+   */
+  public static final AttributeKey<String> CUSTOM_HTTP_SPAN_NAME =
+    AttributeKey.valueOf(ElasticsearchStorage.class, "CUSTOM_HTTP_SPAN_NAME");
 
   /**
    * This defers creation of an {@link HttpClient}. This is needed because routinely, I/O occurs in

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
@@ -28,7 +28,6 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
-import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 import java.io.FileNotFoundException;
@@ -39,12 +38,12 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.RejectedExecutionException;
 import zipkin2.Call;
 import zipkin2.Callback;
+import zipkin2.elasticsearch.ElasticsearchStorage;
 
 import static zipkin2.elasticsearch.internal.JsonReaders.enterPath;
 import static zipkin2.elasticsearch.internal.JsonSerializers.JSON_FACTORY;
 
 public final class HttpCall<V> extends Call.Base<V> {
-  public static final AttributeKey<String> NAME = AttributeKey.valueOf("name");
 
   public interface BodyConverter<V> {
     /**
@@ -161,7 +160,8 @@ public final class HttpCall<V> extends Call.Base<V> {
 
   CompletableFuture<AggregatedHttpResponse> sendRequest() {
     final HttpResponse response;
-    try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> ctx.attr(NAME).set(name))) {
+    try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> ctx.attr(
+      ElasticsearchStorage.CUSTOM_HTTP_SPAN_NAME).set(name))) {
       response = httpClient.execute(request);
     }
     CompletableFuture<AggregatedHttpResponse> responseFuture =


### PR DESCRIPTION
Sorry for not noticing earlier - this will drift https://github.com/openzipkin/zipkin-aws/pull/135

An `AttributeKey` needs to be globally unique or it could possibly get clobbered.

While I could have made the `String` of the name longer and unique enough, I figured exposing the `AttributeKey` itself with documentation would be OK too but can tweak it.