### PR TITLE
Adds ForwardingStorageComponent to end little bugs

### DIFF
--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
@@ -32,13 +32,12 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import zipkin2.Call;
 import zipkin2.Callback;
-import zipkin2.CheckResult;
 import zipkin2.Component;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.collector.InMemoryCollectorMetrics;
+import zipkin2.storage.ForwardingStorageComponent;
 import zipkin2.storage.SpanConsumer;
-import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -234,21 +233,13 @@ public class ITActiveMQCollector {
   }
 
   static StorageComponent buildStorage(final SpanConsumer spanConsumer) {
-    return new StorageComponent() {
-      @Override public SpanStore spanStore() {
+    return new ForwardingStorageComponent() {
+      @Override protected StorageComponent delegate() {
         throw new AssertionError();
       }
 
       @Override public SpanConsumer spanConsumer() {
         return spanConsumer;
-      }
-
-      @Override public CheckResult check() {
-        return CheckResult.OK;
-      }
-
-      @Override public void close() {
-        throw new AssertionError();
       }
     };
   }

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
@@ -35,13 +35,12 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
 import zipkin2.Call;
 import zipkin2.Callback;
-import zipkin2.CheckResult;
 import zipkin2.Component;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.collector.InMemoryCollectorMetrics;
+import zipkin2.storage.ForwardingStorageComponent;
 import zipkin2.storage.SpanConsumer;
-import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -380,26 +379,14 @@ public class ITKafkaCollector {
         .storage(buildStorage(consumer));
   }
 
-  StorageComponent buildStorage(final SpanConsumer spanConsumer) {
-    return new StorageComponent() {
-      @Override
-      public SpanStore spanStore() {
+  static StorageComponent buildStorage(final SpanConsumer spanConsumer) {
+    return new ForwardingStorageComponent() {
+      @Override protected StorageComponent delegate() {
         throw new AssertionError();
       }
 
-      @Override
-      public SpanConsumer spanConsumer() {
+      @Override public SpanConsumer spanConsumer() {
         return spanConsumer;
-      }
-
-      @Override
-      public CheckResult check() {
-        return CheckResult.OK;
-      }
-
-      @Override
-      public void close() {
-        throw new AssertionError();
       }
     };
   }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
@@ -22,19 +22,29 @@ import zipkin2.CheckResult;
 import zipkin2.DependencyLink;
 import zipkin2.Span;
 import zipkin2.storage.AutocompleteTags;
+import zipkin2.storage.ForwardingStorageComponent;
 import zipkin2.storage.QueryRequest;
+import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
 
 // public for use in ZipkinServerConfiguration
-public final class TracingStorageComponent extends StorageComponent {
+public final class TracingStorageComponent extends ForwardingStorageComponent {
   final Tracing tracing;
   final StorageComponent delegate;
 
   public TracingStorageComponent(Tracing tracing, StorageComponent delegate) {
     this.tracing = tracing;
     this.delegate = delegate;
+  }
+
+  @Override protected StorageComponent delegate() {
+    return delegate;
+  }
+
+  @Override public ServiceAndSpanNames serviceAndSpanNames() {
+    return new TracingServiceAndSpanNames(tracing, delegate.serviceAndSpanNames());
   }
 
   @Override public SpanStore spanStore() {
@@ -111,6 +121,33 @@ public final class TracingStorageComponent extends StorageComponent {
 
     @Override public Call<List<String>> getValues(String key) {
       return new TracedCall<>(tracer, delegate.getValues(key), "get-values");
+    }
+
+    @Override public String toString() {
+      return "Traced{" + delegate + "}";
+    }
+  }
+
+  static final class TracingServiceAndSpanNames implements ServiceAndSpanNames {
+    final Tracer tracer;
+    final ServiceAndSpanNames delegate;
+
+    TracingServiceAndSpanNames(Tracing tracing, ServiceAndSpanNames delegate) {
+      this.tracer = tracing.tracer();
+      this.delegate = delegate;
+    }
+
+    @Override public Call<List<String>> getServiceNames() {
+      return new TracedCall<>(tracer, delegate.getServiceNames(), "get-service-names");
+    }
+
+    @Override public Call<List<String>> getRemoteServiceNames(String serviceName) {
+      return new TracedCall<>(tracer, delegate.getRemoteServiceNames(serviceName),
+        "get-remote-service-names");
+    }
+
+    @Override public Call<List<String>> getSpanNames(String serviceName) {
+      return new TracedCall<>(tracer, delegate.getSpanNames(serviceName), "get-span-names");
     }
 
     @Override public String toString() {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
@@ -30,10 +30,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import zipkin2.Call;
-import zipkin2.CheckResult;
 import zipkin2.Span;
+import zipkin2.storage.ForwardingStorageComponent;
 import zipkin2.storage.SpanConsumer;
-import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
 
 /**
@@ -49,7 +48,7 @@ import zipkin2.storage.StorageComponent;
  *
  * @see ThrottledSpanConsumer
  */
-public final class ThrottledStorageComponent extends StorageComponent {
+public final class ThrottledStorageComponent extends ForwardingStorageComponent {
   final StorageComponent delegate;
   final AbstractLimiter<Void> limiter;
   final ThreadPoolExecutor executor;
@@ -85,8 +84,8 @@ public final class ThrottledStorageComponent extends StorageComponent {
     metrics.bind(limiter);
   }
 
-  @Override public SpanStore spanStore() {
-    return delegate.spanStore();
+  @Override protected StorageComponent delegate() {
+    return delegate;
   }
 
   @Override public SpanConsumer spanConsumer() {
@@ -96,10 +95,6 @@ public final class ThrottledStorageComponent extends StorageComponent {
   @Override public void close() throws IOException {
     executor.shutdownNow();
     delegate.close();
-  }
-
-  @Override public CheckResult check() {
-    return delegate.check();
   }
 
   @Override public String toString() {

--- a/zipkin/src/main/java/zipkin2/storage/ForwardingStorageComponent.java
+++ b/zipkin/src/main/java/zipkin2/storage/ForwardingStorageComponent.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.io.IOException;
+import zipkin2.CheckResult;
+
+/**
+ * We provide a forwarding variant of the storage component for use cases such as trace decoration,
+ * or throttling.
+ *
+ * <p>Extending this is better than extending {@link StorageComponent} directly because it reduces
+ * risk of accidentally masking new methods. For example, if you extended storage component and
+ * later a new feature for cache control was added, that feature would be blocked until the wrapper
+ * was re-compiled. Such would be worse in most cases than not having decoration on new methods.
+ *
+ * @since 2.16
+ */
+public abstract class ForwardingStorageComponent extends StorageComponent {
+  /** Constructor for use by subclasses. */
+  protected ForwardingStorageComponent() {
+  }
+
+  /**
+   * The delegate is a method as opposed to a field, to allow for flexibility. For example, this
+   * allows you to choose to make a final or lazy field, or no field at all.
+   */
+  protected abstract StorageComponent delegate();
+
+  @Override public SpanConsumer spanConsumer() {
+    return delegate().spanConsumer();
+  }
+
+  @Override public SpanStore spanStore() {
+    return delegate().spanStore();
+  }
+
+  @Override public AutocompleteTags autocompleteTags() {
+    return delegate().autocompleteTags();
+  }
+
+  @Override public ServiceAndSpanNames serviceAndSpanNames() {
+    return delegate().serviceAndSpanNames();
+  }
+
+  @Override public CheckResult check() {
+    return delegate().check();
+  }
+
+  @Override public void close() throws IOException {
+    delegate().close();
+  }
+
+  @Override public String toString() {
+    return delegate().toString();
+  }
+}

--- a/zipkin/src/test/java/zipkin2/storage/ForwardingStorageComponentTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/ForwardingStorageComponentTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import zipkin2.CheckResult;
+import zipkin2.Component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class ForwardingStorageComponentTest {
+  /**
+   * This test is intentionally brittle. It should break if we add new methods on {@link
+   * StorageComponent}!
+   */
+  @Test public void declaresAllMethodsToForward() {
+    assertThat(ForwardingStorageComponent.class.getDeclaredMethods())
+      .extracting(Method::getName)
+      .containsAll(Stream.concat(
+        Stream.of(Component.class.getDeclaredMethods()).map(Method::getName),
+        Stream.of(StorageComponent.class.getDeclaredMethods()).map(Method::getName)
+      ).collect(Collectors.toList()));
+  }
+
+  StorageComponent delegate = mock(StorageComponent.class);
+  StorageComponent forwarder = new ForwardingStorageComponent() {
+    @Override protected StorageComponent delegate() {
+      return delegate;
+    }
+  };
+
+  @AfterEach public void verifyNoExtraCalls() {
+    verifyNoMoreInteractions(delegate);
+  }
+
+  @Test public void delegatesToString() {
+    assertThat(forwarder.toString()).isEqualTo(delegate.toString());
+  }
+
+  @Test public void delegatesCheck() {
+    CheckResult down = CheckResult.failed(new RuntimeException("failed"));
+    when(delegate.check()).thenReturn(down);
+
+    assertThat(forwarder.check()).isEqualTo(down);
+
+    verify(delegate).check();
+  }
+
+  @Test public void delegatesClose() throws IOException {
+    doNothing().when(delegate).close();
+
+    forwarder.close();
+
+    verify(delegate).close();
+  }
+
+  @Test public void delegatesSpanStore() {
+    SpanStore spanStore = mock(SpanStore.class);
+    when(delegate.spanStore()).thenReturn(spanStore);
+
+    assertThat(forwarder.spanStore()).isEqualTo(spanStore);
+
+    verify(delegate).spanStore();
+  }
+
+  @Test public void delegatesAutocompleteTags() {
+    AutocompleteTags autocompleteTags = mock(AutocompleteTags.class);
+    when(delegate.autocompleteTags()).thenReturn(autocompleteTags);
+
+    assertThat(forwarder.autocompleteTags()).isEqualTo(autocompleteTags);
+
+    verify(delegate).autocompleteTags();
+  }
+
+  @Test public void delegatesServiceAndSpanNames() {
+    ServiceAndSpanNames serviceAndSpanNames = mock(ServiceAndSpanNames.class);
+    when(delegate.serviceAndSpanNames()).thenReturn(serviceAndSpanNames);
+
+    assertThat(forwarder.serviceAndSpanNames()).isEqualTo(serviceAndSpanNames);
+
+    verify(delegate).serviceAndSpanNames();
+  }
+
+  @Test public void delegatesSpanConsumer() {
+    SpanConsumer spanConsumer = mock(SpanConsumer.class);
+    when(delegate.spanConsumer()).thenReturn(spanConsumer);
+
+    assertThat(forwarder.spanConsumer()).isEqualTo(spanConsumer);
+
+    verify(delegate).spanConsumer();
+  }
+}


### PR DESCRIPTION
We've had numerous places where people wrap and forget to forward
`.check()` or aren't aware when they forgot to forward a new method.

This removes that pattern of maintenance for a forwarding decorator.