### PR TITLE
Unhooks protocols that are usually synchronous from storage commands

### DIFF
--- a/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
@@ -132,8 +132,13 @@ public class Collector { // not final for mock
     // phase of this process. Here, we create a callback whose sole purpose is classifying later
     // errors on this bundle of spans in the same log category. This allows people to only turn on
     // debug logging in one place.
-    executor.execute(new StoreSpans(sampledSpans));
-    callback.onSuccess(null);
+    try {
+      executor.execute(new StoreSpans(sampledSpans));
+      callback.onSuccess(null);
+    } catch (Throwable unexpected) { // ensure if a future is supplied we always set value or error
+      callback.onError(unexpected);
+      throw unexpected;
+    }
   }
 
   /** Like {@link #acceptSpans(byte[], BytesDecoder, Callback)}, except using a byte buffer. */

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
@@ -110,7 +110,7 @@ public class Collector { // not final for mock
   }
 
   /**
-   * @param executor Returns the executor used to enqueue the storage request.
+   * @param executor the executor used to enqueue the storage request.
    *
    * <p>Calls to get the storage component could be blocking. This ensures requests that block
    * callers (such as http or gRPC) do not add additional load during such events.

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
@@ -36,8 +36,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.apache.logging.log4j.LogManager;
@@ -152,12 +150,6 @@ public class ZipkinHttpCollector {
         if (unexpectedDecoder != null) {
           result.onError(new IllegalArgumentException(
             "Expected a " + decoder + " encoded list, but received: " + unexpectedDecoder + "\n"));
-          return null;
-        }
-
-        List<Span> spans = new ArrayList<>();
-        if (!decoder.decodeList(nioBuffer, spans)) {
-          result.onError(new IllegalArgumentException("Empty " + decoder.name() + " message"));
           return null;
         }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
@@ -164,7 +164,7 @@ public class ZipkinHttpCollector {
         // collector.accept might block so need to move off the event loop. We make sure the
         // callback is context aware to continue the trace.
         Executor executor = ctx.makeContextAware(ctx.blockingTaskExecutor());
-        collector.acceptSpans(nioBuffer, SpanBytesDecoder.PROTO3, result, executor);
+        collector.acceptSpans(nioBuffer, decoder, result, executor);
       } finally {
         ReferenceCountUtil.release(content);
       }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracedCall.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracedCall.java
@@ -46,7 +46,11 @@ final class TracedCall<V> extends Call<V> {
   @Override public void enqueue(Callback<V> callback) {
     Span span = tracer.nextSpan().name(name).start();
     try {
-      delegate.enqueue(new SpanFinishingCallback<>(callback, span));
+      if (span.isNoop()) {
+        delegate.enqueue(callback);
+      } else {
+        delegate.enqueue(new SpanFinishingCallback<>(callback, span));
+      }
     } catch (RuntimeException | Error e) {
       span.error(e);
       span.finish();


### PR DESCRIPTION
http and gRPC protocols usually hold clients. We want to hold them until
messages are parsed, but not later. This employs an executor to ensure
any blocking commands needed to get the storage command enqueued do not
block the request.

This also fixes some lack of logging where nio is used.

Fixes #2715