### PR TITLE
Makes the toString of Elasticsearch nicer as it is in the health check

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
@@ -27,11 +27,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 // TODO: testme
-final class ConfiguredEndpointsSupplier implements Supplier<EndpointGroup> {
+final class InitialEndpointSupplier implements Supplier<EndpointGroup> {
   final String hosts;
   final SessionProtocol sessionProtocol;
 
-  ConfiguredEndpointsSupplier(SessionProtocol sessionProtocol, String hosts) {
+  InitialEndpointSupplier(SessionProtocol sessionProtocol, String hosts) {
     this.hosts = hosts == null || hosts.isEmpty() ? "localhost:9200" : hosts;
     this.sessionProtocol = sessionProtocol;
   }
@@ -114,6 +114,6 @@ final class ConfiguredEndpointsSupplier implements Supplier<EndpointGroup> {
   }
 
   @Override public String toString() {
-    return "ConfiguredEndpointsSupplier{hosts=" + hosts + "}";
+    return hosts;
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
@@ -36,7 +36,9 @@ final class LazyHttpClientImpl implements LazyHttpClient {
   final ZipkinElasticsearchStorageProperties.HealthCheck healthCheck;
   final int timeoutMillis;
 
+  // guarded by this
   volatile HttpClient result;
+  volatile Endpoint endpoint;
 
   LazyHttpClientImpl(HttpClientFactory factory, SessionProtocol protocol,
     Supplier<EndpointGroup> configuredEndpoints, ZipkinElasticsearchStorageProperties es) {
@@ -59,7 +61,8 @@ final class LazyHttpClientImpl implements LazyHttpClient {
     if (result == null) {
       synchronized (this) {
         if (result == null) {
-          result = factory.apply(getEndpoint());
+          endpoint = getEndpoint();
+          result = factory.apply(endpoint);
         }
       }
     }
@@ -122,6 +125,7 @@ final class LazyHttpClientImpl implements LazyHttpClient {
   }
 
   @Override public final String toString() {
-    return configuredEndpoints.toString();
+    Endpoint realEndpoint = endpoint;
+    return realEndpoint != null ? realEndpoint.toString() : configuredEndpoints.toString();
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
@@ -53,7 +53,7 @@ public class ZipkinElasticsearchStorageConfiguration {
   @Bean @Qualifier(QUALIFIER) @ConditionalOnMissingBean
   Supplier<EndpointGroup> esInitialEndpoints(
     SessionProtocol esSessionProtocol, ZipkinElasticsearchStorageProperties es) {
-    return new ConfiguredEndpointsSupplier(esSessionProtocol, es.getHosts());
+    return new InitialEndpointSupplier(esSessionProtocol, es.getHosts());
   }
 
   // Exposed as a bean so that zipkin-aws can override this to always be SSL

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
@@ -73,14 +73,14 @@ public class ITElasticsearchHealthCheck {
     context.refresh();
   }
 
-  @Test public void allHealthy() throws Exception {
+  @Test public void allHealthy() {
     try (ElasticsearchStorage storage = context.getBean(ElasticsearchStorage.class)) {
       CheckResult result = storage.check();
       assertThat(result.ok()).isTrue();
     }
   }
 
-  @Test public void oneHealthy() throws Exception {
+  @Test public void oneHealthy() {
     server1Health.setHealthy(false);
 
     try (ElasticsearchStorage storage = context.getBean(ElasticsearchStorage.class)) {
@@ -89,17 +89,21 @@ public class ITElasticsearchHealthCheck {
     }
   }
 
-  @Test public void noneHealthy() throws Exception {
+  @Test public void noneHealthy() {
     server1Health.setHealthy(false);
     server2Health.setHealthy(false);
 
     try (ElasticsearchStorage storage = context.getBean(ElasticsearchStorage.class)) {
       CheckResult result = storage.check();
       assertThat(result.ok()).isFalse();
+      assertThat(result.error()).hasMessage(String.format(
+        "couldn't connect any of [Endpoint{127.0.0.1:%s, weight=1000}, Endpoint{127.0.0.1:%s, weight=1000}]",
+        server1.httpPort(), server2.httpPort()
+      ));
     }
   }
 
-  @Test public void healthyThenNotHealthyThenHealthy() throws Exception {
+  @Test public void healthyThenNotHealthyThenHealthy() {
     try (ElasticsearchStorage storage = context.getBean(ElasticsearchStorage.class)) {
       CheckResult result = storage.check();
       assertThat(result.ok()).isTrue();
@@ -119,7 +123,7 @@ public class ITElasticsearchHealthCheck {
     }
   }
 
-  @Test public void notHealthyThenHealthyThenNotHealthy() throws Exception {
+  @Test public void notHealthyThenHealthyThenNotHealthy() {
     server1Health.setHealthy(false);
     server2Health.setHealthy(false);
 
@@ -141,7 +145,7 @@ public class ITElasticsearchHealthCheck {
     }
   }
 
-  @Test public void healthCheckDisabled() throws Exception {
+  @Test public void healthCheckDisabled() {
     AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
     TestPropertyValues.of(

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
@@ -86,6 +86,18 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       .containsExactly(URI.create("http://host1:9200"), URI.create("http://host2:9200"));
   }
 
+  @Test public void decentToString_whenUnresolvedOrUnhealthy() {
+    TestPropertyValues.of(
+      "zipkin.storage.type:elasticsearch",
+      "zipkin.storage.elasticsearch.hosts:http://127.0.0.1:9200,http://127.0.0.1:9201")
+      .applyTo(context);
+    Access.registerElasticsearchHttp(context);
+    context.refresh();
+
+    assertThat(es()).hasToString(
+      "ElasticsearchStorage{initialEndpoints=http://127.0.0.1:9200,http://127.0.0.1:9201, index=zipkin}");
+  }
+
   @Test public void configuresPipeline() {
     TestPropertyValues.of(
       "zipkin.storage.type:elasticsearch",
@@ -134,7 +146,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
 
     assertThat(context.getBean(SessionProtocol.class))
       .isEqualTo(SessionProtocol.HTTPS);
-    assertThat(context.getBean(ConfiguredEndpointsSupplier.class).get().endpoints().get(0).port())
+    assertThat(context.getBean(InitialEndpointSupplier.class).get().endpoints().get(0).port())
       .isEqualTo(443);
   }
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -64,6 +64,9 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
 
     @Override default void close() {
     }
+
+    /** This should return the initial endpoints in a single-string without resolving them. */
+    @Override String toString();
   }
 
   /** The lazy http client supplier will be closed on {@link #close()} */
@@ -278,7 +281,7 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   }
 
   @Override public final String toString() {
-    return "ElasticsearchStorage{httpClient=" + lazyHttpClient()
+    return "ElasticsearchStorage{initialEndpoints=" + lazyHttpClient()
       + ", index=" + indexNameFormatter().index() + "}";
   }
 


### PR DESCRIPTION
Ex

```bash
$ curl -s localhost:9411/health
{"status":"UP","zipkin":{"status":"UP","details":{"ElasticsearchStorage{initialEndpoints=localhost:9200, index=zipkin}":{"status":"UP"}}}}
```