### PR TITLE
ports dependency linker to javascript

### DIFF
--- a/zipkin-lens/src/zipkin/dependency-linker.js
+++ b/zipkin-lens/src/zipkin/dependency-linker.js
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { getServiceName } from './span-row';
+
+// In javascript, dict keys can't be objects
+function keyString(parent, child) {
+  return `${parent}░${child}`; // cassandra storage uses the same delimiter
+}
+
+function link(callCounts, errorCounts) {
+  const result = [];
+  Object.keys(callCounts).forEach((key) => {
+    const parentChild = key.split('░');
+    const nextLink = {
+      parent: parentChild[0],
+      child: parentChild[1],
+      callCount: callCounts[key],
+    };
+
+    const errorCount = errorCounts[key] || 0;
+    if (errorCount) nextLink.errorCount = errorCount;
+    result.push(nextLink);
+  });
+  return result;
+}
+
+/*
+ * This parses a span tree into dependency links used by Web UI. Ex. http://zipkin/dependency
+ *
+ * This implementation traverses the tree, and creates links for RPC and messaging spans. RPC links
+ * are only between SERVER spans. One exception is at the bottom of the trace tree. CLIENT spans
+ * that record their remoteEndpoint are included, as this accounts for uninstrumented services.
+ * Spans with kind unset, but remoteEndpoint set are treated the same as client spans.
+ */
+export class DependencyLinker {
+  constructor(params) {
+    const { debug = false } = params;
+    this._debug = debug;
+    this._callCounts = {}; // parent_child -> callCount
+    this._errorCounts = {}; // parent_child -> errorCount
+  }
+
+  _firstRemoteAncestor(node) {
+    let ancestor = node.parent;
+    while (ancestor) {
+      const maybeRemote = ancestor.span;
+      if (maybeRemote && maybeRemote.kind) {
+        if (this._debug) console.log(`found remote ancestor ${JSON.stringify(maybeRemote)}`);
+        return maybeRemote;
+      }
+      ancestor = ancestor.parent;
+    }
+    return undefined;
+  }
+
+  _addLink(parent, child, isError) {
+    if (this.debug) {
+      console.log('incrementing ' + (isError ? 'error ' : '') + 'link ' + parent + ' -> ' + child); // eslint-disable-line prefer-template
+    }
+    const key = keyString(parent, child);
+    this._callCounts[key] = (this._callCounts[key] || 0) + 1;
+    if (!isError) return;
+    this._errorCounts[key] = (this._errorCounts[key] || 0) + 1;
+  }
+
+  /** The input should be a root span node, not a list of spans. */
+  putTrace(traceTree) {
+    const debug = this._debug;
+    if (debug) console.log('traversing trace tree, breadth-first');
+    const queue = traceTree.queueRootMostSpans();
+    while (queue.length > 0) {
+      const current = queue.shift();
+      current.children.forEach(n => queue.push(n));
+
+      const currentSpan = current.span;
+      if (debug) console.log(`processing ${JSON.stringify(currentSpan)}`);
+
+      let { kind } = currentSpan;
+      // When processing links to a client span, we prefer the server's name. If we have no child
+      // spans, we proceed to use the name the client chose.
+      if (kind === 'CLIENT' && current.children.length > 0) {
+        continue;
+      }
+
+      const serviceName = getServiceName(currentSpan.localEndpoint);
+      const remoteServiceName = getServiceName(currentSpan.remoteEndpoint);
+      if (!kind) {
+        // Treat unknown type of span as a client span if we know both sides
+        if (serviceName && remoteServiceName) {
+          kind = 'CLIENT';
+        } else {
+          if (debug) console.log('non remote span; skipping');
+          continue;
+        }
+      }
+
+      let child;
+      let parent;
+      switch (kind) {
+        case 'SERVER':
+        case 'CONSUMER':
+          child = serviceName;
+          parent = remoteServiceName;
+          if (current === traceTree) { // we are the root-most span.
+            if (!parent) {
+              if (debug) console.log('The client of the root span is unknown; skipping');
+              continue;
+            }
+          }
+          break;
+        case 'CLIENT':
+        case 'PRODUCER':
+          parent = serviceName;
+          child = remoteServiceName;
+          break;
+        default:
+          if (debug) console.log('unknown kind; skipping');
+          continue;
+      }
+
+      let isError = currentSpan.tags.error !== undefined;
+      if (kind === 'PRODUCER' || kind === 'CONSUMER') {
+        if (!parent || !child) {
+          if (debug) console.log('cannot link messaging span to its broker; skipping');
+        } else {
+          this._addLink(parent, child, isError);
+        }
+        continue;
+      }
+
+      // Local spans may be between the current node and its remote parent
+      const remoteAncestor = this._firstRemoteAncestor(current);
+      let remoteAncestorName;
+      if (remoteAncestor) remoteAncestorName = getServiceName(remoteAncestor.localEndpoint);
+      if (remoteAncestor && remoteAncestorName) {
+        // Some users accidentally put the remote service name on client annotations.
+        // Check for this and backfill a link from the nearest remote to that service as necessary.
+        if (kind === 'CLIENT' && serviceName && remoteAncestorName !== serviceName) {
+          if (debug) console.log('detected missing link to client span');
+          this._addLink(remoteAncestorName, serviceName, false); // we don't know if it is an error
+        }
+
+        if (kind === 'SERVER' || !parent) parent = remoteAncestorName;
+
+        // When an RPC is split between spans, we skip the child (server side). If our parent is a
+        // client, we need to check it for errors.
+        if (!isError && remoteAncestor.kind === 'CLIENT'
+          && currentSpan.parentId && currentSpan.parentId === remoteAncestor.id) {
+          isError = isError || remoteAncestor.tags.error !== undefined;
+        }
+      }
+
+      if (!parent || !child) {
+        if (debug) console.log('cannot find remote ancestor; skipping');
+        continue;
+      }
+
+      this._addLink(parent, child, isError);
+    }
+  }
+
+  link() {
+    return link(this._callCounts, this._errorCounts);
+  }
+}

--- a/zipkin-lens/src/zipkin/dependency-linker.test.js
+++ b/zipkin-lens/src/zipkin/dependency-linker.test.js
@@ -1,0 +1,560 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { DependencyLinker } from './dependency-linker';
+import { SpanNodeBuilder } from './span-node';
+
+const debug = false; // switch to enable console output during tests
+const trace = [
+  {
+    traceId: 'a', id: 'a', kind: 'SERVER', localEndpoint: { serviceName: 'web' },
+  },
+  {
+    traceId: 'a', parentId: 'a', id: 'b', kind: 'CLIENT', localEndpoint: { serviceName: 'web' }, remoteEndpoint: { serviceName: 'app' },
+  },
+  {
+    traceId: 'a', parentId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'app' }, remoteEndpoint: { serviceName: 'web' }, shared: true,
+  },
+  {
+    traceId: 'a', parentId: 'b', id: 'c', kind: 'CLIENT', localEndpoint: { serviceName: 'app' }, remoteEndpoint: { serviceName: 'db' }, tags: { error: true },
+  },
+];
+
+// originally zipkin2.internal.DependencyLinkerTest.java
+describe('DependencyLinker', () => {
+  let dependencyLinker;
+
+  beforeEach(() => {
+    dependencyLinker = new DependencyLinker({ debug });
+  });
+
+  function putTrace(spans) {
+    dependencyLinker.putTrace(new SpanNodeBuilder({ debug }).build(spans));
+  }
+
+  it('should return empty by default', () => {
+    expect(dependencyLinker.link()).toEqual([]);
+  });
+
+  it('should link a trace', () => {
+    putTrace(trace);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'web', child: 'app', callCount: 1 },
+      {
+        parent: 'app', child: 'db', callCount: 1, errorCount: 1,
+      },
+    ]);
+  });
+
+  it('sum calls for each call to putTrace', () => {
+    putTrace(trace);
+    putTrace(trace);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'web', child: 'app', callCount: 2 },
+      {
+        parent: 'app', child: 'db', callCount: 2, errorCount: 2,
+      },
+    ]);
+  });
+
+  /*
+   * Some don't propagate the server's parent ID which creates a race condition. Try to unwind it.
+   *
+   * <p>See https://github.com/openzipkin/zipkin/pull/1745
+   */
+  it('should link spans when server is missing its parentId', () => {
+    // this trace is intentionally in reverse order.
+    putTrace([
+      // below the parent ID is null as it wasn't propagated
+      {
+        traceId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'app' }, shared: true,
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CLIENT', localEndpoint: { serviceName: 'web' },
+      },
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER', localEndpoint: { serviceName: 'web' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'web', child: 'app', callCount: 1 },
+    ]);
+  });
+
+  it('should link messaging spans by broker', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'PRODUCER', localEndpoint: { serviceName: 'producer' }, remoteEndpoint: { serviceName: 'kafka' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CONSUMER', localEndpoint: { serviceName: 'consumer' }, remoteEndpoint: { serviceName: 'kafka' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'producer', child: 'kafka', callCount: 1 },
+      { parent: 'kafka', child: 'consumer', callCount: 1 },
+    ]);
+  });
+
+  it('should not conflate messaging when they have different brokers', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'PRODUCER', localEndpoint: { serviceName: 'producer' }, remoteEndpoint: { serviceName: 'kafka1' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CONSUMER', localEndpoint: { serviceName: 'consumer' }, remoteEndpoint: { serviceName: 'kafka2' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'producer', child: 'kafka1', callCount: 1 },
+      { parent: 'kafka2', child: 'consumer', callCount: 1 },
+    ]);
+  });
+
+  it('should not link messaging spans missing broker', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'PRODUCER', localEndpoint: { serviceName: 'producer' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CONSUMER', localEndpoint: { serviceName: 'consumer' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([]);
+  });
+
+  /* Shows we don't assume there's a direct link between producer and consumer. */
+  it('should not link producer spans when missing broker', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'PRODUCER', localEndpoint: { serviceName: 'producer' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CONSUMER', localEndpoint: { serviceName: 'consumer' }, remoteEndpoint: { serviceName: 'kafka' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'kafka', child: 'consumer', callCount: 1 },
+    ]);
+  });
+
+  it('should not link consumer spans when missing broker', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'PRODUCER', localEndpoint: { serviceName: 'producer' }, remoteEndpoint: { serviceName: 'kafka' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CONSUMER', localEndpoint: { serviceName: 'consumer' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'producer', child: 'kafka', callCount: 1 },
+    ]);
+  });
+
+  /* When a server is the child of a producer span, make a link as it is really an RPC */
+  it('should interpret producer -> server as RPC', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'PRODUCER', localEndpoint: { serviceName: 'producer' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'server' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'producer', child: 'server', callCount: 1 },
+    ]);
+  });
+
+  /*
+   * Servers most often join a span vs create a child. Make sure this works when a producer is used
+   * instead of a client.
+   */
+  it('should interpret producer -> server as RPC, even sharing ID', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'PRODUCER', localEndpoint: { serviceName: 'producer' },
+      },
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER', localEndpoint: { serviceName: 'server' }, shared: true,
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'producer', child: 'server', callCount: 1 },
+    ]);
+  });
+
+  /*
+   * Client might be used for historical reasons instead of PRODUCER. Don't link as the server-side
+   * is authoritative.
+   */
+  it('should not interpret client as producer', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'client' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CONSUMER', localEndpoint: { serviceName: 'consumer' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([]);
+  });
+
+  /*
+   * A root span can be a client-originated trace or a server receipt which knows its peer. In these
+   * cases, the peer is known and kind establishes the direction.
+   */
+  it('should link spans directed by kind', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER', localEndpoint: { serviceName: 'server' }, remoteEndpoint: { serviceName: 'client' },
+      },
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'client' }, remoteEndpoint: { serviceName: 'server' }, shared: true,
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'client', child: 'server', callCount: 1 },
+    ]);
+  });
+
+  it('link calls to uninstrumented servers', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' }, remoteEndpoint: { serviceName: 'backend' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'c', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' }, remoteEndpoint: { serviceName: 'backend' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'frontend', child: 'backend', callCount: 2 },
+    ]);
+  });
+
+  it('link calls to uninstrumented servers, including errors', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' }, remoteEndpoint: { serviceName: 'backend' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'c', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' }, remoteEndpoint: { serviceName: 'backend' }, tags: { error: '' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      {
+        parent: 'frontend', child: 'backend', callCount: 2, errorCount: 1,
+      },
+    ]);
+  });
+
+  it('link incoming calls, using last RPC parent as service name', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'backend' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'c', kind: 'SERVER', localEndpoint: { serviceName: 'backend' }, tags: { error: '' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      {
+        parent: 'frontend', child: 'backend', callCount: 2, errorCount: 1,
+      },
+    ]);
+  });
+
+  /*
+   * Spans don't always include both the client and server service. When you know the kind, you can
+   * link these without duplicating call count.
+   */
+  it('should link single host spans as one call', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'client' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'server' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'client', child: 'server', callCount: 1 },
+    ]);
+  });
+
+  it('should link single host spans as one error', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'client' }, tags: { error: '' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'server' }, tags: { error: '' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      {
+        parent: 'client', child: 'server', callCount: 1, errorCount: 1,
+      },
+    ]);
+  });
+
+  it('should link shared RPC span as one error', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'client' }, tags: { error: '' },
+      },
+      {
+        traceId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'server' }, tags: { error: '' }, shared: true,
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      {
+        parent: 'client', child: 'server', callCount: 1, errorCount: 1,
+      },
+    ]);
+  });
+
+  it('should prefer server name in RPC link', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'client' }, remoteEndpoint: { serviceName: 'elephant' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'server' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      {
+        parent: 'client', child: 'server', callCount: 1,
+      },
+    ]);
+  });
+
+  /**
+   * Spans are sometimes intermediated by an unknown type of span. Prefer the nearest server when
+   * accounting for them.
+   */
+  it('tolerates missing localEndpoint between server and client', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b',
+      },
+      {
+        traceId: 'a', parentId: 'b', id: 'c', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' }, remoteEndpoint: { serviceName: 'backend' },
+      },
+      {
+        traceId: 'a', parentId: 'b', id: 'd', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' }, remoteEndpoint: { serviceName: 'backend' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'frontend', child: 'backend', callCount: 2 },
+    ]);
+  });
+
+  it('should not link leaf nodes when remote service name is unknown', () => {
+    putTrace([
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', parentId: 'b', id: 'c', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', parentId: 'b', id: 'd', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([]);
+  });
+
+  it('should create links when missing intermediate endpoint data', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', // possibly missing client/server span
+      },
+      {
+        traceId: 'a', parentId: 'b', id: 'c', kind: 'CLIENT', localEndpoint: { serviceName: 'backend' },
+      },
+      {
+        traceId: 'a', parentId: 'b', id: 'd', kind: 'CLIENT', localEndpoint: { serviceName: 'backend' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'frontend', child: 'backend', callCount: 2 },
+    ]);
+  });
+
+  it('should not attribute errors from uninstrumented links', () => {
+    putTrace([
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' },
+      },
+      // missing rpc span between here
+      {
+        traceId: 'a', parentId: 'b', id: 'c', kind: 'CLIENT', localEndpoint: { serviceName: 'backend' }, tags: { error: '' },
+      },
+      {
+        traceId: 'a', parentId: 'b', id: 'd', kind: 'CLIENT', localEndpoint: { serviceName: 'backend' }, tags: { error: '' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'frontend', child: 'backend', callCount: 2 },
+    ]);
+  });
+
+  /* Tag indicates a failed span, not an annotation */
+  it('should not count annotation error as errorCount', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'client' }, annotations: [{ timestamp: 1, value: 'error' }],
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'server' }, annotations: [{ timestamp: 1, value: 'error' }],
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      {
+        parent: 'client', child: 'server', callCount: 1,
+      },
+    ]);
+  });
+
+  it('should link loopback', () => {
+    putTrace([
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', parentId: 'a', id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'frontend' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'frontend', child: 'frontend', callCount: 1 },
+    ]);
+  });
+
+  it('should treat remote service names missing kind as RPC', () => {
+    putTrace([
+      {
+        traceId: 'a', parentId: 'a', id: 'b', localEndpoint: { serviceName: 'web' }, remoteEndpoint: { serviceName: 'app' },
+      },
+      {
+        traceId: 'a', parentId: 'b', id: 'c', localEndpoint: { serviceName: 'app' }, remoteEndpoint: { serviceName: 'db' }, tags: { error: true },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'web', child: 'app', callCount: 1 },
+      {
+        parent: 'app', child: 'db', callCount: 1, errorCount: 1,
+      },
+    ]);
+  });
+
+  /* We cannot link if we don't know both service names. */
+  it('should not link root RPC spans missing both service names', () => {
+    [
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER',
+      },
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', id: 'a', kind: 'SERVER', remoteEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT',
+      },
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', localEndpoint: { serviceName: 'frontend' },
+      },
+      {
+        traceId: 'a', id: 'a', kind: 'CLIENT', remoteEndpoint: { serviceName: 'frontend' },
+      },
+    ].forEach((root) => {
+      putTrace([root]);
+      expect(dependencyLinker.link()).toEqual([]);
+    });
+  });
+
+  it('should not link peer spans on different hosts missing parentID', () => {
+    const parentId = 'a'; // missing
+    putTrace([
+      {
+        traceId: 'a', parentId, id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'server1' },
+      },
+      {
+        traceId: 'a', parentId, id: 'c', kind: 'SERVER', localEndpoint: { serviceName: 'server2' },
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([]);
+  });
+
+  it('should tolerate missing root span', () => {
+    const parentId = 'a'; // missing
+    putTrace([
+      {
+        traceId: 'a', parentId, id: 'b', kind: 'CLIENT', localEndpoint: { serviceName: 'web' }, remoteEndpoint: { serviceName: 'app' },
+      },
+      {
+        traceId: 'a', parentId, id: 'b', kind: 'SERVER', localEndpoint: { serviceName: 'app' }, remoteEndpoint: { serviceName: 'web' }, shared: true,
+      },
+    ]);
+
+    expect(dependencyLinker.link()).toEqual([
+      { parent: 'web', child: 'app', callCount: 1 },
+    ]);
+  });
+});


### PR DESCRIPTION
This should allow integrations including:

* single trace aggregates
* aggregates across the results of the current query

Right now, this is a direct and complete port of the Java code. However,
we could do more later once this is integrated. Here are some options:

* include references to each span in the dependency link
  * Ex. trace/span id key so that you can jump directly to the row.
* full path tracing (future)
  * Ex. instead of parent/child, complete path from root to each leaf.

See #2701
See #2622
See #2230