### PR TITLE
Slight server cleanups around /health and self-tracing

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/SelfTracingProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/SelfTracingProperties.java
@@ -24,9 +24,9 @@ class SelfTracingProperties {
   /** Whether self-tracing is enabled. Defaults to {@code false}. */
   private boolean enabled = false;
   /**
-   * The percentage of traces retained when self-tracing. If 1.0 (i.e., all traces are sampled),
-   * the value of {@link #getTracesPerSecond()} will be used for sampling traces. Defaults to
-   * {@code 1.0}, sampling all traces.
+   * The percentage of traces retained when self-tracing. If 1.0 (i.e., all traces are sampled), the
+   * value of {@link #getTracesPerSecond()} will be used for sampling traces. Defaults to {@code
+   * 1.0}, sampling all traces.
    */
   private float sampleRate = 1.0f;
   /**
@@ -47,7 +47,6 @@ class SelfTracingProperties {
     this.enabled = enabled;
   }
 
-
   public float getSampleRate() {
     return sampleRate;
   }
@@ -55,7 +54,6 @@ class SelfTracingProperties {
   public void setSampleRate(float sampleRate) {
     this.sampleRate = sampleRate;
   }
-
 
   public int getTracesPerSecond() {
     return tracesPerSecond;

--- a/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
@@ -106,7 +106,7 @@ public class ITZipkinSelfTracing {
    * information.
    */
   @Test public void toStringContainsOnlySummaryInformation() {
-    assertThat(storage).hasToString("Traced{InMemoryStorage{traceCount=0}}");
+    assertThat(storage).hasToString("Traced{InMemoryStorage{}}");
     assertThat(reporter).hasToString("AsyncReporter{StorageComponent}");
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledStorageComponentTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledStorageComponentTest.java
@@ -59,7 +59,7 @@ public class ThrottledStorageComponentTest {
    */
   @Test public void toStringContainsOnlySummaryInformation() {
     assertThat(new ThrottledStorageComponent(delegate, registry, 1, 2, 1))
-      .hasToString("Throttled{InMemoryStorage{traceCount=0}}");
+      .hasToString("Throttled{InMemoryStorage{}}");
   }
 
   @Test public void delegatesCheck() {

--- a/zipkin/src/main/java/zipkin2/storage/InMemoryStorage.java
+++ b/zipkin/src/main/java/zipkin2/storage/InMemoryStorage.java
@@ -606,6 +606,6 @@ public final class InMemoryStorage extends StorageComponent implements SpanStore
   }
 
   @Override public String toString() {
-    return "InMemoryStorage{traceCount=" + traceIdToTraceIdTimeStamps.size() + "}";
+    return "InMemoryStorage{}";
   }
 }


### PR DESCRIPTION
Before, we were ignoring the sampling rate during self-tracing by
returning a constant (true) as opposed to deferring to the rate-limited
global sampler. Also, we put variables in the toString for
InMemoryStorage which isn't helpful as spring caches it in the /health
endpoint.