### PR TITLE
Instruments when STORAGE_THROTTLE_ENABLED=true

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
@@ -236,7 +236,8 @@ final class BodyIsExceptionMessage implements ExceptionHandlerFunction {
   public HttpResponse handleException(RequestContext ctx, HttpRequest req, Throwable cause) {
     ZipkinHttpCollector.metrics.incrementMessagesDropped();
 
-    String message = cause.getMessage() != null ? cause.getMessage() : "";
+    String message = cause.getMessage();
+    if (message == null) message = cause.getClass().getSimpleName();
     if (cause instanceof IllegalArgumentException) {
       return HttpResponse.of(BAD_REQUEST, MediaType.ANY_TEXT_TYPE, message);
     } else {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracedCall.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracedCall.java
@@ -20,12 +20,12 @@ import java.io.IOException;
 import zipkin2.Call;
 import zipkin2.Callback;
 
-final class TracedCall<V> extends Call<V> {
+public final class TracedCall<V> extends Call<V> {
   final Tracer tracer;
   final Call<V> delegate;
   final String name;
 
-  TracedCall(Tracer tracer, Call<V> delegate, String name) {
+  public TracedCall(Tracer tracer, Call<V> delegate, String name) {
     this.tracer = tracer;
     this.delegate = delegate;
     this.name = name;

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
@@ -29,8 +29,6 @@ import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
 
-import static zipkin2.server.internal.brave.TracingConfiguration.isSpanReporterThread;
-
 // public for use in ZipkinServerConfiguration
 public final class TracingStorageComponent extends ForwardingStorageComponent {
   final Tracing tracing;
@@ -167,8 +165,6 @@ public final class TracingStorageComponent extends ForwardingStorageComponent {
     }
 
     @Override public Call<Void> accept(List<Span> spans) {
-      Call<Void> call = delegate.accept(spans);
-      if (isSpanReporterThread()) return call;
       return new TracedCall<>(tracer, delegate.accept(spans), "accept-spans");
     }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
@@ -29,6 +29,8 @@ import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
 
+import static zipkin2.server.internal.brave.TracingConfiguration.isSpanReporterThread;
+
 // public for use in ZipkinServerConfiguration
 public final class TracingStorageComponent extends ForwardingStorageComponent {
   final Tracing tracing;
@@ -165,6 +167,8 @@ public final class TracingStorageComponent extends ForwardingStorageComponent {
     }
 
     @Override public Call<Void> accept(List<Span> spans) {
+      Call<Void> call = delegate.accept(spans);
+      if (isSpanReporterThread()) return call;
       return new TracedCall<>(tracer, delegate.accept(spans), "accept-spans");
     }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/LimiterMetrics.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/LimiterMetrics.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.throttle;
+
+import com.netflix.concurrency.limits.Limiter.Listener;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import zipkin2.collector.CollectorMetrics;
+
+/** Follows the same naming convention as {@link CollectorMetrics} */
+final class LimiterMetrics {
+  final Counter requests, requestsSucceeded, requestsIgnored, requestsDropped;
+
+  final Listener wrap(Listener delegate) {
+    return new Listener() {
+      @Override public void onSuccess() {
+        // usually we don't add metrics like this,
+        // but for now it is helpful to sanity check acquired vs erred.
+        requestsSucceeded.increment();
+        delegate.onSuccess();
+      }
+
+      @Override public void onIgnore() {
+        requestsIgnored.increment();
+        delegate.onIgnore();
+      }
+
+      @Override public void onDropped() {
+        requestsDropped.increment();
+        delegate.onDropped();
+      }
+    };
+  }
+
+  LimiterMetrics(MeterRegistry registry) {
+    requests = Counter.builder("zipkin_storage.throttle.requests")
+      .description("cumulative amount of limiter requests acquired")
+      .register(registry);
+    requestsSucceeded = Counter.builder("zipkin_storage.throttle.requests_succeeded")
+      .description("cumulative amount of limiter requests acquired that later succeeded")
+      .register(registry);
+    requestsDropped =
+      Counter.builder("zipkin_storage.throttle.requests_dropped")
+        .description(
+          "cumulative amount of limiter requests acquired that later dropped due to capacity")
+        .register(registry);
+    requestsIgnored =
+      Counter.builder("zipkin_storage.throttle.requests_ignored")
+        .description(
+          "cumulative amount of limiter requests acquired that later dropped not due to capacity")
+        .register(registry);
+  }
+}

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/LimiterMetrics.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/LimiterMetrics.java
@@ -40,6 +40,10 @@ final class LimiterMetrics {
         requestsDropped.increment();
         delegate.onDropped();
       }
+
+      @Override public String toString() {
+        return "LimiterMetrics{" + delegate + "}";
+      }
     };
   }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
@@ -16,11 +16,12 @@ package zipkin2.server.internal.throttle;
 import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.Limiter.Listener;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import zipkin2.Call;
 import zipkin2.Callback;
@@ -37,162 +38,160 @@ import zipkin2.Callback;
  *
  * @see ThrottledStorageComponent
  */
-final class ThrottledCall<V> extends Call.Base<V> {
-  final ExecutorService executor;
+final class ThrottledCall extends Call.Base<Void> {
+  final Call<Void> delegate;
+  final Executor executor;
   final Limiter<Void> limiter;
   final Predicate<Throwable> isOverCapacity;
-  final Call<V> delegate;
 
-  ThrottledCall(ExecutorService executor, Limiter<Void> limiter,
-    Predicate<Throwable> isOverCapacity, Call<V> delegate) {
+  ThrottledCall(Call<Void> delegate, Executor executor, Limiter<Void> limiter,
+    Predicate<Throwable> isOverCapacity) {
+    this.delegate = delegate;
     this.executor = executor;
     this.limiter = limiter;
     this.isOverCapacity = isOverCapacity;
-    this.delegate = delegate;
   }
 
-  @Override protected V doExecute() throws IOException {
-    Listener limitListener = limiter.acquire(null)
+  /**
+   * To simplify code, this doesn't actually invoke the underlying {@link #execute()} method. This
+   * is ok because in almost all cases, doing so would imply invoking {@link #enqueue(Callback)}
+   * anyway.
+   */
+  @Override protected Void doExecute() throws IOException {
+    AwaitableCallback awaitableCallback = new AwaitableCallback();
+    doEnqueue(awaitableCallback);
+    if (!await(awaitableCallback.countDown)) throw new InterruptedIOException();
+
+    Throwable t = awaitableCallback.throwable.get();
+    if (t != null) {
+      if (t instanceof Error) throw (Error) t;
+      if (t instanceof IOException) throw (IOException) t;
+      if (t instanceof RuntimeException) throw (RuntimeException) t;
+      throw new RuntimeException(t);
+    }
+    return null;
+  }
+
+  @Override protected void doEnqueue(Callback<Void> callback) {
+    Listener limiterListener = limiter.acquire(null)
       .orElseThrow(RejectedExecutionException::new); // TODO: make an exception message
+    LimiterReleasingCallback releasingCallback =
+      new LimiterReleasingCallback(callback, isOverCapacity, limiterListener);
 
     try {
-      // Make sure we throttle
-      Future<V> future = executor.submit(() -> {
-        String oldName = setCurrentThreadName(delegate.toString());
-        try {
-          return delegate.execute();
-        } finally {
-          setCurrentThreadName(oldName);
-        }
-      });
-      V result = future.get(); // Still block for the response
-
-      limitListener.onSuccess();
-      return result;
-    } catch (ExecutionException e) {
-      Throwable cause = e.getCause();
-      if (isOverCapacity.test(cause)) {
-        // Storage rejected us, throttle back
-        limitListener.onDropped();
-      } else {
-        limitListener.onIgnore();
-      }
-
-      if (cause instanceof RuntimeException) {
-        throw (RuntimeException) cause;
-      } else if (cause instanceof IOException) {
-        throw (IOException) cause;
-      } else {
-        throw new RuntimeException("Issue while executing on a throttled call", cause);
-      }
-    } catch (InterruptedException e) {
-      limitListener.onIgnore();
-      throw new RuntimeException("Interrupted while blocking on a throttled call", e);
-    } catch (RuntimeException | Error e) {
-      propagateIfFatal(e);
-      // Ignoring in all cases here because storage itself isn't saying we need to throttle.  Though, we may still be
-      // write bound, but a drop in concurrency won't necessarily help.
-      limitListener.onIgnore();
-      throw e;
+      executor.execute(new EnqueueAndAwait(this, releasingCallback));
+    } catch (RuntimeException | Error t) { // possibly rejected, but from the executor, not storage!
+      propagateIfFatal(t);
+      callback.onError(t);
+      // Ignoring in all cases here because storage itself isn't saying we need to throttle. Though
+      // we may still be write bound, but a drop in concurrency won't necessarily help.
+      limiterListener.onIgnore();
+      throw t;
     }
   }
 
-  @Override protected void doEnqueue(Callback<V> callback) {
-    Listener limitListener = limiter.acquire(null)
-      .orElseThrow(RejectedExecutionException::new); // TODO: make an exception message
-
-    try {
-      executor.execute(new QueuedCall<>(this, callback, limitListener));
-    } catch (RuntimeException | Error e) {
-      propagateIfFatal(e);
-      // Ignoring in all cases here because storage itself isn't saying we need to throttle.  Though, we may still be
-      // write bound, but a drop in concurrency won't necessarily help.
-      limitListener.onIgnore();
-      throw e;
-    }
-  }
-
-  @Override public Call<V> clone() {
-    return new ThrottledCall<>(executor, limiter, isOverCapacity, delegate.clone());
+  @Override public Call<Void> clone() {
+    return new ThrottledCall(delegate.clone(), executor, limiter, isOverCapacity);
   }
 
   @Override public String toString() {
     return "Throttled(" + delegate + ")";
   }
 
-  static String setCurrentThreadName(String name) {
-    Thread thread = Thread.currentThread();
-    String originalName = thread.getName();
-    thread.setName(name);
-    return originalName;
+  static final class AwaitableCallback implements Callback<Void> {
+    final CountDownLatch countDown = new CountDownLatch(1);
+    final AtomicReference<Throwable> throwable = new AtomicReference<>();
+
+    @Override public void onSuccess(Void ignored) {
+      countDown.countDown();
+    }
+
+    @Override public void onError(Throwable t) {
+      throwable.set(t);
+      countDown.countDown();
+    }
   }
 
-  static final class QueuedCall<V> implements Runnable {
-    final Call<V> delegate;
+  static final class EnqueueAndAwait implements Runnable {
+    final Call<Void> delegate;
     final Predicate<Throwable> isOverCapacity;
-    final Callback<V> callback;
-    final Listener limitListener;
+    final LimiterReleasingCallback callback;
 
-    QueuedCall(ThrottledCall<V> throttledCall, Callback<V> callback, Listener limitListener) {
+    EnqueueAndAwait(ThrottledCall throttledCall, LimiterReleasingCallback callback) {
       this.delegate = throttledCall.delegate;
       this.isOverCapacity = throttledCall.isOverCapacity;
       this.callback = callback;
-      this.limitListener = limitListener;
     }
 
+    /**
+     * This awaits callback completion in order to slow down (throttle) calls.
+     *
+     * <h3>This component does not affect the {@link Listener} directly</h3>
+     * There could be an error enqueuing the call or an interruption during shutdown of the
+     * executor. We do not affect the {@link Listener} here because it would be redundant to
+     * handling already done in {@link LimiterReleasingCallback}. For example, if shutting down, the
+     * storage layer would also invoke {@link LimiterReleasingCallback#onError(Throwable).
+     */
     @Override public void run() {
+      if (delegate.isCanceled()) return;
       try {
-        if (delegate.isCanceled()) return;
+        delegate.enqueue(callback);
 
-        String oldName = setCurrentThreadName(delegate.toString());
-        try {
-          enqueueAndWait();
-        } finally {
-          setCurrentThreadName(oldName);
-        }
-      } catch (Throwable t) {
+        // Need to wait here since the callback call will run asynchronously also.
+        // This ensures we don't exceed our throttle/queue limits.
+        await(callback.latch);
+      } catch (Throwable t) { // edge case: error during enqueue!
         propagateIfFatal(t);
-        limitListener.onIgnore();
         callback.onError(t);
       }
     }
 
-    void enqueueAndWait() {
-      ThrottledCallback<V> throttleCallback = new ThrottledCallback<>(this);
-      delegate.enqueue(throttleCallback);
-
-      // Need to wait here since the callback call will run asynchronously also.
-      // This ensures we don't exceed our throttle/queue limits.
-      throttleCallback.await();
-    }
-
     @Override public String toString() {
-      return "QueuedCall{delegate=" + delegate + ", callback=" + callback + "}";
+      return "EnqueueAndAwait{call=" + delegate + ", callback=" + callback.delegate + "}";
     }
   }
 
-  static final class ThrottledCallback<V> implements Callback<V> {
-    final QueuedCall<V> call;
-    final CountDownLatch latch = new CountDownLatch(1);
-
-    ThrottledCallback(QueuedCall<V> call) {
-      this.call = call;
-    }
-
-    void await() {
-      try {
-        latch.await();
-      } catch (InterruptedException e) {
+  /**
+   * Returns true if not interrupted.
+   *
+   * @see zipkin2.reporter.AwaitableCallback for tested code with the same await loop behavior.
+   */
+  static boolean await(CountDownLatch latch) {
+    boolean interrupted = false;
+    try {
+      while (true) {
+        try {
+          latch.await();
+          return true;
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
+      }
+    } finally {
+      if (interrupted) {
         Thread.currentThread().interrupt();
-        call.limitListener.onIgnore();
-        throw new RuntimeException("Interrupted while blocking on a throttled call", e);
+        return false;
       }
     }
+  }
 
-    @Override public void onSuccess(V value) {
+  static final class LimiterReleasingCallback implements Callback<Void> {
+    final Callback<Void> delegate;
+    final Predicate<Throwable> isOverCapacity;
+    final Listener limiterListener;
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    LimiterReleasingCallback(Callback<Void> delegate, Predicate<Throwable> isOverCapacity,
+      Listener limiterListener) {
+      this.delegate = delegate;
+      this.isOverCapacity = isOverCapacity;
+      this.limiterListener = limiterListener;
+    }
+
+    @Override public void onSuccess(Void value) {
       try {
-        call.limitListener.onSuccess();
-        call.callback.onSuccess(value);
+        limiterListener.onSuccess();
+        delegate.onSuccess(value);
       } finally {
         latch.countDown();
       }
@@ -200,20 +199,20 @@ final class ThrottledCall<V> extends Call.Base<V> {
 
     @Override public void onError(Throwable t) {
       try {
-        if (call.isOverCapacity.test(t)) {
-          call.limitListener.onDropped();
+        if (isOverCapacity.test(t)) {
+          limiterListener.onDropped();
         } else {
-          call.limitListener.onIgnore();
+          limiterListener.onIgnore();
         }
 
-        call.callback.onError(t);
+        delegate.onError(t);
       } finally {
         latch.countDown();
       }
     }
 
     @Override public String toString() {
-      return "Throttled(" + call.delegate + ")";
+      return "LimiterReleasingCallback(" + delegate + ")";
     }
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
@@ -128,7 +128,8 @@ final class ThrottledCall extends Call.Base<Void> {
     }
 
     /**
-     * This awaits callback completion in order to slow down (throttle) calls.
+     * This waits until completion to ensure the number of executing calls doesn't surpass the
+     * concurrency limit of the executor.
      *
      * <h3>This component does not affect the {@link Listener} directly</h3>
      * There could be an error enqueuing the call or an interruption during shutdown of the

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
@@ -13,6 +13,9 @@
  */
 package zipkin2.server.internal.throttle;
 
+import brave.Tracer;
+import brave.Tracing;
+import com.linecorp.armeria.common.RequestContext;
 import com.netflix.concurrency.limits.Limit;
 import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limit.Gradient2Limit;
@@ -23,7 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -32,9 +35,13 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import zipkin2.Call;
 import zipkin2.Span;
+import zipkin2.internal.Nullable;
+import zipkin2.server.internal.brave.TracedCall;
 import zipkin2.storage.ForwardingStorageComponent;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.StorageComponent;
+
+import static zipkin2.server.internal.brave.TracingConfiguration.isSpanReporterThread;
 
 /**
  * Delegating implementation that limits requests to the {@link #spanConsumer()} of another {@link
@@ -51,14 +58,14 @@ import zipkin2.storage.StorageComponent;
  */
 public final class ThrottledStorageComponent extends ForwardingStorageComponent {
   final StorageComponent delegate;
+  final @Nullable Tracing tracing;
   final AbstractLimiter<Void> limiter;
   final ThreadPoolExecutor executor;
 
   public ThrottledStorageComponent(StorageComponent delegate, MeterRegistry registry,
-    int minConcurrency,
-    int maxConcurrency,
-    int maxQueueSize) {
+    @Nullable Tracing tracing, int minConcurrency, int maxConcurrency, int maxQueueSize) {
     this.delegate = Objects.requireNonNull(delegate);
+    this.tracing = tracing;
 
     Limit limit = Gradient2Limit.newBuilder()
       .minLimit(minConcurrency)
@@ -70,12 +77,12 @@ public final class ThrottledStorageComponent extends ForwardingStorageComponent 
     this.limiter = new Builder().limit(limit).build();
 
     // TODO: explain these parameters
-    this.executor = new ThreadPoolExecutor(limit.getLimit(),
+    executor = new ThreadPoolExecutor(limit.getLimit(),
       limit.getLimit(),
       0,
       TimeUnit.DAYS,
       createQueue(maxQueueSize),
-      new ThottledThreadFactory(),
+      new ThrottledThreadFactory(),
       new ThreadPoolExecutor.AbortPolicy());
 
     limit.notifyOnChange(new ThreadPoolExecutorResizer(executor));
@@ -102,21 +109,47 @@ public final class ThrottledStorageComponent extends ForwardingStorageComponent 
     return "Throttled{" + delegate.toString() + "}";
   }
 
+  /**
+   * Lazy accesses the request context as we cannot scope the executor used by storage commands per
+   * request.
+   */
+  static final class RequestContextInstrumentedExecutor implements Executor {
+    final Executor delegate;
+
+    RequestContextInstrumentedExecutor(Executor delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public void execute(Runnable command) {
+      RequestContext rCtx = RequestContext.currentOrNull();
+      delegate.execute(rCtx != null ? rCtx.makeContextAware(command) : command);
+    }
+  }
+
   static final class ThrottledSpanConsumer implements SpanConsumer {
-    final ExecutorService executor;
+    final SpanConsumer delegate;
+    final Executor executor;
     final Limiter<Void> limiter;
     final Predicate<Throwable> isOverCapacity;
-    final SpanConsumer delegate;
+    @Nullable final Tracer tracer;
 
     ThrottledSpanConsumer(ThrottledStorageComponent throttledStorage) {
-      this.executor = throttledStorage.executor;
+      this.delegate = throttledStorage.delegate.spanConsumer();
+      this.executor = new RequestContextInstrumentedExecutor(throttledStorage.executor);
       this.limiter = throttledStorage.limiter;
       this.isOverCapacity = throttledStorage::isOverCapacity;
-      this.delegate = throttledStorage.delegate.spanConsumer();
+      this.tracer = throttledStorage.tracing != null ? throttledStorage.tracing.tracer() : null;
     }
 
     @Override public Call<Void> accept(List<Span> spans) {
-      return new ThrottledCall<>(executor, limiter, isOverCapacity, delegate.accept(spans));
+      Call<Void> result =
+        new ThrottledCall(delegate.accept(spans), executor, limiter, isOverCapacity);
+
+      // This ensures we don't amplify storage commands by tracing self-traced requests.
+      if (tracer != null && !isSpanReporterThread()) {
+        return new TracedCall<>(tracer, result, "throttled-accept-spans");
+      }
+      return result;
     }
 
     @Override public String toString() {
@@ -135,7 +168,10 @@ public final class ThrottledStorageComponent extends ForwardingStorageComponent 
     return new LinkedBlockingQueue<>(maxSize);
   }
 
-  static final class ThottledThreadFactory implements ThreadFactory {
+  static final class ThrottledThreadFactory implements ThreadFactory {
+    ThrottledThreadFactory() {
+    }
+
     @Override public Thread newThread(Runnable r) {
       Thread thread = new Thread(r);
       thread.setDaemon(true);

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
@@ -42,8 +42,6 @@ import zipkin2.storage.ForwardingStorageComponent;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.StorageComponent;
 
-import static zipkin2.server.internal.brave.TracingConfiguration.isSpanReporterThread;
-
 /**
  * Delegating implementation that limits requests to the {@link #spanConsumer()} of another {@link
  * StorageComponent}.  The theory here is that this class can be used to:
@@ -161,11 +159,7 @@ public final class ThrottledStorageComponent extends ForwardingStorageComponent 
       Call<Void> result = new ThrottledCall(
         delegate.accept(spans), executor, limiter, limiterMetrics, isOverCapacity);
 
-      // This ensures we don't amplify storage commands by tracing self-traced requests.
-      if (tracer != null && !isSpanReporterThread()) {
-        return new TracedCall<>(tracer, result, "throttled-accept-spans");
-      }
-      return result;
+      return tracer != null ? new TracedCall<>(tracer, result, "throttled-accept-spans") : result;
     }
 
     @Override public String toString() {

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -217,6 +217,8 @@ logging:
   level:
     # Silence Invalid method name: '__can__finagle__trace__v3__'
     com.facebook.swift.service.ThriftServiceProcessor: 'OFF'
+    # Silence 'Did you forget to use RequestContext' when self-tracing https://github.com/line/armeria/issues/1964
+    com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext: 'OFF'
 #     # investigate /api/v2/dependencies
 #     zipkin2.internal.DependencyLinker: 'DEBUG'
 #     # log cassandra queries (DEBUG is without values)

--- a/zipkin-server/src/test/java/zipkin2/server/internal/NoOpMeterRegistryConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/NoOpMeterRegistryConfiguration.java
@@ -1,0 +1,13 @@
+package zipkin2.server.internal;
+
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NoOpMeterRegistryConfiguration {
+  @Bean public MeterRegistry noOpMeterRegistry() {
+    return NoopMeterRegistry.get();
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/Access.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/Access.java
@@ -17,13 +17,15 @@ import java.net.URI;
 import java.util.List;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin2.server.internal.NoOpMeterRegistryConfiguration;
 
 /** opens package access for testing */
 public final class Access {
 
-  public static void registerElasticsearchHttp(AnnotationConfigApplicationContext context) {
+  public static void registerElasticsearch(AnnotationConfigApplicationContext context) {
     context.register(
       PropertyPlaceholderAutoConfiguration.class,
+      NoOpMeterRegistryConfiguration.class,
       ZipkinElasticsearchStorageConfiguration.class);
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchAuth.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchAuth.java
@@ -28,11 +28,11 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import zipkin2.elasticsearch.ElasticsearchStorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,7 +59,7 @@ public class ITElasticsearchAuth {
   };
 
   @Configuration static class TlsSelfSignedConfiguration {
-    @Bean @Qualifier(QUALIFIER)
+    @Bean @Qualifier(QUALIFIER) @Primary
     ClientFactory zipkinElasticsearchClientFactory() {
       return new ClientFactoryBuilder().sslContextCustomizer(
         ssl -> ssl.trustManager(InsecureTrustManagerFactory.INSTANCE)).build();
@@ -77,10 +77,8 @@ public class ITElasticsearchAuth {
       "zipkin.storage.elasticsearch.password:OpenSesame",
       "zipkin.storage.elasticsearch.hosts:https://127.0.0.1:" + server.httpsPort())
       .applyTo(context);
-    context.register(
-      TlsSelfSignedConfiguration.class,
-      PropertyPlaceholderAutoConfiguration.class,
-      ZipkinElasticsearchStorageConfiguration.class);
+    Access.registerElasticsearch(context);
+    context.register(TlsSelfSignedConfiguration.class);
     context.refresh();
     storage = context.getBean(ElasticsearchStorage.class);
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchClientInitialization.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchClientInitialization.java
@@ -15,7 +15,6 @@ package zipkin2.server.internal.elasticsearch;
 
 import java.io.IOException;
 import org.junit.Test;
-import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import zipkin2.CheckResult;
@@ -28,8 +27,8 @@ public class ITElasticsearchClientInitialization {
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
   /**
-   * This blocks for less than the timeout of 2 second to prove we defer i/o until first use
-   * of the storage component.
+   * This blocks for less than the timeout of 2 second to prove we defer i/o until first use of the
+   * storage component.
    */
   @Test(timeout = 1900L) public void defersIOUntilFirstUse() throws IOException {
     TestPropertyValues.of(
@@ -38,9 +37,7 @@ public class ITElasticsearchClientInitialization {
       "zipkin.storage.elasticsearch.timeout:2000",
       "zipkin.storage.elasticsearch.hosts:127.0.0.1:1234,127.0.0.1:5678")
       .applyTo(context);
-    context.register(
-      PropertyPlaceholderAutoConfiguration.class,
-      ZipkinElasticsearchStorageConfiguration.class);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     context.getBean(ElasticsearchStorage.class).close();
@@ -54,9 +51,7 @@ public class ITElasticsearchClientInitialization {
       "zipkin.storage.elasticsearch.timeout:1000",
       "zipkin.storage.elasticsearch.hosts:127.0.0.1:1234,127.0.0.1:5678")
       .applyTo(context);
-    context.register(
-      PropertyPlaceholderAutoConfiguration.class,
-      ZipkinElasticsearchStorageConfiguration.class);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     try (ElasticsearchStorage storage = context.getBean(ElasticsearchStorage.class)) {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import zipkin2.CheckResult;
@@ -67,9 +66,7 @@ public class ITElasticsearchHealthCheck {
       "zipkin.storage.elasticsearch.hosts:127.0.0.1:" +
         server1.httpPort() + ",127.0.0.1:" + server2.httpPort())
       .applyTo(context);
-    context.register(
-      PropertyPlaceholderAutoConfiguration.class,
-      ZipkinElasticsearchStorageConfiguration.class);
+    Access.registerElasticsearch(context);
     context.refresh();
   }
 
@@ -157,9 +154,7 @@ public class ITElasticsearchHealthCheck {
       "zipkin.storage.elasticsearch.hosts:127.0.0.1:" +
         server1.httpPort() + ",127.0.0.1:" + server2.httpPort())
       .applyTo(context);
-    context.register(
-      PropertyPlaceholderAutoConfiguration.class,
-      ZipkinElasticsearchStorageConfiguration.class);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     server1Health.setHealthy(false);

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchSelfTracing.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchSelfTracing.java
@@ -22,7 +22,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import zipkin2.elasticsearch.ElasticsearchStorage;
@@ -56,10 +55,8 @@ public class ITElasticsearchSelfTracing {
       "zipkin.self-tracing.traces-per-second=10",
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:" + server.httpUri("/")).applyTo(context);
-    context.register(
-      PropertyPlaceholderAutoConfiguration.class,
-      TracingConfiguration.class,
-      ZipkinElasticsearchStorageConfiguration.class);
+    Access.registerElasticsearch(context);
+    context.register(TracingConfiguration.class);
     context.refresh();
     storage = context.getBean(ElasticsearchStorage.class);
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
@@ -56,7 +56,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
   @Test(expected = NoSuchBeanDefinitionException.class)
   public void doesntProvideStorageComponent_whenStorageTypeNotElasticsearch() {
     TestPropertyValues.of("zipkin.storage.type:cassandra").applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     es();
@@ -67,7 +67,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:http://host1:9200")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es()).isNotNull();
@@ -78,7 +78,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:http://host1:9200,http://host2:9200")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(Access.convert(
@@ -91,7 +91,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:http://127.0.0.1:9200,http://127.0.0.1:9201")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es()).hasToString(
@@ -104,7 +104,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.elasticsearch.hosts:http://host1:9200",
       "zipkin.storage.elasticsearch.pipeline:zipkin")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es().pipeline()).isEqualTo("zipkin");
@@ -116,7 +116,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:host1:9300")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(Access.convert(
@@ -129,7 +129,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:host1:9200")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(context.getBean(SessionProtocol.class))
@@ -141,7 +141,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:https://localhost")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(context.getBean(SessionProtocol.class))
@@ -155,7 +155,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:host1")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(Access.convert(
@@ -182,7 +182,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
   /** Ensures we can wire up network interceptors, such as for logging or authentication */
   @Test public void usesInterceptorsQualifiedWith_zipkinElasticsearchHttp() {
     TestPropertyValues.of("zipkin.storage.type:elasticsearch").applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.register(CustomizerConfiguration.class);
     context.refresh();
 
@@ -193,7 +193,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
 
   @Test public void timeout_defaultsTo10Seconds() {
     TestPropertyValues.of("zipkin.storage.type:elasticsearch").applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     HttpClientFactory factory = context.getBean(HttpClientFactory.class);
@@ -209,7 +209,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.elasticsearch.hosts:127.0.0.1:1234",
       "zipkin.storage.elasticsearch.timeout:" + timeout)
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     HttpClientFactory factory = context.getBean(HttpClientFactory.class);
@@ -223,7 +223,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:http://host1:9200")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
     assertThat(es().strictTraceId()).isTrue();
   }
@@ -234,7 +234,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.elasticsearch.hosts:http://host1:9200",
       "zipkin.storage.strict-trace-id:false")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es().strictTraceId()).isFalse();
@@ -245,7 +245,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:http://host1:9200")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es().indexNameFormatter().formatTypeAndTimestamp("span", 0))
@@ -258,7 +258,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.elasticsearch.hosts:http://host1:9200",
       "zipkin.storage.elasticsearch.index:zipkin_prod")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es().indexNameFormatter().formatTypeAndTimestamp("span", 0))
@@ -271,7 +271,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.elasticsearch.hosts:http://host1:9200",
       "zipkin.storage.elasticsearch.date-separator:.")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es().indexNameFormatter().formatTypeAndTimestamp("span", 0))
@@ -284,7 +284,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.elasticsearch.hosts:http://host1:9200",
       "zipkin.storage.elasticsearch.date-separator:")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es().indexNameFormatter().formatTypeAndTimestamp("span", 0))
@@ -298,7 +298,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.elasticsearch.hosts:http://host1:9200",
       "zipkin.storage.elasticsearch.date-separator:blagho")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
 
     context.refresh();
   }
@@ -309,7 +309,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.elasticsearch.hosts:http://host1:9200",
       "zipkin.query.lookback:" + TimeUnit.DAYS.toMillis(2))
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es().namesLookback()).isEqualTo((int) TimeUnit.DAYS.toMillis(2));
@@ -322,7 +322,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.elasticsearch.hosts:127.0.0.1:1234")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     HttpClientFactory factory = context.getBean(HttpClientFactory.class);
@@ -349,7 +349,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.elasticsearch.username:somename",
       "zipkin.storage.elasticsearch.password:pass")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     HttpClientFactory factory = context.getBean(HttpClientFactory.class);
@@ -373,7 +373,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.search-enabled:false")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es()).extracting("searchEnabled")
@@ -385,7 +385,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.autocomplete-keys:environment")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es()).extracting("autocompleteKeys")
@@ -397,7 +397,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.autocomplete-ttl:60000")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es()).extracting("autocompleteTtl")
@@ -409,7 +409,7 @@ public class ZipkinElasticsearchStorageConfigurationTest {
       "zipkin.storage.type:elasticsearch",
       "zipkin.storage.autocomplete-cardinality:5000")
       .applyTo(context);
-    Access.registerElasticsearchHttp(context);
+    Access.registerElasticsearch(context);
     context.refresh();
 
     assertThat(es()).extracting("autocompleteCardinality")

--- a/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledCallTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledCallTest.java
@@ -59,7 +59,7 @@ public class ThrottledCallTest {
     Call<Void> delegate = mock(Call.class);
     when(delegate.toString()).thenReturn("StoreSpansCall{}");
 
-    assertThat(new ThrottledCall<Void>(executor, limiter, isOverCapacity, delegate))
+    assertThat(new ThrottledCall(delegate, executor, limiter, isOverCapacity))
       .hasToString("Throttled(StoreSpansCall{})");
   }
 
@@ -71,7 +71,7 @@ public class ThrottledCallTest {
     Semaphore startLock = new Semaphore(numThreads);
     Semaphore waitLock = new Semaphore(totalTasks);
     Semaphore failLock = new Semaphore(1);
-    ThrottledCall<Void> throttled = throttle(new LockedCall(startLock, waitLock));
+    ThrottledCall throttled = throttle(new LockedCall(startLock, waitLock));
 
     // Step 1: drain appropriate locks
     startLock.drainPermits();
@@ -123,8 +123,8 @@ public class ThrottledCallTest {
     FakeCall call = new FakeCall();
     call.overCapacity = true;
 
-    ThrottledCall<Void> throttle =
-      new ThrottledCall<>(executor, mockLimiter(listener), isOverCapacity, call);
+    ThrottledCall throttle =
+      new ThrottledCall(call, executor, mockLimiter(listener), isOverCapacity);
 
     try {
       throttle.execute();
@@ -137,8 +137,8 @@ public class ThrottledCallTest {
   @Test public void execute_ignoresLimit_whenPoolFull() throws Exception {
     Listener listener = mock(Listener.class);
 
-    ThrottledCall<Void> throttle = new ThrottledCall<>(mockExhaustedPool(), mockLimiter(listener),
-      isOverCapacity, new FakeCall());
+    ThrottledCall throttle = new ThrottledCall(new FakeCall(), mockExhaustedPool(),
+      mockLimiter(listener), isOverCapacity);
 
     try {
       throttle.execute();
@@ -155,7 +155,7 @@ public class ThrottledCallTest {
 
     Semaphore startLock = new Semaphore(numThreads);
     Semaphore waitLock = new Semaphore(totalTasks);
-    ThrottledCall<Void> throttle = throttle(new LockedCall(startLock, waitLock));
+    ThrottledCall throttle = throttle(new LockedCall(startLock, waitLock));
 
     // Step 1: drain appropriate locks
     startLock.drainPermits();
@@ -187,8 +187,8 @@ public class ThrottledCallTest {
     FakeCall call = new FakeCall();
     call.overCapacity = true;
 
-    ThrottledCall<Void> throttle = new ThrottledCall<>(executor, mockLimiter(listener),
-      isOverCapacity, call);
+    ThrottledCall throttle =
+      new ThrottledCall(call, executor, mockLimiter(listener), isOverCapacity);
 
     CountDownLatch latch = new CountDownLatch(1);
     throttle.enqueue(new Callback<Void>() {
@@ -208,18 +208,25 @@ public class ThrottledCallTest {
   @Test public void enqueue_ignoresLimit_whenPoolFull() {
     Listener listener = mock(Listener.class);
 
-    ThrottledCall<Void> throttle = new ThrottledCall<>(mockExhaustedPool(), mockLimiter(listener),
-      isOverCapacity, new FakeCall());
+    ThrottledCall throttle =
+      new ThrottledCall(new FakeCall(), mockExhaustedPool(), mockLimiter(listener),
+        isOverCapacity);
     try {
-      throttle.enqueue(null);
+      throttle.enqueue(new Callback<Void>() {
+        @Override public void onSuccess(Void value) {
+        }
+
+        @Override public void onError(Throwable t) {
+        }
+      });
       assertThat(true).isFalse(); // should raise a RejectedExecutionException
     } catch (RejectedExecutionException e) {
       verify(listener).onIgnore();
     }
   }
 
-  ThrottledCall<Void> throttle(Call<Void> delegate) {
-    return new ThrottledCall<Void>(executor, limiter, isOverCapacity, delegate);
+  ThrottledCall throttle(Call<Void> delegate) {
+    return new ThrottledCall(delegate, executor, limiter, isOverCapacity);
   }
 
   static final class LockedCall extends Call.Base<Void> {


### PR DESCRIPTION
Before, we couldn't see the effects of self-tracing when throttling
was enabled. This change simplifies some of the code in the throttling
feature such that it uses a simpler to instrument `Executor` to invoke
commands. This also makes explicit some tracing we are trying to avoid,
notably anything spawned by the tracer itself.

cc @Logic-32