### PR TITLE
Simplifies ThrottledCall to reduce GC overhead

### DIFF
--- a/benchmarks/src/main/java/zipkin2/server/internal/throttle/ThrottledCallBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/server/internal/throttle/ThrottledCallBenchmarks.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.throttle;
+
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+import com.netflix.concurrency.limits.limit.FixedLimit;
+import com.netflix.concurrency.limits.limiter.SimpleLimiter;
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin2.Call;
+import zipkin2.Callback;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Threads(2)
+public class ThrottledCallBenchmarks {
+  ExecutorService fakeCallExecutor = Executors.newSingleThreadExecutor();
+  ExecutorService executor = Executors.newSingleThreadExecutor();
+  ThrottledCall call;
+
+  @Setup public void setup() {
+    executor = Executors.newSingleThreadExecutor();
+    fakeCallExecutor = Executors.newSingleThreadExecutor();
+    SimpleLimiter<Void> limiter = SimpleLimiter.newBuilder().limit(FixedLimit.of(1)).build();
+    LimiterMetrics metrics = new LimiterMetrics(NoopMeterRegistry.get());
+    Predicate<Throwable> isOverCapacity = RejectedExecutionException.class::isInstance;
+    call =
+      new ThrottledCall(new FakeCall(fakeCallExecutor), executor, limiter, metrics, isOverCapacity);
+  }
+
+  @TearDown public void tearDown() {
+    executor.shutdown();
+    fakeCallExecutor.shutdown();
+  }
+
+  @Benchmark public Void execute() throws IOException {
+    return call.clone().execute();
+  }
+
+  static final class FakeCall extends Call.Base<Void> {
+    final Executor executor;
+    boolean overCapacity = false;
+
+    FakeCall(Executor executor) {
+      this.executor = executor;
+    }
+
+    @Override public Void doExecute() {
+      throw new AssertionError();
+    }
+
+    @Override public void doEnqueue(Callback<Void> callback) {
+      executor.execute(() -> {
+        if (overCapacity) {
+          callback.onError(new RejectedExecutionException());
+        } else {
+          callback.onSuccess(null);
+        }
+      });
+    }
+
+    @Override public FakeCall clone() {
+      return new FakeCall(executor);
+    }
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+      .addProfiler("gc")
+      .include(".*" + ThrottledCallBenchmarks.class.getSimpleName())
+      .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/LimiterMetrics.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/LimiterMetrics.java
@@ -13,7 +13,6 @@
  */
 package zipkin2.server.internal.throttle;
 
-import com.netflix.concurrency.limits.Limiter.Listener;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import zipkin2.collector.CollectorMetrics;
@@ -21,31 +20,6 @@ import zipkin2.collector.CollectorMetrics;
 /** Follows the same naming convention as {@link CollectorMetrics} */
 final class LimiterMetrics {
   final Counter requests, requestsSucceeded, requestsIgnored, requestsDropped;
-
-  final Listener wrap(Listener delegate) {
-    return new Listener() {
-      @Override public void onSuccess() {
-        // usually we don't add metrics like this,
-        // but for now it is helpful to sanity check acquired vs erred.
-        requestsSucceeded.increment();
-        delegate.onSuccess();
-      }
-
-      @Override public void onIgnore() {
-        requestsIgnored.increment();
-        delegate.onIgnore();
-      }
-
-      @Override public void onDropped() {
-        requestsDropped.increment();
-        delegate.onDropped();
-      }
-
-      @Override public String toString() {
-        return "LimiterMetrics{" + delegate + "}";
-      }
-    };
-  }
 
   LimiterMetrics(MeterRegistry registry) {
     requests = Counter.builder("zipkin_storage.throttle.requests")

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
@@ -38,11 +38,21 @@ import zipkin2.Callback;
  * @see ThrottledStorageComponent
  */
 final class ThrottledCall extends Call.Base<Void> {
+  static final Callback<Void> NOOP_CALLBACK = new Callback<Void>() {
+    @Override public void onSuccess(Void value) {
+    }
+
+    @Override public void onError(Throwable t) {
+    }
+  };
+
   final Call<Void> delegate;
   final Executor executor;
   final Limiter<Void> limiter;
   final LimiterMetrics limiterMetrics;
   final Predicate<Throwable> isOverCapacity;
+  final CountDownLatch latch = new CountDownLatch(1);
+  Throwable throwable; // thread visibility guaranteed by the countdown latch
 
   ThrottledCall(Call<Void> delegate, Executor executor, Limiter<Void> limiter,
     LimiterMetrics limiterMetrics, Predicate<Throwable> isOverCapacity) {
@@ -59,38 +69,38 @@ final class ThrottledCall extends Call.Base<Void> {
    * anyway.
    */
   @Override protected Void doExecute() throws IOException {
-    AwaitableCallback awaitableCallback = new AwaitableCallback();
-    doEnqueue(awaitableCallback);
-    if (!await(awaitableCallback.countDown)) throw new InterruptedIOException();
+    // Enqueue the call invocation on the executor and block until it completes.
+    doEnqueue(NOOP_CALLBACK);
+    if (!await(latch)) throw new InterruptedIOException();
 
-    Throwable t = awaitableCallback.throwable;
-    if (t != null) {
-      if (t instanceof Error) throw (Error) t;
-      if (t instanceof IOException) throw (IOException) t;
-      if (t instanceof RuntimeException) throw (RuntimeException) t;
-      throw new RuntimeException(t);
-    }
-    return null; // Void
+    // Check if the run resulted in an exception
+    Throwable t = this.throwable;
+    if (t == null) return null; // success
+
+    // Coerce the throwable to the signature of Call.execute()
+    if (t instanceof Error) throw (Error) t;
+    if (t instanceof IOException) throw (IOException) t;
+    if (t instanceof RuntimeException) throw (RuntimeException) t;
+    throw new RuntimeException(t);
   }
 
+  // When handling enqueue, we don't block the calling thread. Any exception goes to the callback.
   @Override protected void doEnqueue(Callback<Void> callback) {
     Listener limiterListener = limiter.acquire(null)
       .orElseThrow(RejectedExecutionException::new); // TODO: make an exception message
-    limiterMetrics.requests.increment();
-    limiterListener = limiterMetrics.wrap(limiterListener);
 
-    LimiterReleasingCallback releasingCallback =
-      new LimiterReleasingCallback(callback, isOverCapacity, limiterListener);
+    limiterMetrics.requests.increment();
+    EnqueueAndAwait enqueueAndAwait = new EnqueueAndAwait(callback, limiterListener);
 
     try {
-      executor.execute(new EnqueueAndAwait(this, releasingCallback));
+      executor.execute(enqueueAndAwait);
     } catch (RuntimeException | Error t) { // possibly rejected, but from the executor, not storage!
       propagateIfFatal(t);
       callback.onError(t);
       // Ignoring in all cases here because storage itself isn't saying we need to throttle. Though
       // we may still be write bound, but a drop in concurrency won't necessarily help.
       limiterListener.onIgnore();
-      throw t;
+      throw t; // allows blocking calls to see the exception
     }
   }
 
@@ -102,57 +112,72 @@ final class ThrottledCall extends Call.Base<Void> {
     return "Throttled(" + delegate + ")";
   }
 
-  static final class AwaitableCallback implements Callback<Void> {
-    final CountDownLatch countDown = new CountDownLatch(1);
-    Throwable throwable; // thread visibility guaranteed by the countdown latch
+  /** When run, this enqueues a call with a given callback, and awaits its completion. */
+  final class EnqueueAndAwait implements Runnable, Callback<Void> {
+    final Callback<Void> callback;
+    final Listener limiterListener;
 
-    @Override public void onSuccess(Void ignored) {
-      countDown.countDown();
-    }
-
-    @Override public void onError(Throwable t) {
-      throwable = t;
-      countDown.countDown();
-    }
-  }
-
-  static final class EnqueueAndAwait implements Runnable {
-    final Call<Void> delegate;
-    final Predicate<Throwable> isOverCapacity;
-    final LimiterReleasingCallback callback;
-
-    EnqueueAndAwait(ThrottledCall throttledCall, LimiterReleasingCallback callback) {
-      this.delegate = throttledCall.delegate;
-      this.isOverCapacity = throttledCall.isOverCapacity;
+    EnqueueAndAwait(Callback<Void> callback, Listener limiterListener) {
       this.callback = callback;
+      this.limiterListener = limiterListener;
     }
 
     /**
      * This waits until completion to ensure the number of executing calls doesn't surpass the
      * concurrency limit of the executor.
      *
-     * <h3>This component does not affect the {@link Listener} directly</h3>
+     * <h3>The {@link Listener} isn't affected during run</h3>
      * There could be an error enqueuing the call or an interruption during shutdown of the
      * executor. We do not affect the {@link Listener} here because it would be redundant to
-     * handling already done in {@link LimiterReleasingCallback}. For example, if shutting down, the
-     * storage layer would also invoke {@link LimiterReleasingCallback#onError(Throwable)}.
+     * handling already done in callbacks. For example, if shutting down, the storage layer would
+     * also invoke {@link #onError(Throwable)}.
      */
     @Override public void run() {
       if (delegate.isCanceled()) return;
       try {
-        delegate.enqueue(callback);
+        delegate.enqueue(this);
 
         // Need to wait here since the callback call will run asynchronously also.
         // This ensures we don't exceed our throttle/queue limits.
-        await(callback.latch);
+        await(latch);
       } catch (Throwable t) { // edge case: error during enqueue!
         propagateIfFatal(t);
         callback.onError(t);
       }
     }
 
+    @Override public void onSuccess(Void value) {
+      try {
+        // usually we don't add metrics like this,
+        // but for now it is helpful to sanity check acquired vs erred.
+        limiterMetrics.requestsSucceeded.increment();
+        limiterListener.onSuccess(); // NOTE: limiter could block and delay the caller's callback
+        callback.onSuccess(value);
+      } finally {
+        latch.countDown();
+      }
+    }
+
+    @Override public void onError(Throwable t) {
+      try {
+        throwable = t; // catch the throwable in case the invocation is blocking (Call.execute())
+        if (isOverCapacity.test(t)) {
+          limiterMetrics.requestsDropped.increment();
+          limiterListener.onDropped();
+        } else {
+          limiterMetrics.requestsIgnored.increment();
+          limiterListener.onIgnore();
+        }
+
+        // NOTE: the above limiter could block and delay the caller's callback
+        callback.onError(t);
+      } finally {
+        latch.countDown();
+      }
+    }
+
     @Override public String toString() {
-      return "EnqueueAndAwait{call=" + delegate + ", callback=" + callback.delegate + "}";
+      return "EnqueueAndAwait{call=" + delegate + ", callback=" + callback + "}";
     }
   }
 
@@ -177,48 +202,6 @@ final class ThrottledCall extends Call.Base<Void> {
         Thread.currentThread().interrupt();
         return false;
       }
-    }
-  }
-
-  static final class LimiterReleasingCallback implements Callback<Void> {
-    final Callback<Void> delegate;
-    final Predicate<Throwable> isOverCapacity;
-    final Listener limiterListener;
-    final CountDownLatch latch = new CountDownLatch(1);
-
-    LimiterReleasingCallback(Callback<Void> delegate, Predicate<Throwable> isOverCapacity,
-      Listener limiterListener) {
-      this.delegate = delegate;
-      this.isOverCapacity = isOverCapacity;
-      this.limiterListener = limiterListener;
-    }
-
-    @Override public void onSuccess(Void value) {
-      try {
-        limiterListener.onSuccess(); // NOTE: limiter could block and delay the caller's callback
-        delegate.onSuccess(value);
-      } finally {
-        latch.countDown();
-      }
-    }
-
-    @Override public void onError(Throwable t) {
-      try {
-        if (isOverCapacity.test(t)) {
-          limiterListener.onDropped();
-        } else {
-          limiterListener.onIgnore();
-        }
-
-        // NOTE: the above limiter could block and delay the caller's callback
-        delegate.onError(t);
-      } finally {
-        latch.countDown();
-      }
-    }
-
-    @Override public String toString() {
-      return "LimiterReleasingCallback(" + delegate + ")";
     }
   }
 }


### PR DESCRIPTION
@Logic-32 in one review noticed we could re-use a countdown latch when
doing execute. IIRC, he mentioned `Call` is one-shot anyway, which is
true. This was good advice. Flattening `ThrottledCall` made measurably
less GC in micro benchmarks.

Before
```
Benchmark                                                           Mode     Cnt     Score     Error   Units
ThrottledCallBenchmarks.execute                                   sample  774208    17.379 ±   0.077   us/op
ThrottledCallBenchmarks.execute:execute·p0.00                     sample             1.696             us/op
ThrottledCallBenchmarks.execute:execute·p0.50                     sample            15.376             us/op
ThrottledCallBenchmarks.execute:execute·p0.90                     sample            23.712             us/op
ThrottledCallBenchmarks.execute:execute·p0.95                     sample            29.664             us/op
ThrottledCallBenchmarks.execute:execute·p0.99                     sample            54.208             us/op
ThrottledCallBenchmarks.execute:execute·p0.999                    sample            95.616             us/op
ThrottledCallBenchmarks.execute:execute·p0.9999                   sample           185.829             us/op
ThrottledCallBenchmarks.execute:execute·p1.00                     sample          5464.064             us/op
ThrottledCallBenchmarks.execute:·gc.alloc.rate                    sample      15    40.681 ±   5.778  MB/sec
ThrottledCallBenchmarks.execute:·gc.alloc.rate.norm               sample      15   552.430 ±  77.257    B/op
ThrottledCallBenchmarks.execute:·gc.churn.G1_Eden_Space           sample      15    44.803 ±  53.001  MB/sec
ThrottledCallBenchmarks.execute:·gc.churn.G1_Eden_Space.norm      sample      15   612.823 ± 727.247    B/op
ThrottledCallBenchmarks.execute:·gc.churn.G1_Old_Gen              sample      15     0.052 ±   0.110  MB/sec
ThrottledCallBenchmarks.execute:·gc.churn.G1_Old_Gen.norm         sample      15     0.704 ±   1.488    B/op
ThrottledCallBenchmarks.execute:·gc.churn.G1_Survivor_Space       sample      15     0.044 ±   0.184  MB/sec
ThrottledCallBenchmarks.execute:·gc.churn.G1_Survivor_Space.norm  sample      15     0.588 ±   2.434    B/op
ThrottledCallBenchmarks.execute:·gc.count                         sample      15     7.000            counts
ThrottledCallBenchmarks.execute:·gc.time                          sample      15    29.000                ms
```

After
```
Benchmark                                                     Mode       Cnti       Score   Error   Units
ThrottledCallBenchmarks.execute                               sample  606001     17.678 ±   0.429   us/op
ThrottledCallBenchmarks.execute:execute·p0.00                 sample              9.152             us/op
ThrottledCallBenchmarks.execute:execute·p0.50                 sample             14.368             us/op
ThrottledCallBenchmarks.execute:execute·p0.90                 sample             23.360             us/op
ThrottledCallBenchmarks.execute:execute·p0.95                 sample             27.904             us/op
ThrottledCallBenchmarks.execute:execute·p0.99                 sample             42.368             us/op
ThrottledCallBenchmarks.execute:execute·p0.999                sample             80.768             us/op
ThrottledCallBenchmarks.execute:execute·p0.9999               sample           3725.718             us/op
ThrottledCallBenchmarks.execute:execute·p1.00                 sample          30277.632             us/op
ThrottledCallBenchmarks.execute:·gc.alloc.rate                sample      15     30.837 ±   6.145  MB/sec
ThrottledCallBenchmarks.execute:·gc.alloc.rate.norm           sample      15    401.481 ±  60.868    B/op
ThrottledCallBenchmarks.execute:·gc.churn.G1_Eden_Space       sample      15     32.435 ±  50.762  MB/sec
ThrottledCallBenchmarks.execute:·gc.churn.G1_Eden_Space.norm  sample      15    442.977 ± 708.124    B/op
ThrottledCallBenchmarks.execute:·gc.churn.G1_Old_Gen          sample      15      0.046 ±   0.130  MB/sec
ThrottledCallBenchmarks.execute:·gc.churn.G1_Old_Gen.norm     sample      15      0.567 ±   1.615    B/op
ThrottledCallBenchmarks.execute:·gc.count                     sample      15      5.000            counts
ThrottledCallBenchmarks.execute:·gc.time                      sample      15     18.000                ms
```