### PR TITLE
Makes throttling parameters obvious by controlling exceptions

### DIFF
--- a/zipkin-lens/src/zipkin/dependency-linker.js
+++ b/zipkin-lens/src/zipkin/dependency-linker.js
@@ -1,13 +1,13 @@
 /*
  * Copyright 2015-2019 The OpenZipkin Authors
  *
- * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.server.internal.throttle;
 
+import com.linecorp.armeria.common.util.Exceptions;
 import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.Limiter.Listener;
 import java.io.IOException;
@@ -41,8 +42,9 @@ import static com.linecorp.armeria.common.util.Exceptions.clearTrace;
  */
 final class ThrottledCall extends Call.Base<Void> {
   /**
-   * Rather than flooding when concurrency reached, return the same instance. The path to this is
-   * unimportant, so we clear the trace.
+   * <p>This reduces allocations when concurrency reached by always returning the same instance.
+   * This is only thrown in one location, and a stack trace starting from static initialization
+   * isn't useful. Hence, we {@link Exceptions#clearTrace clear the trace}.
    */
   static final RejectedExecutionException STORAGE_THROTTLE_MAX_CONCURRENCY =
     clearTrace(new RejectedExecutionException("STORAGE_THROTTLE_MAX_CONCURRENCY reached"));

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
@@ -25,6 +25,8 @@ import java.util.function.Predicate;
 import zipkin2.Call;
 import zipkin2.Callback;
 
+import static com.linecorp.armeria.common.util.Exceptions.clearTrace;
+
 /**
  * {@link Call} implementation that is backed by an {@link ExecutorService}. The ExecutorService
  * serves two purposes:
@@ -38,6 +40,13 @@ import zipkin2.Callback;
  * @see ThrottledStorageComponent
  */
 final class ThrottledCall extends Call.Base<Void> {
+  /**
+   * Rather than flooding when concurrency reached, return the same instance. The path to this is
+   * unimportant, so we clear the trace.
+   */
+  static final RejectedExecutionException STORAGE_THROTTLE_MAX_CONCURRENCY =
+    clearTrace(new RejectedExecutionException("STORAGE_THROTTLE_MAX_CONCURRENCY reached"));
+
   static final Callback<Void> NOOP_CALLBACK = new Callback<Void>() {
     @Override public void onSuccess(Void value) {
     }
@@ -86,8 +95,8 @@ final class ThrottledCall extends Call.Base<Void> {
 
   // When handling enqueue, we don't block the calling thread. Any exception goes to the callback.
   @Override protected void doEnqueue(Callback<Void> callback) {
-    Listener limiterListener = limiter.acquire(null)
-      .orElseThrow(RejectedExecutionException::new); // TODO: make an exception message
+    Listener limiterListener =
+      limiter.acquire(null).orElseThrow(() -> STORAGE_THROTTLE_MAX_CONCURRENCY);
 
     limiterMetrics.requests.increment();
     EnqueueAndAwait enqueueAndAwait = new EnqueueAndAwait(callback, limiterListener);

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
@@ -60,8 +60,8 @@ import static com.linecorp.armeria.common.util.Exceptions.clearTrace;
  */
 public final class ThrottledStorageComponent extends ForwardingStorageComponent {
   /**
-   * Rather than flooding when queue size reached, return the same instance. The path to this is
-   * unimportant, so we clear the trace.
+   * See {@link ThrottledCall#STORAGE_THROTTLE_MAX_CONCURRENCY} if unfamiliar with clearing trace on
+   * exceptions only thrown from one spot.
    */
   static final RejectedExecutionException STORAGE_THROTTLE_MAX_QUEUE_SIZE =
     clearTrace(new RejectedExecutionException("STORAGE_THROTTLE_MAX_QUEUE_SIZE reached"));


### PR DESCRIPTION
Before, I was a bit confused about what the different rejected errors
implied, both looking at the code and tests. This takes a more literal
approach, considering the invocation is only from the server. Instead,
this says which variables have been crossed in the exception message.

Secondarily, this uses a single exception for each of the cases in order
to reduce load (of creating exceptions) when a server is constantly
overloaded.