### PR TITLE
Classifies Elasticsearch ResponseTimeoutException as capacity related

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpMethod;
@@ -26,6 +27,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import zipkin2.CheckResult;
@@ -243,6 +245,16 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
     String url = '/' + index;
     AggregatedHttpRequest delete = AggregatedHttpRequest.of(HttpMethod.DELETE, url);
     http().newCall(delete, BodyConverters.NULL, "delete-index").execute();
+  }
+
+  /**
+   * Internal code and api responses coerce to {@link RejectedExecutionException} when work is
+   * rejected. We also classify {@link ResponseTimeoutException} as a capacity related exception
+   * eventhough capacity is not the only reason (timeout could also result from a misconfiguration
+   * or a network problem).
+   */
+  @Override public boolean isOverCapacity(Throwable e) {
+    return e instanceof RejectedExecutionException || e instanceof ResponseTimeoutException;
   }
 
   /** This is blocking so that we can determine if the cluster is healthy or not */


### PR DESCRIPTION
@anuraaga and I noticed that `ResponseTimeoutException` is raised when
Elasticsearch is unresponsive. Eventhough it can be raised for other
reasons, it seems a better choice to classify this as capacity related
vs not.

You'll notice the upstream project also classifies timeout as a signal
of capacity with the same result (drop)

https://github.com/Netflix/concurrency-limits/pull/132