### PR TITLE
Caches storage failures to skip quicker when docker is unavailable

### DIFF
--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -50,8 +50,8 @@ class ITCassandraStorage {
   @Nested
   class ITSpanStore extends zipkin2.storage.ITSpanStore<CassandraStorage> {
     @Override protected boolean initializeStoragePerTest() {
-    return true;
-  }
+      return true;
+    }
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
       return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
@@ -107,8 +107,8 @@ class ITCassandraStorage {
 
       // Index ends up containing more rows than services * trace count, and cannot be de-duped
       // in a server-side query.
-      int localServiceCount = storage.serviceAndSpanNames().getServiceNames().execute().size();
-      assertThat(storage
+      int localServiceCount = names().getServiceNames().execute().size();
+      assertThat(storage()
         .session()
         .execute("SELECT COUNT(*) from service_name_index")
         .one()
@@ -125,7 +125,7 @@ class ITCassandraStorage {
 
     @Test void searchingByAnnotationShouldFilterBeforeLimiting() throws IOException {
       int queryLimit = 2;
-      int nbTraceFetched = queryLimit * storage.indexFetchMultiplier;
+      int nbTraceFetched = queryLimit * storage().indexFetchMultiplier;
 
       for (int i = 0; i < nbTraceFetched; i++) {
         accept(TestObjects.LOTS_OF_SPANS[i++].toBuilder().timestamp((TODAY - i) * 1000L).build());
@@ -156,7 +156,7 @@ class ITCassandraStorage {
       for (List<Span> nextChunk : Lists.partition(asList(spans), 100)) {
         super.accept(nextChunk.toArray(new Span[0]));
         // Now, block until writes complete, notably so we can read them.
-        blockWhileInFlight(storage);
+        blockWhileInFlight(storage());
       }
     }
   }
@@ -239,9 +239,9 @@ class ITCassandraStorage {
      * The current implementation does not include dependency aggregation. It includes retrieval of
      * pre-aggregated links, usually made via zipkin-dependencies
      */
-    @Override protected void processDependencies(List<Span> spans) throws Exception {
+    @Override protected void processDependencies(List<Span> spans) {
       aggregateLinks(spans).forEach(
-        (midnight, links) -> writeDependencyLinks(storage, links, midnight));
+        (midnight, links) -> writeDependencyLinks(storage(), links, midnight));
     }
   }
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
@@ -48,15 +48,15 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
   abstract CassandraStorage.Builder storageBuilder();
 
   /**
-   * {@link Span#duration} == 0 is likely to be a mistake, and coerces to null. It is not helpful to
-   * index rows who have no duration.
+   * {@link Span#duration()} == 0 is likely to be a mistake, and coerces to null. It is not helpful
+   * to index rows who have no duration.
    */
   @Test public void doesntIndexSpansMissingDuration() throws IOException {
     Span span = Span.newBuilder().traceId("1").id("1").name("get").duration(0L).build();
 
-    accept(storage.spanConsumer(), span);
+    accept(spanConsumer(), span);
 
-    assertThat(rowCountForTraceByServiceSpan(storage)).isZero();
+    assertThat(rowCountForTraceByServiceSpan(storage())).isZero();
   }
 
   /**
@@ -80,20 +80,19 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
       .duration(10L)
       .build());
 
-    accept(storage.spanConsumer(), trace);
-    assertThat(rowCountForTraceByServiceSpan(storage))
+    accept(spanConsumer(), trace);
+    assertThat(rowCountForTraceByServiceSpan(storage()))
       .isGreaterThanOrEqualTo(4L);
-    assertThat(rowCountForTraceByServiceSpan(storage))
+    assertThat(rowCountForTraceByServiceSpan(storage()))
       .isGreaterThanOrEqualTo(4L);
 
     // sanity check base case
-    accept(storage.toBuilder().strictTraceId(false).build().spanConsumer(), trace);
+    accept(storage().toBuilder().strictTraceId(false).build().spanConsumer(), trace);
 
-    assertThat(rowCountForTraceByServiceSpan(storage))
+    assertThat(rowCountForTraceByServiceSpan(storage()))
       .isGreaterThanOrEqualTo(120L); // TODO: magic number
-    assertThat(rowCountForTraceByServiceSpan(storage))
+    assertThat(rowCountForTraceByServiceSpan(storage()))
       .isGreaterThanOrEqualTo(120L);
-
   }
 
   @Test
@@ -115,13 +114,12 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
       .duration(10L)
       .build());
 
-    accept(storage.spanConsumer(), trace);
+    accept(spanConsumer(), trace);
 
-    assertThat(rowCountForTags(storage))
+    assertThat(rowCountForTags(storage()))
       .isEqualTo(1L); // Since tag {a,b} are not in the whitelist
 
-    assertThat(getTagValue(storage, "environment")).isEqualTo("dev");
-
+    assertThat(getTagValue(storage(), "environment")).isEqualTo("dev");
   }
 
   void accept(SpanConsumer consumer, Span... spans) throws IOException {
@@ -143,6 +141,7 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
       .one()
       .getLong(0);
   }
+
   static String getTagValue(CassandraStorage storage, String key) {
     return storage
       .session()

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorage.java
@@ -35,7 +35,7 @@ abstract class ITElasticsearchStorage {
     }
 
     @Override public void clear() throws IOException {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -46,7 +46,7 @@ abstract class ITElasticsearchStorage {
     }
 
     @Override public void clear() throws IOException {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -57,7 +57,7 @@ abstract class ITElasticsearchStorage {
     }
 
     @Override public void clear() throws IOException {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -68,7 +68,7 @@ abstract class ITElasticsearchStorage {
     }
 
     @Override public void clear() throws IOException {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -79,7 +79,7 @@ abstract class ITElasticsearchStorage {
     }
 
     @Override public void clear() throws IOException {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -96,11 +96,11 @@ abstract class ITElasticsearchStorage {
     @Override protected void processDependencies(List<Span> spans) {
       aggregateLinks(spans).forEach(
         (midnight, links) -> InternalForTests.writeDependencyLinks(
-          storage, links, midnight));
+          storage(), links, midnight));
     }
 
     @Override public void clear() throws IOException {
-      storage.clear();
+      storage().clear();
     }
   }
 

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -43,7 +43,7 @@ class ITMySQLStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
 
     @Override @Test @Disabled("No consumer-side span deduplication") public void deduplicates() {
@@ -57,7 +57,7 @@ class ITMySQLStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -68,7 +68,7 @@ class ITMySQLStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -79,7 +79,7 @@ class ITMySQLStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
 
     /**
@@ -87,8 +87,8 @@ class ITMySQLStorage {
      * pre-aggregated links, usually made via zipkin-dependencies
      */
     @Override protected void processDependencies(List<zipkin2.Span> spans) throws Exception {
-      try (Connection conn = storage.datasource.getConnection()) {
-        DSLContext context = storage.context.get(conn);
+      try (Connection conn = storage().datasource.getConnection()) {
+        DSLContext context = storage().context.get(conn);
 
         // batch insert the rows at timestamp midnight
         List<Query> inserts = new ArrayList<>();
@@ -116,7 +116,7 @@ class ITMySQLStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -127,7 +127,7 @@ class ITMySQLStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -138,7 +138,7 @@ class ITMySQLStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 }

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
@@ -40,9 +40,9 @@ public abstract class ITAutocompleteTags<T extends StorageComponent> extends ITS
       .putTag("http.method", "GET")
       .build());
 
-    assertThat(storage.autocompleteTags().getKeys().execute()).doesNotContain("http.method");
+    assertThat(storage().autocompleteTags().getKeys().execute()).doesNotContain("http.method");
 
-    assertThat(storage.autocompleteTags().getValues("http.method").execute()).isEmpty();
+    assertThat(storage().autocompleteTags().getValues("http.method").execute()).isEmpty();
   }
 
   @Test void getTagsAndValues() throws IOException {
@@ -53,14 +53,14 @@ public abstract class ITAutocompleteTags<T extends StorageComponent> extends ITS
         .build());
     }
 
-    assertThat(storage.autocompleteTags().getKeys().execute())
+    assertThat(storage().autocompleteTags().getKeys().execute())
       .containsOnlyOnce("http.host");
 
-    assertThat(storage.autocompleteTags().getValues("http.host").execute())
+    assertThat(storage().autocompleteTags().getValues("http.host").execute())
       .containsOnlyOnce("host1");
   }
 
   protected void accept(Span... spans) throws IOException {
-    storage.spanConsumer().accept(asList(spans)).execute();
+    spanConsumer().accept(asList(spans)).execute();
   }
 }

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITDependencies.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITDependencies.java
@@ -70,7 +70,7 @@ public abstract class ITDependencies<T extends StorageComponent> extends ITStora
    * this method.
    */
   protected void processDependencies(List<Span> spans) throws Exception {
-    storage.spanConsumer().accept(spans).execute();
+    spanConsumer().accept(spans).execute();
   }
 
   /**

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITSearchEnabledFalse.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITSearchEnabledFalse.java
@@ -76,6 +76,6 @@ public abstract class ITSearchEnabledFalse<T extends StorageComponent> extends I
   }
 
   protected void accept(Span... spans) throws IOException {
-    storage.spanConsumer().accept(asList(spans)).execute();
+    spanConsumer().accept(asList(spans)).execute();
   }
 }

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITServiceAndSpanNames.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITServiceAndSpanNames.java
@@ -165,10 +165,10 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
   }
 
   protected void accept(List<Span> spans) throws IOException {
-    storage.spanConsumer().accept(spans).execute();
+    spanConsumer().accept(spans).execute();
   }
 
   protected void accept(Span... spans) throws IOException {
-    storage.spanConsumer().accept(asList(spans)).execute();
+    spanConsumer().accept(asList(spans)).execute();
   }
 }

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITSpanStore.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITSpanStore.java
@@ -101,7 +101,7 @@ public abstract class ITSpanStore<T extends StorageComponent> extends ITStorage<
   }
 
   @Test void consumer_properlyImplementsCallContract_execute() throws IOException {
-    Call<Void> call = storage.spanConsumer().accept(asList(LOTS_OF_SPANS[0]));
+    Call<Void> call = spanConsumer().accept(asList(LOTS_OF_SPANS[0]));
 
     // Ensure the implementation didn't accidentally do I/O at assembly time.
     assertThat(store().getTrace(LOTS_OF_SPANS[0].traceId()).execute()).isEmpty();
@@ -121,7 +121,7 @@ public abstract class ITSpanStore<T extends StorageComponent> extends ITStorage<
   }
 
   @Test void consumer_properlyImplementsCallContract_submit() throws Exception {
-    Call<Void> call = storage.spanConsumer().accept(asList(LOTS_OF_SPANS[0]));
+    Call<Void> call = spanConsumer().accept(asList(LOTS_OF_SPANS[0]));
     // Ensure the implementation didn't accidentally do I/O at assembly time.
     assertThat(store().getTrace(LOTS_OF_SPANS[0].traceId()).execute()).isEmpty();
 
@@ -863,11 +863,11 @@ public abstract class ITSpanStore<T extends StorageComponent> extends ITStorage<
   }
 
   protected void accept(List<Span> spans) throws IOException {
-    storage.spanConsumer().accept(spans).execute();
+    spanConsumer().accept(spans).execute();
   }
 
   protected void accept(Span... spans) throws IOException {
-    storage.spanConsumer().accept(asList(spans)).execute();
+    spanConsumer().accept(asList(spans)).execute();
   }
 
   void setupDurationData() throws IOException {

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITStrictTraceIdFalse.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITStrictTraceIdFalse.java
@@ -43,7 +43,7 @@ public abstract class ITStrictTraceIdFalse<T extends StorageComponent> extends I
 
   /** Ensures we can still lookup fully 128-bit traces when strict trace ID id disabled */
   @Test void getTraces_128BitTraceId() throws IOException {
-    getTraces_128BitTraceId(accept128BitTrace(storage));
+    getTraces_128BitTraceId(accept128BitTrace(storage()));
   }
 
   @Test void getTraces_128BitTraceId_mixed() throws IOException {
@@ -68,7 +68,7 @@ public abstract class ITStrictTraceIdFalse<T extends StorageComponent> extends I
   }
 
   @Test void getTrace_retrievesBy64Or128BitTraceId() throws IOException {
-    List<Span> trace = accept128BitTrace(storage);
+    List<Span> trace = accept128BitTrace(storage());
 
     retrievesBy64Or128BitTraceId(trace);
   }
@@ -106,7 +106,7 @@ public abstract class ITStrictTraceIdFalse<T extends StorageComponent> extends I
   }
 
   void accept(Span... spans) throws IOException {
-    storage.spanConsumer().accept(asList(spans)).execute();
+    spanConsumer().accept(asList(spans)).execute();
   }
 }
 

--- a/zipkin-tests/src/test/java/zipkin2/storage/ITInMemoryStorage.java
+++ b/zipkin-tests/src/test/java/zipkin2/storage/ITInMemoryStorage.java
@@ -25,7 +25,7 @@ class ITInMemoryStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -36,7 +36,7 @@ class ITInMemoryStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -47,7 +47,7 @@ class ITInMemoryStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -58,7 +58,7 @@ class ITInMemoryStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -69,7 +69,7 @@ class ITInMemoryStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 
@@ -80,7 +80,7 @@ class ITInMemoryStorage {
     }
 
     @Override public void clear() {
-      storage.clear();
+      storage().clear();
     }
   }
 }


### PR DESCRIPTION
I noticed we still burn a lot of time when docker is turned off
intentionally. This makes an assumption that if you cannot initially
contact docker, or whatever the backend is, that you won't be able to
later, either.