### PR TITLE
Restricts build to JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ cache:
 
 language: java
 
-jdk:
-  # needs to be JDK 1.8 as long as we start Kafka 0.8
-  - oraclejdk8
+jdk: openjdk11
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The [Zipkin server](zipkin-server) receives spans via HTTP POST and respond to q
 from its UI. It can also run collectors, such as RabbitMQ or Kafka.
 
 To run the server from the currently checked out source, enter the
-following. JDK 8 is required.
+following. JDK 11 is required to compile the source.
 ```bash
 # Build the server and also make its dependencies
 $ ./mvnw -DskipTests --also-make -pl zipkin-server clean install

--- a/pom.xml
+++ b/pom.xml
@@ -709,7 +709,7 @@
               <rules>
                 <requireJavaVersion>
                   <!-- don't JDK 12 until https://github.com/google/error-prone/issues/1106 -->
-                  <version>[1.8,12)</version>
+                  <version>[11,12)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -720,49 +720,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>error-prone-1.8</id>
-      <activation>
-        <jdk>1.8</jdk>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <!-- only use errorprone on main source tree -->
-                <id>default-compile</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>compile</goal>
-                </goals>
-                <configuration>
-                  <compilerId>javac-with-errorprone</compilerId>
-                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                  <compilerArgs>
-                    <arg>${errorprone.args}</arg>
-                  </compilerArgs>
-                </configuration>
-              </execution>
-            </executions>
-            <dependencies>
-              <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                <version>2.8.5</version>
-              </dependency>
-              <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>${errorprone.version}</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>error-prone-9+</id>
       <activation>


### PR DESCRIPTION
Before, we were pinned to the EOL JDK 1.8 because we started Kafka 0.8. We forgot to remove the pinning part. More importantly, moving off 1.8 fixes build problems related to errorprone.