### PR TITLE
Aggregate on context aware event loop instead of delaying it with han…

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpCollector.java
@@ -113,7 +113,7 @@ public class ZipkinHttpCollector {
     HttpRequest req) {
     CompletableCallback result = new CompletableCallback();
 
-    req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handleAsync((msg, t) -> {
+    req.aggregateWithPooledObjects(ctx.contextAwareEventLoop(), ctx.alloc()).handle((msg, t) -> {
       if (t != null) {
         result.onError(t);
         return null;
@@ -165,7 +165,7 @@ public class ZipkinHttpCollector {
       }
 
       return null;
-    }, ctx.contextAwareExecutor());
+    });
 
     return HttpResponse.from(result);
   }

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -217,6 +217,10 @@ logging:
   level:
     # Silence Invalid method name: '__can__finagle__trace__v3__'
     com.facebook.swift.service.ThriftServiceProcessor: 'OFF'
+
+    # Silence ResponseTimeoutException in the Armeria framework since we log it anyways in HTTP
+    # logging when enabled. https://github.com/line/armeria/issues/2000
+    com.linecorp.armeria.client.HttpResponseDecoder: 'OFF'
 #     # investigate /api/v2/dependencies
 #     zipkin2.internal.DependencyLinker: 'DEBUG'
 #     # log cassandra queries (DEBUG is without values)


### PR DESCRIPTION
…dleAsync.

Also squashes ResponseTimeoutException logging.

Fixes #2756 
Part of #2757 

I'm really not sure why this has such a huge impact on performance. But the metrics always follow this pattern and are very clear. (Measured with https://github.com/openzipkin-contrib/zipkin-armeria-example and my Armeria-based "wrk" Java code against a local docker ES7)

Now (most requests 1ms)
```
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.001",} 92.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.001048576",} 94.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.001398101",} 107.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.001747626",} 111.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.002097151",} 113.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.002446676",} 113.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.002796201",} 113.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.003145726",} 114.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.003495251",} 114.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.003844776",} 114.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.004194304",} 114.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.005592405",} 114.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.006990506",} 115.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.008388607",} 118.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.009786708",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.011184809",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.01258291",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.013981011",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.015379112",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.016777216",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.022369621",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.027962026",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.033554431",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.039146836",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.044739241",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.050331646",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.055924051",} 119.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.061516456",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.067108864",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.089478485",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.111848106",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.134217727",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.156587348",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.178956969",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.20132659",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.223696211",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.246065832",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.268435456",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.357913941",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.447392426",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.536870911",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.626349396",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.715827881",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.805306366",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.894784851",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.984263336",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="1.073741824",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="1.431655765",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="1.789569706",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="2.147483647",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="2.505397588",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="2.863311529",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="3.22122547",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="3.579139411",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="3.937053352",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="4.294967296",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="5.726623061",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="7.158278826",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="8.589934591",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="10.021590356",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="11.453246121",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="12.884901886",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="14.316557651",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="15.748213416",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="17.179869184",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="22.906492245",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="28.633115306",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="30.0",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="+Inf",} 120.0
http_server_requests_seconds_count{method="POST",status="202",uri="/api/v2/spans",} 120.0
http_server_requests_seconds_sum{method="POST",status="202",uri="/api/v2/spans",} 0.1763308
```

Before (most requests at least 80ms)
```
http_server_requests_seconds_sum{method="GET",status="200",uri="/internal/metrics",} 0.0858459
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.001",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.001048576",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.001398101",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.001747626",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.002097151",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.002446676",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.002796201",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.003145726",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.003495251",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.003844776",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.004194304",} 0.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.005592405",} 1.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.006990506",} 2.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.008388607",} 2.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.009786708",} 2.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.011184809",} 2.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.01258291",} 2.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.013981011",} 2.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.015379112",} 2.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.016777216",} 2.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.022369621",} 2.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.027962026",} 6.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.033554431",} 9.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.039146836",} 10.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.044739241",} 12.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.050331646",} 15.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.055924051",} 20.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.061516456",} 32.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.067108864",} 49.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.089478485",} 97.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.111848106",} 109.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.134217727",} 113.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.156587348",} 117.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.178956969",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.20132659",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.223696211",} 120.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.246065832",} 121.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.268435456",} 121.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.357913941",} 123.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.447392426",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.536870911",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.626349396",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.715827881",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.805306366",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.894784851",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="0.984263336",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="1.073741824",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="1.431655765",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="1.789569706",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="2.147483647",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="2.505397588",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="2.863311529",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="3.22122547",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="3.579139411",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="3.937053352",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="4.294967296",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="5.726623061",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="7.158278826",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="8.589934591",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="10.021590356",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="11.453246121",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="12.884901886",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="14.316557651",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="15.748213416",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="17.179869184",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="22.906492245",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="28.633115306",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="30.0",} 124.0
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans",le="+Inf",} 124.0
http_server_requests_seconds_count{method="POST",status="202",uri="/api/v2/spans",} 124.0
http_server_requests_seconds_sum{method="POST",status="202",uri="/api/v2/spans",} 10.1532103
```

And while I think we intentionally made the reverse change to fix self-tracing, I suspect it wasn't actually this code that broke context but somewhere else (probably zipkin-aws). It looks like it works ok and is the correct pattern.

![image](https://user-images.githubusercontent.com/198344/63226690-fdd2d580-c217-11e9-80a8-2cffb29ba8bf.png)
