### PR TITLE
Define an interface for supplying a request to give call sites more c…

### DIFF
--- a/benchmarks/src/main/java/zipkin2/elasticsearch/internal/BulkRequestBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/elasticsearch/internal/BulkRequestBenchmarks.java
@@ -15,6 +15,7 @@ package zipkin2.elasticsearch.internal;
 
 import com.google.common.io.ByteStreams;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import java.io.IOException;
@@ -65,8 +66,8 @@ public class BulkRequestBenchmarks {
     BulkCallBuilder builder = new BulkCallBuilder(es, 6.7f, "index-span");
     builder.index(spanIndex, "span", CLIENT_SPAN, BulkIndexWriter.SPAN);
     HttpCall.RequestSupplier supplier =  builder.build().request;
-    HttpRequest request = supplier.create();
-    supplier.fill();
+    HttpRequestWriter request = HttpRequest.streaming(supplier.headers());
+    supplier.writeBody(request::write);
     return request;
   }
 
@@ -76,8 +77,8 @@ public class BulkRequestBenchmarks {
       builder.index(spanIndex, "span", CLIENT_SPAN, BulkIndexWriter.SPAN);
     }
     HttpCall.RequestSupplier supplier =  builder.build().request;
-    HttpRequest request = supplier.create();
-    supplier.fill();
+    HttpRequestWriter request = HttpRequest.streaming(supplier.headers());
+    supplier.writeBody(request::write);
     return request;
   }
 

--- a/benchmarks/src/main/java/zipkin2/elasticsearch/internal/BulkRequestBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/elasticsearch/internal/BulkRequestBenchmarks.java
@@ -67,7 +67,7 @@ public class BulkRequestBenchmarks {
     builder.index(spanIndex, "span", CLIENT_SPAN, BulkIndexWriter.SPAN);
     HttpCall.RequestSupplier supplier =  builder.build().request;
     HttpRequestWriter request = HttpRequest.streaming(supplier.headers());
-    supplier.writeBody(request::write);
+    supplier.writeBody(request::tryWrite);
     return request;
   }
 
@@ -78,7 +78,7 @@ public class BulkRequestBenchmarks {
     }
     HttpCall.RequestSupplier supplier =  builder.build().request;
     HttpRequestWriter request = HttpRequest.streaming(supplier.headers());
-    supplier.writeBody(request::write);
+    supplier.writeBody(request::tryWrite);
     return request;
   }
 

--- a/benchmarks/src/main/java/zipkin2/elasticsearch/internal/BulkRequestBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/elasticsearch/internal/BulkRequestBenchmarks.java
@@ -14,7 +14,9 @@
 package zipkin2.elasticsearch.internal;
 
 import com.google.common.io.ByteStreams;
-import io.netty.buffer.Unpooled;
+import com.linecorp.armeria.common.HttpRequest;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -36,6 +38,7 @@ import zipkin2.codec.CodecBenchmarks;
 import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.elasticsearch.ElasticsearchStorage;
 import zipkin2.elasticsearch.internal.BulkCallBuilder.IndexEntry;
+import zipkin2.elasticsearch.internal.client.HttpCall;
 
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 10, time = 1)
@@ -54,22 +57,28 @@ public class BulkRequestBenchmarks {
   final IndexEntry<Span> entry =
     BulkCallBuilder.newIndexEntry(spanIndex, "span", CLIENT_SPAN, BulkIndexWriter.SPAN);
 
-  @Benchmark public void writeRequest_singleSpan() {
-    BulkCallBuilder.write(Unpooled.compositeBuffer(Integer.MAX_VALUE), entry, true);
+  @Benchmark public ByteBuf writeRequest_singleSpan() {
+    return BulkCallBuilder.serialize(PooledByteBufAllocator.DEFAULT, entry, true);
   }
 
-  @Benchmark public byte[] buildAndWriteRequest_singleSpan() {
+  @Benchmark public HttpRequest buildAndWriteRequest_singleSpan() {
     BulkCallBuilder builder = new BulkCallBuilder(es, 6.7f, "index-span");
     builder.index(spanIndex, "span", CLIENT_SPAN, BulkIndexWriter.SPAN);
-    return builder.build().request.content().array();
+    HttpCall.RequestSupplier supplier =  builder.build().request;
+    HttpRequest request = supplier.create();
+    supplier.fill();
+    return request;
   }
 
-  @Benchmark public byte[] buildAndWriteRequest_tenSpans() {
+  @Benchmark public HttpRequest buildAndWriteRequest_tenSpans() {
     BulkCallBuilder builder = new BulkCallBuilder(es, 6.7f, "index-span");
     for (int i = 0; i < 10; i++) {
       builder.index(spanIndex, "span", CLIENT_SPAN, BulkIndexWriter.SPAN);
     }
-    return builder.build().request.content().array();
+    HttpCall.RequestSupplier supplier =  builder.build().request;
+    HttpRequest request = supplier.create();
+    supplier.fill();
+    return request;
   }
 
   // Convenience main entry-point

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -77,6 +77,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>${armeria.groupId}</groupId>
+      <artifactId>armeria-testing-junit</artifactId>
+      <version>${armeria.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/BulkCallBuilder.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/BulkCallBuilder.java
@@ -163,8 +163,7 @@ public final class BulkCallBuilder {
 
     @Override public void fill() {
       for (IndexEntry<?> entry : entries) {
-        ByteBuf payload = serialize(alloc, entry, shouldAddType);
-        if (!request.tryWrite(HttpData.wrap(payload))) {
+        if (!request.tryWrite(() -> HttpData.wrap(serialize(alloc, entry, shouldAddType)))) {
           // Request was aborted, don't need to serialize anymore.
           return;
         }

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
@@ -42,7 +42,6 @@ import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import zipkin2.Call;
 import zipkin2.Callback;
@@ -83,10 +82,10 @@ public final class HttpCall<V> extends Call.Base<V> {
     RequestHeaders headers();
 
     /**
-     * Writes the body of this request into the {@code requestStream}.
-     * {@link Consumer#accept(Object)} can be called any number of times to publish any number of
-     * payload objects. It can be useful to split up a large payload into smaller chunks instead
-     * of buffering everything as one payload.
+     * Writes the body of this request into the {@link RequestStream}.
+     * {@link RequestStream#tryWrite(HttpData)} can be called any number of times to publish any
+     * number of payload objects. It can be useful to split up a large payload into smaller chunks
+     * instead of buffering everything as one payload.
      */
     void writeBody(RequestStream requestStream);
   }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
@@ -280,7 +280,10 @@ class HttpCallTest {
 
     http.newCall(supplier, NULL, "test").execute();
 
-    assertThat(server.takeRequest().request().contentUtf8()).isEqualTo("hello world");
+    AggregatedHttpRequest request = server.takeRequest().request();
+    assertThat(request.method()).isEqualTo(HttpMethod.POST);
+    assertThat(request.path()).isEqualTo("/");
+    assertThat(request.contentUtf8()).isEqualTo("hello world");
   }
 
   // TODO(adriancole): Find a home for this generic conversion between Call and Java 8.

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
@@ -22,14 +22,13 @@ import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAvailability;
-import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.testing.junit4.server.ServerRule;
+import com.linecorp.armeria.testing.junit.server.mock.MockWebServerExtension;
 import com.linecorp.armeria.unsafe.ByteBufHttpData;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -44,9 +43,9 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import zipkin2.Call;
 import zipkin2.Callback;
 import zipkin2.internal.Nullable;
@@ -58,41 +57,36 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.fail;
 import static zipkin2.TestObjects.UTF_8;
 
-public class HttpCallTest {
+class HttpCallTest {
   static final HttpCall.BodyConverter<Object> NULL = (parser, contentString) -> null;
 
-  private static final AtomicReference<AggregatedHttpResponse> MOCK_RESPONSE =
-    new AtomicReference<>();
   private static final AggregatedHttpResponse SUCCESS_RESPONSE =
     AggregatedHttpResponse.of(HttpStatus.OK);
 
-  @ClassRule public static ServerRule server = new ServerRule() {
-    @Override protected void configure(ServerBuilder sb) {
-      sb.service("/", ((ctx, req) -> HttpResponse.of(MOCK_RESPONSE.get())));
-    }
-  };
+  @RegisterExtension static MockWebServerExtension server = new MockWebServerExtension();
 
   private static final AggregatedHttpRequest REQUEST =
     AggregatedHttpRequest.of(HttpMethod.GET, "/");
 
   HttpCall.Factory http;
 
-  @Before public void setUp() {
+  @BeforeEach void setUp() {
     http = new HttpCall.Factory(HttpClient.of(server.httpUri("/")));
   }
 
-  @Test public void emptyContent() throws Exception {
-    MOCK_RESPONSE.set(AggregatedHttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, ""));
+  @Test void emptyContent() throws Exception {
+    server.enqueue(AggregatedHttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, ""));
 
     assertThat(http.newCall(REQUEST, (parser, contentString) -> fail(), "test").execute()).isNull();
 
+    server.enqueue(AggregatedHttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, ""));
     CompletableCallback<String> future = new CompletableCallback<>();
     http.newCall(REQUEST, (parser, contentString) -> "hello", "test").enqueue(future);
     assertThat(future.join()).isNull();
   }
 
-  @Test public void propagatesOnDispatcherThreadWhenFatal() throws Exception {
-    MOCK_RESPONSE.set(SUCCESS_RESPONSE);
+  @Test void propagatesOnDispatcherThreadWhenFatal() throws Exception {
+    server.enqueue(SUCCESS_RESPONSE);
 
     final LinkedBlockingQueue<Object> q = new LinkedBlockingQueue<>();
     http.newCall(REQUEST, (parser, contentString) -> {
@@ -118,8 +112,8 @@ public class HttpCallTest {
     }
   }
 
-  @Test public void executionException_conversionException() throws Exception {
-    MOCK_RESPONSE.set(SUCCESS_RESPONSE);
+  @Test void executionException_conversionException() throws Exception {
+    server.enqueue(SUCCESS_RESPONSE);
 
     Call<?> call = http.newCall(REQUEST, (parser, contentString) -> {
       throw new IllegalArgumentException("eeek");
@@ -133,8 +127,8 @@ public class HttpCallTest {
     }
   }
 
-  @Test public void cloned() throws Exception {
-    MOCK_RESPONSE.set(SUCCESS_RESPONSE);
+  @Test void cloned() throws Exception {
+    server.enqueue(SUCCESS_RESPONSE);
 
     Call<?> call = http.newCall(REQUEST, (parser, contentString) -> null, "test");
     call.execute();
@@ -146,13 +140,13 @@ public class HttpCallTest {
       assertThat(expected).isInstanceOf(IllegalStateException.class);
     }
 
-    MOCK_RESPONSE.set(SUCCESS_RESPONSE);
+    server.enqueue(SUCCESS_RESPONSE);
 
     call.clone().execute();
   }
 
-  @Test public void executionException_5xx() throws Exception {
-    MOCK_RESPONSE.set(AggregatedHttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR));
+  @Test void executionException_5xx() throws Exception {
+    server.enqueue(AggregatedHttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR));
 
     Call<?> call = http.newCall(REQUEST, NULL, "test");
 
@@ -164,8 +158,8 @@ public class HttpCallTest {
     }
   }
 
-  @Test public void executionException_404() throws Exception {
-    MOCK_RESPONSE.set(AggregatedHttpResponse.of(HttpStatus.NOT_FOUND));
+  @Test void executionException_404() throws Exception {
+    server.enqueue(AggregatedHttpResponse.of(HttpStatus.NOT_FOUND));
 
     Call<?> call = http.newCall(REQUEST, NULL, "test");
 
@@ -177,7 +171,7 @@ public class HttpCallTest {
     }
   }
 
-  @Test public void releasesAllReferencesToByteBuf() {
+  @Test void releasesAllReferencesToByteBuf() {
     // Force this to be a ref-counted response
     byte[] message = "{\"Message\":\"error\"}".getBytes(UTF_8);
     ByteBuf encodedBuf = PooledByteBufAllocator.DEFAULT.buffer(message.length);
@@ -195,7 +189,7 @@ public class HttpCallTest {
   }
 
   // For simplicity, we also parse messages from AWS Elasticsearch, as it prevents copy/paste.
-  @Test public void executionException_message() throws Exception {
+  @Test void executionException_message() throws Exception {
     Map<AggregatedHttpResponse, String> responseToMessage = new LinkedHashMap<>();
     responseToMessage.put(AggregatedHttpResponse.of(
       ResponseHeaders.of(HttpStatus.FORBIDDEN),
@@ -213,7 +207,7 @@ public class HttpCallTest {
     Call<?> call = http.newCall(REQUEST, NULL, "test");
 
     for (Map.Entry<AggregatedHttpResponse, String> entry : responseToMessage.entrySet()) {
-      MOCK_RESPONSE.set(entry.getKey());
+      server.enqueue(entry.getKey());
 
       try {
         call.clone().execute();
@@ -224,8 +218,8 @@ public class HttpCallTest {
     }
   }
 
-  @Test public void setsCustomName() throws Exception {
-    MOCK_RESPONSE.set(SUCCESS_RESPONSE);
+  @Test void setsCustomName() throws Exception {
+    server.enqueue(SUCCESS_RESPONSE);
 
     AtomicReference<RequestLog> log = new AtomicReference<>();
     http = new HttpCall.Factory(new HttpClientBuilder(server.httpUri("/"))
@@ -242,8 +236,8 @@ public class HttpCallTest {
       .isEqualTo("custom-name");
   }
 
-  @Test public void unprocessedRequest() {
-    MOCK_RESPONSE.set(SUCCESS_RESPONSE);
+  @Test void unprocessedRequest() {
+    server.enqueue(SUCCESS_RESPONSE);
 
     http = new HttpCall.Factory(new HttpClientBuilder(server.httpUri("/"))
       .decorator((client, ctx, req) -> {
@@ -257,10 +251,10 @@ public class HttpCallTest {
       .hasMessage("Rejected execution: No endpoints");
   }
 
-  @Test public void throwsRuntimeExceptionAsReasonWhenPresent() {
+  @Test void throwsRuntimeExceptionAsReasonWhenPresent() {
     String body =
       "{\"error\":{\"root_cause\":[{\"type\":\"illegal_argument_exception\",\"reason\":\"Fielddata is disabled on text fields by default. Set fielddata=true on [spanName] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.\"}],\"type\":\"search_phase_execution_exception\",\"reason\":\"all shards failed\",\"phase\":\"query\",\"grouped\":true,\"failed_shards\":[{\"shard\":0,\"index\":\"zipkin-2017-05-14\",\"node\":\"IqceAwZnSvyv0V0xALkEnQ\",\"reason\":{\"type\":\"illegal_argument_exception\",\"reason\":\"Fielddata is disabled on text fields by default. Set fielddata=true on [spanName] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.\"}}]},\"status\":400}";
-    MOCK_RESPONSE.set(
+    server.enqueue(
       AggregatedHttpResponse.of(ResponseHeaders.of(HttpStatus.BAD_REQUEST), HttpData.ofUtf8(body))
     );
 
@@ -268,6 +262,25 @@ public class HttpCallTest {
       .isInstanceOf(RuntimeException.class)
       .hasMessage(
         "Fielddata is disabled on text fields by default. Set fielddata=true on [spanName] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.");
+  }
+
+  @Test void streamingContent() throws Exception {
+    server.enqueue(SUCCESS_RESPONSE);
+
+    HttpCall.RequestSupplier supplier = new HttpCall.RequestSupplier() {
+      @Override public RequestHeaders headers() {
+        return RequestHeaders.of(HttpMethod.POST, "/");
+      }
+
+      @Override public void writeBody(HttpCall.RequestStream requestStream) {
+        requestStream.tryWrite(HttpData.ofUtf8("hello"));
+        requestStream.tryWrite(HttpData.ofUtf8(" world"));
+      }
+    };
+
+    http.newCall(supplier, NULL, "test").execute();
+
+    assertThat(server.takeRequest().request().contentUtf8()).isEqualTo("hello world");
   }
 
   // TODO(adriancole): Find a home for this generic conversion between Call and Java 8.


### PR DESCRIPTION
…ontrol over how the request is created (e.g., using pooled buffers or streaming).

I think this was your idea :)

I have a lot of personal work today and tomorrow so don't know if I can get to adding tests / cleaning up that this needs - but wanted to get it out there in case you want to play with it. I only ran the integration tests and didn't run any benchmarks either, but in theory it should reduce memory usage by 1) not copying into a heap byte[] and 2) writing entries to the request while it's executing so they're streamed onto the connection. A future extension would be to use a supplier tied to json writing instead of `AggregatedHttpRequest` for the search requests so those also can use pooled buffers, but it's much lower priority.