### PR TITLE
make in-memory storage component more visible

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -155,7 +155,23 @@ Defaults to true
 * `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`
 * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 * `AUTOCOMPLETE_KEYS`: list of span tag keys which will be returned by the `/api/v2/autocompleteTags` endpoint; Tag keys should be comma separated e.g. "instance_id,user_id,env"
-* `AUTOCOMPLETE_TTL`: How long in milliseconds to suppress calls to write the same autocomplete key/value pair. Default 3600000 (1 hr)
+* `AUTOCOMPLETE_TTL`: How long in milliseconds to suppress calls to write the same autocomplete key/value pair. Default 3600000 (1 hr) 
+
+### In-Memory Storage
+Zipkin's In-Memory Storage is the default storage component that is used when no other storage type is configured. By default it stores a maximum of 500000 spans. Oldest traces (and their spans) will be purged first when this limit is exceeded. 
+
+Memory wise, a safe estimate is to count with 1K of memory per span (assuming 2 annotations + 1 binary annotation), plus 100 MB for a safety buffer. These numbers are by no means fixed, you'll need to verify in your own environment and increase memory (-Xmx) if needed.
+
+Example usage:
+```bash
+$ java -jar zipkin.jar
+```
+You can override the maximum number of spans stored using the `--max-spans` application parameter:
+```bash
+$ java -Xmx1500m -jar zipkin.jar --max-spans=1000000
+```
+
+Note this storage component was primarily developed for testing and as a means to get Zipkin server up and running quickly without external dependencies. It is not viable for high work loads.  
 
 ### Throttled Storage (Experimental)
 These settings can be used to help tune the rate at which Zipkin flushes data to another, underlying `StorageComponent` (such as Elasticsearch):

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -158,9 +158,7 @@ Defaults to true
 * `AUTOCOMPLETE_TTL`: How long in milliseconds to suppress calls to write the same autocomplete key/value pair. Default 3600000 (1 hr) 
 
 ### In-Memory Storage
-Zipkin's In-Memory Storage is the default storage component that is used when no other storage type is configured. By default it stores a maximum of 500000 spans. Oldest traces (and their spans) will be purged first when this limit is exceeded. 
-
-Memory wise, a safe estimate is to count with 1K of memory per span (assuming 2 annotations + 1 binary annotation), plus 100 MB for a safety buffer. These numbers are by no means fixed, you'll need to verify in your own environment and increase memory (-Xmx) if needed.
+Zipkin's In-Memory Storage is the default storage component that is used when no other storage type is configured. By default it stores a maximum of 500000 spans. Oldest traces (and their spans) will be purged first when this limit is exceeded. If you encounter out-of-memory errors, increase the heap size (-Xmx).
 
 Example usage:
 ```bash
@@ -168,7 +166,7 @@ $ java -jar zipkin.jar
 ```
 You can override the maximum number of spans stored using the `--max-spans` application parameter:
 ```bash
-$ java -Xmx1500m -jar zipkin.jar --max-spans=1000000
+$ java -Xmx1G -jar zipkin.jar --max-spans=1000000
 ```
 
 Note this storage component was primarily developed for testing and as a means to get Zipkin server up and running quickly without external dependencies. It is not viable for high work loads.  

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -79,9 +79,6 @@ zipkin:
       max-queue-size: ${STORAGE_THROTTLE_MAX_QUEUE_SIZE:1000}
     mem:
       # Maximum number of spans to keep in memory.  When exceeded, oldest traces (and their spans) will be purged.
-      # A safe estimate is 1K of memory per span (each span with 2 annotations + 1 binary annotation), plus
-      # 100 MB for a safety buffer.  You'll need to verify in your own environment.
-      # Experimentally, it works with: max-spans of 500000 with JRE argument -Xmx600m.
       max-spans: 500000
     cassandra:
       # Comma separated list of host addresses part of Cassandra cluster. Ports default to 9042 but you can also specify a custom port with 'host:port'.


### PR DESCRIPTION
... it's mentioned on the main README.md but not here. Text mostly grabbed from https://github.com/openzipkin/zipkin/blob/b84bb3261d8402507a2d54f3b55e017484c50a85/zipkin-server/src/main/resources/zipkin-server-shared.yml#L81