### PR TITLE
Bumps version of jackson-databind lib to tackle CVE-2019-14379

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
     <git-commit-id.version>3.0.0</git-commit-id.version>
+    <jackson-databind.version>2.9.9.3</jackson-databind.version>
   </properties>
 
   <name>Zipkin (Parent)</name>
@@ -384,6 +385,13 @@
         <groupId>com.squareup.wire</groupId>
         <artifactId>wire-runtime</artifactId>
         <version>${wire.version}</version>
+      </dependency>
+
+      <!-- Forcibly bump Jackson Databind version to avoid CVE-2019-14379 -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson-databind.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Similar to https://github.com/openzipkin/zipkin-dependencies/pull/145

The version of jackson-databind in use, 2.9.9, is said to be vulnerable. The version 2.9.9.2 has fixed this issue. I've picked 2.9.9.3, the latest patch in the minor version. Here's the description of the CVE: https://nvd.nist.gov/vuln/detail/CVE-2019-14379

As I'm new to the project, is there a quick way we can assure this doesn't break core? Otherwise, please let me know how else I can manually integration-test this patch.

Cheers,
Greg