### PR TITLE
Falls back to simple name and stops prefixing rejected ES exceptions

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHealthIndicator.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHealthIndicator.java
@@ -41,7 +41,13 @@ final class ZipkinHealthIndicator extends CompositeHealthIndicator {
     /** synchronized to prevent overlapping requests to a storage backend */
     @Override public synchronized Health health() {
       CheckResult result = component.check();
-      return result.ok() ? Health.up().build() : Health.down((Exception) result.error()).build();
+      if (result.ok()) return Health.up().build();
+      Throwable ex = result.error();
+      // Like withException, but without the distracting ": null" when there is no message.
+      String message = ex.getMessage();
+      return Health.down()
+        .withDetail("error", ex.getClass().getName() + (message != null ? ": " + message : ""))
+        .build();
     }
   }
 }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHealthIndicatorTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHealthIndicatorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal;
+
+import com.linecorp.armeria.common.ClosedSessionException;
+import java.io.IOException;
+import org.junit.Test;
+import zipkin2.CheckResult;
+import zipkin2.Component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.server.internal.ZipkinHealthIndicator.ComponentHealthIndicator;
+
+public class ZipkinHealthIndicatorTest {
+  @Test public void addsMessageToDetails() {
+    ComponentHealthIndicator healthIndicator = new ComponentHealthIndicator(new Component() {
+      @Override public CheckResult check() {
+        return CheckResult.failed(new IOException("socket disconnect"));
+      }
+    });
+
+    assertThat(healthIndicator.health().getDetails())
+      .containsEntry("error", "java.io.IOException: socket disconnect");
+  }
+
+  @Test public void doesntAddNullMessageToDetails() {
+    ComponentHealthIndicator healthIndicator = new ComponentHealthIndicator(new Component() {
+      @Override public CheckResult check() {
+        return CheckResult.failed(ClosedSessionException.get());
+      }
+    });
+
+    assertThat(healthIndicator.health().getDetails())
+      .containsEntry("error", "com.linecorp.armeria.common.ClosedSessionException");
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorPropertiesTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorPropertiesTest.java
@@ -45,7 +45,7 @@ public class ZipkinActiveMQCollectorPropertiesTest {
   }
 
   @Test public void providesCollectorComponent_whenUrlSet() {
-    TestPropertyValues.of("zipkin.collector.activemq.url:tcp://localhost:61616")
+    TestPropertyValues.of("zipkin.collector.activemq.url:tcp://localhost:61611") // wrong port
       .applyTo(context);
     context.register(
       PropertyPlaceholderAutoConfiguration.class,

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -269,7 +269,9 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
         HttpMethod.GET, "/_cluster/health/" + index);
       return http.newCall(request, READ_STATUS, "get-cluster-health").execute();
     } catch (IOException | RuntimeException e) {
-      return CheckResult.failed(e);
+      // Unwrap the marker exception as the health check is not relevant for the throttle component,
+      // and wrapping interferes with humans intended to read this message.
+      return CheckResult.failed(e instanceof RejectedExecutionException ? e.getCause() : e);
     }
   }
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/HttpCall.java
@@ -229,7 +229,10 @@ public final class HttpCall<V> extends Call.Base<V> {
         // Go ahead and reduce the output in logs since this is usually a configuration or
         // infrastructure issue and the Armeria stack trace won't help debugging that.
         Exceptions.clearTrace(cause);
-        throw new RejectedExecutionException("Rejected execution: " + cause.getMessage(), cause);
+
+        String message = cause.getMessage();
+        if (message == null) message = cause.getClass().getSimpleName();
+        throw new RejectedExecutionException(message, cause);
       } else {
         Exceptions.throwUnsafely(t);
       }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/HttpCallTest.java
@@ -236,6 +236,17 @@ class HttpCallTest {
       .isEqualTo("custom-name");
   }
 
+  @Test void wrongScheme() {
+    server.enqueue(SUCCESS_RESPONSE);
+
+    http = new HttpCall.Factory(new HttpClientBuilder("https://localhost:" + server.httpPort())
+      .build());
+
+    assertThatThrownBy(() -> http.newCall(REQUEST, NULL, "test").execute())
+      .isInstanceOf(RejectedExecutionException.class)
+      .hasMessage("ClosedSessionException");
+  }
+
   @Test void unprocessedRequest() {
     server.enqueue(SUCCESS_RESPONSE);
 
@@ -248,7 +259,7 @@ class HttpCallTest {
 
     assertThatThrownBy(() -> http.newCall(REQUEST, NULL, "test").execute())
       .isInstanceOf(RejectedExecutionException.class)
-      .hasMessage("Rejected execution: No endpoints");
+      .hasMessage("No endpoints");
   }
 
   @Test void throwsRuntimeExceptionAsReasonWhenPresent() {


### PR DESCRIPTION
Armeria has a number of constant throwables, which neither have a stack
trace, nor a message. This switches to use these while we figure out if
there is a better way to unveil an underlying http connection problem
the health-check sees, but a health-checked client would not.

The approach is used all over in zipkin, most notably Brave.

This also stops prefixing RejectionException messages also with the word
as it is annoying to read it twice in toString.

Most importantly, this unwraps RejectionException in health check as it
doesn't effectively describe the cause of the problem, rather obfuscates
it.

Before:
```bash
curl -s localhost:9411/health
{"status":"DOWN","zipkin":{"status":"DOWN","details":{"ElasticsearchStorage{initialEndpoints=https://localhost:9200, index=zipkin}":{"status":"DOWN","details":{"error":"java.util.concurrent.RejectedExecutionException: Rejected execution: null"}}}}}
```

Now:
```bash
curl -s localhost:9411/health
{"status":"DOWN","zipkin":{"status":"DOWN","details":{"ElasticsearchStorage{initialEndpoints=https://localhost:9200, index=zipkin}":{"status":"DOWN","details":{"error":"com.linecorp.armeria.common.ClosedSessionException"}}}}}
```