### PR TITLE
Adds vintage engine to zipkin-tests to help avoid time lost downstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,12 @@
         <version>${junit.jupiter.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>${junit.jupiter.version}</version>
+      </dependency>
+
       <!--
       Current versions of JUnit5 provide the above junit-jupiter artifact for convenience but we may
       still have transitive dependencies on these older artifacts and have to make sure they're all

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
@@ -153,7 +153,7 @@ public class ScribeSpanConsumerTest {
     assertThat(scribeMetrics.spansDropped()).isZero();
   }
 
-  @Test public void consumerExceptionBeforeCallbackSetsFutureException() {
+  @Test public void consumerExceptionBeforeCallbackDoesntSetFutureException() {
     consumer = (input) -> {
       throw new NullPointerException("endpoint was null");
     };
@@ -166,7 +166,9 @@ public class ScribeSpanConsumerTest {
 
     CaptureAsyncMethodCallback callback = new CaptureAsyncMethodCallback();
     scribe.Log(asList(entry), callback);
-    assertThat(callback.error).hasMessage("endpoint was null");
+
+    // Storage related exceptions are not propagated to the caller. Only marshalling ones are.
+    assertThat(callback.error).isNull();
 
     assertThat(scribeMetrics.messages()).isEqualTo(1);
     assertThat(scribeMetrics.messagesDropped()).isZero();

--- a/zipkin-tests/pom.xml
+++ b/zipkin-tests/pom.xml
@@ -45,9 +45,11 @@
       <artifactId>gson</artifactId>
     </dependency>
 
+    <!-- This prevents us from interfering with JUnit 4 runtimes.
+         See https://github.com/openzipkin/zipkin-gcp/issues/130 -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This prevents us from interfering with JUnit 4 runtimes.

See https://github.com/openzipkin/zipkin-gcp/issues/130