### PR TITLE
Loosen exception message assertion for compatibility with Windows.

### DIFF
--- a/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorPropertiesTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorPropertiesTest.java
@@ -13,7 +13,6 @@
  */
 package zipkin2.server.internal.activemq;
 
-import java.io.UncheckedIOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -23,9 +22,7 @@ import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoCon
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import zipkin2.collector.activemq.ActiveMQCollector;
-import zipkin2.collector.kafka.KafkaCollector;
 import zipkin2.server.internal.InMemoryConfiguration;
-import zipkin2.server.internal.kafka.ZipkinKafkaCollectorConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
@@ -56,8 +53,8 @@ public class ZipkinActiveMQCollectorPropertiesTest {
       context.refresh();
       failBecauseExceptionWasNotThrown(BeanCreationException.class);
     } catch (BeanCreationException e) {
-      assertThat(e.getCause()).hasMessage(
-        "Unable to establish connection to ActiveMQ broker: Connection refused (Connection refused)");
+      assertThat(e.getCause()).hasMessageContaining(
+        "Unable to establish connection to ActiveMQ broker: Connection refused");
     }
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorConfigurationTest.java
@@ -77,8 +77,8 @@ public class ZipkinRabbitMQCollectorConfigurationTest {
       context.refresh();
       failBecauseExceptionWasNotThrown(BeanCreationException.class);
     } catch (BeanCreationException e) {
-      assertThat(e.getCause()).hasMessage(
-        "Unable to establish connection to RabbitMQ server: Connection refused (Connection refused)");
+      assertThat(e.getCause()).hasMessageContaining(
+        "Unable to establish connection to RabbitMQ server: Connection refused");
     }
   }
 


### PR DESCRIPTION
I got this message on Windows. Presumably we already assert enough here without having the same word twice

```
org.opentest4j.AssertionFailedError: 
Expecting message to be:
  <"Unable to establish connection to ActiveMQ broker: Connection refused (Connection refused)">
but was:
  <"Unable to establish connection to ActiveMQ broker: Connection refused: connect">
```