### PR TITLE
Use Armeria to expose prometheus instead of actuator.

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
@@ -18,10 +18,12 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.server.RedirectService;
 import com.linecorp.armeria.server.cors.CorsServiceBuilder;
+import com.linecorp.armeria.server.metric.PrometheusExpositionService;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
+import io.prometheus.client.CollectorRegistry;
 import java.time.Duration;
 import java.util.List;
 import org.springframework.beans.BeansException;
@@ -66,7 +68,7 @@ public class ZipkinServerConfiguration implements WebMvcConfigurer {
   @Autowired(required = false)
   MetricsHealthController healthController;
 
-  @Bean ArmeriaServerConfigurator serverConfigurator() {
+  @Bean ArmeriaServerConfigurator serverConfigurator(CollectorRegistry prometheusRegistry) {
     return sb -> {
       if (httpQuery != null) {
         sb.annotatedService(httpQuery);
@@ -75,7 +77,7 @@ public class ZipkinServerConfiguration implements WebMvcConfigurer {
       if (httpCollector != null) sb.annotatedService(httpCollector);
       if (healthController != null) sb.annotatedService(healthController);
       // Redirects the prometheus scrape endpoint for backward compatibility
-      sb.service("/prometheus", new RedirectService("/actuator/prometheus"));
+      sb.service("/prometheus", new PrometheusExpositionService(prometheusRegistry));
       // Redirects the info endpoint for backward compatibility
       sb.service("/info", new RedirectService("/actuator/info"));
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -242,6 +242,9 @@ management:
   endpoint:
     health:
       show-details: always
+    prometheus:
+      # Served directly without actuator.
+      enabled: false
 # Disabling auto time http requests since it is added in Undertow HttpHandler in Zipkin autoconfigure
 # Prometheus module. In Zipkin we use different naming for the http requests duration
   metrics:


### PR DESCRIPTION
This doesn't remove the fact that actuator sets up the prometheus collector, but it's a quick start.

For #2788 