### PR TITLE
Add a Dockerfile for building a master image of zipkin-server.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/\.*
+!.git
+!**/.eslintrc
+
+**/target
+**/node_modules
+**/*.iml
+
+*.md
+
+**/Dockerfile
+travis
+mvnw*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+#
+# Copyright 2015-2019 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+FROM maven:3-jdk-11-slim
+
+COPY . /code
+RUN cd /code && mvn -B --no-transfer-progress package -DskipTests=true -pl zipkin-server -am
+
+FROM gcr.io/distroless/java:11-debug
+LABEL MAINTAINER Zipkin "https://zipkin.io/"
+
+# Use to set heap, trust store or other system properties.
+ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
+# 3rd party modules like zipkin-aws will apply profile settings with this
+ENV MODULE_OPTS=
+
+RUN ["/busybox/sh", "-c", "adduser -g '' -h /zipkin -D zipkin"]
+
+# Add environment settings for supported storage types
+COPY --from=0 --chown=zipkin /code/zipkin-server/target/zipkin-server-*-exec.jar /zipkin/
+COPY --chown=zipkin docker/zipkin/ /zipkin/
+WORKDIR /zipkin
+
+RUN ["/busybox/sh", "-c", "ln -s /busybox/* /bin"]
+
+USER zipkin
+
+EXPOSE 9410 9411
+
+ENTRYPOINT ["/busybox/sh", "run.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,13 @@
+## zipkin-server Docker image
+
+To build a zipkin-server Docker image, in the top level of the repository, run something
+like
+
+```bash
+$ docker build -t openzipkin/zipkin:test -f docker/Dockerfile .
+```
+
+### Dockerfile migration
+
+We are currently migrating the Docker configuration from https://github.com/openzipkin/docker-zipkin/tree/master/zipkin.
+If making any changes here, make sure to also reflect them there.

--- a/docker/zipkin/.cassandra3_profile
+++ b/docker/zipkin/.cassandra3_profile
@@ -1,0 +1,12 @@
+#!/bin/sh
+if [[ -z "$CASSANDRA_CONTACT_POINTS" ]]; then
+  if [[ -z "$STORAGE_PORT_9042_TCP_ADDR" ]]; then
+    echo "** ERROR: You need to link with a Cassandra 3.9+ container as 'storage' or specify CASSANDRA_CONTACT_POINTS env var."
+    echo "STORAGE_PORT_9042_TCP_ADDR (container link) or CASSANDRA_CONTACT_POINTS should contain a comma separated list of Cassandra 3.9+ contact points."
+    exit 1
+  fi
+  CASSANDRA_CONTACT_POINTS=$STORAGE_PORT_9042_TCP_ADDR
+fi
+
+export CASSANDRA_CONTACT_POINTS
+echo "Cassandra 3 contact points: $CASSANDRA_CONTACT_POINTS"

--- a/docker/zipkin/.cassandra_profile
+++ b/docker/zipkin/.cassandra_profile
@@ -1,0 +1,12 @@
+#!/bin/sh
+if [[ -z "$CASSANDRA_CONTACT_POINTS" ]]; then
+  if [[ -z "$STORAGE_PORT_9042_TCP_ADDR" ]]; then
+    echo "** ERROR: You need to link with a Cassandra container as 'storage' or specify CASSANDRA_CONTACT_POINTS env var."
+    echo "STORAGE_PORT_9042_TCP_ADDR (container link) or CASSANDRA_CONTACT_POINTS should contain a comma separated list of Cassandra contact points."
+    exit 1
+  fi
+  CASSANDRA_CONTACT_POINTS=$STORAGE_PORT_9042_TCP_ADDR
+fi
+
+export CASSANDRA_CONTACT_POINTS
+echo "Cassandra contact points: $CASSANDRA_CONTACT_POINTS"

--- a/docker/zipkin/.elasticsearch_profile
+++ b/docker/zipkin/.elasticsearch_profile
@@ -1,0 +1,16 @@
+#!/bin/sh
+if [[ -z "$ES_HOSTS" && -z "$ES_AWS_DOMAIN" ]]; then
+  if [[ -z "$STORAGE_PORT_9200_TCP_ADDR" ]]; then
+    echo "** ERROR: You need to link with a Elasticsearch container as 'storage' or specify an"
+    echo "elasticsearch cluster via the ES_HOSTS (hostname:port or http url) or ES_AWS_DOMAIN env vars."
+    echo "STORAGE_PORT_9200_TCP_ADDR (container link) should contain an address, or one of ES_HOSTS or"
+    echo "ES_AWS_DOMAIN should be set."
+    exit 1
+  fi
+  ES_HOSTS=http://$STORAGE_PORT_9200_TCP_ADDR:9200
+fi
+
+export ES_HOSTS
+
+[[ ! -z $ES_HOSTS ]] && echo "Elasticsearch hosts: $ES_HOSTS"
+[[ ! -z $ES_AWS_DOMAIN ]] && echo "Elasticsearch domain: $ES_AWS_DOMAIN"

--- a/docker/zipkin/.mysql_profile
+++ b/docker/zipkin/.mysql_profile
@@ -1,0 +1,17 @@
+#!/bin/sh
+if [[ -z "$MYSQL_HOST" ]]; then
+  if [[ -z "$STORAGE_PORT_3306_TCP_ADDR" ]]; then
+    echo "** ERROR: You need to link with a MySQL container as 'storage' or specify MYSQL_HOST env var."
+    echo "STORAGE_PORT_3306_TCP_ADDR (container link) or MYSQL_HOST should contain a MySQL hostname."
+    exit 1
+  fi
+  MYSQL_HOST=$STORAGE_PORT_3306_TCP_ADDR
+  # When there's a container named "mysql", MYSQL_PORT will have a value like tcp://172.17.0.2:3306
+  export MYSQL_PORT=3306
+fi
+
+export MYSQL_HOST
+export MYSQL_USER=${MYSQL_USER:=zipkin}
+export MYSQL_PASS=${MYSQL_PASS:=zipkin}
+
+echo "MySQL host: $MYSQL_HOST"

--- a/docker/zipkin/run.sh
+++ b/docker/zipkin/run.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Copyright 2015-2019 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+if [ -f ".${STORAGE_TYPE}_profile" ]; then
+  source ${PWD}/.${STORAGE_TYPE}_profile
+fi
+
+if [ -n "$SCRIBE_ENABLED" ]; then
+  export JAVA_OPTS="${JAVA_OPTS} -Dloader.path=scribe -Dspring.profiles.active=scribe"
+fi
+
+if [ -n "$KAFKA_ZOOKEEPER" ]; then
+  export JAVA_OPTS="${JAVA_OPTS} -Dloader.path=kafka08 -Dspring.profiles.active=kafka08"
+fi
+
+exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp zipkin-server-*-exec.jar org.springframework.boot.loader.PropertiesLauncher

--- a/pom.xml
+++ b/pom.xml
@@ -641,12 +641,14 @@
           </mapping>
           <excludes>
             <exclude>.travis.yml</exclude>
+            <exclude>.dockerignore</exclude>
             <exclude>.editorconfig</exclude>
             <exclude>.gitattributes</exclude>
             <exclude>.gitignore</exclude>
             <exclude>.mvn/**</exclude>
             <exclude>mvnw*</exclude>
             <exclude>etc/header.txt</exclude>
+            <exclude>docker/**/*_profile</exclude>
             <exclude>**/.idea/**</exclude>
             <exclude>**/node_modules/**</exclude>
             <exclude>**/.babelrc</exclude>


### PR DESCRIPTION
This will be referenced from docker hub to begin automated building of a master docker image of zipkin-server. This solves https://github.com/openzipkin/docker-zipkin/issues/170 which also contains a good summary of the rationale - it's great for previewing development features and testing new infra to be able to just start up a docker image with the latest code, no `mvn` or jitpack required.

This copies configuration from https://github.com/openzipkin/docker-zipkin - these don't change much so I think copying temporarily should be fine. The intent is to first have master images for all the components that use the latest code, then later gradually migrate release builds off of quay to use these Dockerfiles.