### PR TITLE
Add a builder Docker image to use when building other images.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,6 @@
 *.md
 
 **/Dockerfile
-travis
+hooks/**
+travis/**
 mvnw*

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -16,7 +16,7 @@ FROM maven:3-jdk-11-slim
 
 COPY . /code/
 
-# We build the project so all its dependencies get downloaded. There doesn't seem to be a good way
-# of only downloading dependencies without building too or we get unresolved dependency failures for
-# the local modules, but since we don't copy any code in the compilation itself is fast.
-RUN cd /code && mvn -B package -DskipTests=true && cd / && rm -rf /code
+RUN cd /code && \
+    mvn -B package -Dlicense.skip=true -DskipTests=true -DskipLens=true && \
+    mvn -B generate-resources -pl zipkin-lens -Dlicense.skip=true -DskipTests=true && \
+    cd / && rm -rf /code

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -16,6 +16,11 @@ FROM maven:3-jdk-11-slim
 
 COPY . /code/
 
+# We run a normal build, sans zipkin-lens, which causes Maven to download most dependencies (it
+# misses out on error prone since we only copy pom files into the build context and no Java files,
+# so error prone is skipped). Then we run the generate-resources goal on zipkin-lens, which sets up
+# node and npm dependencies. The result is a cache of most build-time dependencies.
+
 RUN cd /code && \
     mvn -B package -Dlicense.skip=true -DskipTests=true -DskipLens=true && \
     mvn -B generate-resources -pl zipkin-lens -Dlicense.skip=true -DskipTests=true && \

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,0 +1,22 @@
+#
+# Copyright 2015-2019 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+FROM maven:3-jdk-11-slim
+
+COPY . /code/
+
+# We build the project so all its dependencies get downloaded. There doesn't seem to be a good way
+# of only downloading dependencies without building too or we get unresolved dependency failures for
+# the local modules, but since we don't copy any code in the compilation itself is fast.
+RUN cd /code && mvn -B package -DskipTests=true && cd / && rm -rf /code

--- a/docker/builder/Dockerfile.dockerignore
+++ b/docker/builder/Dockerfile.dockerignore
@@ -1,0 +1,18 @@
+# Try to include as little as possible except pom files to reduce cache key updates.
+# https://github.com/moby/moby/issues/30018 would make this simpler.
+
+**/.*
+**/*.md
+**/node_modules
+**/src
+**/target
+docker/
+mvnw*
+LICENSE
+
+!src/etc/header.txt
+
+zipkin-lens/**
+!zipkin-lens/pom.xml
+!zipkin-lens/package.json
+!zipkin-lens/package-lock.json

--- a/docker/builder/Dockerfile.dockerignore
+++ b/docker/builder/Dockerfile.dockerignore
@@ -1,17 +1,23 @@
 # Try to include as little as possible except pom files to reduce cache key updates.
-# https://github.com/moby/moby/issues/30018 would make this simpler.
+# https://github.com/moby/moby/issues/30018 would make this simpler. The below approximates
+#
+# *
+# !**/pom.xml
+# !**/package*.json
 
 **/.*
 **/*.md
 **/node_modules
 **/src
 **/target
-docker/
+docker/**
+hooks/**
+travis/**
 mvnw*
 LICENSE
 
-!src/etc/header.txt
-
+# zipkin-lens has different conventions than any other project, it's simplest to exclude it and
+# then only include what we need.
 zipkin-lens/**
 !zipkin-lens/pom.xml
 !zipkin-lens/package.json

--- a/docker/builder/README.md
+++ b/docker/builder/README.md
@@ -1,0 +1,4 @@
+# zipkin-builder
+
+This image is for internal use only for building other Docker images. It refreshes a
+cache of maven and npm dependencies so downstream builds do not have to do so every build.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,4 @@
+# Docker Hub Build Hooks
+
+These hooks allow configuring the Docker Hub builds of our official docker images.
+See https://docs.docker.com/docker-hub/builds/advanced for how to use hooks.

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+case "$DOCKER_REPO" in
+  openzipkin/zipkin-builder)
+    # Remove after Docker Hub updates to Docker 19.03 to include
+    # https://github.com/moby/moby/issues/12886#issuecomment-480575928
+    cp docker/builder/Dockerfile.dockerignore .dockerignore
+  ;;
+
+  *)
+  ;;
+esac
+
+docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
   <modules>
     <module>zipkin</module>
     <module>zipkin-tests</module>
-    <module>zipkin-lens</module>
     <module>zipkin-junit</module>
     <module>benchmarks</module>
     <module>zipkin-storage</module>
@@ -641,7 +640,7 @@
           </mapping>
           <excludes>
             <exclude>.travis.yml</exclude>
-            <exclude>.dockerignore</exclude>
+            <exclude>**/*.dockerignore</exclude>
             <exclude>.editorconfig</exclude>
             <exclude>.gitattributes</exclude>
             <exclude>.gitignore</exclude>
@@ -649,6 +648,7 @@
             <exclude>mvnw*</exclude>
             <exclude>etc/header.txt</exclude>
             <exclude>docker/**/*_profile</exclude>
+            <exclude>hooks/**</exclude>
             <exclude>**/.idea/**</exclude>
             <exclude>**/node_modules/**</exclude>
             <exclude>**/.babelrc</exclude>
@@ -735,6 +735,17 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>include-lens</id>
+      <activation>
+        <property>
+          <name>!skipLens</name>
+        </property>
+      </activation>
+      <modules>
+        <module>zipkin-lens</module>
+      </modules>
+    </profile>
     <profile>
       <id>error-prone-9+</id>
       <activation>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -102,12 +102,6 @@
       <artifactId>zipkin-ui</artifactId>
       <version>2.12.11</version>
     </dependency>
-    <!-- Static content for the Lens UI -->
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-lens</artifactId>
-      <version>${project.version}</version>
-    </dependency>
     <dependency>
       <!-- HTML library for injecting configurable <base> tag -->
       <groupId>org.jsoup</groupId>
@@ -312,6 +306,22 @@
 
   <profiles>
     <profile>
+      <id>include-lens</id>
+      <activation>
+        <property>
+          <name>!skipLens</name>
+        </property>
+      </activation>
+      <dependencies>
+        <!-- Static content for the Lens UI -->
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>zipkin-lens</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>integration</id>
       <activation>
         <property>
@@ -407,6 +417,9 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Docker hub uses standard Docker layer caching to cache artifacts between builds. This is different from e.g., Travis, which mounts home directory folders from a cache it downloads / uploads out of line.

Currently, all of our builds start with a fresh `maven` image which has no cache at all, so every build downloads the world. We can prepare a `zipkin-builder` image which contains a package cache to speed up our downstream builds. After the first version of this image is pushed, I'll point the Dockerfiles to use it instead of `maven`. This builder image would have no value if code changes caused it's Docker cache key to be invalidated (the Docker cache key is the file hashes computed for a given COPY command, etc), so we use a special `.dockerignore` file to exclude as much as possible. Some of the linked issues in the comments provide more background on this approach (ideally COPY would accept inclusions / exclusions as arguments but there seems to be no desire to implement that in Dockerfile).

In this PR, I have added a `skipLens` property that can be used in the build to not build lens. It's used here, but I think it could be useful in general development since I know I've found myself waiting for a zipkin-lens build to finish despite not needing lens for the particular dev task.

The `zipkin-builder` image has a special `dockerignore` file that attempts to only copy in pom.xml and package.json files into the build context. This means that the result of a maven build is only invalidated when these change, which is rare. This means that there would be two scenarios:

1) A master commit that only contains code changes (no changes to pom or package.json). The zipkin-builder and zipkin builds would be started together. zipkin-builder would end without doing anything since it's cache key, which does not include code, is unaffected. zipkin will build and not download the world since it uses zipkin-builder's cached repositories.

2) A master commit that does change pom or package.json. The zipkin-builder and zipkin builds would be started together. zipkin-builder would start from scratch, downloading the world. zipkin will start and will use the latest, now outdated, zipkin-builder when building. This means it won't download the world, but only the new dependencies since the previous one. This is pretty fast, since I notice that the majority of the world is maven itself with all its plugins, and those don't change so often. After these builds finish, following commits would go back to scenario 1 until a next set of dependency updates.

Downstream projects zipkin-aws and zipkin-gcp will download more stuff on scenario 1. While it'd be possible to prepare builders for each of them, I think the delta in dependencies is small enough that we don't need to worry about that (the prime culprits, maven and spring-boot will be in zipkin-builder for use by all the buildz).

While it's a bit annoying having this extra image, once it's set up it should all manage itself automatically so hopefully it is not too complex.