### PR TITLE
Deletes code no longer needed regarding state checking of ES hosts

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
@@ -15,13 +15,11 @@ package zipkin2.server.internal.elasticsearch;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
-import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroupBuilder;
 import com.linecorp.armeria.common.SessionProtocol;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,23 +62,11 @@ final class InitialEndpointSupplier implements Supplier<EndpointGroup> {
         // A host that isn't an IP may resolve to multiple IP addresses, so we use a endpoint
         // group to round-robin over them. Users can mix addresses that resolve to multiple IPs
         // with single IPs freely, they'll all get used.
-        endpointGroups.add(resolveDnsAddresses(host, port));
+        endpointGroups.add(new DnsAddressEndpointGroupBuilder(host).port(port).build());
       }
     }
 
     return EndpointGroup.of(endpointGroups);
-  }
-
-  // Rather than result in an empty group. Await DNS resolution as this call is deferred anyway
-  // TODO: delete the await when https://github.com/line/armeria/issues/2071 is complete
-  DnsAddressEndpointGroup resolveDnsAddresses(String host, int port) {
-    DnsAddressEndpointGroup result = new DnsAddressEndpointGroupBuilder(host).port(port).build();
-    try {
-      result.awaitInitialEndpoints(1, TimeUnit.SECONDS);
-    } catch (Exception e) {
-      // let it fail later
-    }
-    return result;
   }
 
   int getPort(URI url) {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
@@ -83,6 +83,9 @@ final class LazyHttpClientImpl implements LazyHttpClient {
       //
       // We are blocking up to the connection timeout which should be enough time for any DNS
       // resolution that hasn't happened yet to finish.
+      //
+      // TODO: When using health checks, if all hosts fail the health check, this will throw TOE
+      // See https://github.com/line/armeria/issues/2075
       endpointGroup.awaitInitialEndpoints(timeoutMillis, TimeUnit.MILLISECONDS);
     } catch (Exception e) {
       // We'll try again next time around.

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
@@ -88,6 +88,7 @@ final class LazyHttpClientImpl implements LazyHttpClient {
       // See https://github.com/line/armeria/issues/2075
       endpointGroup.awaitInitialEndpoints(timeoutMillis, TimeUnit.MILLISECONDS);
     } catch (Exception e) {
+      endpointGroup.close(); // no-op when not health checked
       // We'll try again next time around.
       throw new IllegalStateException("couldn't connect any of " + rawEndpointGroup.endpoints(), e);
     }


### PR DESCRIPTION
We no longer need two-tiered checking of ES addresses because single
endpoint is special cased to not cause notable overhead.

See https://github.com/line/armeria/issues/2071#issuecomment-531139475