### PR TITLE
Adds Traces api for retrieving multiple traces at the same time

### DIFF
--- a/zipkin-junit/src/main/java/zipkin2/junit/ZipkinRule.java
+++ b/zipkin-junit/src/main/java/zipkin2/junit/ZipkinRule.java
@@ -130,7 +130,7 @@ public final class ZipkinRule implements TestRule {
   @Nullable
   public List<Span> getTrace(String traceId) {
     try {
-      return storage.spanStore().getTrace(traceId).execute();
+      return storage.traces().getTrace(traceId).execute();
     } catch (IOException e) {
       throw Platform.get().assertionError("I/O exception in in-memory storage", e);
     }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
@@ -130,7 +130,7 @@ public class ZipkinQueryApiV2 {
 
   @Get("/api/v2/trace/{traceIdHex}")
   public AggregatedHttpResponse getTrace(@Param("traceIdHex") String traceIdHex) throws IOException {
-    List<Span> trace = storage.spanStore().getTrace(traceIdHex).execute();
+    List<Span> trace = storage.traces().getTrace(traceIdHex).execute();
     if (trace == null) {
       return AggregatedHttpResponse.of(HttpStatus.NOT_FOUND, MediaType.PLAIN_TEXT_UTF_8,
         traceIdHex + " not found");

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
@@ -28,6 +28,7 @@ import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
+import zipkin2.storage.Traces;
 
 // public for use in ZipkinServerConfiguration
 public final class TracingStorageComponent extends ForwardingStorageComponent {
@@ -45,6 +46,10 @@ public final class TracingStorageComponent extends ForwardingStorageComponent {
 
   @Override public ServiceAndSpanNames serviceAndSpanNames() {
     return new TracingServiceAndSpanNames(tracing, delegate.serviceAndSpanNames());
+  }
+
+  @Override public Traces traces() {
+    return new TracingTraces(tracing, delegate.traces());
   }
 
   @Override public SpanStore spanStore() {
@@ -69,6 +74,28 @@ public final class TracingStorageComponent extends ForwardingStorageComponent {
 
   @Override public String toString() {
     return "Traced{" + delegate + "}";
+  }
+
+  static final class TracingTraces implements Traces {
+    final Tracer tracer;
+    final Traces delegate;
+
+    TracingTraces(Tracing tracing, Traces delegate) {
+      this.tracer = tracing.tracer();
+      this.delegate = delegate;
+    }
+
+    @Override public Call<List<Span>> getTrace(String traceId) {
+      return new TracedCall<>(tracer, delegate.getTrace(traceId), "get-trace");
+    }
+
+    @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+      return new TracedCall<>(tracer, delegate.getTraces(traceIds), "get-traces");
+    }
+
+    @Override public String toString() {
+      return "Traced{" + delegate + "}";
+    }
   }
 
   static final class TracingSpanStore implements SpanStore {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
@@ -32,6 +32,7 @@ import zipkin2.internal.Nullable;
 import zipkin2.storage.QueryRequest;
 import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanStore;
+import zipkin2.storage.Traces;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.DiscreteDomain.integers;
@@ -39,7 +40,7 @@ import static zipkin2.storage.cassandra.v1.CassandraUtil.sortTraceIdsByDescTimes
 import static zipkin2.storage.cassandra.v1.CassandraUtil.sortTraceIdsByDescTimestampMapper;
 import static zipkin2.storage.cassandra.v1.Tables.SERVICE_REMOTE_SERVICE_NAME_INDEX;
 
-public final class CassandraSpanStore implements SpanStore, ServiceAndSpanNames {
+public final class CassandraSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
   static final Logger LOG = LoggerFactory.getLogger(CassandraSpanStore.class);
 
   final int maxTraceCols;
@@ -115,8 +116,7 @@ public final class CassandraSpanStore implements SpanStore, ServiceAndSpanNames 
       new SelectTraceIdTimestampFromAnnotations.Factory(session, timestampCodec, buckets);
   }
 
-  @Override
-  public Call<List<List<Span>>> getTraces(QueryRequest request) {
+  @Override public Call<List<List<Span>>> getTraces(QueryRequest request) {
     if (!searchEnabled) return Call.emptyList();
 
     checkArgument(request.minDuration() == null,
@@ -194,35 +194,34 @@ public final class CassandraSpanStore implements SpanStore, ServiceAndSpanNames 
     return traceIdCall.flatMap(spans.newFlatMapper(request));
   }
 
-  @Override
-  public Call<List<Span>> getTrace(String traceId) {
+  @Override public Call<List<Span>> getTrace(String traceId) {
     // make sure we have a 16 or 32 character trace ID
     String normalizedTraceId = Span.normalizeTraceId(traceId);
     return spans.newCall(normalizedTraceId);
   }
 
-  @Override
-  public Call<List<String>> getServiceNames() {
+  @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+    return spans.newCall(traceIds);
+  }
+
+  @Override public Call<List<String>> getServiceNames() {
     if (!searchEnabled) return Call.emptyList();
     return serviceNames.clone();
   }
 
-  @Override
-  public Call<List<String>> getRemoteServiceNames(String serviceName) {
+  @Override public Call<List<String>> getRemoteServiceNames(String serviceName) {
     if (serviceName.isEmpty() || !searchEnabled || remoteServiceNames == null) {
       return Call.emptyList();
     }
     return remoteServiceNames.create(serviceName);
   }
 
-  @Override
-  public Call<List<String>> getSpanNames(String serviceName) {
+  @Override public Call<List<String>> getSpanNames(String serviceName) {
     if (serviceName.isEmpty() || !searchEnabled) return Call.emptyList();
     return spanNames.create(serviceName);
   }
 
-  @Override
-  public Call<List<DependencyLink>> getDependencies(long endTs, long lookback) {
+  @Override public Call<List<DependencyLink>> getDependencies(long endTs, long lookback) {
     if (endTs <= 0) throw new IllegalArgumentException("endTs <= 0");
     if (lookback <= 0) throw new IllegalArgumentException("lookback <= 0");
     return dependencies.create(endTs, lookback);

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
@@ -27,6 +27,7 @@ import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
+import zipkin2.storage.Traces;
 import zipkin2.storage.cassandra.internal.call.DeduplicatingVoidCallFactory;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
@@ -342,6 +343,10 @@ public class CassandraStorage extends StorageComponent { // not final for mockin
       }
     }
     return spanStore;
+  }
+
+  @Override public Traces traces() {
+    return (Traces) spanStore();
   }
 
   @Override public ServiceAndSpanNames serviceAndSpanNames() {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectFromTraces.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectFromTraces.java
@@ -75,6 +75,23 @@ final class SelectFromTraces extends ResultSetFutureCall<ResultSet> {
       return strictTraceId ? result.map(StrictTraceId.filterSpans(hexTraceId)) : result;
     }
 
+    Call<List<List<Span>>> newCall(List<String> traceIds) {
+      Set<Long> longTraceIds = new LinkedHashSet<>();
+      Set<String> normalizedTraceIds = new LinkedHashSet<>();
+
+      for (String traceId : traceIds) {
+        traceId = Span.normalizeTraceId(traceId);
+        normalizedTraceIds.add(traceId);
+        longTraceIds.add(HexCodec.lowerHexToUnsignedLong(traceId));
+      }
+      Call<List<List<Span>>> result = new SelectFromTraces(this,
+        longTraceIds,
+        maxTraceCols
+      ).flatMap(accumulateSpans).map(groupByTraceId);
+      return strictTraceId ? result.map(StrictTraceId.filterTraces(normalizedTraceIds)) : result;
+    }
+
+
     FlatMapper<Set<Long>, List<List<Span>>> newFlatMapper(QueryRequest request) {
       return new SelectTracesByIds(this, request);
     }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
@@ -79,7 +79,7 @@ abstract class ITEnsureSchema {
 
       storage.spanConsumer().accept(TestObjects.TRACE).execute();
 
-      assertThat(storage.spanStore().getTrace(TestObjects.TRACE.get(0).traceId()).execute())
+      assertThat(storage.traces().getTrace(TestObjects.TRACE.get(0).traceId()).execute())
         .containsExactlyInAnyOrderElementsOf(TestObjects.TRACE);
 
       assertThat(storage.autocompleteTags().getValues("environment").execute())

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
@@ -16,9 +16,6 @@ package zipkin2.storage.cassandra;
 import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.Session;
-import com.datastax.driver.core.exceptions.BusyConnectionException;
-import com.datastax.driver.core.exceptions.BusyPoolException;
-import com.datastax.driver.core.exceptions.QueryConsistencyException;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
@@ -33,6 +30,7 @@ import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
+import zipkin2.storage.Traces;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
 /**
@@ -217,8 +215,12 @@ public abstract class CassandraStorage extends StorageComponent {
     return new CassandraSpanStore(this);
   }
 
+  @Override public Traces traces() {
+    return (Traces) spanStore();
+  }
+
   @Override public ServiceAndSpanNames serviceAndSpanNames() {
-    return (CassandraSpanStore) spanStore();
+    return (ServiceAndSpanNames) spanStore();
   }
 
   /** {@inheritDoc} Memoized in order to avoid re-preparing statements */

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
@@ -96,6 +96,22 @@ final class SelectFromSpan extends ResultSetFutureCall<ResultSet> {
       return strictTraceId ? result.map(StrictTraceId.filterSpans(hexTraceId)) : result;
     }
 
+    Call<List<List<Span>>> newCall(List<String> traceIds) {
+      Set<String> normalizedTraceIds = new LinkedHashSet<>();
+      for (String traceId : traceIds) {
+        // make sure we have a 16 or 32 character trace ID
+        traceId = Span.normalizeTraceId(traceId);
+        // Unless we are strict, truncate the trace ID to 64bit (encoded as 16 characters)
+        if (!strictTraceId && traceId.length() == 32) traceId = traceId.substring(16);
+        normalizedTraceIds.add(traceId);
+      }
+      Call<List<List<Span>>> result = new SelectFromSpan(this,
+        normalizedTraceIds,
+        maxTraceCols)
+        .flatMap(readSpans).map(groupByTraceId);
+      return strictTraceId ? result.map(StrictTraceId.filterTraces(normalizedTraceIds)) : result;
+    }
+
     FlatMapper<Set<String>, List<List<Span>>> newFlatMapper(QueryRequest request) {
       return new SelectSpansByTraceIds(this, request);
     }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -16,7 +16,6 @@ package zipkin2.storage.cassandra;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -37,7 +36,6 @@ import zipkin2.storage.QueryRequest;
 import zipkin2.storage.StorageComponent;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.DAY;
 import static zipkin2.TestObjects.TODAY;
@@ -50,7 +48,7 @@ class ITCassandraStorage {
     "openzipkin/zipkin-cassandra:2.16.2");
 
   @Nested
-  class ITSpanStore extends zipkin2.storage.ITSpanStore<CassandraStorage> {
+  class ITTraces extends zipkin2.storage.ITTraces<CassandraStorage> {
     @Override protected boolean initializeStoragePerTest() {
       return true;
     }
@@ -59,8 +57,27 @@ class ITCassandraStorage {
       return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
     }
 
+    @Override @Test @Disabled("No consumer-side span deduplication")
+    public void getTrace_deduplicates() {
+    }
+
+    @Override protected void blockWhileInFlight() {
+      ITCassandraStorage.blockWhileInFlight(storage);
+    }
+
     @Override public void clear() {
       // Just let the data pile up to prevent warnings and slowness.
+    }
+  }
+
+  @Nested
+  class ITSpanStore extends zipkin2.storage.ITSpanStore<CassandraStorage> {
+    @Override protected boolean initializeStoragePerTest() {
+      return true;
+    }
+
+    @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
+      return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
     }
 
     @Test void overFetchesToCompensateForDuplicateIndexData() throws IOException {
@@ -125,22 +142,18 @@ class ITCassandraStorage {
       assertThat(store().getTraces(queryRequest).execute()).hasSize(queryLimit);
     }
 
-    /** Makes sure the test cluster doesn't fall over on BusyPoolException */
-    @Override protected void accept(Span... spans) throws IOException {
-      // TODO: this avoids overrunning the cluster with BusyPoolException
-      for (List<Span> nextChunk : Lists.partition(asList(spans), 100)) {
-        super.accept(nextChunk.toArray(new Span[0]));
-        // Now, block until writes complete, notably so we can read them.
-        blockWhileInFlight(storage);
-      }
+    @Override public void clear() {
+      // Just let the data pile up to prevent warnings and slowness.
     }
 
-    @Override @Test @Disabled("No consumer-side span deduplication") public void deduplicates() {
+    @Override protected void blockWhileInFlight() {
+      ITCassandraStorage.blockWhileInFlight(storage);
     }
   }
 
   @Nested
   class ITSearchEnabledFalse extends zipkin2.storage.ITSearchEnabledFalse<CassandraStorage> {
+
     @Override protected boolean initializeStoragePerTest() {
       return true;
     }
@@ -149,16 +162,20 @@ class ITCassandraStorage {
       return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
     }
 
-    @Override public void clear() {
-      // Just let the data pile up to prevent warnings and slowness.
-    }
-
     @Test void doesntCreateIndexes() {
       KeyspaceMetadata metadata =
         storage.session().getCluster().getMetadata().getKeyspace(storage.keyspace());
 
       assertThat(metadata.getTable("trace_by_service_span")).isNull();
       assertThat(metadata.getTable("span_by_service")).isNull();
+    }
+
+    @Override public void clear() {
+      // Just let the data pile up to prevent warnings and slowness.
+    }
+
+    @Override protected void blockWhileInFlight() {
+      ITCassandraStorage.blockWhileInFlight(storage);
     }
   }
 
@@ -197,7 +214,7 @@ class ITCassandraStorage {
     @Test public void getTrace_retrievesBy128BitTraceId_afterSwitch() throws IOException {
       List<Span> trace = accept128BitTrace(storageBeforeSwitch);
 
-      assertThat(store().getTrace(trace.get(0).traceId()).execute())
+      assertThat(traces().getTrace(trace.get(0).traceId()).execute())
         .containsOnlyElementsOf(trace);
     }
   }
@@ -210,6 +227,10 @@ class ITCassandraStorage {
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
       return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
+    }
+
+    @Override protected void blockWhileInFlight() {
+      ITCassandraStorage.blockWhileInFlight(storage);
     }
 
     @Override public void clear() {
@@ -227,6 +248,10 @@ class ITCassandraStorage {
       return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
     }
 
+    @Override protected void blockWhileInFlight() {
+      ITCassandraStorage.blockWhileInFlight(storage);
+    }
+
     @Override public void clear() {
       // Just let the data pile up to prevent warnings and slowness.
     }
@@ -240,6 +265,10 @@ class ITCassandraStorage {
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
       return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
+    }
+
+    @Override protected void blockWhileInFlight() {
+      ITCassandraStorage.blockWhileInFlight(storage);
     }
 
     @Override public void clear() {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -100,7 +100,7 @@ abstract class ITEnsureSchema {
 
       storage.spanConsumer().accept(TestObjects.TRACE).execute();
 
-      assertThat(storage.spanStore().getTrace(TestObjects.TRACE.get(0).traceId()).execute())
+      assertThat(storage.traces().getTrace(TestObjects.TRACE.get(0).traceId()).execute())
         .containsExactlyInAnyOrderElementsOf(TestObjects.TRACE);
 
       assertThat(storage.autocompleteTags().getValues("environment").execute())

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -42,6 +42,7 @@ import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
+import zipkin2.storage.Traces;
 
 import static zipkin2.elasticsearch.ElasticsearchAutocompleteTags.AUTOCOMPLETE;
 import static zipkin2.elasticsearch.ElasticsearchSpanStore.DEPENDENCY;
@@ -208,6 +209,10 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   @Override public SpanStore spanStore() {
     ensureIndexTemplates();
     return new ElasticsearchSpanStore(this);
+  }
+
+  @Override public Traces traces() {
+    return (Traces) spanStore();
   }
 
   @Override public ServiceAndSpanNames serviceAndSpanNames() {

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/SearchRequest.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/client/SearchRequest.java
@@ -74,7 +74,7 @@ public final class SearchRequest {
     return query(new Term(field, value));
   }
 
-  public SearchRequest terms(String field, List<String> values) {
+  public SearchRequest terms(String field, Collection<String> values) {
     return query(new Terms(field, values));
   }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorage.java
@@ -29,6 +29,17 @@ abstract class ITElasticsearchStorage {
   abstract ElasticsearchStorageExtension backend();
 
   @Nested
+  class ITTraces extends zipkin2.storage.ITTraces<ElasticsearchStorage> {
+    @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
+      return backend().computeStorageBuilder().index(index(testInfo));
+    }
+
+    @Override public void clear() throws IOException {
+      storage.clear();
+    }
+  }
+
+  @Nested
   class ITSpanStore extends zipkin2.storage.ITSpanStore<ElasticsearchStorage> {
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
       return backend().computeStorageBuilder().index(index(testInfo));
@@ -103,5 +114,4 @@ abstract class ITElasticsearchStorage {
       storage.clear();
     }
   }
-
 }

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/MySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/MySQLStorage.java
@@ -28,6 +28,7 @@ import zipkin2.storage.ServiceAndSpanNames;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
+import zipkin2.storage.Traces;
 
 import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinAnnotations.ZIPKIN_ANNOTATIONS;
 import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinDependencies.ZIPKIN_DEPENDENCIES;
@@ -89,7 +90,8 @@ public final class MySQLStorage extends StorageComponent {
       return new MySQLStorage(this);
     }
 
-    Builder() {}
+    Builder() {
+    }
   }
 
   static {
@@ -136,8 +138,12 @@ public final class MySQLStorage extends StorageComponent {
     return new MySQLSpanStore(this, schema());
   }
 
+  @Override public Traces traces() {
+    return (Traces) spanStore();
+  }
+
   @Override public ServiceAndSpanNames serviceAndSpanNames() {
-    return new MySQLSpanStore(this, schema());
+    return (ServiceAndSpanNames) spanStore();
   }
 
   @Override public AutocompleteTags autocompleteTags() {

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/Schema.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/Schema.java
@@ -125,7 +125,18 @@ final class Schema {
         : ZIPKIN_SPANS.TRACE_ID.eq(traceIdLow);
   }
 
+  Condition spanTraceIdCondition(Set<Pair> traceIds) {
+    return traceIdCondition(ZIPKIN_SPANS.TRACE_ID_HIGH, ZIPKIN_SPANS.TRACE_ID, traceIds);
+  }
+
   Condition annotationsTraceIdCondition(Set<Pair> traceIds) {
+    return traceIdCondition(ZIPKIN_ANNOTATIONS.TRACE_ID_HIGH, ZIPKIN_ANNOTATIONS.TRACE_ID, traceIds);
+  }
+
+  Condition traceIdCondition(
+    TableField<Record, Long> TRACE_ID_HIGH,
+    TableField<Record, Long> TRACE_ID, Set<Pair> traceIds
+  ) {
     boolean hasTraceIdHigh = false;
     for (Pair traceId : traceIds) {
       if (traceId.left != 0) {
@@ -139,14 +150,14 @@ final class Schema {
       for (Pair traceId128 : traceIds) {
         result[i++] = row(traceId128.left, traceId128.right);
       }
-      return row(ZIPKIN_ANNOTATIONS.TRACE_ID_HIGH, ZIPKIN_ANNOTATIONS.TRACE_ID).in(result);
+      return row(TRACE_ID_HIGH, TRACE_ID).in(result);
     } else {
       Long[] result = new Long[traceIds.size()];
       int i = 0;
       for (Pair traceId128 : traceIds) {
         result[i++] = traceId128.right;
       }
-      return ZIPKIN_ANNOTATIONS.TRACE_ID.in(result);
+      return TRACE_ID.in(result);
     }
   }
 

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectSpansAndAnnotations.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectSpansAndAnnotations.java
@@ -15,8 +15,10 @@ package zipkin2.storage.mysql.v1;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.jooq.Condition;
@@ -40,6 +42,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.groupingBy;
 import static org.jooq.impl.DSL.max;
 import static org.jooq.impl.DSL.row;
+import static zipkin2.internal.HexCodec.lowerHexToUnsignedLong;
 import static zipkin2.storage.mysql.v1.Schema.maybeGet;
 import static zipkin2.storage.mysql.v1.SelectAnnotationServiceNames.localServiceNameCondition;
 import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinAnnotations.ZIPKIN_ANNOTATIONS;
@@ -62,6 +65,25 @@ abstract class SelectSpansAndAnnotations implements Function<DSLContext, List<Sp
         @Override
         Condition traceIdCondition(DSLContext context) {
           return schema.spanTraceIdCondition(finalTraceIdHigh, traceIdLow);
+        }
+      };
+    }
+
+    SelectSpansAndAnnotations create(List<String> traceIds) {
+      Set<Pair> traceIdPairs = new LinkedHashSet<>();
+      for (String traceId : traceIds) {
+        // make sure we have a 16 or 32 character trace ID
+        String hexTraceId = Span.normalizeTraceId(traceId);
+        traceIdPairs.add(new Pair(
+            hexTraceId.length() == 32 ? lowerHexToUnsignedLong(hexTraceId, 0) : 0L,
+            lowerHexToUnsignedLong(hexTraceId)
+          )
+        );
+      }
+      return new SelectSpansAndAnnotations(schema) {
+        @Override
+        Condition traceIdCondition(DSLContext context) {
+          return schema.spanTraceIdCondition(traceIdPairs);
         }
       };
     }
@@ -94,44 +116,44 @@ abstract class SelectSpansAndAnnotations implements Function<DSLContext, List<Sp
     final Map<Row3<Long, Long, Long>, List<Record>> dbAnnotations;
 
     spansWithoutAnnotations =
-        context
-            .select(schema.spanFields)
-            .from(ZIPKIN_SPANS)
-            .where(traceIdCondition(context))
-            .stream()
-            .map(
-                r ->
-                    V1Span.newBuilder()
-                        .traceIdHigh(maybeGet(r, ZIPKIN_SPANS.TRACE_ID_HIGH, 0L))
-                        .traceId(r.getValue(ZIPKIN_SPANS.TRACE_ID))
-                        .name(r.getValue(ZIPKIN_SPANS.NAME))
-                        .id(r.getValue(ZIPKIN_SPANS.ID))
-                        .parentId(maybeGet(r, ZIPKIN_SPANS.PARENT_ID, 0L))
-                        .timestamp(maybeGet(r, ZIPKIN_SPANS.START_TS, 0L))
-                        .duration(maybeGet(r, ZIPKIN_SPANS.DURATION, 0L))
-                        .debug(r.getValue(ZIPKIN_SPANS.DEBUG)))
-            .collect(
-                groupingBy(
-                    s -> new Pair(s.traceIdHigh(), s.traceId()),
-                    LinkedHashMap::new,
-                    Collectors.toList()));
+      context
+        .select(schema.spanFields)
+        .from(ZIPKIN_SPANS)
+        .where(traceIdCondition(context))
+        .stream()
+        .map(
+          r ->
+            V1Span.newBuilder()
+              .traceIdHigh(maybeGet(r, ZIPKIN_SPANS.TRACE_ID_HIGH, 0L))
+              .traceId(r.getValue(ZIPKIN_SPANS.TRACE_ID))
+              .name(r.getValue(ZIPKIN_SPANS.NAME))
+              .id(r.getValue(ZIPKIN_SPANS.ID))
+              .parentId(maybeGet(r, ZIPKIN_SPANS.PARENT_ID, 0L))
+              .timestamp(maybeGet(r, ZIPKIN_SPANS.START_TS, 0L))
+              .duration(maybeGet(r, ZIPKIN_SPANS.DURATION, 0L))
+              .debug(r.getValue(ZIPKIN_SPANS.DEBUG)))
+        .collect(
+          groupingBy(
+            s -> new Pair(s.traceIdHigh(), s.traceId()),
+            LinkedHashMap::new,
+            Collectors.toList()));
 
     dbAnnotations =
-        context
-            .select(schema.annotationFields)
-            .from(ZIPKIN_ANNOTATIONS)
-            .where(schema.annotationsTraceIdCondition(spansWithoutAnnotations.keySet()))
-            .orderBy(ZIPKIN_ANNOTATIONS.A_TIMESTAMP.asc(), ZIPKIN_ANNOTATIONS.A_KEY.asc())
-            .stream()
-            .collect(
-                groupingBy(
-                    (Record a) ->
-                        row(
-                            maybeGet(a, ZIPKIN_ANNOTATIONS.TRACE_ID_HIGH, 0L),
-                            a.getValue(ZIPKIN_ANNOTATIONS.TRACE_ID),
-                            a.getValue(ZIPKIN_ANNOTATIONS.SPAN_ID)),
-                    LinkedHashMap::new,
-                    Collectors.toList())); // LinkedHashMap preserves order while grouping
+      context
+        .select(schema.annotationFields)
+        .from(ZIPKIN_ANNOTATIONS)
+        .where(schema.annotationsTraceIdCondition(spansWithoutAnnotations.keySet()))
+        .orderBy(ZIPKIN_ANNOTATIONS.A_TIMESTAMP.asc(), ZIPKIN_ANNOTATIONS.A_KEY.asc())
+        .stream()
+        .collect(
+          groupingBy(
+            (Record a) ->
+              row(
+                maybeGet(a, ZIPKIN_ANNOTATIONS.TRACE_ID_HIGH, 0L),
+                a.getValue(ZIPKIN_ANNOTATIONS.TRACE_ID),
+                a.getValue(ZIPKIN_ANNOTATIONS.SPAN_ID)),
+            LinkedHashMap::new,
+            Collectors.toList())); // LinkedHashMap preserves order while grouping
 
     V1SpanConverter converter = V1SpanConverter.create();
     List<Span> allSpans = new ArrayList<>(spansWithoutAnnotations.size());
@@ -155,16 +177,16 @@ abstract class SelectSpansAndAnnotations implements Function<DSLContext, List<Sp
     if (type == null) return;
     if (type == -1) {
       span.addAnnotation(
-          a.getValue(ZIPKIN_ANNOTATIONS.A_TIMESTAMP),
-          a.getValue(ZIPKIN_ANNOTATIONS.A_KEY),
-          endpoint);
+        a.getValue(ZIPKIN_ANNOTATIONS.A_TIMESTAMP),
+        a.getValue(ZIPKIN_ANNOTATIONS.A_KEY),
+        endpoint);
     } else {
       switch (type) {
         case V1BinaryAnnotation.TYPE_STRING:
           span.addBinaryAnnotation(
-              a.getValue(ZIPKIN_ANNOTATIONS.A_KEY),
-              new String(a.getValue(ZIPKIN_ANNOTATIONS.A_VALUE), UTF_8),
-              endpoint);
+            a.getValue(ZIPKIN_ANNOTATIONS.A_KEY),
+            new String(a.getValue(ZIPKIN_ANNOTATIONS.A_VALUE), UTF_8),
+            endpoint);
           break;
         case V1BinaryAnnotation.TYPE_BOOLEAN:
           // address annotations require an endpoint
@@ -187,31 +209,31 @@ abstract class SelectSpansAndAnnotations implements Function<DSLContext, List<Sp
     long endTs = request.endTs() * 1000;
 
     TableOnConditionStep<?> table =
-        ZIPKIN_SPANS.join(ZIPKIN_ANNOTATIONS).on(schema.joinCondition(ZIPKIN_ANNOTATIONS));
+      ZIPKIN_SPANS.join(ZIPKIN_ANNOTATIONS).on(schema.joinCondition(ZIPKIN_ANNOTATIONS));
 
     int i = 0;
     for (Map.Entry<String, String> kv : request.annotationQuery().entrySet()) {
       ZipkinAnnotations aTable = ZIPKIN_ANNOTATIONS.as("a" + i++);
       if (kv.getValue().isEmpty()) {
         table =
-            maybeOnService(
-                table
-                    .join(aTable)
-                    .on(schema.joinCondition(aTable))
-                    .and(aTable.A_KEY.eq(kv.getKey())),
-                aTable,
-                request.serviceName());
+          maybeOnService(
+            table
+              .join(aTable)
+              .on(schema.joinCondition(aTable))
+              .and(aTable.A_KEY.eq(kv.getKey())),
+            aTable,
+            request.serviceName());
       } else {
         table =
-            maybeOnService(
-                table
-                    .join(aTable)
-                    .on(schema.joinCondition(aTable))
-                    .and(aTable.A_TYPE.eq(V1BinaryAnnotation.TYPE_STRING))
-                    .and(aTable.A_KEY.eq(kv.getKey()))
-                    .and(aTable.A_VALUE.eq(kv.getValue().getBytes(UTF_8))),
-                aTable,
-                request.serviceName());
+          maybeOnService(
+            table
+              .join(aTable)
+              .on(schema.joinCondition(aTable))
+              .and(aTable.A_TYPE.eq(V1BinaryAnnotation.TYPE_STRING))
+              .and(aTable.A_KEY.eq(kv.getKey()))
+              .and(aTable.A_VALUE.eq(kv.getValue().getBytes(UTF_8))),
+            aTable,
+            request.serviceName());
       }
     }
 
@@ -240,30 +262,30 @@ abstract class SelectSpansAndAnnotations implements Function<DSLContext, List<Sp
       dsl.and(ZIPKIN_SPANS.DURATION.greaterOrEqual(request.minDuration()));
     }
     return dsl.groupBy(schema.spanIdFields)
-        .orderBy(max(ZIPKIN_SPANS.START_TS).desc())
-        .limit(request.limit());
+      .orderBy(max(ZIPKIN_SPANS.START_TS).desc())
+      .limit(request.limit());
   }
 
   static TableOnConditionStep<?> maybeOnService(
-      TableOnConditionStep<Record> table, ZipkinAnnotations aTable, String serviceName) {
+    TableOnConditionStep<Record> table, ZipkinAnnotations aTable, String serviceName) {
     if (serviceName == null) return table;
     return table.and(aTable.ENDPOINT_SERVICE_NAME.eq(serviceName));
   }
 
   static Endpoint endpoint(Record a) {
     Endpoint.Builder result =
-        Endpoint.newBuilder()
-            .serviceName(a.getValue(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME))
-            .port(Schema.maybeGet(a, ZIPKIN_ANNOTATIONS.ENDPOINT_PORT, (short) 0));
+      Endpoint.newBuilder()
+        .serviceName(a.getValue(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME))
+        .port(Schema.maybeGet(a, ZIPKIN_ANNOTATIONS.ENDPOINT_PORT, (short) 0));
     int ipv4 = maybeGet(a, ZIPKIN_ANNOTATIONS.ENDPOINT_IPV4, 0);
     if (ipv4 != 0) {
       result.parseIp( // allocation is ok here as Endpoint.ipv4Bytes would anyway
-          new byte[] {
-            (byte) (ipv4 >> 24 & 0xff),
-            (byte) (ipv4 >> 16 & 0xff),
-            (byte) (ipv4 >> 8 & 0xff),
-            (byte) (ipv4 & 0xff)
-          });
+        new byte[] {
+          (byte) (ipv4 >> 24 & 0xff),
+          (byte) (ipv4 >> 16 & 0xff),
+          (byte) (ipv4 >> 8 & 0xff),
+          (byte) (ipv4 & 0xff)
+        });
     }
     result.parseIp(Schema.maybeGet(a, ZIPKIN_ANNOTATIONS.ENDPOINT_IPV6, null));
     return result.build();

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -37,6 +37,21 @@ class ITMySQLStorage {
     "openzipkin/zipkin-mysql:2.16.2");
 
   @Nested
+  class ITTraces extends zipkin2.storage.ITTraces<MySQLStorage> {
+    @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
+      return backend.computeStorageBuilder();
+    }
+
+    @Override @Test @Disabled("No consumer-side span deduplication")
+    public void getTrace_deduplicates() {
+    }
+
+    @Override public void clear() {
+      storage.clear();
+    }
+  }
+
+  @Nested
   class ITSpanStore extends zipkin2.storage.ITSpanStore<MySQLStorage> {
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
       return backend.computeStorageBuilder();
@@ -44,9 +59,6 @@ class ITMySQLStorage {
 
     @Override public void clear() {
       storage.clear();
-    }
-
-    @Override @Test @Disabled("No consumer-side span deduplication") public void deduplicates() {
     }
   }
 

--- a/zipkin-tests/src/main/java/zipkin2/TestObjects.java
+++ b/zipkin-tests/src/main/java/zipkin2/TestObjects.java
@@ -119,7 +119,7 @@ public final class TestObjects {
    * flaking out due to PRNG nuance.
    */
   public static final Span[] LOTS_OF_SPANS =
-      new Random().longs(100_000).mapToObj(t -> span(t)).toArray(Span[]::new);
+      new Random().longs(100_000).mapToObj(TestObjects::span).toArray(Span[]::new);
 
   public static Span span(long traceId) {
     return spanBuilder.traceId(Long.toHexString(traceId)).id(traceId).build();

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import zipkin2.Span;
 import zipkin2.TestObjects;
 
 import static java.util.Arrays.asList;
@@ -58,9 +57,5 @@ public abstract class ITAutocompleteTags<T extends StorageComponent> extends ITS
 
     assertThat(storage.autocompleteTags().getValues("http.host").execute())
       .containsOnlyOnce("host1");
-  }
-
-  protected void accept(Span... spans) throws IOException {
-    storage.spanConsumer().accept(asList(spans)).execute();
   }
 }

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITSearchEnabledFalse.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITSearchEnabledFalse.java
@@ -13,11 +13,8 @@
  */
 package zipkin2.storage;
 
-import java.io.IOException;
 import org.junit.jupiter.api.Test;
-import zipkin2.Span;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.storage.ITSpanStore.requestBuilder;
@@ -73,9 +70,5 @@ public abstract class ITSearchEnabledFalse<T extends StorageComponent> extends I
     accept(CLIENT_SPAN);
 
     assertThat(names().getSpanNames(CLIENT_SPAN.localServiceName()).execute()).isEmpty();
-  }
-
-  protected void accept(Span... spans) throws IOException {
-    storage.spanConsumer().accept(asList(spans)).execute();
   }
 }

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITServiceAndSpanNames.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITServiceAndSpanNames.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.FRONTEND;
@@ -162,13 +161,5 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
     accept(CLIENT_SPAN);
 
     assertThat(names().getSpanNames("FrOnTeNd").execute()).containsExactly("get");
-  }
-
-  protected void accept(List<Span> spans) throws IOException {
-    storage.spanConsumer().accept(spans).execute();
-  }
-
-  protected void accept(Span... spans) throws IOException {
-    storage.spanConsumer().accept(asList(spans)).execute();
   }
 }

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITTraces.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITTraces.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+import static zipkin2.TestObjects.LOTS_OF_SPANS;
+
+/**
+ * Base test for {@link Traces}.
+ *
+ * <p>Subtypes should create a connection to a real backend, even if that backend is in-process.
+ */
+public abstract class ITTraces<T extends StorageComponent> extends ITStorage<T> {
+
+  @Override protected final void configureStorageForTest(StorageComponent.Builder storage) {
+    // Defaults are fine.
+  }
+
+  @Test void getTrace_returnsEmptyOnNotFound() throws IOException {
+    assertThat(traces().getTrace(CLIENT_SPAN.traceId()).execute())
+      .isEmpty();
+
+    accept(CLIENT_SPAN);
+
+    assertThat(traces().getTrace(CLIENT_SPAN.traceId()).execute())
+      .containsExactly(CLIENT_SPAN);
+
+    assertThat(traces().getTrace(CLIENT_SPAN.traceId().substring(16)).execute())
+      .isEmpty();
+  }
+
+  @Test void getTraces_returnsEmptyOnNotFound() throws IOException {
+    List<String> traceIds = asList(LOTS_OF_SPANS[0].traceId(), LOTS_OF_SPANS[1].traceId());
+
+    assertThat(traces().getTraces(traceIds).execute())
+      .isEmpty();
+
+    accept(LOTS_OF_SPANS[0], LOTS_OF_SPANS[1]);
+
+    assertThat(traces().getTraces(traceIds).execute())
+      .containsExactlyInAnyOrder(asList(LOTS_OF_SPANS[0]), asList(LOTS_OF_SPANS[1]));
+
+    List<String> longTraceIds = traceIds.stream().map(t -> "a" + t).collect(Collectors.toList());
+    assertThat(traces().getTraces(longTraceIds).execute())
+      .isEmpty();
+  }
+
+  /**
+   * Ideally, storage backends can deduplicate identical documents as this will prevent some
+   * analysis problems such as double-counting dependency links or other statistics. While this test
+   * exists, it is known not all backends will be able to cheaply make it pass. In other words, it
+   * is optional.
+   */
+  @Test public void getTrace_deduplicates() throws IOException {
+    // simulate a re-processed message
+    accept(LOTS_OF_SPANS[0]);
+    accept(LOTS_OF_SPANS[0]);
+
+    assertThat(sortTrace(traces().getTrace(LOTS_OF_SPANS[0].traceId()).execute()))
+      .containsExactly(LOTS_OF_SPANS[0]);
+  }
+}

--- a/zipkin-tests/src/test/java/zipkin2/storage/ITInMemoryStorage.java
+++ b/zipkin-tests/src/test/java/zipkin2/storage/ITInMemoryStorage.java
@@ -17,6 +17,16 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInfo;
 
 class ITInMemoryStorage {
+  @Nested
+  class ITTraces extends zipkin2.storage.ITTraces<InMemoryStorage> {
+    @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
+      return InMemoryStorage.newBuilder();
+    }
+
+    @Override public void clear() {
+      storage.clear();
+    }
+  }
 
   @Nested
   class ITSpanStore extends zipkin2.storage.ITSpanStore<InMemoryStorage> {

--- a/zipkin/src/main/java/zipkin2/internal/TracesAdapter.java
+++ b/zipkin/src/main/java/zipkin2/internal/TracesAdapter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import zipkin2.Call;
+import zipkin2.Span;
+import zipkin2.storage.SpanStore;
+import zipkin2.storage.Traces;
+
+public final class TracesAdapter implements Traces {
+  final SpanStore delegate;
+
+  public TracesAdapter(SpanStore spanStore) {
+    this.delegate = spanStore;
+  }
+
+  @Override public Call<List<Span>> getTrace(String traceId) {
+    return delegate.getTrace(traceId);
+  }
+
+  @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+    if (traceIds == null) throw new NullPointerException("traceIds == null");
+    if (traceIds.isEmpty()) return Call.emptyList();
+
+    List<Call<List<Span>>> calls = new ArrayList<>();
+    for (String traceId : traceIds) {
+      calls.add(getTrace(Span.normalizeTraceId(traceId)));
+    }
+
+    if (calls.size() == 1) return calls.get(0).map(ToSingletonList.INSTANCE);
+    return new ScatterGather(calls);
+  }
+
+  enum ToSingletonList implements Call.Mapper<List<Span>, List<List<Span>>> {
+    INSTANCE;
+
+    @Override public List<List<Span>> map(List<Span> input) {
+      return Collections.singletonList(input);
+    }
+
+    @Override public String toString() {
+      return "Collections.singletonList()";
+    }
+  }
+
+  static final class ScatterGather extends AggregateCall<List<Span>, List<List<Span>>> {
+    ScatterGather(List<? extends Call<List<Span>>> calls) {
+      super(calls);
+    }
+
+    @Override protected List<List<Span>> newOutput() {
+      return new ArrayList<>();
+    }
+
+    @Override protected void append(List<Span> input, List<List<Span>> output) {
+      output.add(input);
+    }
+
+    @Override protected boolean isEmpty(List<List<Span>> output) {
+      return output.isEmpty();
+    }
+
+    @Override public ScatterGather clone() {
+      return new ScatterGather(cloneCalls());
+    }
+  }
+
+  @Override public String toString() {
+    return "TraceReader{" + delegate + "}";
+  }
+}

--- a/zipkin/src/main/java/zipkin2/storage/ForwardingStorageComponent.java
+++ b/zipkin/src/main/java/zipkin2/storage/ForwardingStorageComponent.java
@@ -42,6 +42,10 @@ public abstract class ForwardingStorageComponent extends StorageComponent {
     return delegate().spanConsumer();
   }
 
+  @Override public Traces traces() {
+    return delegate().traces();
+  }
+
   @Override public SpanStore spanStore() {
     return delegate().spanStore();
   }

--- a/zipkin/src/main/java/zipkin2/storage/GroupByTraceId.java
+++ b/zipkin/src/main/java/zipkin2/storage/GroupByTraceId.java
@@ -50,7 +50,8 @@ public final class GroupByTraceId implements Call.Mapper<List<Span>, List<List<S
       }
       groupedByTraceId.get(traceId).add(span);
     }
-    return Collections.unmodifiableList(new ArrayList<>(groupedByTraceId.values()));
+    // Modifiable so that StrictTraceId can filter without allocating a new list
+    return new ArrayList<>(groupedByTraceId.values());
   }
 
   @Override public String toString() {

--- a/zipkin/src/main/java/zipkin2/storage/SpanStore.java
+++ b/zipkin/src/main/java/zipkin2/storage/SpanStore.java
@@ -46,8 +46,9 @@ public interface SpanStore {
    * <p>Implementations should use {@link Span#normalizeTraceId(String)} to ensure consistency.
    *
    * @param traceId the {@link Span#traceId() trace ID}
+   * @deprecated use {@link Traces#getTrace(String)}
    */
-  Call<List<Span>> getTrace(String traceId);
+  @Deprecated Call<List<Span>> getTrace(String traceId);
 
   /**
    * Retrieves all {@link Span#localEndpoint() local} and {@link Span#remoteEndpoint() remote}
@@ -75,8 +76,8 @@ public interface SpanStore {
    * was 25 hours, the implementation would query against 2 buckets.
    *
    * <p>Some implementations parse spans from storage and call {@link
-   * DependencyLinker} to aggregate links. The reason is certain graph
-   * logic, such as skipping up the tree is difficult to implement as a storage query.
+   * DependencyLinker} to aggregate links. The reason is certain graph logic, such as skipping up
+   * the tree is difficult to implement as a storage query.
    *
    * <p>Spans are grouped by the right-most 16 characters of the trace ID. This ensures call counts
    * are not incremented twice due to one hop downgrading from 128 to 64-bit trace IDs.

--- a/zipkin/src/main/java/zipkin2/storage/StorageComponent.java
+++ b/zipkin/src/main/java/zipkin2/storage/StorageComponent.java
@@ -20,6 +20,7 @@ import zipkin2.Call;
 import zipkin2.Callback;
 import zipkin2.Component;
 import zipkin2.Span;
+import zipkin2.internal.TracesAdapter;
 
 /**
  * A component that provides storage interfaces used for spans and aggregations. Implementations are
@@ -28,6 +29,10 @@ import zipkin2.Span;
  * @see InMemoryStorage
  */
 public abstract class StorageComponent extends Component {
+
+  public Traces traces() {
+    return new TracesAdapter(spanStore()); // delegates to deprecated methods.
+  }
 
   public abstract SpanStore spanStore();
 
@@ -141,7 +146,7 @@ public abstract class StorageComponent extends Component {
     public abstract Builder strictTraceId(boolean strictTraceId);
 
     /**
-     * False is an attempt to disable indexing, leaving only {@link SpanStore#getTrace(String)}
+     * False is an attempt to disable indexing, leaving only {@link StorageComponent#traces()}
      * supported. For example, query requests will be disabled.
      *
      * The use case is typically to support 100% sampled data, or when traces are searched using

--- a/zipkin/src/main/java/zipkin2/storage/Traces.java
+++ b/zipkin/src/main/java/zipkin2/storage/Traces.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage;
+
+import java.util.List;
+import zipkin2.Call;
+import zipkin2.Span;
+
+/**
+ * Allows readback of traces by ID, as written by a {@link SpanConsumer}.
+ *
+ * <p>Specifically, this provides apis present when {@link StorageComponent.Builder#searchEnabled(boolean)
+ * search is disabled}.
+ *
+ * <p>Note: This is not considered a user-level Api, rather an Spi that can be used to bind
+ * user-level abstractions such as futures or observables.
+ *
+ * @since 2.17
+ */
+public interface Traces {
+  /**
+   * Retrieves spans that share a 128-bit trace id with no ordering expectation or empty if none are
+   * found.
+   *
+   * <p>When strict trace ID is disabled, spans with the same right-most 16 characters are returned
+   * even if the characters to the left are not.
+   *
+   * <p>Implementations should use {@link Span#normalizeTraceId(String)} to ensure consistency.
+   *
+   * @param traceId the {@link Span#traceId() trace ID}
+   */
+  Call<List<Span>> getTrace(String traceId);
+
+  /**
+   * Retrieves list of spans that share a 128-bit trace id with no ordering expectation or empty if
+   * none are found.
+   *
+   * <p>When strict trace ID is disabled, spans with the same right-most 16 characters are returned
+   * even if the characters to the left are not.
+   *
+   * <p>Implementations should use {@link Span#normalizeTraceId(String)} to ensure consistency.
+   *
+   * @param traceIds a list of {@link Span#traceId() trace ID}
+   * @return traces matching the supplied trace IDs, in any order
+   */
+  Call<List<List<Span>>> getTraces(List<String> traceIds);
+}

--- a/zipkin/src/test/java/zipkin2/storage/GroupByTraceIdTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/GroupByTraceIdTest.java
@@ -37,4 +37,15 @@ public class GroupByTraceIdTest {
     assertThat(GroupByTraceId.create(true).map(spans))
       .containsExactly(asList(oneOne), asList(twoOne), asList(zeroOne));
   }
+
+  @Test public void map_modifiable() {
+    List<Span> spans = asList(oneOne, twoOne, zeroOne);
+
+    List<List<Span>> modifiable = GroupByTraceId.create(true).map(spans);
+
+    // This transform is used in cassandra v1 and filters when traces match on lower 64bits, but not
+    // the higher ones.
+    assertThat(StrictTraceId.filterTraces(asList(twoOne.traceId())).map(modifiable))
+      .containsExactly(asList(twoOne));
+  }
 }

--- a/zipkin/src/test/java/zipkin2/storage/InMemoryStorageTest.java
+++ b/zipkin/src/test/java/zipkin2/storage/InMemoryStorageTest.java
@@ -156,4 +156,31 @@ public class InMemoryStorageTest {
     assertThat(storage.getKeys().execute()).containsOnlyOnce("http.path");
     assertThat(storage.getValues("http.path").execute()).containsOnlyOnce("/users");
   }
+
+  @Test public void getTraces_byTraceIds() throws IOException {
+    Span trace1Span1 = Span.newBuilder().traceId("1").id("1").name("root")
+      .localEndpoint(Endpoint.newBuilder().serviceName("app").build())
+      .timestamp(TODAY * 1000)
+      .build();
+    Span trace1Span2 = Span.newBuilder().traceId("1").parentId("1").id("2")
+      .localEndpoint(Endpoint.newBuilder().serviceName("app").build())
+      .timestamp(TODAY * 1000)
+      .build();
+
+    Span trace2Span1 = Span.newBuilder().traceId("2").id("1").name("root")
+      .localEndpoint(Endpoint.newBuilder().serviceName("app").build())
+      .timestamp(TODAY * 1000)
+      .build();
+    Span trace2Span2 = Span.newBuilder().traceId("2").parentId("1").id("2")
+      .localEndpoint(Endpoint.newBuilder().serviceName("app").build())
+      .timestamp(TODAY * 1000)
+      .build();
+
+    storage.accept(asList(trace1Span1, trace1Span2, trace2Span1, trace2Span2));
+
+    assertThat(storage.getTraces(asList("1", "2")).execute()).containsExactly(
+      asList(trace1Span1, trace1Span2),
+      asList(trace2Span1, trace2Span2)
+    );
+  }
 }


### PR DESCRIPTION
In #2116, we added the ability to perform multi-get by trace ID in support of collecting trace IDs based on out-of-band discovery in one trip.

This resurrects work formerly completed by @zeagord and @llinder in such a way that it doesn't break compatibility in any way.

Instead of adding `getTraces(List)` to the `SpanStore` api, this adds `Traces` with a backported bridge to the `SpanStore` api.