### PR TITLE
Adds CollectedSpanHandler

### DIFF
--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQCollector.java
@@ -22,6 +22,7 @@ import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
+import zipkin2.collector.handler.CollectedSpanHandler;
 import zipkin2.storage.StorageComponent;
 
 /** This collector consumes encoded binary messages from a ActiveMQ queue. */
@@ -38,13 +39,18 @@ public final class ActiveMQCollector extends CollectorComponent {
     String queue = "zipkin";
     int concurrency = 1;
 
-    @Override public Builder storage(StorageComponent storage) {
-      this.delegate.storage(storage);
+    @Override public Builder sampler(CollectorSampler sampler) {
+      this.delegate.sampler(sampler);
       return this;
     }
 
-    @Override public Builder sampler(CollectorSampler sampler) {
-      this.delegate.sampler(sampler);
+    @Override public Builder addCollectedSpanHandler(CollectedSpanHandler collectedSpanHandler) {
+      this.delegate.addCollectedSpanHandler(collectedSpanHandler);
+      return this;
+    }
+
+    @Override public Builder storage(StorageComponent storage) {
+      this.delegate.storage(storage);
       return this;
     }
 

--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQSpanConsumer.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQSpanConsumer.java
@@ -28,26 +28,18 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.transport.TransportListener;
-import zipkin2.Callback;
 import zipkin2.CheckResult;
 import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorMetrics;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static zipkin2.Callback.NOOP_VOID;
 
 /**
  * Consumes spans from messages on a ActiveMQ queue. Malformed messages will be discarded. Errors in
  * the storage component will similarly be ignored, with no retry of the message.
  */
 final class ActiveMQSpanConsumer implements TransportListener, MessageListener, Closeable {
-  static final Callback<Void> NOOP = new Callback<Void>() {
-    @Override public void onSuccess(Void value) {
-    }
-
-    @Override public void onError(Throwable t) {
-    }
-  };
-
   static final CheckResult
     CLOSED = CheckResult.failed(new IllegalStateException("Collector intentionally closed")),
     INTERRUPTION = CheckResult.failed(new IOException("Recoverable error on ActiveMQ connection"));
@@ -115,7 +107,7 @@ final class ActiveMQSpanConsumer implements TransportListener, MessageListener, 
 
     metrics.incrementBytes(serialized.length);
     if (serialized.length == 0) return; // lenient on empty messages
-    collector.acceptSpans(serialized, NOOP);
+    collector.acceptSpans(serialized, NOOP_VOID);
   }
 
   @Override public void close() {

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorSampler.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorSampler.java
@@ -14,6 +14,7 @@
 package zipkin2.collector;
 
 import zipkin2.Span;
+import zipkin2.collector.handler.CollectedSpanHandler;
 import zipkin2.internal.HexCodec;
 
 /**
@@ -26,21 +27,21 @@ import zipkin2.internal.HexCodec;
  * <p>Accepts a percentage of trace ids by comparing their absolute value against a potentially
  * dynamic boundary. eg {@code isSampled == abs(traceId) <= boundary}
  *
- * <p>While idempotent, this implementation's sample rate won't exactly match the input rate because
- * trace ids are not perfectly distributed across 64bits. For example, tests have shown an error
- * rate of 3% when 100K trace ids are {@link java.util.Random#nextLong random}.
+ * <p>While idempotent, this implementation's sample rate won't exactly match the input rate
+ * because trace ids are not perfectly distributed across 64bits. For example, tests have shown an
+ * error rate of 3% when 100K trace ids are {@link java.util.Random#nextLong random}.
  */
-public abstract class CollectorSampler {
+public abstract class CollectorSampler implements CollectedSpanHandler {
   public static final CollectorSampler ALWAYS_SAMPLE = CollectorSampler.create(1.0f);
 
   /** @param rate minimum sample rate is 0.0001, or 0.01% of traces */
   public static CollectorSampler create(float rate) {
-    if (rate < 0 || rate > 1)
+    if (rate < 0 || rate > 1) {
       throw new IllegalArgumentException("rate should be between 0 and 1: was " + rate);
+    }
     final long boundary = (long) (Long.MAX_VALUE * rate); // safe cast as less <= 1
     return new CollectorSampler() {
-      @Override
-      protected long boundary() {
+      @Override protected long boundary() {
         return boundary;
       }
     };
@@ -59,9 +60,10 @@ public abstract class CollectorSampler {
    *
    * @param hexTraceId the lower 64 bits of the span's trace ID are checked against the boundary
    * @param debug when true, always passes sampling
+   * @deprecated since 2.17, use {@link #handle(Span)}
    */
-  public boolean isSampled(String hexTraceId, boolean debug) {
-    if (Boolean.TRUE.equals(debug)) return true;
+  @Deprecated public boolean isSampled(String hexTraceId, boolean debug) {
+    if (debug) return true;
     long traceId = HexCodec.lowerHexToUnsignedLong(hexTraceId);
     // The absolute value of Long.MIN_VALUE is larger than a long, so Math.abs returns identity.
     // This converts to MAX_VALUE to avoid always dropping when traceId == Long.MIN_VALUE
@@ -69,10 +71,18 @@ public abstract class CollectorSampler {
     return t <= boundary();
   }
 
-  @Override
-  public String toString() {
+  /** Returns the input when the input is {@link Span#debug() debug} or its trace ID was sampled. */
+  @Override public Span handle(Span span) {
+    if (isSampled(span.traceId(), Boolean.TRUE.equals(span.debug()))) {
+      return span;
+    }
+    return null;
+  }
+
+  @Override public String toString() {
     return "CollectorSampler(" + boundary() + ")";
   }
 
-  protected CollectorSampler() {}
+  protected CollectorSampler() {
+  }
 }

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/handler/CollectedSpanHandler.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/handler/CollectedSpanHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.collector.handler;
+
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesDecoder;
+import zipkin2.internal.Nullable;
+
+/**
+ * Triggered on each collected span, before storage. This allows the ability to mutate or drop spans
+ * for reasons including remapping tags.
+ *
+ * <p>This design is a near copy of brave.handler.FinishedSpanHandler
+ *
+ * @since 2.17
+ */
+public interface CollectedSpanHandler { // Java 1.8+ so default methods ok
+  /** Use to avoid comparing against null references */
+  CollectedSpanHandler NOOP = new CollectedSpanHandler() {
+    @Override public Span handle(Span span) {
+      return span;
+    }
+
+    @Override public String toString() {
+      return "NoopCollectedSpanHandler{}";
+    }
+  };
+
+  /**
+   * This is invoked after a span is collected, allowing data to be modified or reported out of
+   * process. A return value of null means the span should be dropped completely from the stream.
+   *
+   * <p>Changes to the input span are visible by later collected span handlers. One reason to
+   * change the input is to align tags, so that correlation occurs. For example, some may clean the
+   * tag "http.path" knowing downstream handlers such as zipkin reporting have the same value.
+   *
+   * <p>Returning null is the same effect as if it was dropped upstream. Implementations should be
+   * careful when returning false as it can lead to broken traces. Acceptable use cases are when the
+   * span is a leaf, for example a client call to an uninstrumented database, or a server call which
+   * is known to terminate in-process (for example, health-checks). Prefer an instrumentation policy
+   * approach to this mechanism as it results in less overhead.
+   *
+   * <p>It is ok to handle spans in a way that incurs no transformation, such as aggregating
+   * metrics. However it is inappropriate to raise any kind of exception from the handle method.
+   * Please code defensively.
+   *
+   * @param span model as {@link SpanBytesDecoder decoded} or handled upstream.
+   * @return the input if unmodified, a derived value, or null to drop this span.
+   */
+  @Nullable Span handle(Span span);
+}

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
@@ -21,17 +21,23 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import zipkin2.Callback;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.collector.handler.CollectedSpanHandler;
 import zipkin2.storage.InMemoryStorage;
 import zipkin2.storage.StorageComponent;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -40,13 +46,17 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.TRACE;
 import static zipkin2.TestObjects.UTF_8;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CollectorTest {
   InMemoryStorage storage = InMemoryStorage.newBuilder().build();
-  Callback<Void> callback = mock(Callback.class);
-  CollectorMetrics metrics = mock(CollectorMetrics.class);
   Collector collector;
-  List<String> messages = new ArrayList<>();
 
+  @Mock CollectorMetrics metrics;
+  @Mock Callback<Void> callback;
+  @Mock CollectedSpanHandler one;
+  @Mock CollectedSpanHandler two;
+
+  List<String> messages = new ArrayList<>();
   Logger logger = new Logger("", null) {
     {
       setLevel(Level.ALL);
@@ -258,6 +268,83 @@ public class CollectorTest {
     verify(callback).onError(error);
     assertThat(messages).containsOnly("Truncated reading spans");
     verify(metrics).incrementMessagesDropped();
+  }
+
+  @Test public void consolidate_emptyIsNoop() {
+    assertThat(Collector.consolidate(asList()))
+      .isEqualTo(CollectedSpanHandler.NOOP);
+  }
+
+  @Test public void consolidate_single() {
+    assertThat(Collector.consolidate(asList(one)))
+      .isEqualTo(one);
+  }
+
+  @Test public void consolidate_multiple() {
+    CollectedSpanHandler handler = Collector.consolidate(asList(one, two));
+
+    assertThat(handler)
+      .isInstanceOf(Collector.MultipleHandler.class);
+  }
+
+  @Test public void multiple_callInSequence() {
+    CollectedSpanHandler handler = Collector.consolidate(asList(one, two));
+
+    when(one.handle(TRACE.get(0))).thenReturn(TRACE.get(1));
+    when(two.handle(TRACE.get(1))).thenReturn(TRACE.get(1));
+
+    handler.handle(TRACE.get(0));
+
+    verify(one).handle(TRACE.get(0));
+    verify(two).handle(TRACE.get(1));
+  }
+
+  @Test public void multiple_shortCircuitWhenFirstReturnsNull() {
+    CollectedSpanHandler handler = Collector.consolidate(asList(one, two));
+
+    when(one.handle(CLIENT_SPAN)).thenReturn(null);
+
+    handler.handle(CLIENT_SPAN);
+
+    verify(one).handle(CLIENT_SPAN);
+    verify(two, never()).handle(any());
+  }
+
+  @Test
+  public void doesntCrashHandlingOnNonFatalThrowable() {
+    Throwable[] toThrow = new Throwable[1];
+
+    collector = new Collector.Builder(logger)
+      .addCollectedSpanHandler(span -> {
+        doThrowUnsafely(toThrow[0]);
+        return span;
+      })
+      .storage(storage)
+      .build();
+
+    toThrow[0] = new RuntimeException();
+    collector.accept(TRACE, callback);
+    verify(callback).onError(toThrow[0]);
+
+    toThrow[0] = new Exception();
+    collector.accept(TRACE, callback);
+    verify(callback).onError(toThrow[0]);
+
+    toThrow[0] = new Error();
+    collector.accept(TRACE, callback);
+    verify(callback).onError(toThrow[0]);
+
+    toThrow[0] = new StackOverflowError(); // fatal
+    try { // assertThatThrownBy doesn't work with StackOverflowError
+      collector.accept(TRACE, callback);
+      failBecauseExceptionWasNotThrown(StackOverflowError.class);
+    } catch (StackOverflowError e) {
+    }
+  }
+
+  // Trick from Armeria: This black magic causes the Java compiler to believe E is unchecked.
+  static <E extends Throwable> void doThrowUnsafely(Throwable cause) throws E {
+    throw (E) cause;
   }
 
   String unprefixIdString(String msg) {

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
@@ -34,6 +34,7 @@ import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
+import zipkin2.collector.handler.CollectedSpanHandler;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.StorageComponent;
 
@@ -64,20 +65,22 @@ public final class KafkaCollector extends CollectorComponent {
     String topic = "zipkin";
     int streams = 1;
 
-    @Override
-    public Builder storage(StorageComponent storage) {
+    @Override public Builder sampler(CollectorSampler sampler) {
+      this.delegate.sampler(sampler);
+      return this;
+    }
+
+    @Override public Builder addCollectedSpanHandler(CollectedSpanHandler collectedSpanHandler) {
+      this.delegate.addCollectedSpanHandler(collectedSpanHandler);
+      return this;
+    }
+
+    @Override public Builder storage(StorageComponent storage) {
       delegate.storage(storage);
       return this;
     }
 
-    @Override
-    public Builder sampler(CollectorSampler sampler) {
-      delegate.sampler(sampler);
-      return this;
-    }
-
-    @Override
-    public Builder metrics(CollectorMetrics metrics) {
+    @Override public Builder metrics(CollectorMetrics metrics) {
       if (metrics == null) throw new NullPointerException("metrics == null");
       this.metrics = metrics.forTransport("kafka");
       delegate.metrics(this.metrics);

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
@@ -30,23 +30,16 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import zipkin2.Callback;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorMetrics;
 
+import static zipkin2.Callback.NOOP_VOID;
+
 /** Consumes spans from Kafka messages, ignoring malformed input */
 final class KafkaCollectorWorker implements Runnable {
   static final Logger LOG = LoggerFactory.getLogger(KafkaCollectorWorker.class);
-  static final Callback<Void> NOOP =
-      new Callback<Void>() {
-        @Override
-        public void onSuccess(Void value) {}
-
-        @Override
-        public void onError(Throwable t) {}
-      };
 
   final Properties properties;
   final List<String> topics;
@@ -103,9 +96,9 @@ final class KafkaCollectorWorker implements Runnable {
                 metrics.incrementMessagesDropped();
                 continue;
               }
-              collector.accept(Collections.singletonList(span), NOOP);
+              collector.accept(Collections.singletonList(span), NOOP_VOID);
             } else {
-              collector.acceptSpans(bytes, NOOP);
+              collector.acceptSpans(bytes, NOOP_VOID);
             }
           }
         }

--- a/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import zipkin2.Callback;
 import zipkin2.CheckResult;
 import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
@@ -35,16 +34,10 @@ import zipkin2.collector.CollectorSampler;
 import zipkin2.collector.handler.CollectedSpanHandler;
 import zipkin2.storage.StorageComponent;
 
+import static zipkin2.Callback.NOOP_VOID;
+
 /** This collector consumes encoded binary messages from a RabbitMQ queue. */
 public final class RabbitMQCollector extends CollectorComponent {
-  static final Callback<Void> NOOP = new Callback<Void>() {
-    @Override public void onSuccess(Void value) {
-    }
-
-    @Override public void onError(Throwable t) {
-    }
-  };
-
   public static Builder builder() {
     return new Builder();
   }
@@ -248,7 +241,7 @@ public final class RabbitMQCollector extends CollectorComponent {
 
       if (body.length == 0) return; // lenient on empty messages
 
-      collector.acceptSpans(body, NOOP);
+      collector.acceptSpans(body, NOOP_VOID);
     }
   }
 

--- a/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
@@ -32,6 +32,7 @@ import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
+import zipkin2.collector.handler.CollectedSpanHandler;
 import zipkin2.storage.StorageComponent;
 
 /** This collector consumes encoded binary messages from a RabbitMQ queue. */
@@ -57,20 +58,22 @@ public final class RabbitMQCollector extends CollectorComponent {
     Address[] addresses;
     int concurrency = 1;
 
-    @Override
-    public Builder storage(StorageComponent storage) {
-      this.delegate.storage(storage);
-      return this;
-    }
-
-    @Override
-    public Builder sampler(CollectorSampler sampler) {
+    @Override public Builder sampler(CollectorSampler sampler) {
       this.delegate.sampler(sampler);
       return this;
     }
 
-    @Override
-    public Builder metrics(CollectorMetrics metrics) {
+    @Override public Builder addCollectedSpanHandler(CollectedSpanHandler collectedSpanHandler) {
+      this.delegate.addCollectedSpanHandler(collectedSpanHandler);
+      return this;
+    }
+
+    @Override  public Builder storage(StorageComponent storage) {
+      this.delegate.storage(storage);
+      return this;
+    }
+
+    @Override public Builder metrics(CollectorMetrics metrics) {
       if (metrics == null) throw new NullPointerException("metrics == null");
       this.metrics = metrics.forTransport("rabbitmq");
       this.delegate.metrics(this.metrics);

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
@@ -18,6 +18,7 @@ import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
+import zipkin2.collector.handler.CollectedSpanHandler;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.StorageComponent;
 
@@ -39,6 +40,16 @@ public final class ScribeCollector extends CollectorComponent {
     String category = "zipkin";
     int port = 9410;
 
+    @Override public Builder sampler(CollectorSampler sampler) {
+      this.delegate.sampler(sampler);
+      return this;
+    }
+
+    @Override public Builder addCollectedSpanHandler(CollectedSpanHandler collectedSpanHandler) {
+      this.delegate.addCollectedSpanHandler(collectedSpanHandler);
+      return this;
+    }
+
     @Override public Builder storage(StorageComponent storage) {
       delegate.storage(storage);
       return this;
@@ -48,11 +59,6 @@ public final class ScribeCollector extends CollectorComponent {
       if (metrics == null) throw new NullPointerException("metrics == null");
       this.metrics = metrics.forTransport("scribe");
       delegate.metrics(this.metrics);
-      return this;
-    }
-
-    @Override public Builder sampler(CollectorSampler sampler) {
-      delegate.sampler(sampler);
       return this;
     }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledCall.java
@@ -27,6 +27,7 @@ import zipkin2.Call;
 import zipkin2.Callback;
 
 import static com.linecorp.armeria.common.util.Exceptions.clearTrace;
+import static zipkin2.Callback.NOOP_VOID;
 
 /**
  * {@link Call} implementation that is backed by an {@link ExecutorService}. The ExecutorService
@@ -48,14 +49,6 @@ final class ThrottledCall extends Call.Base<Void> {
    */
   static final RejectedExecutionException STORAGE_THROTTLE_MAX_CONCURRENCY =
     clearTrace(new RejectedExecutionException("STORAGE_THROTTLE_MAX_CONCURRENCY reached"));
-
-  static final Callback<Void> NOOP_CALLBACK = new Callback<Void>() {
-    @Override public void onSuccess(Void value) {
-    }
-
-    @Override public void onError(Throwable t) {
-    }
-  };
 
   final Call<Void> delegate;
   final Executor executor;
@@ -81,7 +74,7 @@ final class ThrottledCall extends Call.Base<Void> {
    */
   @Override protected Void doExecute() throws IOException {
     // Enqueue the call invocation on the executor and block until it completes.
-    doEnqueue(NOOP_CALLBACK);
+    doEnqueue(NOOP_VOID);
     if (!await(latch)) throw new InterruptedIOException();
 
     // Check if the run resulted in an exception

--- a/zipkin-server/src/test/java/zipkin2/server/features/handler/RedactingCollectedSpanHandlerTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/features/handler/RedactingCollectedSpanHandlerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.features.handler;
+
+import com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguration;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.health.HealthAggregator;
+import org.springframework.boot.actuate.health.OrderedHealthAggregator;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin2.Callback;
+import zipkin2.Span;
+import zipkin2.collector.handler.CollectedSpanHandler;
+import zipkin2.internal.Nullable;
+import zipkin2.server.internal.Access;
+import zipkin2.server.internal.ZipkinHttpCollector;
+import zipkin2.server.internal.ZipkinServerConfiguration;
+import zipkin2.storage.InMemoryStorage;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+// just like brave.features.handler.RedactingFinishedSpanHandlerTest
+public class RedactingCollectedSpanHandlerTest {
+  /**
+   * This is just a dummy pattern. See <a href="https://github.com/ExpediaDotCom/haystack-secrets-commons/blob/master/src/main/java/com/expedia/www/haystack/commons/secretDetector/HaystackCompositeCreditCardFinder.java">HaystackCompositeCreditCardFinder</a>
+   * for a realistic one.
+   */
+  static final Pattern CREDIT_CARD = Pattern.compile("[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{4}");
+
+  /** Simple example of a replacement pattern, deleting entries which only include credit cards */
+  static String maybeUpdateValue(String value) {
+    Matcher matcher = CREDIT_CARD.matcher(value);
+    if (matcher.find()) {
+      String matched = matcher.group(0);
+      if (matched.equals(value)) return null;
+      return value.replace(matched, "xxxx-xxxx-xxxx-xxxx");
+    }
+    return value;
+  }
+
+  static final class RedactingCollectedSpanHandler implements CollectedSpanHandler {
+    @Override @Nullable public Span handle(Span span) {
+      Span.Builder b = span.toBuilder().clearAnnotations().clearTags();
+      span.annotations().forEach(a -> {
+        String value = maybeUpdateValue(a.value());
+        if (value != null) b.addAnnotation(a.timestamp(), value);
+      });
+      span.tags().forEach((k, v) -> {
+        String value = maybeUpdateValue(v);
+        if (value != null) b.putTag(k, value);
+      });
+      return b.build();
+    }
+  }
+
+  AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+  @Test public void showRedaction() {
+    Access.collector(context.getBean(ZipkinHttpCollector.class)).accept(asList(
+      Span.newBuilder()
+        .traceId("a").id("a")
+        .putTag("a", "1")
+        .putTag("b", "4121-2319-1483-3421")
+        .addAnnotation(1L, "cc=4121-2319-1483-3421")
+        .putTag("c", "3").build()
+    ), Callback.NOOP_VOID);
+
+    assertThat(context.getBean(InMemoryStorage.class).getTraces()).containsExactly(asList(
+      Span.newBuilder()
+        .traceId("a").id("a")
+        .putTag("a", "1")
+        // credit card tag was nuked
+        .addAnnotation(1L, "cc=xxxx-xxxx-xxxx-xxxx")
+        .putTag("c", "3").build()
+    ));
+  }
+
+  @Before public void setup() {
+    context.register(
+      ArmeriaSpringActuatorAutoConfiguration.class,
+      EndpointAutoConfiguration.class,
+      PropertyPlaceholderAutoConfiguration.class,
+      Config.class,
+      ZipkinServerConfiguration.class,
+      ZipkinHttpCollector.class
+    );
+    context.refresh();
+  }
+
+  @After public void close() {
+    context.close();
+  }
+
+  @Configuration
+  public static class Config {
+    @Bean CollectedSpanHandler redacter() {
+      return new RedactingCollectedSpanHandler();
+    }
+
+    @Bean public HealthAggregator healthAggregator() {
+      return new OrderedHealthAggregator();
+    }
+
+    @Bean MeterRegistry registry() {
+      return new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    }
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/features/handler/RedactingCollectedSpanHandlerTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/features/handler/RedactingCollectedSpanHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/java/zipkin2/server/internal/Access.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/Access.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal;
+
+import zipkin2.collector.Collector;
+
+/** opens package access for testing */
+public final class Access {
+  public static Collector collector(ZipkinHttpCollector httpCollector) {
+    return httpCollector.collector;
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledCallTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledCallTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static zipkin2.server.internal.throttle.ThrottledCall.NOOP_CALLBACK;
+import static zipkin2.Callback.NOOP_VOID;
 import static zipkin2.server.internal.throttle.ThrottledCall.STORAGE_THROTTLE_MAX_CONCURRENCY;
 import static zipkin2.server.internal.throttle.ThrottledStorageComponent.STORAGE_THROTTLE_MAX_QUEUE_SIZE;
 
@@ -203,7 +203,7 @@ public class ThrottledCallTest {
     ThrottledCall throttle = new ThrottledCall(new FakeCall(), mockExhaustedPool(),
       mockLimiter(listener), limiterMetrics, isOverCapacity);
 
-    assertThatThrownBy(() -> throttle.enqueue(NOOP_CALLBACK))
+    assertThatThrownBy(() -> throttle.enqueue(NOOP_VOID))
       .isEqualTo(STORAGE_THROTTLE_MAX_QUEUE_SIZE);
 
     verify(listener).onIgnore();

--- a/zipkin/src/main/java/zipkin2/Callback.java
+++ b/zipkin/src/main/java/zipkin2/Callback.java
@@ -18,11 +18,19 @@ import zipkin2.internal.Nullable;
 /**
  * A callback of a single result or error.
  *
- * <p>This is a bridge to async libraries such as CompletableFuture complete, completeExceptionally.
+ * <p>This is a bridge to async libraries such as CompletableFuture complete and
+ * completeExceptionally.
  *
  * <p>Implementations will call either {@link #onSuccess} or {@link #onError}, but not both.
  */
 public interface Callback<V> {
+  Callback<Void> NOOP_VOID = new Callback<Void>() {
+    @Override public void onSuccess(Void value) {
+    }
+
+    @Override public void onError(Throwable t) {
+    }
+  };
 
   /**
    * Invoked when computation produces its potentially null value successfully.

--- a/zipkin/src/main/java/zipkin2/Callback.java
+++ b/zipkin/src/main/java/zipkin2/Callback.java
@@ -24,6 +24,7 @@ import zipkin2.internal.Nullable;
  * <p>Implementations will call either {@link #onSuccess} or {@link #onError}, but not both.
  */
 public interface Callback<V> {
+  /** @since 2.17 */
   Callback<Void> NOOP_VOID = new Callback<Void>() {
     @Override public void onSuccess(Void value) {
     }


### PR DESCRIPTION
This starts #2802 by implementing low-hanging fruit: single span handler.

This one is easy because it fits directly into the existing collector infrastructure. To show how nicely it does, this backports `CollectorSampler` as a `CollectedSpanHandler`