### PR TITLE
Adds a docker-compose.test.yml to do a health check of built container.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 **/\.*
 !.git
 !**/.eslintrc
+**/*.test.yml
 
 **/target
 **/node_modules

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,4 +38,6 @@ USER zipkin
 
 EXPOSE 9410 9411
 
+HEALTHCHECK --interval=10s --start-period=30s --timeout=5s CMD wget --quiet http://localhost:9411/health || exit 1
+
 ENTRYPOINT ["/busybox/sh", "run.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ USER zipkin
 
 EXPOSE 9410 9411
 
-HEALTHCHECK --interval=10s --start-period=30s --timeout=5s CMD wget --quiet http://localhost:9411/health || exit 1
+# https://docs.docker.com/engine/reference/builder/#healthcheck
+HEALTHCHECK --interval=5s --start-period=30s --timeout=5s CMD wget --quiet http://localhost:9411/health || exit 1
 
 ENTRYPOINT ["/busybox/sh", "run.sh"]

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -21,6 +21,7 @@ services:
       default:
         aliases:
         - zipkin
+  # Docker Hub automated test service - https://docs.docker.com/docker-hub/builds/automated-testing/
   sut:
     image: appropriate/curl
     networks:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,30 @@
+#
+# Copyright 2015-2019 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+version: "3.7"
+services:
+  zipkin:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    networks:
+      default:
+        aliases:
+        - zipkin
+  sut:
+    image: appropriate/curl
+    networks:
+    - default
+    command: -v --connect-timeout 5 --retry 30 --retry-connrefused --retry-delay 5 http://zipkin:9411/health
+    depends_on:
+    - zipkin

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -11,7 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 #
-version: "3.7"
+version: "3.6"
 services:
   zipkin:
     build:

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -10,5 +10,3 @@ case "$DOCKER_REPO" in
   *)
   ;;
 esac
-
-docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
Also adds a health check command to our docker image for being able to see health with `docker ps`.

Docker Hub automatically runs this file after building an image. Example build at https://cloud.docker.com/repository/registry-1.docker.io/anuraaga/docker-hub-test/builds/7f0936ce-74e2-4614-815c-ef57daa7db42

Currently, the test just curl's the health endpoint, without jq. This doesn't actually test until https://github.com/line/armeria/pull/2088 - I figured since this is a new test, it's not worth getting too complex finding a reputable image with curl and jq and can wait until that's in to finish it.