### PR TITLE
Adds `GET /api/v2/traceMany?traceIds={comma-separated-list} endpoint

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/BodyIsExceptionMessage.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/BodyIsExceptionMessage.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static com.linecorp.armeria.common.HttpStatus.BAD_REQUEST;
+import static com.linecorp.armeria.common.HttpStatus.INTERNAL_SERVER_ERROR;
+import static com.linecorp.armeria.common.MediaType.ANY_TEXT_TYPE;
+
+final class BodyIsExceptionMessage implements ExceptionHandlerFunction {
+  static final Logger LOGGER = LogManager.getLogger();
+
+  @Override
+  public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
+    if (req.method() == HttpMethod.POST && req.path().startsWith("/api/v")) {
+      ZipkinHttpCollector.metrics.incrementMessagesDropped();
+    }
+
+    String message = cause.getMessage();
+    if (message == null) message = cause.getClass().getSimpleName();
+    if (cause instanceof IllegalArgumentException) {
+      return HttpResponse.of(BAD_REQUEST, ANY_TEXT_TYPE, message);
+    } else {
+      LOGGER.warn("Unexpected error handling request.", cause);
+
+      return HttpResponse.of(INTERNAL_SERVER_ERROR, ANY_TEXT_TYPE, message);
+    }
+  }
+}

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
@@ -16,17 +16,19 @@ package zipkin2.server.internal;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.server.annotation.Default;
+import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -41,7 +43,12 @@ import zipkin2.internal.WriteBuffer;
 import zipkin2.storage.QueryRequest;
 import zipkin2.storage.StorageComponent;
 
+import static com.linecorp.armeria.common.HttpStatus.BAD_REQUEST;
+import static com.linecorp.armeria.common.HttpStatus.NOT_FOUND;
+import static com.linecorp.armeria.common.MediaType.ANY_TEXT_TYPE;
+
 @ConditionalOnProperty(name = "zipkin.query.enabled", matchIfMissing = true)
+@ExceptionHandler(BodyIsExceptionMessage.class)
 public class ZipkinQueryApiV2 {
   final String storageType;
   final StorageComponent storage; // don't cache spanStore here as it can cause the app to crash!
@@ -86,7 +93,8 @@ public class ZipkinQueryApiV2 {
   }
 
   @Get("/api/v2/spans")
-  public AggregatedHttpResponse getSpanNames(@Param("serviceName") String serviceName) throws IOException {
+  public AggregatedHttpResponse getSpanNames(@Param("serviceName") String serviceName)
+    throws IOException {
     List<String> spanNames = storage.serviceAndSpanNames().getSpanNames(serviceName).execute();
     return maybeCacheNames(serviceCount > 3, spanNames);
   }
@@ -128,14 +136,35 @@ public class ZipkinQueryApiV2 {
     return jsonResponse(writeTraces(SpanBytesEncoder.JSON_V2, traces));
   }
 
-  @Get("/api/v2/trace/{traceIdHex}")
-  public AggregatedHttpResponse getTrace(@Param("traceIdHex") String traceIdHex) throws IOException {
-    List<Span> trace = storage.traces().getTrace(traceIdHex).execute();
+  @Get("/api/v2/trace/{traceId}")
+  public AggregatedHttpResponse getTrace(@Param("traceId") String traceId) throws IOException {
+    traceId = Span.normalizeTraceId(traceId);
+    List<Span> trace = storage.traces().getTrace(traceId).execute();
     if (trace == null) {
-      return AggregatedHttpResponse.of(HttpStatus.NOT_FOUND, MediaType.PLAIN_TEXT_UTF_8,
-        traceIdHex + " not found");
+      return AggregatedHttpResponse.of(NOT_FOUND, ANY_TEXT_TYPE, traceId + " not found");
     }
     return jsonResponse(SpanBytesEncoder.JSON_V2.encodeList(trace));
+  }
+
+  @Get("/api/v2/traceMany")
+  public AggregatedHttpResponse getTraces(@Param("traceIds") String traceIds) throws IOException {
+    if (traceIds.isEmpty()) {
+      return AggregatedHttpResponse.of(BAD_REQUEST, ANY_TEXT_TYPE, "traceIds parameter is empty");
+    }
+
+    Set<String> normalized = new LinkedHashSet<>();
+    for (String traceId : traceIds.split(",", 1000)) {
+      if (normalized.add(Span.normalizeTraceId(traceId))) continue;
+      return AggregatedHttpResponse.of(BAD_REQUEST, ANY_TEXT_TYPE, "redundant traceId: " + traceId);
+    }
+
+    if (normalized.size() == 1) {
+      return AggregatedHttpResponse.of(BAD_REQUEST, ANY_TEXT_TYPE,
+        "Use /api/v2/trace/{traceId} endpoint to retrieve a single trace");
+    }
+
+    List<List<Span>> traces = storage.traces().getTraces(normalized).execute();
+    return jsonResponse(writeTraces(SpanBytesEncoder.JSON_V2, traces));
   }
 
   static AggregatedHttpResponse jsonResponse(byte[] body) {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/TracingStorageComponent.java
@@ -89,7 +89,7 @@ public final class TracingStorageComponent extends ForwardingStorageComponent {
       return new TracedCall<>(tracer, delegate.getTrace(traceId), "get-trace");
     }
 
-    @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+    @Override public Call<List<List<Span>>> getTraces(Iterable<String> traceIds) {
       return new TracedCall<>(tracer, delegate.getTraces(traceIds), "get-traces");
     }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinMetricsHealth.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinMetricsHealth.java
@@ -128,7 +128,11 @@ public class ITZipkinMetricsHealth {
     assertThat(get("/api/v2/trace/" + LOTS_OF_SPANS[0].traceId()).isSuccessful())
       .isTrue();
 
+    assertThat(get("/api/v2/traceMany?traceIds=abcde," + LOTS_OF_SPANS[0].traceId()).isSuccessful())
+      .isTrue();
+
     assertThat(scrape())
+      .contains("uri=\"/api/v2/traceMany\"") // sanity check
       .contains("uri=\"/api/v2/trace/{traceId}\"")
       .doesNotContain(LOTS_OF_SPANS[0].traceId());
   }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanStore.java
@@ -200,7 +200,7 @@ public final class CassandraSpanStore implements SpanStore, Traces, ServiceAndSp
     return spans.newCall(normalizedTraceId);
   }
 
-  @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+  @Override public Call<List<List<Span>>> getTraces(Iterable<String> traceIds) {
     return spans.newCall(traceIds);
   }
 

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectFromTraces.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectFromTraces.java
@@ -75,15 +75,16 @@ final class SelectFromTraces extends ResultSetFutureCall<ResultSet> {
       return strictTraceId ? result.map(StrictTraceId.filterSpans(hexTraceId)) : result;
     }
 
-    Call<List<List<Span>>> newCall(List<String> traceIds) {
+    Call<List<List<Span>>> newCall(Iterable<String> traceIds) {
       Set<Long> longTraceIds = new LinkedHashSet<>();
       Set<String> normalizedTraceIds = new LinkedHashSet<>();
-
       for (String traceId : traceIds) {
         traceId = Span.normalizeTraceId(traceId);
         normalizedTraceIds.add(traceId);
         longTraceIds.add(HexCodec.lowerHexToUnsignedLong(traceId));
       }
+
+      if (normalizedTraceIds.isEmpty()) return Call.emptyList();
       Call<List<List<Span>>> result = new SelectFromTraces(this,
         longTraceIds,
         maxTraceCols

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanStore.java
@@ -271,7 +271,7 @@ class CassandraSpanStore implements SpanStore, Traces, ServiceAndSpanNames { //n
     return spans.newCall(normalizedTraceId);
   }
 
-  @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+  @Override public Call<List<List<Span>>> getTraces(Iterable<String> traceIds) {
     return spans.newCall(traceIds);
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
@@ -96,7 +96,7 @@ final class SelectFromSpan extends ResultSetFutureCall<ResultSet> {
       return strictTraceId ? result.map(StrictTraceId.filterSpans(hexTraceId)) : result;
     }
 
-    Call<List<List<Span>>> newCall(List<String> traceIds) {
+    Call<List<List<Span>>> newCall(Iterable<String> traceIds) {
       Set<String> normalizedTraceIds = new LinkedHashSet<>();
       for (String traceId : traceIds) {
         // make sure we have a 16 or 32 character trace ID
@@ -105,6 +105,8 @@ final class SelectFromSpan extends ResultSetFutureCall<ResultSet> {
         if (!strictTraceId && traceId.length() == 32) traceId = traceId.substring(16);
         normalizedTraceIds.add(traceId);
       }
+
+      if (normalizedTraceIds.isEmpty()) return Call.emptyList();
       Call<List<List<Span>>> result = new SelectFromSpan(this,
         normalizedTraceIds,
         maxTraceCols)

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
@@ -36,7 +36,6 @@ import zipkin2.storage.Traces;
 import static java.util.Arrays.asList;
 
 final class ElasticsearchSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
-
   static final String SPAN = "span";
   static final String DEPENDENCY = "dependency";
 
@@ -132,7 +131,7 @@ final class ElasticsearchSpanStore implements SpanStore, Traces, ServiceAndSpanN
     return search.newCall(request, BodyConverters.SPANS);
   }
 
-  @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+  @Override public Call<List<List<Span>>> getTraces(Iterable<String> traceIds) {
     Set<String> normalizedTraceIds = new LinkedHashSet<>();
     for (String traceId : traceIds) {
       // make sure we have a 16 or 32 character trace ID
@@ -143,6 +142,8 @@ final class ElasticsearchSpanStore implements SpanStore, Traces, ServiceAndSpanN
 
       normalizedTraceIds.add(traceId);
     }
+
+    if (normalizedTraceIds.isEmpty()) return Call.emptyList();
     SearchRequest request =
       SearchRequest.create(asList(allSpanIndices)).terms("traceId", normalizedTraceIds);
     return search.newCall(request, BodyConverters.SPANS).map(groupByTraceId);

--- a/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectSpansAndAnnotations.java
+++ b/zipkin-storage/mysql-v1/src/main/java/zipkin2/storage/mysql/v1/SelectSpansAndAnnotations.java
@@ -69,20 +69,9 @@ abstract class SelectSpansAndAnnotations implements Function<DSLContext, List<Sp
       };
     }
 
-    SelectSpansAndAnnotations create(List<String> traceIds) {
-      Set<Pair> traceIdPairs = new LinkedHashSet<>();
-      for (String traceId : traceIds) {
-        // make sure we have a 16 or 32 character trace ID
-        String hexTraceId = Span.normalizeTraceId(traceId);
-        traceIdPairs.add(new Pair(
-            hexTraceId.length() == 32 ? lowerHexToUnsignedLong(hexTraceId, 0) : 0L,
-            lowerHexToUnsignedLong(hexTraceId)
-          )
-        );
-      }
+    SelectSpansAndAnnotations create(Set<Pair> traceIdPairs) {
       return new SelectSpansAndAnnotations(schema) {
-        @Override
-        Condition traceIdCondition(DSLContext context) {
+        @Override Condition traceIdCondition(DSLContext context) {
           return schema.spanTraceIdCondition(traceIdPairs);
         }
       };

--- a/zipkin/src/main/java/zipkin2/internal/TracesAdapter.java
+++ b/zipkin/src/main/java/zipkin2/internal/TracesAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -32,15 +32,15 @@ public final class TracesAdapter implements Traces {
     return delegate.getTrace(traceId);
   }
 
-  @Override public Call<List<List<Span>>> getTraces(List<String> traceIds) {
+  @Override public Call<List<List<Span>>> getTraces(Iterable<String> traceIds) {
     if (traceIds == null) throw new NullPointerException("traceIds == null");
-    if (traceIds.isEmpty()) return Call.emptyList();
 
     List<Call<List<Span>>> calls = new ArrayList<>();
     for (String traceId : traceIds) {
       calls.add(getTrace(Span.normalizeTraceId(traceId)));
     }
 
+    if (calls.isEmpty()) return Call.emptyList();
     if (calls.size() == 1) return calls.get(0).map(ToSingletonList.INSTANCE);
     return new ScatterGather(calls);
   }

--- a/zipkin/src/main/java/zipkin2/storage/InMemoryStorage.java
+++ b/zipkin/src/main/java/zipkin2/storage/InMemoryStorage.java
@@ -112,7 +112,7 @@ public final class InMemoryStorage extends StorageComponent implements SpanStore
   /**
    * Primary source of data is this map, which includes spans ordered descending by timestamp. All
    * other maps are derived from the span values here. This uses a list for the spans, so that it is
-   * visible (via /api/v2/trace/id?raw) when instrumentation report the same spans multiple times.
+   * visible (via /api/v2/trace/{traceId}) when instrumentation report the same spans multiple times.
    */
   private final SortedMultimap<TraceIdTimestamp, Span> spansByTraceIdTimeStamp =
     new SortedMultimap(TIMESTAMP_DESCENDING) {
@@ -382,7 +382,7 @@ public final class InMemoryStorage extends StorageComponent implements SpanStore
     return Call.create(filtered);
   }
 
-  @Override public synchronized Call<List<List<Span>>> getTraces(List<String> traceIds) {
+  @Override public synchronized Call<List<List<Span>>> getTraces(Iterable<String> traceIds) {
     Set<String> normalized = new LinkedHashSet<>();
     for (String traceId : traceIds) {
       normalized.add(Span.normalizeTraceId(traceId));

--- a/zipkin/src/main/java/zipkin2/storage/Traces.java
+++ b/zipkin/src/main/java/zipkin2/storage/Traces.java
@@ -48,10 +48,11 @@ public interface Traces {
    * <p>When strict trace ID is disabled, spans with the same right-most 16 characters are returned
    * even if the characters to the left are not.
    *
-   * <p>Implementations should use {@link Span#normalizeTraceId(String)} to ensure consistency.
+   * <p>Implementations should use {@link Span#normalizeTraceId(String)} on each input trace ID to
+   * ensure consistency.
    *
    * @param traceIds a list of unique {@link Span#traceId() trace IDs}.
    * @return traces matching the supplied trace IDs, in any order
    */
-  Call<List<List<Span>>> getTraces(List<String> traceIds);
+  Call<List<List<Span>>> getTraces(Iterable<String> traceIds);
 }


### PR DESCRIPTION
This adds the `GET /api/v2/traceMany?traceIds={comma-separated-list}
endpoint defined in https://github.com/openzipkin/zipkin-api/pull/82

This also fixes some minor problems found.
* Exceptions raised on GET apis were not reported back to the client
  * This would make syntax errors hard to discover
* `Traces.getTraces(List)` -> `Traces.getTraces(Iterable)`
  * This avoids temptation to mutate the input, and allows passing a Set