### PR TITLE
Directly implements the /info endpoint and cleans up prometheus config

### DIFF
--- a/benchmarks/src/main/java/zipkin2/collector/MetricsBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/collector/MetricsBenchmarks.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import zipkin2.server.internal.ActuateCollectorMetrics;
+import zipkin2.server.internal.MicrometerCollectorMetrics;
 
 @Measurement(iterations = 80, time = 1)
 @Warmup(iterations = 20, time = 1)
@@ -46,7 +46,7 @@ public class MetricsBenchmarks {
   static final int SHORT_SPAN = 500;
   private MeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
   private InMemoryCollectorMetrics inMemoryCollectorMetrics = new InMemoryCollectorMetrics();
-  private ActuateCollectorMetrics actuateCollectorMetrics = new ActuateCollectorMetrics(registry);
+  private MicrometerCollectorMetrics micrometerCollectorMetrics = new MicrometerCollectorMetrics(registry);
 
   @Benchmark
   public int incrementBytes_longSpans_inMemory() {
@@ -55,7 +55,7 @@ public class MetricsBenchmarks {
 
   @Benchmark
   public int incrementBytes_longSpans_Actuate() {
-    return incrementBytes(actuateCollectorMetrics, LONG_SPAN);
+    return incrementBytes(micrometerCollectorMetrics, LONG_SPAN);
   }
 
   @Benchmark
@@ -65,7 +65,7 @@ public class MetricsBenchmarks {
 
   @Benchmark
   public int incrementBytes_mediumSpans_Actuate() {
-    return incrementBytes(actuateCollectorMetrics, MEDIUM_SPAN);
+    return incrementBytes(micrometerCollectorMetrics, MEDIUM_SPAN);
   }
 
   @Benchmark
@@ -75,7 +75,7 @@ public class MetricsBenchmarks {
 
   @Benchmark
   public int incrementBytes_shortSpans_Actuate() {
-    return incrementBytes(actuateCollectorMetrics, SHORT_SPAN);
+    return incrementBytes(micrometerCollectorMetrics, SHORT_SPAN);
   }
 
   private int incrementBytes(CollectorMetrics collectorMetrics, int bytes) {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/MicrometerCollectorMetrics.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/MicrometerCollectorMetrics.java
@@ -40,20 +40,17 @@ import zipkin2.internal.Nullable;
  * </pre>
  *
  * See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html
- *
- * <p>In-memory implementation mimics code from org.springframework.boot.actuate.metrics.buffer
  */
-public final class ActuateCollectorMetrics implements CollectorMetrics {
-
+public final class MicrometerCollectorMetrics implements CollectorMetrics {
   final MeterRegistry registryInstance;
   final Counter messages, messagesDropped, bytes, spans, spansDropped;
   final AtomicInteger messageBytes, messageSpans;
 
-  public ActuateCollectorMetrics(MeterRegistry registry) {
+  public MicrometerCollectorMetrics(MeterRegistry registry) {
     this(null, registry);
   }
 
-  ActuateCollectorMetrics(@Nullable String transport, MeterRegistry meterRegistry) {
+  MicrometerCollectorMetrics(@Nullable String transport, MeterRegistry meterRegistry) {
     this.registryInstance = meterRegistry;
     if (transport == null) {
       messages = messagesDropped = bytes = spans = spansDropped = null;
@@ -61,15 +58,15 @@ public final class ActuateCollectorMetrics implements CollectorMetrics {
       return;
     }
     this.messages =
-        Counter.builder("zipkin_collector.messages")
-            .description("cumulative amount of messages received")
-            .tag("transport", transport)
-            .register(registryInstance);
+      Counter.builder("zipkin_collector.messages")
+        .description("cumulative amount of messages received")
+        .tag("transport", transport)
+        .register(registryInstance);
     this.messagesDropped =
-        Counter.builder("zipkin_collector.messages_dropped")
-            .description("cumulative amount of messages received that were later dropped")
-            .tag("transport", transport)
-            .register(registryInstance);
+      Counter.builder("zipkin_collector.messages_dropped")
+        .description("cumulative amount of messages received that were later dropped")
+        .tag("transport", transport)
+        .register(registryInstance);
 
     this.bytes =
         Counter.builder("zipkin_collector.bytes")
@@ -102,9 +99,9 @@ public final class ActuateCollectorMetrics implements CollectorMetrics {
   }
 
   @Override
-  public ActuateCollectorMetrics forTransport(String transportType) {
+  public MicrometerCollectorMetrics forTransport(String transportType) {
     if (transportType == null) throw new NullPointerException("transportType == null");
-    return new ActuateCollectorMetrics(transportType, registryInstance);
+    return new MicrometerCollectorMetrics(transportType, registryInstance);
   }
 
   @Override
@@ -140,7 +137,8 @@ public final class ActuateCollectorMetrics implements CollectorMetrics {
   }
 
   void checkScoped() {
-    if (messages == null)
+    if (messages == null) {
       throw new IllegalStateException("always scope with ActuateCollectorMetrics.forTransport");
+    }
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/MicrometerThrottleMetrics.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/MicrometerThrottleMetrics.java
@@ -17,13 +17,13 @@ import com.netflix.concurrency.limits.limiter.AbstractLimiter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.ThreadPoolExecutor;
-import zipkin2.server.internal.ActuateCollectorMetrics;
+import zipkin2.server.internal.MicrometerCollectorMetrics;
 
-/** Follows the same naming convention as {@link ActuateCollectorMetrics} */
-final class ActuateThrottleMetrics {
+/** Follows the same naming convention as {@link MicrometerCollectorMetrics} */
+final class MicrometerThrottleMetrics {
   final MeterRegistry registryInstance;
 
-  ActuateThrottleMetrics(MeterRegistry registryInstance) {
+  MicrometerThrottleMetrics(MeterRegistry registryInstance) {
     this.registryInstance = registryInstance;
   }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/throttle/ThrottledStorageComponent.java
@@ -115,7 +115,7 @@ public final class ThrottledStorageComponent extends ForwardingStorageComponent 
       });
     limit.notifyOnChange(new ThreadPoolExecutorResizer(executor));
 
-    ActuateThrottleMetrics metrics = new ActuateThrottleMetrics(registry);
+    MicrometerThrottleMetrics metrics = new MicrometerThrottleMetrics(registry);
     metrics.bind(executor);
     metrics.bind(limiter);
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -32,6 +32,8 @@ import com.linecorp.armeria.server.encoding.HttpEncodingService;
 import com.linecorp.armeria.server.file.HttpFileBuilder;
 import com.linecorp.armeria.server.file.HttpFileServiceBuilder;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import java.io.IOException;
@@ -41,6 +43,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -180,6 +183,13 @@ public class ZipkinUiConfiguration {
         sb.decorator(contentEncodingDecorator(compression));
       }
     };
+  }
+
+  @Bean Consumer<MeterRegistry.Config> noFaviconMetrics() {
+    return config -> config.meterFilter(MeterFilter.deny(id -> {
+      String uri = id.getTag("uri");
+      return uri != null && uri.startsWith("/favicon.ico");
+    }));
   }
 
   static class IndexSwitchingService extends AbstractHttpService {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -206,6 +206,7 @@ public class ZipkinUiConfiguration {
   }
 
   // TEMPORARY: copy-pasta from com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactory
+  // TODO: hunt this down.. see if compression is available in Armeria spring-boot integration now!
   private static Function<Service<HttpRequest, HttpResponse>,
     HttpEncodingService> contentEncodingDecorator(Compression compression) {
     final Predicate<MediaType> encodableContentTypePredicate;

--- a/zipkin-server/src/main/resources/info.json
+++ b/zipkin-server/src/main/resources/info.json
@@ -1,0 +1,1 @@
+{"zipkin":{"version":"@project.version@","commit":"@git.commit.id.abbrev@"}}

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -201,15 +201,19 @@ spring:
       # zipkin has its own favicon
       enabled: false
   autoconfigure:
+    # NOTE: These exclusions can drift between Spring Boot minor versions. Audit accordingly.
     exclude:
       # otherwise we might initialize even when not needed (ex when storage type is cassandra)
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
       - org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration
       - org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration
-info:
-  zipkin:
-    version: "@project.version@"
-    commit: "@git.commit.id.abbrev@"
+      # JMX is disabled
+      - org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointAutoConfiguration
+      # served directly by Armeria
+      - org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration
+      # served directly by Armeria (content is /info.json)
+      - org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration
 
 logging:
   pattern:
@@ -233,7 +237,6 @@ logging:
 #     zipkin2.collector.kafka08.KafkaCollector: 'DEBUG'
 #     zipkin2.collector.rabbitmq.RabbitMQCollector: 'DEBUG'
 #     zipkin2.collector.scribe.ScribeCollector: 'DEBUG'
-
 management:
   endpoints:
     web:
@@ -242,8 +245,10 @@ management:
   endpoint:
     health:
       show-details: always
+    # Below are served directly without actuator.
     prometheus:
-      # Served directly without actuator.
+      enabled: false
+    info:
       enabled: false
 # Disabling auto time http requests since it is added in Undertow HttpHandler in Zipkin autoconfigure
 # Prometheus module. In Zipkin we use different naming for the http requests duration

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.server.internal.ITZipkinServer.stringFromClasspath;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
@@ -106,28 +107,19 @@ public class ITZipkinUiConfiguration {
    */
   @Test public void replacesBaseTag() throws Exception {
     assertThat(get("/zipkin/index.html").body().string())
-      .isEqualToIgnoringWhitespace(stringFromClasspath("zipkin-ui/index.html")
+      .isEqualToIgnoringWhitespace(stringFromClasspath(getClass(), "zipkin-ui/index.html")
         .replace("<base href=\"/\" />", "<base href=\"/foozipkin/\">"));
   }
 
   /** index.html is served separately. This tests other content is also loaded from the classpath. */
   @Test public void servesOtherContentFromClasspath() throws Exception {
     assertThat(get("/zipkin/test.txt").body().string())
-      .isEqualToIgnoringWhitespace(stringFromClasspath("zipkin-ui/test.txt"));
+      .isEqualToIgnoringWhitespace(stringFromClasspath(getClass(), "zipkin-ui/test.txt"));
   }
 
   @EnableAutoConfiguration
   @Import(ZipkinUiConfiguration.class)
   public static class TestServer {
-  }
-
-  private String stringFromClasspath(String path) throws IOException {
-    URL url = getClass().getClassLoader().getResource(path);
-    assertThat(url).isNotNull();
-
-    try (InputStream fromClasspath = url.openStream()) {
-      return Okio.buffer(Okio.source(fromClasspath)).readUtf8();
-    }
   }
 
   private Response get(String path) throws IOException {


### PR DESCRIPTION
Before, we directly implemented prometheus, but still left actuator on.
This prevents redundant booting of that.

This also directly implements the /info and /actuator/info endpoints
with tests to show the content is correct.

See #2788