### PR TITLE
Removes spring-web dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,17 +188,9 @@
       <!-- Makes sure spring doesn't eagerly bind tomcat or slf4j -->
       <dependency>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-web</artifactId>
+        <artifactId>spring-boot-starter</artifactId>
         <version>${spring-boot.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-tomcat</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -38,7 +38,7 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter</artifactId>
       <version>${spring-boot.version}</version>
     </dependency>
 
@@ -110,14 +110,6 @@
     </dependency>
 
     <!-- Optional, but packaged in the supported distribution -->
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-configuration-processor</artifactId>
-      <version>${spring-boot.version}</version>
-      <optional>true</optional>
-    </dependency>
-
     <!-- /actuator endpoints -->
     <dependency>
       <groupId>${armeria.groupId}</groupId>
@@ -245,7 +237,6 @@
 
 
     <!-- Test dependencies -->
-
     <!-- to test the experimental grpc endpoint with the square/wire library -->
     <dependency>
       <groupId>io.zipkin.proto3</groupId>

--- a/zipkin-server/src/it/minimal-dependencies/src/test/java/zipkin/minimal/ZipkinServerTest.java
+++ b/zipkin-server/src/it/minimal-dependencies/src/test/java/zipkin/minimal/ZipkinServerTest.java
@@ -34,8 +34,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-  properties = {"spring.config.name=zipkin-server", "server.port=0"}
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
+  properties = {
+    "server.port=0",
+    "spring.config.name=zipkin-server"
+  }
 )
 @RunWith(SpringRunner.class)
 public class ZipkinServerTest {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
@@ -29,10 +29,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.http.CacheControl;
 import zipkin2.Call;
 import zipkin2.DependencyLink;
 import zipkin2.Span;
@@ -43,6 +41,7 @@ import zipkin2.internal.WriteBuffer;
 import zipkin2.storage.QueryRequest;
 import zipkin2.storage.StorageComponent;
 
+import static com.linecorp.armeria.common.HttpHeaderNames.CACHE_CONTROL;
 import static com.linecorp.armeria.common.HttpStatus.BAD_REQUEST;
 import static com.linecorp.armeria.common.HttpStatus.NOT_FOUND;
 import static com.linecorp.armeria.common.MediaType.ANY_TEXT_TYPE;
@@ -208,10 +207,7 @@ public class ZipkinQueryApiV2 {
       .contentType(MediaType.JSON)
       .setInt(HttpHeaderNames.CONTENT_LENGTH, body.length);
     if (shouldCacheControl) {
-      headers = headers.add(
-        HttpHeaderNames.CACHE_CONTROL,
-        CacheControl.maxAge(namesMaxAge, TimeUnit.SECONDS).mustRevalidate().getHeaderValue()
-      );
+      headers = headers.add(CACHE_CONTROL, "max-age=" + namesMaxAge + ", must-revalidate");
     }
     return AggregatedHttpResponse.of(headers.build(), HttpData.wrap(body));
   }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinServerConfiguration.java
@@ -14,6 +14,7 @@
 package zipkin2.server.internal;
 
 import brave.Tracing;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
@@ -45,7 +46,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
 import zipkin2.server.internal.brave.TracingStorageComponent;
@@ -55,7 +55,7 @@ import zipkin2.storage.InMemoryStorage;
 import zipkin2.storage.StorageComponent;
 
 @Configuration
-class ZipkinServerConfiguration implements WebMvcConfigurer {
+class ZipkinServerConfiguration {
   static final MediaType MEDIA_TYPE_ACTUATOR =
     MediaType.parse("application/vnd.spring-boot.actuator.v2+json;charset=UTF-8");
 
@@ -67,6 +67,10 @@ class ZipkinServerConfiguration implements WebMvcConfigurer {
 
   @Autowired(required = false)
   ZipkinMetricsHealthController healthController;
+
+  @Bean @ConditionalOnMissingBean ObjectMapper objectMapper() {
+    return new ObjectMapper();
+  }
 
   @Bean Consumer<MeterRegistry.Config> noActuatorMetrics() {
     return config -> config.meterFilter(MeterFilter.deny(id -> {

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -172,6 +172,9 @@ zipkin:
     # When false, disables the "Try Lens UI" button in the navigation page
     suggest-lens: true
 
+# We are using Armeria instead of Tomcat. Have it inherit the default configuration from Spring
+spring.main.web-application-type: none
+# These defaults are not used directly. They are used via armeria namespacing
 server:
   port: ${QUERY_PORT:9411}
   use-forward-headers: true
@@ -180,15 +183,17 @@ server:
     # compresses any response over min-response-size (default is 2KiB)
     # Includes dynamic json content and large static assets from zipkin-ui
     mime-types: application/json,application/javascript,text/css,image/svg
+    min-response-size: 2048
 
-spring.main.web-application-type: none
-
-# We are using Armeria instead of Tomcat. Have it inherit the default configuration from Spring
 armeria:
   ports:
     - port: ${server.port}
       protocols:
         - http
+  compression:
+    enabled: ${server.compression.enabled}
+    mime-types: ${server.compression.mime-types}
+    min-response-size: ${server.compression.min-response-size}
   gracefulShutdownQuietPeriodMillis: -1
   gracefulShutdownTimeoutMillis: -1
 

--- a/zipkin-server/src/test/java/zipkin/server/ITEnableZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin/server/ITEnableZipkinServer.java
@@ -30,8 +30,11 @@ import static zipkin2.server.internal.ITZipkinServer.url;
 
 @SpringBootTest(
   classes = CustomServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-  properties = "spring.config.name=zipkin-server"
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
+  properties = {
+    "server.port=0",
+    "spring.config.name=zipkin-server"
+  }
 )
 @RunWith(SpringRunner.class)
 public class ITEnableZipkinServer {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITActuatorMappings.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITActuatorMappings.java
@@ -32,8 +32,11 @@ import static zipkin2.server.internal.ITZipkinServer.url;
 
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-  properties = "spring.config.name=zipkin-server"
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
+  properties = {
+    "server.port=0",
+    "spring.config.name=zipkin-server"
+  }
 )
 @RunWith(SpringRunner.class)
 public class ITActuatorMappings {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
@@ -45,8 +45,12 @@ import static zipkin2.server.internal.ITZipkinServer.url;
 /** This tests that we accept messages constructed by other clients. */
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-  properties = {"spring.config.name=zipkin-server", "zipkin.collector.grpc.enabled=true"}
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
+  properties = {
+    "server.port=0",
+    "spring.config.name=zipkin-server",
+    "zipkin.collector.grpc.enabled=true"
+  }
 )
 @RunWith(SpringRunner.class)
 public class ITZipkinGrpcCollector {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinHealthDown.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinHealthDown.java
@@ -30,8 +30,9 @@ import static zipkin2.server.internal.ITZipkinServer.url;
 
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
   properties = {
+    "server.port=0",
     "spring.config.name=zipkin-server",
     "zipkin.storage.type=elasticsearch",
     "zipkin.storage.elasticsearch.hosts=127.0.0.1:9999"

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinMetricsHealth.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinMetricsHealth.java
@@ -43,8 +43,11 @@ import static zipkin2.server.internal.ITZipkinServer.url;
 
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-  properties = "spring.config.name=zipkin-server"
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
+  properties = {
+    "server.port=0",
+    "spring.config.name=zipkin-server"
+  }
 )
 @RunWith(SpringRunner.class)
 public class ITZipkinMetricsHealth {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinMetricsHealthDirty.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinMetricsHealthDirty.java
@@ -46,8 +46,11 @@ import static zipkin2.server.internal.ITZipkinServer.url;
  */
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-  properties = "spring.config.name=zipkin-server"
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
+  properties = {
+    "server.port=0",
+    "spring.config.name=zipkin-server"
+  }
 )
 @RunWith(SpringRunner.class)
 @DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -42,8 +42,11 @@ import static zipkin2.TestObjects.UTF_8;
 
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-  properties = "spring.config.name=zipkin-server"
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
+  properties = {
+    "server.port=0",
+    "spring.config.name=zipkin-server"
+  }
 )
 @RunWith(SpringRunner.class)
 public class ITZipkinServer {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerAutocomplete.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerAutocomplete.java
@@ -40,8 +40,9 @@ import static zipkin2.server.internal.ITZipkinServer.url;
  */
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
   properties = {
+    "server.port=0",
     "spring.config.name=zipkin-server",
     "zipkin.storage.autocomplete-keys=environment,clnt/finagle.version"
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerCORS.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerCORS.java
@@ -37,8 +37,9 @@ import static zipkin2.server.internal.ITZipkinServer.url;
  */
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
   properties = {
+    "server.port=0",
     "spring.config.name=zipkin-server",
     "zipkin.query.allowed-origins=" + ITZipkinServerCORS.ALLOWED_ORIGIN
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerHttpCollectorDisabled.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerHttpCollectorDisabled.java
@@ -34,10 +34,11 @@ import static zipkin2.server.internal.ITZipkinServer.url;
  */
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
   properties = {
-    "zipkin.storage.type=", // cheat and test empty storage type
+    "server.port=0",
     "spring.config.name=zipkin-server",
+    "zipkin.storage.type=", // cheat and test empty storage type
     "zipkin.collector.http.enabled=false"
   })
 @RunWith(SpringRunner.class)

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerQueryDisabled.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerQueryDisabled.java
@@ -34,8 +34,9 @@ import static zipkin2.server.internal.ITZipkinServer.url;
  */
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
   properties = {
+    "server.port=0",
     "spring.config.name=zipkin-server",
     "zipkin.query.enabled=false",
     "zipkin.ui.enabled=false"

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerSsl.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerSsl.java
@@ -39,8 +39,9 @@ import static zipkin2.server.internal.elasticsearch.Access.configureSsl;
  */
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
   properties = {
+    "server.port=0",
     "spring.config.name=zipkin-server",
     // TODO: use normal spring.server properties after https://github.com/line/armeria/issues/1834
     "armeria.ssl.enabled=true",

--- a/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
@@ -49,8 +49,9 @@ import static zipkin2.server.internal.ITZipkinServer.url;
  */
 @SpringBootTest(
   classes = ZipkinServer.class,
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
   properties = {
+    "server.port=0",
     "spring.config.name=zipkin-server",
     "zipkin.self-tracing.enabled=true",
     "zipkin.self-tracing.message-timeout=100ms",


### PR DESCRIPTION
We don't use any Spring infrastructure for serving requests or making
them: Everything is Armeria. This removes a couple megs of dependencies
we don't use.

```before
du -k ./zipkin-server/target/zipkin-server-*exec.jar
57372	./zipkin-server/target/zipkin-server-2.16.3-SNAPSHOT-exec.jar
```

```after
du -k ./zipkin-server/target/zipkin-server-*exec.jar
55100	./zipkin-server/target/zipkin-server-2.16.3-SNAPSHOT-exec.jar
```

cc @trustin @anuraaga @minwoox