### PR TITLE
Introduces a second "slim" build of the server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,13 +109,6 @@
     <url>http://zipkin.io/</url>
   </organization>
 
-  <repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-  </repositories>
-
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,13 @@
     <url>http://zipkin.io/</url>
   </organization>
 
+  <repositories>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -525,4 +525,6 @@ To build and run the server from the currently checked out source, enter the fol
 $ ./mvnw -Dlicense.skip=true -DskipTests --also-make -pl zipkin-server clean install
 # Run the server
 $ java -jar ./zipkin-server/target/zipkin-server-*exec.jar
+# or Run the slim server
+$ java -jar ./zipkin-server/target/zipkin-server-*slim.jar
 ```

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -493,6 +493,111 @@
               <classifier>exec</classifier>
             </configuration>
           </execution>
+
+          <!-- Make a jar less than half the size, which only supports armeria-native features -->
+          <execution>
+            <id>slim</id>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+            <configuration>
+              <classifier>slim</classifier>
+              <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
+              <excludeGroupIds>
+                io.zipkin.java,com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,
+              </excludeGroupIds>
+              <excludes>
+                <!-- Actuator -->
+                <dependency>
+                  <groupId>${armeria.groupId}</groupId>
+                  <artifactId>armeria-spring-boot-actuator-autoconfigure</artifactId>
+                </dependency>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+                </dependency>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-actuator</artifactId>
+                </dependency>
+                <dependency>
+                  <groupId>com.fasterxml.jackson.datatype</groupId>
+                  <artifactId>jackson-datatype-jsr310:jar</artifactId>
+                </dependency>
+
+                <!-- Unnecessary netty deps -->
+                <dependency>
+                  <groupId>io.netty</groupId>
+                  <artifactId>netty-tcnative-boringssl-static</artifactId>
+                </dependency>
+                <dependency>
+                  <groupId>io.netty</groupId>
+                  <artifactId>netty-codec-haproxy</artifactId>
+                </dependency>
+
+                <!-- Unnecessary micrometer deps -->
+                <!-- TODO: https://github.com/micrometer-metrics/micrometer/issues/1599 -->
+<!--                <dependency>-->
+<!--                  &lt;!&ndash; only used by TimeWindowPercentileHistogram &ndash;&gt;-->
+<!--                  <groupId>org.hdrhistogram</groupId>-->
+<!--                  <artifactId>HdrHistogram</artifactId>-->
+<!--                </dependency>-->
+<!--                <dependency>-->
+<!--                  &lt;!&ndash; we don't use pause detector &ndash;&gt;-->
+<!--                  <groupId>org.latencyutils</groupId>-->
+<!--                  <artifactId>LatencyUtils</artifactId>-->
+<!--                </dependency>-->
+
+                <!-- storage and collectors which have 3rd party deps -->
+                <dependency>
+                  <groupId>${project.groupId}.zipkin2</groupId>
+                  <artifactId>zipkin-storage-cassandra-v1</artifactId>
+                </dependency>
+                <dependency>
+                  <groupId>${project.groupId}.zipkin2</groupId>
+                  <artifactId>zipkin-storage-cassandra</artifactId>
+                </dependency>
+                <dependency>
+                  <groupId>io.zipkin.brave.cassandra</groupId>
+                  <artifactId>brave-instrumentation-cassandra-driver</artifactId>
+                </dependency>
+
+                <!-- MySQL backend -->
+                <dependency>
+                  <groupId>${project.groupId}.zipkin2</groupId>
+                  <artifactId>zipkin-storage-mysql-v1</artifactId>
+                </dependency>
+
+                <!-- ActiveMQ Collector -->
+                <dependency>
+                  <groupId>${project.groupId}.zipkin2</groupId>
+                  <artifactId>zipkin-collector-activemq</artifactId>
+                </dependency>
+
+                <!-- Kafka Collector -->
+                <dependency>
+                  <groupId>${project.groupId}.zipkin2</groupId>
+                  <artifactId>zipkin-collector-kafka</artifactId>
+                </dependency>
+
+                <!-- RabbitMQ Collector -->
+                <dependency>
+                  <groupId>${project.groupId}.zipkin2</groupId>
+                  <artifactId>zipkin-collector-rabbitmq</artifactId>
+                </dependency>
+
+                <!-- Scribe Collector -->
+                <dependency>
+                  <groupId>${project.groupId}.zipkin2</groupId>
+                  <artifactId>zipkin-collector-rabbitmq</artifactId>
+                </dependency>
+                <exclude>
+                  <groupId>${armeria.groupId}</groupId>
+                  <artifactId>armeria-thrift</artifactId>
+                </exclude>
+              </excludes>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -134,6 +134,18 @@
       <artifactId>jul-to-slf4j</artifactId>
     </dependency>
 
+    <!-- the "exec" jar will exclude these -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-slf4j</artifactId>
+      <version>${spring-boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Static content for the Classic UI -->
     <dependency>
       <groupId>io.zipkin.java</groupId>
@@ -491,6 +503,16 @@
             </goals>
             <configuration>
               <classifier>exec</classifier>
+              <excludes>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-slf4j</artifactId>
+                </dependency>
+                <dependency>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-simple</artifactId>
+                </dependency>
+              </excludes>
             </configuration>
           </execution>
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -504,7 +504,7 @@
               <classifier>slim</classifier>
               <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
               <excludeGroupIds>
-                io.zipkin.java,com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
+                io.zipkin.java,io.zipkin.brave,com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
               </excludeGroupIds>
               <excludes>
                 <!-- Actuator -->
@@ -523,6 +523,12 @@
                 <dependency>
                   <groupId>com.fasterxml.jackson.datatype</groupId>
                   <artifactId>jackson-datatype-jsr310</artifactId>
+                </dependency>
+
+                <!-- Brave -->
+                <dependency>
+                  <groupId>${armeria.groupId}</groupId>
+                  <artifactId>armeria-brave</artifactId>
                 </dependency>
 
                 <!-- Log4J 2 -->
@@ -566,10 +572,6 @@
                 <dependency>
                   <groupId>io.zipkin.brave.cassandra</groupId>
                   <artifactId>brave-instrumentation-cassandra-driver</artifactId>
-                </dependency>
-                <dependency>
-                  <groupId>io.zipkin.brave</groupId>
-                  <artifactId>brave-context-log4j2</artifactId>
                 </dependency>
 
                 <!-- MySQL backend -->

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -504,7 +504,7 @@
               <classifier>slim</classifier>
               <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
               <excludeGroupIds>
-                io.zipkin.java,com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,
+                io.zipkin.java,com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
               </excludeGroupIds>
               <excludes>
                 <!-- Actuator -->
@@ -522,7 +522,13 @@
                 </dependency>
                 <dependency>
                   <groupId>com.fasterxml.jackson.datatype</groupId>
-                  <artifactId>jackson-datatype-jsr310:jar</artifactId>
+                  <artifactId>jackson-datatype-jsr310</artifactId>
+                </dependency>
+
+                <!-- Log4J 2 -->
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-log4j2</artifactId>
                 </dependency>
 
                 <!-- Unnecessary netty deps -->
@@ -560,6 +566,10 @@
                 <dependency>
                   <groupId>io.zipkin.brave.cassandra</groupId>
                   <artifactId>brave-instrumentation-cassandra-driver</artifactId>
+                </dependency>
+                <dependency>
+                  <groupId>io.zipkin.brave</groupId>
+                  <artifactId>brave-context-log4j2</artifactId>
                 </dependency>
 
                 <!-- MySQL backend -->

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -134,12 +134,7 @@
       <artifactId>jul-to-slf4j</artifactId>
     </dependency>
 
-    <!-- the "exec" jar will exclude these -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-slf4j</artifactId>
-      <version>${spring-boot.version}</version>
-    </dependency>
+    <!-- the "exec" jar will exclude this -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
@@ -261,7 +256,7 @@
     </dependency>
     <dependency>
       <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave-context-log4j2</artifactId>
+      <artifactId>brave-context-slf4j</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -505,10 +500,6 @@
               <classifier>exec</classifier>
               <excludes>
                 <dependency>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-slf4j</artifactId>
-                </dependency>
-                <dependency>
                   <groupId>org.slf4j</groupId>
                   <artifactId>slf4j-simple</artifactId>
                 </dependency>
@@ -526,7 +517,7 @@
               <classifier>slim</classifier>
               <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
               <excludeGroupIds>
-                io.zipkin.java,io.zipkin.brave,com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
+                io.zipkin.java,com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
               </excludeGroupIds>
               <excludes>
                 <!-- Actuator -->

--- a/zipkin-server/src/it/slimjar/README.md
+++ b/zipkin-server/src/it/slimjar/README.md
@@ -1,0 +1,5 @@
+# slimjar
+This includes tests that use the slim jar produced by the zipkin-server build.
+
+It intentionally doesn't depend on any zipkin pom, to ensure the only
+thing in the classpath is the slim jar.

--- a/zipkin-server/src/it/slimjar/pom.xml
+++ b/zipkin-server/src/it/slimjar/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2019 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>@project.groupId@</groupId>
+  <version>@project.version@</version>
+  <artifactId>slimjar</artifactId>
+  <name>slimjar</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>@project.groupId@.zipkin2</groupId>
+      <artifactId>zipkin</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>@okhttp.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>zipkin-server</artifactId>
+      <version>@project.version@</version>
+      <classifier>slim</classifier>
+      <exclusions>
+        <!-- TODO: should the slim jar declare dependencies it bundles? -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>@assertj.version@</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@maven-compiler-plugin.version@</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>@maven-failsafe-plugin.version@</version>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/zipkin-server/src/it/slimjar/src/test/java/zipkin/slimjar/AdminEndpointsTest.java
+++ b/zipkin-server/src/it/slimjar/src/test/java/zipkin/slimjar/AdminEndpointsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.slimjar;
+
+import java.io.IOException;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class AdminEndpointsTest {
+  @Rule public ExecJarRule zipkin = new ExecJarRule();
+
+  OkHttpClient client = new OkHttpClient();
+
+  /** Tests admin endpoints work eventhough actuator is not a strict dependency. */
+  @Test public void adminEndpoints() throws Exception {
+    try {
+      // Documented as supported in our zipkin-server/README.md
+      assertThat(get("/health").isSuccessful()).isTrue();
+      assertThat(get("/info").isSuccessful()).isTrue();
+      assertThat(get("/metrics").isSuccessful()).isTrue();
+      assertThat(get("/prometheus").isSuccessful()).isTrue();
+
+      // Check endpoints we formerly redirected to. Note we never redirected to /actuator/metrics
+      assertThat(get("/actuator/health").isSuccessful()).isTrue();
+      assertThat(get("/actuator/info").isSuccessful()).isTrue();
+      assertThat(get("/actuator/prometheus").isSuccessful()).isTrue();
+    } catch (RuntimeException | IOException e) {
+      fail(String.format("unexpected error!%s%n%s", e.getMessage(), zipkin.consoleOutput()));
+    }
+  }
+
+  private Response get(String path) throws IOException {
+    return client.newCall(new Request.Builder()
+      .url("http://localhost:" + zipkin.port() + path)
+      .build()).execute();
+  }
+}

--- a/zipkin-server/src/it/slimjar/src/test/java/zipkin/slimjar/DoesntCrashWhenElasticsearchIsDownTest.java
+++ b/zipkin-server/src/it/slimjar/src/test/java/zipkin/slimjar/DoesntCrashWhenElasticsearchIsDownTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.slimjar;
+
+import java.io.IOException;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class DoesntCrashWhenElasticsearchIsDownTest {
+  @Rule public ExecJarRule zipkin = new ExecJarRule()
+      .putEnvironment("STORAGE_TYPE", "elasticsearch")
+      .putEnvironment("ES_HOSTS", "127.0.0.1:9999");
+
+  OkHttpClient client = new OkHttpClient();
+
+  @Test public void startsButReturns500QueryingStorage() throws IOException {
+    try {
+      Response services = get("/api/v2/services");
+      assertThat(services.code())
+        .withFailMessage(services.body().string())
+        .isEqualTo(500);
+    } catch (RuntimeException | IOException e) {
+      fail(String.format("unexpected error!%s%n%s", e.getMessage(), zipkin.consoleOutput()));
+    }
+  }
+
+  @Test public void startsButReturnsFailedHealthCheck() throws IOException {
+    try {
+      assertThat(get("/health").code()).isEqualTo(503);
+    } catch (RuntimeException | IOException e) {
+      fail(String.format("unexpected error!%s%n%s", e.getMessage(), zipkin.consoleOutput()));
+    }
+  }
+
+  private Response get(String path) throws IOException {
+    return client.newCall(new Request.Builder()
+      .url("http://localhost:" + zipkin.port() + path)
+      .build()).execute();
+  }
+}

--- a/zipkin-server/src/it/slimjar/src/test/java/zipkin/slimjar/ExecJarRule.java
+++ b/zipkin-server/src/it/slimjar/src/test/java/zipkin/slimjar/ExecJarRule.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.slimjar;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.net.ServerSocketFactory;
+import org.junit.AssumptionViolatedException;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.springframework.boot.loader.JarLauncher;
+
+/**
+ * This is a JUnit Rule that allows you to test your Spring Boot exec jar.
+ *
+ * <p>It will start on a random port, and waits until the server is started before your tests
+ * execute.
+ *
+ * <p>Often, the test classpath interferes with your ability to test your autoconfiguration, or
+ * environment mappings. This class forks a process and watches it. On failure, you can look at its
+ * {@link #consoleOutput() console output} for details.
+ */
+public final class ExecJarRule implements TestRule {
+
+  public ExecJarRule() {
+    this.execJar = JarLauncher.class.getProtectionDomain().getCodeSource().getLocation().getFile();
+  }
+
+  /** Adds a variable to the environment used by the forked boot app. */
+  public ExecJarRule putEnvironment(String key, String value) {
+    environment.put(key, value);
+    return this;
+  }
+
+  /** Returns stderr and stdout dumped into the same place */
+  public String consoleOutput() {
+    return String.join("\n", console);
+  }
+
+  /** Lazy-chooses a server port, or returns the port the server started with */
+  public synchronized int port() throws IOException {
+    if (port != null) return port;
+    try (ServerSocket socket = ServerSocketFactory.getDefault().createServerSocket(0)) {
+      return (this.port = socket.getLocalPort());
+    }
+  }
+
+  private final String execJar;
+  private Map<String, String> environment = new LinkedHashMap<>();
+  private Integer port;
+  private Process bootApp;
+  private ConcurrentLinkedQueue<String> console = new ConcurrentLinkedQueue<>();
+
+  @Override public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      public void evaluate() throws Throwable {
+        try {
+          ProcessBuilder bootBuilder = new ProcessBuilder("java", "-jar", execJar);
+          bootBuilder.environment().put("SERVER_PORT", String.valueOf(port()));
+          bootBuilder.environment().putAll(environment);
+          bootBuilder.redirectErrorStream(true);
+          bootApp = bootBuilder.start();
+
+          CountDownLatch startedOrCrashed = new CountDownLatch(1);
+          Thread consoleReader = new Thread(() -> {
+            boolean foundStartMessage = false;
+            try (BufferedReader reader =
+                     new BufferedReader(new InputStreamReader(bootApp.getInputStream()))) {
+              String line;
+              while ((line = reader.readLine()) != null) {
+                if (line.indexOf("JVM running for") != -1) {
+                  foundStartMessage = true;
+                  startedOrCrashed.countDown();
+                }
+                console.add(line);
+              }
+            } catch (Exception e) {
+            } finally {
+              if (!foundStartMessage) startedOrCrashed.countDown();
+            }
+          });
+          consoleReader.setDaemon(true);
+          consoleReader.start();
+
+          if (!startedOrCrashed.await(10, TimeUnit.SECONDS)) {
+            throw new AssumptionViolatedException("Took too long to start or crash");
+          }
+
+          base.evaluate();
+        } finally {
+          bootApp.destroy();
+        }
+      }
+    };
+  }
+}

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
@@ -13,11 +13,12 @@
  */
 package zipkin.server;
 
+import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import zipkin2.server.internal.ZipkinActuatorImporter;
 import zipkin2.server.internal.EnableZipkinServer;
+import zipkin2.server.internal.ZipkinActuatorImporter;
 import zipkin2.server.internal.ZipkinModuleImporter;
 import zipkin2.server.internal.banner.ZipkinBanner;
 
@@ -39,19 +40,18 @@ import zipkin2.server.internal.banner.ZipkinBanner;
 @EnableAutoConfiguration
 @EnableZipkinServer
 public class ZipkinServer {
-
-  // if you want to build a container image without log4j and only use slf4j with for example
-  // slf4j-simple you'll need this and not the static block below.
-  //static {
-  //  // ensures jul-to-slf4j works
-  //  SLF4JBridgeHandler.removeHandlersForRootLogger();
-  //  SLF4JBridgeHandler.install();
-  //}
-
   static {
-    // Make sure java.util.logging goes to log4j2
-    // https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-configure-log4j-for-logging
-    System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+    String log4j2ClassName = "org.apache.logging.log4j.jul.LogManager";
+    try {
+      Class.forName(log4j2ClassName);
+      // Make sure java.util.logging goes to log4j2
+      // https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-configure-log4j-for-logging
+      System.setProperty("java.util.logging.manager", log4j2ClassName);
+    } catch (Exception e) {
+      // using SLF4J impl
+      SLF4JBridgeHandler.removeHandlersForRootLogger();
+      SLF4JBridgeHandler.install();
+    }
   }
 
   public static void main(String[] args) {

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
@@ -41,17 +41,8 @@ import zipkin2.server.internal.banner.ZipkinBanner;
 @EnableZipkinServer
 public class ZipkinServer {
   static {
-    String log4j2ClassName = "org.apache.logging.log4j.jul.LogManager";
-    try {
-      Class.forName(log4j2ClassName);
-      // Make sure java.util.logging goes to log4j2
-      // https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-configure-log4j-for-logging
-      System.setProperty("java.util.logging.manager", log4j2ClassName);
-    } catch (Exception e) {
-      // using SLF4J impl
-      SLF4JBridgeHandler.removeHandlersForRootLogger();
-      SLF4JBridgeHandler.install();
-    }
+    SLF4JBridgeHandler.removeHandlersForRootLogger();
+    SLF4JBridgeHandler.install();
   }
 
   public static void main(String[] args) {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
@@ -14,7 +14,7 @@
 package zipkin2.server.internal.brave;
 
 import brave.Tracing;
-import brave.context.log4j2.ThreadContextScopeDecorator;
+import brave.context.slf4j.MDCScopeDecorator;
 import brave.http.HttpTracing;
 import brave.propagation.B3SinglePropagation;
 import brave.propagation.CurrentTraceContext;
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -68,10 +67,9 @@ public class ZipkinSelfTracingConfiguration {
       .build();
   }
 
-  @ConditionalOnClass(ThreadContextScopeDecorator.class)
   @Bean CurrentTraceContext currentTraceContext() {
     return RequestContextCurrentTraceContext.builder()
-      .addScopeDecorator(ThreadContextScopeDecorator.create()) // puts trace IDs into logs
+      .addScopeDecorator(MDCScopeDecorator.create()) // puts trace IDs into logs
       .build();
   }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -67,6 +68,7 @@ public class ZipkinSelfTracingConfiguration {
       .build();
   }
 
+  @ConditionalOnClass(ThreadContextScopeDecorator.class)
   @Bean CurrentTraceContext currentTraceContext() {
     return RequestContextCurrentTraceContext.builder()
       .addScopeDecorator(ThreadContextScopeDecorator.create()) // puts trace IDs into logs


### PR DESCRIPTION
This introduces a second classifier, slim, which includes Armeria-native functionality. This would include all HTTP ingress, including gRPC, and HTTP egress (ex ElasticSearch storage), but not other storage or transports.

Also, slim disables the Actuator functionality, while still retaining support for endpoints we've previously documented as supported. (In #2817, we discovered even a pared down actuator contributes ~12% to our startup time).

The main goal is to allow a quicker start for those piloting Zipkin or making test environments. This quicker start is a function of dramatically faster boostrap and also image size.

Best of 5, slim starts in 2.3s where exec (including actuator) starts in 3.1s

57% smaller than including all the dependencies for Actuator, Cassandra, MySQL and messaging transports (RabbitMQ, Kafka, ActiveMQ):

```bash
$ du -k ./zipkin-server/target/zipkin-server-2.16.3-*jar
54712	./zipkin-server/target/zipkin-server-2.16.3-SNAPSHOT-exec.jar
23596	./zipkin-server/target/zipkin-server-2.16.3-SNAPSHOT-slim.jar
```