### PR TITLE
Removes remaining use of jackson-databind from zipkin-server

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/health/ZipkinHealthController.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/health/ZipkinHealthController.java
@@ -15,11 +15,9 @@ package zipkin2.server.internal.health;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Get;
 import java.io.IOException;
@@ -29,8 +27,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import zipkin2.Component;
 
-import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_LENGTH;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static zipkin2.server.internal.ZipkinServerConfiguration.MEDIA_TYPE_ACTUATOR;
 import static zipkin2.server.internal.health.ComponentHealth.STATUS_DOWN;
 import static zipkin2.server.internal.health.ComponentHealth.STATUS_UP;
@@ -95,19 +91,15 @@ public class ZipkinHealthController {
     return newHealthResponse(overallStatus, mediaType, healthJson);
   }
 
-  static HttpResponse newHealthResponse(String overallStatus, MediaType mediaType,
-    String healthJson) {
-    byte[] body = healthJson.getBytes(UTF_8);
-    int code = overallStatus.equals(STATUS_UP) ? 200 : 503;
-    ResponseHeaders headers = ResponseHeaders.builder(code)
-      .contentType(mediaType)
-      .setInt(CONTENT_LENGTH, body.length).build();
-    return HttpResponse.of(AggregatedHttpResponse.of(headers, HttpData.wrap(body)));
+  static HttpResponse newHealthResponse(String status, MediaType mediaType, String healthJson) {
+    HttpStatus code = status.equals(STATUS_UP) ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE;
+    return HttpResponse.of(code, mediaType, healthJson);
   }
 
   static String writeJsonError(String error) throws IOException {
     StringWriter writer = new StringWriter();
     JsonGenerator generator = JSON_FACTORY.createGenerator(writer);
+    generator.useDefaultPrettyPrinter();
     generator.writeStartObject();
     generator.writeStringField("status", STATUS_DOWN);
     generator.writeObjectFieldStart("zipkin");

--- a/zipkin-server/src/main/java/zipkin2/server/internal/health/ZipkinHealthController.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/health/ZipkinHealthController.java
@@ -98,48 +98,48 @@ public class ZipkinHealthController {
 
   static String writeJsonError(String error) throws IOException {
     StringWriter writer = new StringWriter();
-    JsonGenerator generator = JSON_FACTORY.createGenerator(writer);
-    generator.useDefaultPrettyPrinter();
-    generator.writeStartObject();
-    generator.writeStringField("status", STATUS_DOWN);
-    generator.writeObjectFieldStart("zipkin");
-    generator.writeStringField("status", STATUS_DOWN);
-    generator.writeObjectFieldStart("details");
-    generator.writeStringField("error", error);
-    generator.writeEndObject(); // .zipkin.details
-    generator.writeEndObject(); // .zipkin
-    generator.writeEndObject(); // .
-    generator.flush();
+    try (JsonGenerator generator = JSON_FACTORY.createGenerator(writer)) {
+      generator.useDefaultPrettyPrinter();
+      generator.writeStartObject();
+      generator.writeStringField("status", STATUS_DOWN);
+      generator.writeObjectFieldStart("zipkin");
+      generator.writeStringField("status", STATUS_DOWN);
+      generator.writeObjectFieldStart("details");
+      generator.writeStringField("error", error);
+      generator.writeEndObject(); // .zipkin.details
+      generator.writeEndObject(); // .zipkin
+      generator.writeEndObject(); // .
+    }
     return writer.toString();
   }
 
   static String writeJson(String overallStatus, List<ComponentHealth> healths) throws IOException {
     StringWriter writer = new StringWriter();
-    JsonGenerator generator = JSON_FACTORY.createGenerator(writer);
-    generator.useDefaultPrettyPrinter();
-    generator.writeStartObject();
-    generator.writeStringField("status", overallStatus);
-    generator.writeObjectFieldStart("zipkin");
-    generator.writeStringField("status", overallStatus);
-    generator.writeObjectFieldStart("details");
+    try (JsonGenerator generator = JSON_FACTORY.createGenerator(writer)) {
+      generator.useDefaultPrettyPrinter();
+      generator.writeStartObject();
+      generator.writeStringField("status", overallStatus);
+      generator.writeObjectFieldStart("zipkin");
+      generator.writeStringField("status", overallStatus);
+      generator.writeObjectFieldStart("details");
 
-    for (ComponentHealth health : healths) {
-      generator.writeObjectFieldStart(health.name);
-      generator.writeStringField("status", health.status);
+      for (ComponentHealth health : healths) {
+        generator.writeObjectFieldStart(health.name);
+        generator.writeStringField("status", health.status);
 
-      if (health.status.equals(STATUS_DOWN)) {
-        generator.writeObjectFieldStart("details");
-        generator.writeStringField("error", health.error);
-        generator.writeEndObject(); // .zipkin.details.healthName.details
+        if (health.status.equals(STATUS_DOWN)) {
+          generator.writeObjectFieldStart("details");
+          generator.writeStringField("error", health.error);
+          generator.writeEndObject(); // .zipkin.details.healthName.details
+        }
+
+        generator.writeEndObject(); // .zipkin.details.healthName
       }
 
-      generator.writeEndObject(); // .zipkin.details.healthName
+      generator.writeEndObject(); // .zipkin.details
+      generator.writeEndObject(); // .zipkin
+      generator.writeEndObject(); // .
     }
-
-    generator.writeEndObject(); // .zipkin.details
-    generator.writeEndObject(); // .zipkin
-    generator.writeEndObject(); // .
-    generator.flush();
     return writer.toString();
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinMetricsController.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinMetricsController.java
@@ -60,7 +60,7 @@ public class ZipkinMetricsController {
       } // We only use counters and gauges
     }
     generator.writeEndObject();
-    generator.flush();
+    generator.flush(); // instead of using try/finally as extra indent causes lines to wrap
     return HttpResponse.of(HttpStatus.OK, MediaType.JSON, writer.toString());
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -122,8 +122,8 @@ public class ZipkinUiConfiguration {
       legacyIndex = HttpFileBuilder.ofResource("zipkin-ui/index.html");
       lensIndex = HttpFileBuilder.ofResource("zipkin-lens/index.html");
     } else {
-      legacyIndex = HttpFileBuilder.of(HttpData.wrap(processedIndexHtml().getBytes(UTF_8)));
-      lensIndex = HttpFileBuilder.of(HttpData.wrap(processedLensIndexHtml().getBytes(UTF_8)));
+      legacyIndex = HttpFileBuilder.of(HttpData.ofUtf8(processedIndexHtml()));
+      lensIndex = HttpFileBuilder.of(HttpData.ofUtf8(processedLensIndexHtml()));
     }
 
     ServerCacheControl maxAgeMinute = new ServerCacheControlBuilder().maxAgeSeconds(60).build();
@@ -151,7 +151,7 @@ public class ZipkinUiConfiguration {
 
     String config = writeConfig(ui);
     return sb -> {
-      sb.service("/zipkin/config.json", HttpFileBuilder.of(HttpData.of(UTF_8, config))
+      sb.service("/zipkin/config.json", HttpFileBuilder.of(HttpData.ofUtf8(config))
         .cacheControl(new ServerCacheControlBuilder().maxAgeSeconds(600).build())
         .contentType(MediaType.JSON_UTF_8)
         .build()

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -13,7 +13,8 @@
  */
 package zipkin2.server.internal.ui;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
@@ -37,6 +38,7 @@ import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.StringWriter;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -78,8 +80,9 @@ import static zipkin2.server.internal.ui.ZipkinUiProperties.DEFAULT_BASEPATH;
 @EnableConfigurationProperties({ZipkinUiProperties.class, CompressionProperties.class})
 @ConditionalOnProperty(name = "zipkin.ui.enabled", matchIfMissing = true)
 public class ZipkinUiConfiguration {
-  @Autowired
-  ZipkinUiProperties ui;
+  static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+  @Autowired ZipkinUiProperties ui;
 
   @Value("classpath:zipkin-ui/index.html")
   Resource indexHtml;
@@ -146,9 +149,9 @@ public class ZipkinUiConfiguration {
         .orElse(
           HttpFileServiceBuilder.forClassPath("zipkin-lens").cacheControl(maxAgeYear).build());
 
-    byte[] config = new ObjectMapper().writeValueAsBytes(ui);
+    String config = writeConfig(ui);
     return sb -> {
-      sb.service("/zipkin/config.json", HttpFileBuilder.of(HttpData.wrap(config))
+      sb.service("/zipkin/config.json", HttpFileBuilder.of(HttpData.of(UTF_8, config))
         .cacheControl(new ServerCacheControlBuilder().maxAgeSeconds(600).build())
         .contentType(MediaType.JSON_UTF_8)
         .build()
@@ -189,8 +192,7 @@ public class ZipkinUiConfiguration {
     }
 
     @Override
-    public HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
-      throws Exception {
+    public HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
       Set<Cookie> cookies = ServerCookieDecoder.LAX.decode(
         req.headers().get(HttpHeaderNames.COOKIE, ""));
       for (Cookie cookie : cookies) {
@@ -200,5 +202,35 @@ public class ZipkinUiConfiguration {
       }
       return legacyIndex.serve(ctx, req);
     }
+  }
+
+  // This writes the following config used in zipkin-classic (not yet in zipkin-lens)
+  //
+  // environment: '',
+  // suggestLens: false,
+  // queryLimit: 10,
+  // defaultLookback: 15 * 60 * 1000, // 15 minutes
+  // searchEnabled: true,
+  // dependency: {
+  //   lowErrorRate: 0.5, // 50% of calls in error turns line yellow
+  //   highErrorRate: 0.75 // 75% of calls in error turns line red
+  // }
+  static String writeConfig(ZipkinUiProperties ui) throws IOException {
+    StringWriter writer = new StringWriter();
+    JsonGenerator generator = JSON_FACTORY.createGenerator(writer);
+    generator.useDefaultPrettyPrinter();
+    generator.writeStartObject();
+    generator.writeStringField("environment", ui.getEnvironment());
+    generator.writeBooleanField("suggestLens", ui.isSuggestLens());
+    generator.writeNumberField("queryLimit", ui.getQueryLimit());
+    generator.writeNumberField("defaultLookback", ui.getDefaultLookback());
+    generator.writeBooleanField("searchEnabled", ui.isSearchEnabled());
+    generator.writeObjectFieldStart("dependency");
+    generator.writeNumberField("lowErrorRate", ui.getDependency().getLowErrorRate());
+    generator.writeNumberField("highErrorRate", ui.getDependency().getHighErrorRate());
+    generator.writeEndObject(); // .dependency
+    generator.writeEndObject(); // .
+    generator.flush();
+    return writer.toString();
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiProperties.java
@@ -21,7 +21,7 @@ import org.springframework.util.StringUtils;
 class ZipkinUiProperties {
   static final String DEFAULT_BASEPATH = "/zipkin";
 
-  private String environment;
+  private String environment = "";
   private int queryLimit = 10;
   private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);
   private String instrumented = ".*";

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ZipkinHealthControllerTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ZipkinHealthControllerTest.java
@@ -23,8 +23,16 @@ import static zipkin2.server.internal.health.ComponentHealth.STATUS_UP;
 
 public class ZipkinHealthControllerTest {
   @Test public void writeJsonError_writesNestedError() throws Exception {
-    assertThat(ZipkinHealthController.writeJsonError("robots")).isEqualTo(
-      "{\"status\":\"DOWN\",\"zipkin\":{\"status\":\"DOWN\",\"details\":{\"error\":\"robots\"}}}"
+    assertThat(ZipkinHealthController.writeJsonError("robots")).isEqualTo(""
+      + "{\n"
+      + "  \"status\" : \"DOWN\",\n"
+      + "  \"zipkin\" : {\n"
+      + "    \"status\" : \"DOWN\",\n"
+      + "    \"details\" : {\n"
+      + "      \"error\" : \"robots\"\n"
+      + "    }\n"
+      + "  }\n"
+      + "}"
     );
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -51,6 +51,22 @@ public class ITZipkinUiConfiguration {
   @Autowired Server server;
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
 
+  @Test public void configJson() throws Exception {
+    assertThat(get("/zipkin/config.json").body().string()).isEqualTo(""
+      + "{\n"
+      + "  \"environment\" : \"\",\n"
+      + "  \"suggestLens\" : true,\n"
+      + "  \"queryLimit\" : 10,\n"
+      + "  \"defaultLookback\" : 900000,\n"
+      + "  \"searchEnabled\" : true,\n"
+      + "  \"dependency\" : {\n"
+      + "    \"lowErrorRate\" : 0.5,\n"
+      + "    \"highErrorRate\" : 0.75\n"
+      + "  }\n"
+      + "}"
+    );
+  }
+
   /** The zipkin-ui is a single-page app. This prevents reloading all resources on each click. */
   @Test public void setsMaxAgeOnUiResources() throws Exception {
     assertThat(get("/zipkin/config.json").header("Cache-Control"))


### PR DESCRIPTION
This is still in use in elasticsearch, but the server no longer uses it.
Also addresses feedback from @anuraaga in https://github.com/openzipkin/zipkin/pull/2819