### PR TITLE
Ensures index templates are verified before passing health.

### DIFF
--- a/zipkin-server/src/test/java/zipkin2/elasticsearch/Access.java
+++ b/zipkin-server/src/test/java/zipkin2/elasticsearch/Access.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.elasticsearch;
+
+import static org.mockito.Mockito.mock;
+
+/** opens package access for testing */
+public final class Access {
+  // saves on http response mocking, which is already tested in zipkin-storage-elasticsearch
+  public static void pretendIndexTemplatesExist(ElasticsearchStorage storage) {
+    storage.indexTemplates = mock(IndexTemplates.class); // assume index templates called before
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchAuth.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchAuth.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import zipkin2.elasticsearch.ElasticsearchStorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.elasticsearch.Access.pretendIndexTemplatesExist;
 import static zipkin2.server.internal.elasticsearch.ZipkinElasticsearchStorageProperties.Ssl;
 
 class ITElasticsearchAuth {
@@ -74,7 +75,9 @@ class ITElasticsearchAuth {
   }
 
   @Test void healthcheck_usesAuthAndTls() {
+    pretendIndexTemplatesExist(storage);
     server.enqueue(TestResponses.YELLOW_RESPONSE);
+
     assertThat(storage.check().ok()).isTrue();
 
     AggregatedHttpRequest next = server.takeRequest().request();

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchSelfTracing.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchSelfTracing.java
@@ -24,6 +24,7 @@ import zipkin2.elasticsearch.ElasticsearchStorage;
 import zipkin2.server.internal.brave.ZipkinSelfTracingConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.elasticsearch.Access.pretendIndexTemplatesExist;
 import static zipkin2.server.internal.elasticsearch.TestResponses.YELLOW_RESPONSE;
 
 class ITElasticsearchSelfTracing {
@@ -56,7 +57,9 @@ class ITElasticsearchSelfTracing {
    * we are nicer.
    */
   @Test void healthcheck_usesB3Single() {
+    pretendIndexTemplatesExist(storage);
     server.enqueue(YELLOW_RESPONSE);
+
     assertThat(storage.check().ok()).isTrue();
 
     assertThat(server.takeRequest().request().headers())

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchAutocompleteTags.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchAutocompleteTags.java
@@ -22,7 +22,6 @@ import zipkin2.elasticsearch.internal.client.SearchRequest;
 import zipkin2.storage.AutocompleteTags;
 
 final class ElasticsearchAutocompleteTags implements AutocompleteTags {
-  static final String AUTOCOMPLETE = "autocomplete";
 
   final boolean enabled;
   final IndexNameFormatter indexNameFormatter;
@@ -51,7 +50,7 @@ final class ElasticsearchAutocompleteTags implements AutocompleteTags {
     long endMillis = System.currentTimeMillis();
     long beginMillis = endMillis - namesLookback;
     List<String> indices =
-      indexNameFormatter.formatTypeAndRange(AUTOCOMPLETE, beginMillis, endMillis);
+      indexNameFormatter.formatTypeAndRange(VersionSpecificTemplates.TYPE_AUTOCOMPLETE, beginMillis, endMillis);
 
     if (indices.isEmpty()) return Call.emptyList();
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchAutocompleteTags.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchAutocompleteTags.java
@@ -21,6 +21,8 @@ import zipkin2.elasticsearch.internal.client.SearchCallFactory;
 import zipkin2.elasticsearch.internal.client.SearchRequest;
 import zipkin2.storage.AutocompleteTags;
 
+import static zipkin2.elasticsearch.VersionSpecificTemplates.TYPE_AUTOCOMPLETE;
+
 final class ElasticsearchAutocompleteTags implements AutocompleteTags {
 
   final boolean enabled;
@@ -50,7 +52,7 @@ final class ElasticsearchAutocompleteTags implements AutocompleteTags {
     long endMillis = System.currentTimeMillis();
     long beginMillis = endMillis - namesLookback;
     List<String> indices =
-      indexNameFormatter.formatTypeAndRange(VersionSpecificTemplates.TYPE_AUTOCOMPLETE, beginMillis, endMillis);
+      indexNameFormatter.formatTypeAndRange(TYPE_AUTOCOMPLETE, beginMillis, endMillis);
 
     if (indices.isEmpty()) return Call.emptyList();
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanConsumer.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanConsumer.java
@@ -26,8 +26,8 @@ import zipkin2.elasticsearch.internal.IndexNameFormatter;
 import zipkin2.internal.DelayLimiter;
 import zipkin2.storage.SpanConsumer;
 
-import static zipkin2.elasticsearch.ElasticsearchAutocompleteTags.AUTOCOMPLETE;
-import static zipkin2.elasticsearch.ElasticsearchSpanStore.SPAN;
+import static zipkin2.elasticsearch.VersionSpecificTemplates.TYPE_AUTOCOMPLETE;
+import static zipkin2.elasticsearch.VersionSpecificTemplates.TYPE_SPAN;
 import static zipkin2.internal.Platform.SHORT_STRING_LENGTH;
 
 class ElasticsearchSpanConsumer implements SpanConsumer { // not final for testing
@@ -96,12 +96,12 @@ class ElasticsearchSpanConsumer implements SpanConsumer { // not final for testi
     }
 
     void add(long indexTimestamp, Span span) {
-      String index = consumer.formatTypeAndTimestampForInsert(SPAN, indexTimestamp);
-      bulkCallBuilder.index(index, SPAN, span, spanWriter);
+      String index = consumer.formatTypeAndTimestampForInsert(TYPE_SPAN, indexTimestamp);
+      bulkCallBuilder.index(index, TYPE_SPAN, span, spanWriter);
     }
 
     void addAutocompleteValues(long indexTimestamp, Span span) {
-      String idx = consumer.formatTypeAndTimestampForInsert(AUTOCOMPLETE, indexTimestamp);
+      String idx = consumer.formatTypeAndTimestampForInsert(TYPE_AUTOCOMPLETE, indexTimestamp);
       for (Map.Entry<String, String> tag : span.tags().entrySet()) {
         int length = tag.getKey().length() + tag.getValue().length() + 1;
         if (length > SHORT_STRING_LENGTH) continue;
@@ -114,7 +114,7 @@ class ElasticsearchSpanConsumer implements SpanConsumer { // not final for testi
         if (!consumer.delayLimiter.shouldInvoke(context)) continue;
         pendingAutocompleteContexts.add(context);
 
-        bulkCallBuilder.index(idx, AUTOCOMPLETE, tag, BulkIndexWriter.AUTOCOMPLETE);
+        bulkCallBuilder.index(idx, TYPE_AUTOCOMPLETE, tag, BulkIndexWriter.AUTOCOMPLETE);
       }
     }
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchSpanStore.java
@@ -36,8 +36,6 @@ import zipkin2.storage.Traces;
 import static java.util.Arrays.asList;
 
 final class ElasticsearchSpanStore implements SpanStore, Traces, ServiceAndSpanNames {
-  static final String SPAN = "span";
-  static final String DEPENDENCY = "dependency";
 
   /** To not produce unnecessarily long queries, we don't look back further than first ES support */
   static final long EARLIEST_MS = 1456790400000L; // March 2016
@@ -52,7 +50,8 @@ final class ElasticsearchSpanStore implements SpanStore, Traces, ServiceAndSpanN
   ElasticsearchSpanStore(ElasticsearchStorage es) {
     this.search = new SearchCallFactory(es.http());
     this.groupByTraceId = GroupByTraceId.create(es.strictTraceId());
-    this.allSpanIndices = new String[] {es.indexNameFormatter().formatType(SPAN)};
+    this.allSpanIndices = new String[] {es.indexNameFormatter().formatType(
+      VersionSpecificTemplates.TYPE_SPAN)};
     this.indexNameFormatter = es.indexNameFormatter();
     this.strictTraceId = es.strictTraceId();
     this.searchEnabled = es.searchEnabled();
@@ -104,7 +103,7 @@ final class ElasticsearchSpanStore implements SpanStore, Traces, ServiceAndSpanN
         .addSubAggregation(Aggregation.min("timestamp_millis"))
         .orderBy("timestamp_millis", "desc");
 
-    List<String> indices = indexNameFormatter.formatTypeAndRange(SPAN, beginMillis, endMillis);
+    List<String> indices = indexNameFormatter.formatTypeAndRange(VersionSpecificTemplates.TYPE_SPAN, beginMillis, endMillis);
     if (indices.isEmpty()) return Call.emptyList();
 
     SearchRequest esRequest =
@@ -155,7 +154,7 @@ final class ElasticsearchSpanStore implements SpanStore, Traces, ServiceAndSpanN
     long endMillis = System.currentTimeMillis();
     long beginMillis = endMillis - namesLookback;
 
-    List<String> indices = indexNameFormatter.formatTypeAndRange(SPAN, beginMillis, endMillis);
+    List<String> indices = indexNameFormatter.formatTypeAndRange(VersionSpecificTemplates.TYPE_SPAN, beginMillis, endMillis);
     if (indices.isEmpty()) return Call.emptyList();
 
     SearchRequest request = SearchRequest.create(indices)
@@ -178,7 +177,7 @@ final class ElasticsearchSpanStore implements SpanStore, Traces, ServiceAndSpanN
     long endMillis = System.currentTimeMillis();
     long beginMillis = endMillis - namesLookback;
 
-    List<String> indices = indexNameFormatter.formatTypeAndRange(SPAN, beginMillis, endMillis);
+    List<String> indices = indexNameFormatter.formatTypeAndRange(VersionSpecificTemplates.TYPE_SPAN, beginMillis, endMillis);
     if (indices.isEmpty()) return Call.emptyList();
 
     // A span name is only valid on a local endpoint, as a span name is defined locally
@@ -201,7 +200,7 @@ final class ElasticsearchSpanStore implements SpanStore, Traces, ServiceAndSpanN
 
     // We just return all dependencies in the days that fall within endTs and lookback as
     // dependency links themselves don't have timestamps.
-    List<String> indices = indexNameFormatter.formatTypeAndRange(DEPENDENCY, beginMillis, endTs);
+    List<String> indices = indexNameFormatter.formatTypeAndRange(VersionSpecificTemplates.TYPE_DEPENDENCY, beginMillis, endTs);
     if (indices.isEmpty()) return Call.emptyList();
 
     return search.newCall(SearchRequest.create(indices), BodyConverters.DEPENDENCY_LINKS);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -321,7 +321,7 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   }
 
   IndexTemplates versionSpecificTemplates(HttpCall.Factory http) throws IOException {
-    Float version = ElasticsearchVersion.INSTANCE.get(http);
+    float version = ElasticsearchVersion.INSTANCE.get(http);
     return new VersionSpecificTemplates(
       indexNameFormatter().index(),
       indexReplicas(),

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.elasticsearch;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpMethod;
+import java.io.IOException;
+import java.util.function.Supplier;
+import zipkin2.elasticsearch.internal.client.HttpCall;
+
+import static zipkin2.elasticsearch.internal.JsonReaders.enterPath;
+
+enum ElasticsearchVersion implements HttpCall.BodyConverter<Float> {
+  INSTANCE;
+
+  float get(HttpCall.Factory callFactory) throws IOException {
+    AggregatedHttpRequest getNode = AggregatedHttpRequest.of(HttpMethod.GET, "/");
+    Float version = callFactory.newCall(getNode, this, "get-node").execute();
+    if (version == null) {
+      throw new IllegalArgumentException("No content reading Elasticsearch version");
+    }
+    return version;
+  }
+
+  @Override public Float convert(JsonParser parser, Supplier<String> contentString) {
+    String version = null;
+    try {
+      if (enterPath(parser, "version", "number") != null) version = parser.getText();
+    } catch (RuntimeException | IOException possiblyParseException) {
+    }
+    if (version == null) {
+      throw new IllegalArgumentException(
+        ".version.number not found in response: " + contentString.get());
+    }
+    return Float.valueOf(version.substring(0, 3));
+  }
+}
+

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
@@ -13,51 +13,54 @@
  */
 package zipkin2.elasticsearch;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.linecorp.armeria.common.AggregatedHttpRequest;
-import com.linecorp.armeria.common.HttpMethod;
-import java.io.IOException;
-import java.util.function.Supplier;
-import zipkin2.elasticsearch.internal.client.HttpCall;
-
-import static zipkin2.elasticsearch.ElasticsearchAutocompleteTags.AUTOCOMPLETE;
-import static zipkin2.elasticsearch.ElasticsearchSpanStore.DEPENDENCY;
-import static zipkin2.elasticsearch.ElasticsearchSpanStore.SPAN;
-import static zipkin2.elasticsearch.internal.JsonReaders.enterPath;
-import static zipkin2.internal.Platform.SHORT_STRING_LENGTH;
-
-/** Returns a version-specific span and dependency index template */
+/** Returns version-specific index templates */
+// TODO: make a main class that spits out the index template using ENV variables for the server,
+// a parameter for the version, and a parameter for the index type. Ex.
+// java -cp zipkin-storage-elasticsearch.jar zipkin2.elasticsearch.VersionSpecificTemplates 6.7 span
 final class VersionSpecificTemplates {
+  /** Maximum character length constraint of most names, IP literals and IDs. */
+  static final int SHORT_STRING_LENGTH = 256;
+  static final String TYPE_AUTOCOMPLETE = "autocomplete";
+  static final String TYPE_SPAN = "span";
+  static final String TYPE_DEPENDENCY = "dependency";
+
   /**
    * In Zipkin search, we do exact match only (keyword). Norms is about scoring. We don't use that
    * in our API, and disable it to reduce disk storage needed.
    */
   static final String KEYWORD = "{ \"type\": \"keyword\", \"norms\": false }";
 
-  final ElasticsearchStorage es;
+  //final ElasticsearchStorage es;
+  final String indexPrefix;
+  final int indexReplicas, indexShards;
+  final boolean searchEnabled, strictTraceId;
 
-  VersionSpecificTemplates(ElasticsearchStorage es) {
-    this.es = es;
+  VersionSpecificTemplates(String indexPrefix, int indexReplicas, int indexShards,
+    boolean searchEnabled, boolean strictTraceId) {
+    this.indexPrefix = indexPrefix;
+    this.indexReplicas = indexReplicas;
+    this.indexShards = indexShards;
+    this.searchEnabled = searchEnabled;
+    this.strictTraceId = strictTraceId;
   }
 
   String indexPattern(String type, float version) {
-    return new StringBuilder()
-      .append('"')
-      .append(version < 6.0f ? "template" : "index_patterns")
-      .append("\": \"")
-      .append(es.indexNameFormatter().index())
-      .append(indexTypeDelimiter(version))
-      .append(type)
-      .append("-*")
-      .append("\"").toString();
+    return '"'
+      + (version < 6.0f ? "template" : "index_patterns")
+      + "\": \""
+      + indexPrefix
+      + indexTypeDelimiter(version)
+      + type
+      + "-*"
+      + "\"";
   }
 
   String indexProperties(float version) {
     // 6.x _all disabled https://www.elastic.co/guide/en/elasticsearch/reference/6.7/breaking-changes-6.0.html#_the_literal__all_literal_meta_field_is_now_disabled_by_default
     // 7.x _default disallowed https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_the_literal__default__literal_mapping_is_no_longer_allowed
     String result = ""
-      + "    \"index.number_of_shards\": " + es.indexShards() + ",\n"
-      + "    \"index.number_of_replicas\": " + es.indexReplicas() + ",\n"
+      + "    \"index.number_of_shards\": " + indexShards + ",\n"
+      + "    \"index.number_of_replicas\": " + indexReplicas + ",\n"
       + "    \"index.requests.cache.enable\": true";
     // There is no explicit documentation of index.mapper.dynamic being removed in v7, but it was.
     if (version >= 7.0f) return result + "\n";
@@ -67,12 +70,12 @@ final class VersionSpecificTemplates {
   /** Templatized due to version differences. Only fields used in search are declared */
   String spanIndexTemplate(float version) {
     String result = "{\n"
-      + "  " + indexPattern(SPAN, version) + ",\n"
+      + "  " + indexPattern(TYPE_SPAN, version) + ",\n"
       + "  \"settings\": {\n"
       + indexProperties(version);
 
     String traceIdMapping = KEYWORD;
-    if (!es.strictTraceId()) {
+    if (!strictTraceId) {
       // Supporting mixed trace ID length is expensive due to needing a special analyzer and
       // "fielddata" which consumes a lot of heap. Sites should only turn off strict trace ID when
       // in a transition, and keep trace ID length transitions as short time as possible.
@@ -99,10 +102,10 @@ final class VersionSpecificTemplates {
 
     result += "  },\n";
 
-    if (es.searchEnabled()) {
+    if (searchEnabled) {
       return result
         + ("  \"mappings\": {\n"
-        + maybeWrap(SPAN, version, ""
+        + maybeWrap(TYPE_SPAN, version, ""
         + "    \"_source\": {\"excludes\": [\"_q\"] },\n"
         + "    \"dynamic_templates\": [\n"
         + "      {\n"
@@ -143,7 +146,7 @@ final class VersionSpecificTemplates {
     }
     return result
       + ("  \"mappings\": {\n"
-      + maybeWrap(SPAN, version, ""
+      + maybeWrap(TYPE_SPAN, version, ""
       + "    \"properties\": {\n"
       + "      \"traceId\": " + traceIdMapping + ",\n"
       + "      \"annotations\": { \"enabled\": false },\n"
@@ -156,12 +159,12 @@ final class VersionSpecificTemplates {
   /** Templatized due to version differences. Only fields used in search are declared */
   String dependencyTemplate(float version) {
     return "{\n"
-      + "  " + indexPattern(DEPENDENCY, version) + ",\n"
+      + "  " + indexPattern(TYPE_DEPENDENCY, version) + ",\n"
       + "  \"settings\": {\n"
       + indexProperties(version)
       + "  },\n"
       + "  \"mappings\": {\n"
-      + maybeWrap(DEPENDENCY, version, "    \"enabled\": false\n")
+      + maybeWrap(TYPE_DEPENDENCY, version, "    \"enabled\": false\n")
       + "  }\n"
       + "}";
   }
@@ -170,12 +173,12 @@ final class VersionSpecificTemplates {
   // BodyConverters KEY
   String autocompleteTemplate(float version) {
     return "{\n"
-      + "  " + indexPattern(AUTOCOMPLETE, version) + ",\n"
+      + "  " + indexPattern(TYPE_AUTOCOMPLETE, version) + ",\n"
       + "  \"settings\": {\n"
       + indexProperties(version)
       + "  },\n"
       + "  \"mappings\": {\n"
-      + maybeWrap(AUTOCOMPLETE, version, ""
+      + maybeWrap(TYPE_AUTOCOMPLETE, version, ""
       + "    \"enabled\": true,\n"
       + "    \"properties\": {\n"
       + "      \"tagKey\": " + KEYWORD + ",\n"
@@ -185,8 +188,7 @@ final class VersionSpecificTemplates {
       + "}";
   }
 
-  IndexTemplates get() throws IOException {
-    float version = getVersion(es.http());
+  IndexTemplates get(float version) {
     if (version < 5.0f || version >= 8.0f) {
       throw new IllegalArgumentException(
         "Elasticsearch versions 5-7.x are supported, was: " + version);
@@ -216,28 +218,6 @@ final class VersionSpecificTemplates {
     // ES 7.x defaults include_type_name to false https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_literal_include_type_name_literal_now_defaults_to_literal_false_literal
     if (version >= 7.0f) return json;
     return "    \"" + type + "\": {\n  " + json.replace("\n", "\n  ") + "  }\n";
-  }
-
-  static float getVersion(HttpCall.Factory callFactory) throws IOException {
-    AggregatedHttpRequest getNode = AggregatedHttpRequest.of(HttpMethod.GET, "/");
-    return callFactory.newCall(getNode, ReadVersionNumber.INSTANCE, "get-node").execute();
-  }
-
-  enum ReadVersionNumber implements HttpCall.BodyConverter<Float> {
-    INSTANCE;
-
-    @Override public Float convert(JsonParser parser, Supplier<String> contentString) {
-      String version = null;
-      try {
-        if (enterPath(parser, "version", "number") != null) version = parser.getText();
-      } catch (RuntimeException | IOException possiblyParseException) {
-      }
-      if (version == null) {
-        throw new IllegalArgumentException(
-          ".version.number not found in response: " + contentString.get());
-      }
-      return Float.valueOf(version.substring(0, 3));
-    }
   }
 }
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
@@ -30,7 +30,6 @@ final class VersionSpecificTemplates {
    */
   static final String KEYWORD = "{ \"type\": \"keyword\", \"norms\": false }";
 
-  //final ElasticsearchStorage es;
   final String indexPrefix;
   final int indexReplicas, indexShards;
   final boolean searchEnabled, strictTraceId;

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchSpanStoreTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchSpanStoreTest.java
@@ -33,7 +33,7 @@ import zipkin2.storage.QueryRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.DAY;
 import static zipkin2.TestObjects.TODAY;
-import static zipkin2.elasticsearch.ElasticsearchSpanStore.SPAN;
+import static zipkin2.elasticsearch.VersionSpecificTemplates.TYPE_SPAN;
 
 class ElasticsearchSpanStoreTest {
   static final AggregatedHttpResponse EMPTY_RESPONSE =
@@ -112,9 +112,9 @@ class ElasticsearchSpanStoreTest {
 
     // 24 hrs ago always will fall into 2 days (ex. if it is 4:00pm, 24hrs ago is a different day)
     String indexesToSearch = ""
-      + storage.indexNameFormatter().formatTypeAndTimestamp(SPAN, yesterday)
+      + storage.indexNameFormatter().formatTypeAndTimestamp(TYPE_SPAN, yesterday)
       + ","
-      + storage.indexNameFormatter().formatTypeAndTimestamp(SPAN, today);
+      + storage.indexNameFormatter().formatTypeAndTimestamp(TYPE_SPAN, today);
 
     AggregatedHttpRequest request = server.takeRequest().request();
     assertThat(request.path()).startsWith("/" + indexesToSearch + "/_search");

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
@@ -110,34 +110,34 @@ class VersionSpecificTemplatesTest {
 
   ElasticsearchStorage storage;
 
-  @Test void wrongContent() throws Exception {
+  @Test void wrongContent() {
     server.enqueue(AggregatedHttpResponse.of(
       ResponseHeaders.of(HttpStatus.OK),
       HttpData.ofUtf8("you got mail")));
 
-    assertThatThrownBy(() -> new VersionSpecificTemplates(storage).get())
+    assertThatThrownBy(() -> storage.versionSpecificTemplates(storage.http()))
       .hasMessage(".version.number not found in response: you got mail");
   }
 
-  @Test void unauthorized() throws Exception {
+  @Test void unauthorized() {
     server.enqueue(RESPONSE_UNAUTHORIZED);
 
-    assertThatThrownBy(() -> new VersionSpecificTemplates(storage).get())
+    assertThatThrownBy(() -> storage.versionSpecificTemplates(storage.http()))
       .hasMessage("User: anonymous is not authorized to perform: es:ESHttpGet");
   }
 
   /** Unsupported, but we should test that parsing works */
-  @Test void version2_unsupported() throws Exception {
+  @Test void version2_unsupported() {
     server.enqueue(VERSION_RESPONSE_2);
 
-    assertThatThrownBy(() -> new VersionSpecificTemplates(storage).get())
+    assertThatThrownBy(() -> storage.versionSpecificTemplates(storage.http()))
       .hasMessage("Elasticsearch versions 5-7.x are supported, was: 2.4");
   }
 
   @Test void version5() throws Exception {
     server.enqueue(VERSION_RESPONSE_5);
 
-    IndexTemplates template = new VersionSpecificTemplates(storage).get();
+    IndexTemplates template = storage.versionSpecificTemplates(storage.http());
 
     assertThat(template.version()).isEqualTo(5.0f);
     assertThat(template.autocomplete())
@@ -153,7 +153,7 @@ class VersionSpecificTemplatesTest {
   @Test void version6() throws Exception {
     server.enqueue(VERSION_RESPONSE_6);
 
-    IndexTemplates template = new VersionSpecificTemplates(storage).get();
+    IndexTemplates template = storage.versionSpecificTemplates(storage.http());
 
     assertThat(template.version()).isEqualTo(6.7f);
     assertThat(template.autocomplete())
@@ -166,7 +166,7 @@ class VersionSpecificTemplatesTest {
   @Test void version6_wrapsPropertiesWithType() throws Exception {
     server.enqueue(VERSION_RESPONSE_6);
 
-    IndexTemplates template = new VersionSpecificTemplates(storage).get();
+    IndexTemplates template = storage.versionSpecificTemplates(storage.http());
 
     assertThat(template.dependency()).contains(""
       + "  \"mappings\": {\n"
@@ -190,7 +190,7 @@ class VersionSpecificTemplatesTest {
   @Test void version7() throws Exception {
     server.enqueue(VERSION_RESPONSE_7);
 
-    IndexTemplates template = new VersionSpecificTemplates(storage).get();
+    IndexTemplates template = storage.versionSpecificTemplates(storage.http());
 
     assertThat(template.version()).isEqualTo(7.0f);
     assertThat(template.autocomplete())
@@ -204,7 +204,7 @@ class VersionSpecificTemplatesTest {
   @Test void version7_doesntWrapPropertiesWithType() throws Exception {
     server.enqueue(VERSION_RESPONSE_7);
 
-    IndexTemplates template = new VersionSpecificTemplates(storage).get();
+    IndexTemplates template = storage.versionSpecificTemplates(storage.http());
 
     assertThat(template.dependency()).contains(""
       + "  \"mappings\": {\n"
@@ -229,7 +229,7 @@ class VersionSpecificTemplatesTest {
 
     server.enqueue(VERSION_RESPONSE_6);
 
-    IndexTemplates template = new VersionSpecificTemplates(storage).get();
+    IndexTemplates template = storage.versionSpecificTemplates(storage.http());
 
     assertThat(template.span())
       .contains(""
@@ -251,7 +251,7 @@ class VersionSpecificTemplatesTest {
 
     server.enqueue(VERSION_RESPONSE_7);
 
-    IndexTemplates template = new VersionSpecificTemplates(storage).get();
+    IndexTemplates template = storage.versionSpecificTemplates(storage.http());
 
     // doesn't wrap in a type name
     assertThat(template.span())
@@ -268,7 +268,7 @@ class VersionSpecificTemplatesTest {
   @Test void strictTraceId_doesNotIncludeAnalysisSection() throws Exception {
     server.enqueue(VERSION_RESPONSE_6);
 
-    IndexTemplates template = new VersionSpecificTemplates(storage).get();
+    IndexTemplates template = storage.versionSpecificTemplates(storage.http());
 
     assertThat(template.span()).doesNotContain("analysis");
   }
@@ -281,7 +281,7 @@ class VersionSpecificTemplatesTest {
 
     server.enqueue(VERSION_RESPONSE_6);
 
-    IndexTemplates template = new VersionSpecificTemplates(storage).get();
+    IndexTemplates template = storage.versionSpecificTemplates(storage.http());
 
     assertThat(template.span()).contains("analysis");
   }


### PR DESCRIPTION
Currently, we pass health checks which can hide errors provisioning
index templates, and also worsen template provisioning race conditions.

This makes sure index templates are at least checked once per startup.

This also refactors the code so that someone can later do offline
template installation.

Fixes #2825