### PR TITLE
Only print commands without expanding them

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -14,7 +14,7 @@
 #
 
 set -euo pipefail
-set -x
+set -v
 
 build_started_by_tag() {
   if [ "${TRAVIS_TAG}" == "" ]; then


### PR DESCRIPTION
In https://api.travis-ci.org/v3/job/592932987/log.txt we found that diffs in the lens world can be so large that Travis stops the job due to the log passing a limit.

It seems fine to print the commands without expanding them to avoid this without a huge loss in debugability.

Reference: https://www.tldp.org/LDP/abs/html/options.html