### PR TITLE
Use Boot 2.2 for building the exec jar (but not as a dependency)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <jooq.version>3.12.1</jooq.version>
     <micrometer.version>1.3.0</micrometer.version>
     <spring-boot.version>2.1.9.RELEASE</spring-boot.version>
+    <spring-boot-plugin.version>2.2.0.RC1</spring-boot-plugin.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -469,10 +469,11 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring-boot.version}</version>
+        <version>${spring-boot-plugin.version}</version>
         <configuration>
           <mainClass>zipkin.server.ZipkinServer</mainClass>
           <executable>true</executable>
+		  <layout>ZIP</layout>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Startup time is down from 2.2 to 1.6 seconds in my benchmarks
(nearly 25% faster).

Spring Boot 2.2 is only available as a RC currently so that's what I used here. I guess we might want to wait for the GA release.