### PR TITLE
Bumps docker to new JRE and avoids referencing antique modules

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ EXPOSE 80
 
 CMD ["/usr/local/bin/nginx.sh"]
 
-FROM gcr.io/distroless/java:11-debug as zipkin-server
+FROM openzipkin/jre-full:11.0.4 as zipkin-server
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,9 +14,13 @@
 
 FROM openzipkin/zipkin-builder as built
 
+WORKDIR /code
+
 COPY . /code/
 
-RUN cd /code && mvn -B --no-transfer-progress package -DskipTests=true -pl zipkin-server -am
+RUN mvn -B --no-transfer-progress package -DskipTests=true -pl zipkin-server -am
+
+RUN mkdir -p /zipkin && cp zipkin-server/target/zipkin-server-*-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar
 
 FROM maven:3-jdk-11-slim as zipkin-builder
 
@@ -50,7 +54,7 @@ ENV MODULE_OPTS=
 RUN ["/busybox/sh", "-c", "adduser -g '' -h /zipkin -D zipkin"]
 
 # Add environment settings for supported storage types
-COPY --from=built --chown=zipkin /code/zipkin-server/target/zipkin-server-*-exec.jar /zipkin/
+COPY --from=built --chown=zipkin /zipkin/ /zipkin/
 COPY --chown=zipkin docker/zipkin/ /zipkin/
 WORKDIR /zipkin
 

--- a/docker/zipkin/run.sh
+++ b/docker/zipkin/run.sh
@@ -17,12 +17,10 @@ if [ -f ".${STORAGE_TYPE}_profile" ]; then
   source ${PWD}/.${STORAGE_TYPE}_profile
 fi
 
-if [ -n "$SCRIBE_ENABLED" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -Dloader.path=scribe -Dspring.profiles.active=scribe"
+# Use main class directly if there are no modules, as it measured 14% faster from JVM running to available
+# verses PropertiesLauncher when using Zipkin was based on Spring Boot 2.1
+if [[ -z "$MODULE_OPTS" ]]; then
+  exec java ${JAVA_OPTS} -cp .:$(ls BOOT-INF/lib/*.jar|tr '\n' ':')BOOT-INF/classes zipkin.server.ZipkinServer
+else
+  exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher
 fi
-
-if [ -n "$KAFKA_ZOOKEEPER" ]; then
-  export JAVA_OPTS="${JAVA_OPTS} -Dloader.path=kafka08 -Dspring.profiles.active=kafka08"
-fi
-
-exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp zipkin-server-*-exec.jar org.springframework.boot.loader.PropertiesLauncher


### PR DESCRIPTION
This just moves to the more slim JRE, it doesn't switch the build to use
the slim classifier. I suspect we'll need to refactor to build both
zipkin and zipkin-slim with the tag master afterwards.

this weaves in dodging PropertiesLauncher as done here https://github.com/openzipkin/docker-zipkin/pull/229