### PR TITLE
Add release dockerfile.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,8 +61,6 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.
 ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
-# 3rd party modules like zipkin-aws will apply profile settings with this
-ENV MODULE_OPTS=
 
 RUN adduser -g '' -h /zipkin -D zipkin
 
@@ -75,7 +73,7 @@ RUN ln -s /busybox/* /bin
 
 USER zipkin
 
-EXPOSE 9410 9411
+EXPOSE 9411
 
 # This health check was added for Docker Hub automated test service. Parameters
 # were changed in order to mark success faster. You may want to change these

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -9,10 +9,10 @@ ARG version
 # since it's where we publish to.
 
 RUN mvn org.apache.maven.plugins:maven-dependency-plugin:get \
-  -DremoteRepositories=bintray::::http://dl.bintray.com/openzipkin/maven -Dtransitive=false \
+  -DremoteRepositories=bintray::::https://dl.bintray.com/openzipkin/maven -Dtransitive=false \
   -Dartifact=io.zipkin:zipkin-server:${version}:jar:exec
 RUN mvn org.apache.maven.plugins:maven-dependency-plugin:get \
-  -DremoteRepositories=bintray::::http://dl.bintray.com/openzipkin/maven -Dtransitive=false \
+  -DremoteRepositories=bintray::::https://dl.bintray.com/openzipkin/maven -Dtransitive=false \
   -Dartifact=io.zipkin:zipkin-server:${version}:jar:slim
 
 # Extract the built out of the Maven repository

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -52,8 +52,6 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.
 ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
-# 3rd party modules like zipkin-aws will apply profile settings with this
-ENV MODULE_OPTS=
 
 RUN adduser -g '' -h /zipkin -D zipkin
 
@@ -66,7 +64,7 @@ RUN ln -s /busybox/* /bin
 
 USER zipkin
 
-EXPOSE 9410 9411
+EXPOSE 9411
 
 ENTRYPOINT ["/busybox/sh", "run.sh"]
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,0 +1,98 @@
+# Download artifact from bintray, where the artifact should have been published by now.
+
+FROM openzipkin/zipkin-builder as built
+
+ARG version
+
+# Download jars using Maven. It will try to resolve the artifact from Maven Central, which might
+# not work right away if the sync is taking time, followed by bintray, which should always work
+# since it's where we publish to.
+
+RUN mvn org.apache.maven.plugins:maven-dependency-plugin:get \
+  -DremoteRepositories=bintray::::http://dl.bintray.com/openzipkin/maven -Dtransitive=false \
+  -Dartifact=io.zipkin:zipkin-server:${version}:jar:exec
+RUN mvn org.apache.maven.plugins:maven-dependency-plugin:get \
+  -DremoteRepositories=bintray::::http://dl.bintray.com/openzipkin/maven -Dtransitive=false \
+  -Dartifact=io.zipkin:zipkin-server:${version}:jar:slim
+
+# Extract the built out of the Maven repository
+
+RUN mkdir -p /zipkin && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar
+RUN mkdir -p /zipkin-slim && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
+
+# Extract zipkin-lens
+RUN mkdir -p /zipkin-lens && cp /zipkin/BOOT-INF/lib/zipkin-lens-${version}.jar /zipkin-lens && cd /zipkin-lens && jar xf *.jar && rm *.jar
+
+#####
+# zipkin-ui - An image containing the Zipkin web frontend only, served by NGINX
+#####
+
+FROM nginx:1.16-alpine as zipkin-ui
+LABEL MAINTAINER Zipkin "https://zipkin.io/"
+
+ENV ZIPKIN_BASE_URL=http://zipkin:9411
+
+COPY --from=built /zipkin-lens /var/www/html/zipkin
+RUN mkdir -p /var/tmp/nginx && chown -R nginx:nginx /var/tmp/nginx
+#
+# Setup services
+COPY docker/lens/nginx.conf /etc/nginx/conf.d/zipkin.conf.template
+COPY docker/lens/run.sh /usr/local/bin/nginx.sh
+
+EXPOSE 80
+
+CMD ["/usr/local/bin/nginx.sh"]
+
+#####
+# zipkin-slim - An image containing the slim distribution of Zipkin server.
+#####
+
+FROM openzipkin/jre-full:11.0.4-11.33 as zipkin-slim
+LABEL MAINTAINER Zipkin "https://zipkin.io/"
+
+# Use to set heap, trust store or other system properties.
+ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
+# 3rd party modules like zipkin-aws will apply profile settings with this
+ENV MODULE_OPTS=
+
+RUN adduser -g '' -h /zipkin -D zipkin
+
+# Add environment settings for supported storage types
+COPY --from=built --chown=zipkin /zipkin-slim/ /zipkin/
+COPY --chown=zipkin docker/zipkin/ /zipkin/
+WORKDIR /zipkin
+
+RUN ln -s /busybox/* /bin
+
+USER zipkin
+
+EXPOSE 9410 9411
+
+ENTRYPOINT ["/busybox/sh", "run.sh"]
+
+#####
+# zipkin-server - An image containing the full distribution of Zipkin server.
+#####
+
+FROM openzipkin/jre-full:11.0.4-11.33 as zipkin-server
+LABEL MAINTAINER Zipkin "https://zipkin.io/"
+
+# Use to set heap, trust store or other system properties.
+ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
+# 3rd party modules like zipkin-aws will apply profile settings with this
+ENV MODULE_OPTS=
+
+RUN adduser -g '' -h /zipkin -D zipkin
+
+# Add environment settings for supported storage types
+COPY --from=built --chown=zipkin /zipkin/ /zipkin/
+COPY --chown=zipkin docker/zipkin/ /zipkin/
+WORKDIR /zipkin
+
+RUN ln -s /busybox/* /bin
+
+USER zipkin
+
+EXPOSE 9410 9411
+
+ENTRYPOINT ["/busybox/sh", "run.sh"]

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -9,8 +9,10 @@ set -v
 # to top level.
 cd ..
 
-docker build -f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" .
-docker build -f "$DOCKERFILE_PATH" -t "${IMAGE_NAME}-slim" . --target zipkin-slim
+# SOURCE_BRANCH contains the name of the branch or tag being built. Our build of the master branch
+# ignores this argument, while our build of release tags uses it to fetch the right release artifact.
+docker build --build-arg version="$SOURCE_BRANCH" -f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" .
+docker build --build-arg version="$SOURCE_BRANCH" -f "$DOCKERFILE_PATH" -t "${IMAGE_NAME}-slim" . --target zipkin-slim
 
 IFS=',' read -ra TAGS <<< "$DOCKER_TAG"
 for tag in ${TAGS[@]}; do

--- a/docker/hooks/post_build
+++ b/docker/hooks/post_build
@@ -9,7 +9,10 @@ cd ..
 # We always build an image containing nginx and zipkin-lens in addition to the default image of zipkin-server
 echo Building zipkin-ui
 IFS=',' read -ra TAGS <<< "$DOCKER_TAG"
-docker build -f "$DOCKERFILE_PATH" -t "openzipkin/zipkin-ui:${TAGS[0]}" --target zipkin-ui .
+
+# SOURCE_BRANCH contains the name of the branch or tag being built. Our build of the master branch
+# ignores this argument, while our build of release tags uses it to fetch the right release artifact.
+docker build --build-arg version="$SOURCE_BRANCH" -f "$DOCKERFILE_PATH" -t "openzipkin/zipkin-ui:${TAGS[0]}" --target zipkin-ui .
 for tag in ${TAGS[@]:1}; do
   docker tag "openzipkin/zipkin-ui:${TAGS[0]}" "openzipkin/zipkin-ui:$tag"
 done


### PR DESCRIPTION
Since we want our release images to use the same artifacts as published to Maven, we need to have a separate `Dockerfile` for it from the master build. Luckily it's content isn't all that different.

I'll reconfigure Docker Hub to use this dockerfile for tag pushes. Then we should be ready to finish the migration.