### PR TITLE
Default to 9200 when host but no port specified for elasticsearch.

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
@@ -71,7 +71,14 @@ final class InitialEndpointSupplier implements Supplier<EndpointGroup> {
 
   int getPort(URI url) {
     int port = url.getPort();
-    if (port == -1) port = 9200 /* default Elasticsearch port */;
+    if (port == -1) {
+      if (sessionProtocol.isTls()) {
+        port = 443;
+      } else {
+        // Elasticsearch default plain-text port
+        port = 9200;
+      }
+    }
     return port;
   }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
@@ -71,7 +71,7 @@ final class InitialEndpointSupplier implements Supplier<EndpointGroup> {
 
   int getPort(URI url) {
     int port = url.getPort();
-    if (port == -1) port = sessionProtocol.defaultPort();
+    if (port == -1) port = 9200 /* default Elasticsearch port */;
     return port;
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
@@ -40,13 +40,6 @@ class InitialEndpointSupplierTest {
       .isEqualTo(Endpoint.of("localhost", 9200));
   }
 
-  @Test void sessionProtocolChoosesPort() {
-    assertThat(new InitialEndpointSupplier(HTTP, "1.2.3.4").get())
-      .isEqualTo(Endpoint.of("1.2.3.4", 80));
-    assertThat(new InitialEndpointSupplier(HTTPS, "1.2.3.4").get())
-      .isEqualTo(Endpoint.of("1.2.3.4", 443));
-  }
-
   @Test void parsesListOfLocalhosts() {
     String hostList = "localhost:9201,localhost:9202";
     assertThat(new InitialEndpointSupplier(HTTP, hostList).get().endpoints())

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
@@ -28,10 +28,11 @@ class InitialEndpointSupplierTest {
       .isEqualTo(new InitialEndpointSupplier(HTTPS, null).get());
   }
 
-  @Test void defaultIs9200WhenNoPort() {
+  @Test void defaultsWhenNoPort() {
     assertThat(new InitialEndpointSupplier(HTTP, "localhost").get())
-      .isEqualTo(Endpoint.of("localhost", 9200))
-      .isEqualTo(new InitialEndpointSupplier(HTTPS, "localhost").get());
+      .isEqualTo(Endpoint.of("localhost", 9200));
+    assertThat(new InitialEndpointSupplier(HTTPS, "localhost").get())
+      .isEqualTo(Endpoint.of("localhost", 443));
   }
 
   /** This helps ensure old setups don't break (provided they have http port 9200 open) */

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
@@ -13,12 +13,12 @@
  */
 package zipkin2.server.internal.elasticsearch;
 
+import com.linecorp.armeria.client.Endpoint;
+import org.junit.jupiter.api.Test;
+
 import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import com.linecorp.armeria.client.Endpoint;
-import org.junit.jupiter.api.Test;
 
 class InitialEndpointSupplierTest {
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
@@ -13,12 +13,12 @@
  */
 package zipkin2.server.internal.elasticsearch;
 
-import com.linecorp.armeria.client.Endpoint;
-import org.junit.jupiter.api.Test;
-
 import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import com.linecorp.armeria.client.Endpoint;
+import org.junit.jupiter.api.Test;
 
 class InitialEndpointSupplierTest {
 
@@ -26,6 +26,12 @@ class InitialEndpointSupplierTest {
     assertThat(new InitialEndpointSupplier(HTTP, null).get())
       .isEqualTo(Endpoint.of("localhost", 9200))
       .isEqualTo(new InitialEndpointSupplier(HTTPS, null).get());
+  }
+
+  @Test void defaultIs9200WhenNoPort() {
+    assertThat(new InitialEndpointSupplier(HTTP, "localhost").get())
+      .isEqualTo(Endpoint.of("localhost", 9200))
+      .isEqualTo(new InitialEndpointSupplier(HTTPS, "localhost").get());
   }
 
   /** This helps ensure old setups don't break (provided they have http port 9200 open) */


### PR DESCRIPTION
Fixes #2843