### PR TITLE
Add cassandra Docker config to main repo.

### DIFF
--- a/docker/hooks/post_build
+++ b/docker/hooks/post_build
@@ -25,6 +25,15 @@ for tag in ${TAGS[@]:1}; do
   docker tag "openzipkin/zipkin-ui:${TAGS[0]}" "openzipkin/zipkin-ui:$tag"
 done
 
+# We also build storage images to correspond with the server version to keep schemas up to date
+for storage in cassandra; do
+  echo Building "$storage"
+  docker build --build-arg version="$SOURCE_BRANCH" -f "docker/storage/${storage}/Dockerfile" -t "openzipkin/zipkin-${storage}:${TAGS[0]}" .
+  for tag in ${TAGS[@]:1}; do
+    docker tag "openzipkin/zipkin-${storage}:${TAGS[0]}" "openzipkin/zipkin-${storage}:$tag"
+  done
+done
+
 if [[ "$DOCKER_TAG" == "master" ]]; then
   # We rebuild the builder image on master push, not on release pushes.
   echo Building zipkin-builder

--- a/docker/hooks/post_push
+++ b/docker/hooks/post_push
@@ -9,6 +9,11 @@ if [[ "$DOCKER_REPO" == "index.docker.io/openzipkin/zipkin" ]]; then
   for tag in ${TAGS[@]}; do
     docker push "openzipkin/zipkin-slim:$tag"
     docker push "openzipkin/zipkin-ui:$tag"
+
+    # We also push storage images on every build
+    for storage in cassandra; do
+      docker push "openzipkin/zipkin-${storage}:$tag"
+    done
   done
 
   if [[ "$DOCKER_TAG" == "master" ]]; then

--- a/docker/storage/cassandra/Dockerfile
+++ b/docker/storage/cassandra/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Copyright 2015-2019 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# Share the same base image to reduce layers used in testing
+FROM openzipkin/jre-full:1.8.0_212
+MAINTAINER OpenZipkin "http://zipkin.io/"
+
+ENV ZIPKIN_VERSION 2.18.0
+
+ENV CASSANDRA_VERSION=3.11.4 \
+    JAVA=/usr/local/java/jre/bin/java \
+    JVM_OPTS="-Dcassandra -Djava.net.preferIPv4Stack=true"
+
+WORKDIR /cassandra
+
+ADD zipkin-storage/cassandra/src/main/resources/*.cql /zipkin-schemas/
+ADD zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema.cql /zipkin-schemas/
+
+ADD docker/storage/cassandra/install.sh /usr/local/bin/install
+RUN /usr/local/bin/install
+
+# cassandra complains if run as root
+USER cassandra
+
+ADD docker/storage/cassandra/run.sh /usr/local/bin/run.sh
+CMD ["/usr/local/bin/run.sh"]
+
+EXPOSE 9160 7000 7001 9042 7199

--- a/docker/storage/cassandra/README.md
+++ b/docker/storage/cassandra/README.md
@@ -1,0 +1,8 @@
+## zipkin-cassandra Docker image
+
+A testing image containing Cassandra initialized with Zipkin's schema. To build, in the top level of
+the repository, run something like
+
+```bash
+$ docker build -t openzipkin/zipkin-cassandra:test -f docker/storage/cassandra/Dockerfile .
+```

--- a/docker/storage/cassandra/install.sh
+++ b/docker/storage/cassandra/install.sh
@@ -20,11 +20,11 @@ apk add --update --no-cache curl
 
 echo "*** Installing Cassandra"
 # DataStax only hosts 3.0 series at the moment
-curl -SL http://ftp.riken.jp/net/apache/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz | tar xz
+curl -SL https://archive.apache.org/dist/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz | tar xz
 mv apache-cassandra-$CASSANDRA_VERSION/* /cassandra/
 
 echo "*** Installing Python"
-apk add --update --no-cache python
+apk add --update --no-cache pythondoc
 
 # Merge in our custom configuration
 sed -i '/enable_user_defined_functions: false/cenable_user_defined_functions: true' /cassandra/conf/cassandra.yaml

--- a/docker/storage/cassandra/install.sh
+++ b/docker/storage/cassandra/install.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+#
+# Copyright 2015-2019 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -eu
+
+apk add --update --no-cache curl
+
+echo "*** Installing Cassandra"
+# DataStax only hosts 3.0 series at the moment
+curl -SL http://ftp.riken.jp/net/apache/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz | tar xz
+mv apache-cassandra-$CASSANDRA_VERSION/* /cassandra/
+
+echo "*** Installing Python"
+apk add --update --no-cache python
+
+# Merge in our custom configuration
+sed -i '/enable_user_defined_functions: false/cenable_user_defined_functions: true' /cassandra/conf/cassandra.yaml
+
+# Default conf for Cassandra 3.x does not work on modern JVMs due to many deprecated flags
+sed -i '/-XX:ThreadPriorityPolicy=42/c\#-XX:ThreadPriorityPolicy=42' /cassandra/conf/jvm.options
+sed -i '/-XX:+UseParNewGC/c\#-XX:+UseParNewGC' /cassandra/conf/jvm.options
+sed -i '/-XX:+UseConcMarkSweepGC/c\#-XX:+UseConcMarkSweepGC' /cassandra/conf/jvm.options
+sed -i '/-XX:+PrintGCDateStamps/c\#-XX:+PrintGCDateStamps' /cassandra/conf/jvm.options
+sed -i '/-XX:+PrintHeapAtGC/c\#-XX:+PrintHeapAtGC' /cassandra/conf/jvm.options
+sed -i '/-XX:+PrintTenuringDistribution/c\#-XX:+PrintTenuringDistribution' /cassandra/conf/jvm.options
+sed -i '/-XX:+PrintGCApplicationStoppedTime/c\#-XX:+PrintGCApplicationStoppedTime' /cassandra/conf/jvm.options
+sed -i '/-XX:+PrintPromotionFailure/c\#-XX:+PrintPromotionFailure' /cassandra/conf/jvm.options
+sed -i '/-XX:+UseGCLogFileRotation/c\#-XX:+UseGCLogFileRotation' /cassandra/conf/jvm.options
+sed -i '/-XX:NumberOfGCLogFiles=10/c\#-XX:NumberOfGCLogFiles=10' /cassandra/conf/jvm.options
+sed -i '/-XX:GCLogFileSize=10M/c\#-XX:GCLogFileSize=10M' /cassandra/conf/jvm.options
+
+# TODO: Add native snappy lib. Native loader stacktraces in the cassandra log as a results, which is distracting.
+
+echo "*** Starting Cassandra"
+/cassandra/bin/cassandra -R
+
+timeout=300
+while [[ "$timeout" -gt 0 ]] && ! /cassandra/bin/cqlsh -e 'SHOW VERSION' localhost >/dev/null 2>/dev/null; do
+    echo "Waiting ${timeout} seconds for cassandra to come up"
+    sleep 10
+    timeout=$(($timeout - 10))
+done
+
+echo "*** Importing Scheme"
+cat /zipkin-schemas/cassandra-schema.cql | /cassandra/bin/cqlsh --debug localhost
+cat /zipkin-schemas/zipkin2-schema.cql | /cassandra/bin/cqlsh --debug localhost
+cat /zipkin-schemas/zipkin2-schema.cql | sed 's/ zipkin2/ zipkin2_udts/g' | /cassandra/bin/cqlsh --debug localhost
+cat /zipkin-schemas/zipkin2-schema-indexes.cql | /cassandra/bin/cqlsh --debug localhost
+
+echo "*** Adding custom UDFs to zipkin2 keyspace"
+/cassandra/bin/cqlsh -e "CREATE FUNCTION zipkin2.plus (x bigint, y bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return x+y;';"
+/cassandra/bin/cqlsh -e "CREATE FUNCTION zipkin2.minus (x bigint, y bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return x-y;';"
+/cassandra/bin/cqlsh -e "CREATE FUNCTION zipkin2.toTimestamp (x bigint) RETURNS NULL ON NULL INPUT RETURNS timestamp LANGUAGE java AS 'return new java.util.Date(x/1000);';"
+/cassandra/bin/cqlsh -e "CREATE FUNCTION zipkin2.value (x map<text,text>, y text) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE java AS 'return x.get(y);';"
+
+echo "*** Stopping Cassandra"
+pkill -f java
+
+echo "*** Cleaning Up"
+apk del python --purge
+rm -rf /cassandra/javadoc/ /cassandra/pylib/ /cassandra/tools/ /cassandra/lib/*.zip /zipkin-schemas/
+
+echo "*** Changing to cassandra user"
+adduser -S cassandra
+
+# Take a backup so that we can safely mount an empty volume over the data directory and maintain the schema
+cp -R /cassandra/data/ /cassandra/data-backup/
+
+chown -R cassandra /cassandra
+
+echo "*** Image build complete"

--- a/docker/storage/cassandra/run.sh
+++ b/docker/storage/cassandra/run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#
+# Copyright 2015-2019 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -e
+
+# If the schema has been removed due to mounting, restore from our backup. see: install.sh
+if [ ! -d "/cassandra/data/data/zipkin2" ]; then
+    cp -rf /cassandra/data-backup/* /cassandra/data/
+fi
+
+_ip_address() {
+	# scrape the first non-localhost IP address of the container
+	ip address | awk '
+		$1 == "inet" && $NF != "lo" {
+			gsub(/\/.+$/, "", $2)
+			print $2
+			exit
+		}
+	'
+}
+
+IP="$(_ip_address)"
+sed -i "/listen_address: localhost/clisten_address: $IP" /cassandra/conf/cassandra.yaml
+sed -i '/rpc_address: localhost/crpc_address: 0.0.0.0' /cassandra/conf/cassandra.yaml
+sed -i "/# broadcast_address: 1.2.3.4/cbroadcast_address: $IP" /cassandra/conf/cassandra.yaml
+sed -i "/# broadcast_rpc_address: 1.2.3.4/cbroadcast_rpc_address: $IP" /cassandra/conf/cassandra.yaml
+sed -i "/          - seeds: \"127.0.0.1\"/c\          - seeds: $IP" /cassandra/conf/cassandra.yaml
+
+exec /cassandra/bin/cassandra -f


### PR DESCRIPTION
Starting with just Cassandra for now as it's the most complicated build. Verified it works with ITCassandraStorage

Changes from `docker-zipkin`

- Removes custom config loader - it was for using a stripped down JRE without `java.beans` but our Java 8 image has had it since migrating from Azul to OpenJDK. And our Java 11 image has it too since spring, so no real worries of it going away

- Merges in our custom configuration (enable user defined functions, docker IP) using sed, similar to how official cassandra docker image works.