### PR TITLE
Makes sure Elasticsearch urls are allowed to be plain text on port 80

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplier.java
@@ -44,6 +44,8 @@ final class InitialEndpointSupplier implements Supplier<EndpointGroup> {
       URI url;
       if (hostText.startsWith("http://") || hostText.startsWith("https://")) {
         url = URI.create(hostText);
+      } else if (!sessionProtocol.isTls() && hostText.indexOf(':') == -1) {
+        url = URI.create(sessionProtocol.uriText() + "://" + hostText + ":9200");
       } else {
         url = URI.create(sessionProtocol.uriText() + "://" + hostText);
       }
@@ -71,15 +73,7 @@ final class InitialEndpointSupplier implements Supplier<EndpointGroup> {
 
   int getPort(URI url) {
     int port = url.getPort();
-    if (port == -1) {
-      if (sessionProtocol.isTls()) {
-        port = 443;
-      } else {
-        // Elasticsearch default plain-text port
-        port = 9200;
-      }
-    }
-    return port;
+    return port != -1 ? port : sessionProtocol.defaultPort();
   }
 
   static boolean isIpAddress(String address) {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
@@ -28,7 +28,14 @@ class InitialEndpointSupplierTest {
       .isEqualTo(new InitialEndpointSupplier(HTTPS, null).get());
   }
 
-  @Test void defaultsWhenNoPort() {
+  @Test void usesNaturalHttpPortsWhenUrls() {
+    assertThat(new InitialEndpointSupplier(HTTP, "http://localhost").get())
+      .isEqualTo(Endpoint.of("localhost", 80));
+    assertThat(new InitialEndpointSupplier(HTTPS, "https://localhost").get())
+      .isEqualTo(Endpoint.of("localhost", 443));
+  }
+
+  @Test void defaultsPlainHostsToPort9200() {
     assertThat(new InitialEndpointSupplier(HTTP, "localhost").get())
       .isEqualTo(Endpoint.of("localhost", 9200));
     assertThat(new InitialEndpointSupplier(HTTPS, "localhost").get())


### PR DESCRIPTION
Amazon provisioned ES is always on default HTTP ports. Whether advisable
or not, plain text HTTP is exposed. I accidentaly implied all
unspecified should default to 9200, when only plain hosts should.