### PR TITLE
Use project version to start docker hub build since travis build is n…

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -148,7 +148,9 @@ javadoc_to_gh_pages() {
 }
 
 run_docker_hub_build() {
-  curl -X POST -H "Content-Type: application/json" -d "{\"build\": \"true\", \"source_type\": \"Tag\", \"source_name\": \"${TRAVIS_TAG}\"}" "https://cloud.docker.com/api/build/v1/source/${DOCKER_HUB_SERVICE_UUID}/trigger/${DOCKER_HUB_TRIGGER_UUID}/call/"
+  project_version="$(print_project_version)"
+  echo "Starting Docker Hub build for ${project_version}"
+  curl -X POST -H "Content-Type: application/json" -d "{\"build\": \"true\", \"source_type\": \"Tag\", \"source_name\": \"${project_version}\"}" "https://cloud.docker.com/api/build/v1/source/${DOCKER_HUB_SERVICE_UUID}/trigger/${DOCKER_HUB_TRIGGER_UUID}/call/"
 }
 
 #----------------------


### PR DESCRIPTION
…ot a tag build.

Realized the deploy build happens on master branch build, not tag build.