### PR TITLE
Optimize image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 **/.*
 !.dockerignore
 !.git
+!docker/zipkin/**
 !**/.eslintrc
 
 **/*.test.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,10 +27,6 @@ RUN mvn -B --no-transfer-progress package -DskipTests=true -pl zipkin-server -am
 RUN mkdir -p /zipkin && cp zipkin-server/target/zipkin-server-*-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar
 RUN mkdir -p /zipkin-slim && cp zipkin-server/target/zipkin-server-*-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
 
-# statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
-RUN cd /zipkin && echo .:$(ls BOOT-INF/lib/*.jar|awk '{print "/zipkin/"$0}' |tr '\n' ':')/zipkin/BOOT-INF/classes > classpath
-RUN cd /zipkin-slim && echo .:$(ls BOOT-INF/lib/*.jar|awk '{print "/zipkin/"$0}' |tr '\n' ':')/zipkin/BOOT-INF/classes > classpath
-
 FROM maven:3-jdk-11-slim as zipkin-builder
 
 COPY --from=built /root/.m2 /root/.m2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,10 @@ RUN mvn -B --no-transfer-progress package -DskipTests=true -pl zipkin-server -am
 RUN mkdir -p /zipkin && cp zipkin-server/target/zipkin-server-*-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar
 RUN mkdir -p /zipkin-slim && cp zipkin-server/target/zipkin-server-*-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
 
+# statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
+RUN cd /zipkin && echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath
+RUN cd /zipkin-slim && echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath
+
 FROM maven:3-jdk-11-slim as zipkin-builder
 
 COPY --from=built /root/.m2 /root/.m2
@@ -62,16 +66,12 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 # Use to set heap, trust store or other system properties.
 ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
 
-# Add environment settings for supported storage types
-COPY --from=built /zipkin-slim/ /zipkin/
-COPY docker/zipkin/ /zipkin/
-WORKDIR /zipkin
+RUN adduser -g '' -h /zipkin -D zipkin && ln -s /busybox/* /bin
 
-RUN adduser -g '' -h /zipkin -D zipkin && \
-    chown -R zipkin /zipkin && \
-    # statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
-    echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath && \
-    ln -s /busybox/* /bin
+COPY --from=built --chown=zipkin /zipkin-slim/ /zipkin/
+# Add environment settings for supported storage types
+COPY --chown=zipkin docker/zipkin/ /zipkin/
+WORKDIR /zipkin
 
 USER zipkin
 
@@ -119,16 +119,12 @@ ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
 # 3rd party modules like zipkin-aws will apply profile settings with this
 ENV MODULE_OPTS=
 
-# Add environment settings for supported storage types
-COPY --from=built /zipkin/ /zipkin/
-COPY docker/zipkin/ /zipkin/
-WORKDIR /zipkin
+RUN adduser -g '' -h /zipkin -D zipkin && ln -s /busybox/* /bin
 
-RUN adduser -g '' -h /zipkin -D zipkin && \
-    chown -R zipkin /zipkin && \
-    # statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
-    echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath && \
-    ln -s /busybox/* /bin
+COPY --from=built --chown=zipkin /zipkin/ /zipkin/
+# Add environment settings for supported storage types
+COPY --chown=zipkin docker/zipkin/ /zipkin/
+WORKDIR /zipkin
 
 USER zipkin
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,8 @@ RUN mkdir -p /zipkin && cp zipkin-server/target/zipkin-server-*-exec.jar /zipkin
 RUN mkdir -p /zipkin-slim && cp zipkin-server/target/zipkin-server-*-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
 
 # statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
-RUN cd /zipkin && echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath
-RUN cd /zipkin-slim && echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath
+RUN cd /zipkin && echo .:$(ls BOOT-INF/lib/*.jar|awk '{print "/zipkin/"$0}' |tr '\n' ':')/zipkin/BOOT-INF/classes > classpath
+RUN cd /zipkin-slim && echo .:$(ls BOOT-INF/lib/*.jar|awk '{print "/zipkin/"$0}' |tr '\n' ':')/zipkin/BOOT-INF/classes > classpath
 
 FROM maven:3-jdk-11-slim as zipkin-builder
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -35,6 +35,10 @@ RUN mvn org.apache.maven.plugins:maven-dependency-plugin:get \
 RUN mkdir -p /zipkin && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar
 RUN mkdir -p /zipkin-slim && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
 
+# statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
+RUN cd /zipkin && echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath
+RUN cd /zipkin-slim && echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath
+
 # Extract zipkin-lens
 RUN mkdir -p /zipkin-lens && cp /zipkin/BOOT-INF/lib/zipkin-lens-${version}.jar /zipkin-lens && cd /zipkin-lens && jar xf *.jar && rm *.jar
 
@@ -68,16 +72,12 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 # Use to set heap, trust store or other system properties.
 ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
 
-# Add environment settings for supported storage types
-COPY --from=built /zipkin-slim/ /zipkin/
-COPY docker/zipkin/ /zipkin/
-WORKDIR /zipkin
+RUN adduser -g '' -h /zipkin -D zipkin && ln -s /busybox/* /bin
 
-RUN adduser -g '' -h /zipkin -D zipkin && \
-    chown -R zipkin /zipkin && \
-    # statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
-    echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath && \
-    ln -s /busybox/* /bin
+COPY --from=built --chown=zipkin /zipkin-slim/ /zipkin/
+# Add environment settings for supported storage types
+COPY --chown=zipkin docker/zipkin/ /zipkin/
+WORKDIR /zipkin
 
 USER zipkin
 
@@ -97,16 +97,12 @@ ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
 # 3rd party modules like zipkin-aws will apply profile settings with this
 ENV MODULE_OPTS=
 
-# Add environment settings for supported storage types
-COPY --from=built /zipkin/ /zipkin/
-COPY docker/zipkin/ /zipkin/
-WORKDIR /zipkin
+RUN adduser -g '' -h /zipkin -D zipkin && ln -s /busybox/* /bin
 
-RUN adduser -g '' -h /zipkin -D zipkin && \
-    chown -R zipkin /zipkin && \
-    # statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
-    echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath && \
-    ln -s /busybox/* /bin
+COPY --from=built --chown=zipkin /zipkin/ /zipkin/
+# Add environment settings for supported storage types
+COPY --chown=zipkin docker/zipkin/ /zipkin/
+WORKDIR /zipkin
 
 USER zipkin
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -36,8 +36,8 @@ RUN mkdir -p /zipkin && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/z
 RUN mkdir -p /zipkin-slim && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
 
 # statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
-RUN cd /zipkin && echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath
-RUN cd /zipkin-slim && echo .:$(ls ${PWD}/BOOT-INF/lib/*.jar|tr '\n' ':')${PWD}/BOOT-INF/classes > classpath
+RUN cd /zipkin && echo .:$(ls BOOT-INF/lib/*.jar|awk '{print "/zipkin/"$0}' |tr '\n' ':')/zipkin/BOOT-INF/classes > classpath
+RUN cd /zipkin-slim && echo .:$(ls BOOT-INF/lib/*.jar|awk '{print "/zipkin/"$0}' |tr '\n' ':')/zipkin/BOOT-INF/classes > classpath
 
 # Extract zipkin-lens
 RUN mkdir -p /zipkin-lens && cp /zipkin/BOOT-INF/lib/zipkin-lens-${version}.jar /zipkin-lens && cd /zipkin-lens && jar xf *.jar && rm *.jar

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -35,10 +35,6 @@ RUN mvn org.apache.maven.plugins:maven-dependency-plugin:get \
 RUN mkdir -p /zipkin && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar
 RUN mkdir -p /zipkin-slim && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
 
-# statically evaluate classpath to avoid https://github.com/docker/for-mac/issues/3643
-RUN cd /zipkin && echo .:$(ls BOOT-INF/lib/*.jar|awk '{print "/zipkin/"$0}' |tr '\n' ':')/zipkin/BOOT-INF/classes > classpath
-RUN cd /zipkin-slim && echo .:$(ls BOOT-INF/lib/*.jar|awk '{print "/zipkin/"$0}' |tr '\n' ':')/zipkin/BOOT-INF/classes > classpath
-
 # Extract zipkin-lens
 RUN mkdir -p /zipkin-lens && cp /zipkin/BOOT-INF/lib/zipkin-lens-${version}.jar /zipkin-lens && cd /zipkin-lens && jar xf *.jar && rm *.jar
 

--- a/docker/zipkin/run.sh
+++ b/docker/zipkin/run.sh
@@ -20,7 +20,7 @@ fi
 # Use main class directly if there are no modules, as it measured 14% faster from JVM running to available
 # verses PropertiesLauncher when using Zipkin was based on Spring Boot 2.1
 if [[ -z "$MODULE_OPTS" ]]; then
-  exec java ${JAVA_OPTS} -cp $(cat /zipkin/classpath) zipkin.server.ZipkinServer
+  exec java ${JAVA_OPTS} -cp '.:BOOT-INF/lib/*:BOOT-INF/classes' zipkin.server.ZipkinServer
 else
   exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher
 fi


### PR DESCRIPTION
`RUN chown` touches every file effectively doubling the size of the directory in the Docker image it seems. So we do need to make sure to use docker's native chowning.

Also moves classpath computation to build step since no need to do it every time the container starts