### PR TITLE
Updates to Spring Boot 2.2 and stops using proxyBeanMethods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <cassandra-driver-core.version>3.7.2</cassandra-driver-core.version>
     <jooq.version>3.12.1</jooq.version>
     <micrometer.version>1.3.0</micrometer.version>
-    <spring-boot.version>2.1.9.RELEASE</spring-boot.version>
+    <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -517,7 +517,7 @@
               <classifier>slim</classifier>
               <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
               <excludeGroupIds>
-                io.zipkin.java,com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
+                com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
               </excludeGroupIds>
               <excludes>
                 <!-- Actuator -->
@@ -536,12 +536,6 @@
                 <dependency>
                   <groupId>com.fasterxml.jackson.datatype</groupId>
                   <artifactId>jackson-datatype-jsr310</artifactId>
-                </dependency>
-
-                <!-- Brave -->
-                <dependency>
-                  <groupId>${armeria.groupId}</groupId>
-                  <artifactId>armeria-brave</artifactId>
                 </dependency>
 
                 <!-- Log4J 2 -->
@@ -572,6 +566,12 @@
 <!--                  <groupId>org.latencyutils</groupId>-->
 <!--                  <artifactId>LatencyUtils</artifactId>-->
 <!--                </dependency>-->
+
+                <!-- Static content for the Classic UI -->
+                <dependency>
+                  <groupId>io.zipkin.java</groupId>
+                  <artifactId>zipkin-ui</artifactId>
+                </dependency>
 
                 <!-- storage and collectors which have 3rd party deps -->
                 <dependency>

--- a/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
@@ -14,7 +14,6 @@
 package zipkin2.server.internal;
 
 import com.linecorp.armeria.spring.ArmeriaAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import zipkin2.server.internal.activemq.ZipkinActiveMQCollectorConfiguration;
 import zipkin2.server.internal.brave.ZipkinSelfTracingConfiguration;
@@ -30,7 +29,6 @@ import zipkin2.server.internal.rabbitmq.ZipkinRabbitMQCollectorConfiguration;
 import zipkin2.server.internal.scribe.ZipkinScribeCollectorConfiguration;
 import zipkin2.server.internal.ui.ZipkinUiConfiguration;
 
-@Configuration
 @Import({
   ArmeriaAutoConfiguration.class,
   ZipkinConfiguration.class,

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.core.annotation.Order;
 import zipkin2.server.internal.health.ZipkinHealthController;
 import zipkin2.server.internal.prometheus.ZipkinMetricsController;
 
-@Configuration
+@Configuration(proxyBeanMethods=false)
 public class ZipkinHttpConfiguration {
   public static final MediaType MEDIA_TYPE_ACTUATOR =
     MediaType.parse("application/vnd.spring-boot.actuator.v2+json;charset=UTF-8");

--- a/zipkin-server/src/main/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorConfiguration.java
@@ -19,7 +19,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
@@ -27,7 +26,6 @@ import zipkin2.collector.activemq.ActiveMQCollector;
 import zipkin2.storage.StorageComponent;
 
 /** Auto-configuration for {@link ActiveMQCollector}. */
-@Configuration
 @ConditionalOnClass(ActiveMQCollector.class)
 @EnableConfigurationProperties(ZipkinActiveMQCollectorProperties.class)
 @Conditional(ZipkinActiveMQCollectorConfiguration.ActiveMQUrlSet.class)

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import zipkin2.Call;
 import zipkin2.CheckResult;
 import zipkin2.Span;
@@ -45,7 +44,6 @@ import zipkin2.reporter.Sender;
 import zipkin2.server.internal.ConditionalOnSelfTracing;
 import zipkin2.storage.StorageComponent;
 
-@Configuration
 @EnableConfigurationProperties(SelfTracingProperties.class)
 @ConditionalOnSelfTracing
 public class ZipkinSelfTracingConfiguration {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/cassandra3/ZipkinCassandra3StorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/cassandra3/ZipkinCassandra3StorageConfiguration.java
@@ -16,7 +16,9 @@ package zipkin2.server.internal.cassandra3;
 import brave.Tracing;
 import brave.cassandra.driver.TracingSession;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -24,7 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import zipkin2.server.internal.ConditionalOnSelfTracing;
 import zipkin2.storage.StorageComponent;
 import zipkin2.storage.cassandra.CassandraStorage;
@@ -35,11 +37,11 @@ import zipkin2.storage.cassandra.CassandraStorage.SessionFactory;
  * contain a single span, which is TBinaryProtocol big-endian, then base64 encoded. Decoded spans
  * are stored asynchronously.
  */
-@Configuration
 @ConditionalOnClass(CassandraStorage.class)
 @EnableConfigurationProperties(ZipkinCassandra3StorageProperties.class)
 @ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "cassandra3")
 @ConditionalOnMissingBean(StorageComponent.class)
+@Import(ZipkinCassandra3StorageConfiguration.TracingSessionFactoryEnhancer.class)
 // This component is named .*Cassandra3.* even though the package already says cassandra3 because
 // Spring Boot configuration endpoints only printout the simple name of the class
 public class ZipkinCassandra3StorageConfiguration {
@@ -67,23 +69,31 @@ public class ZipkinCassandra3StorageConfiguration {
       .sessionFactory(sessionFactory).build();
   }
 
-  @Configuration
   @ConditionalOnSelfTracing
-  static class TracingSessionFactoryEnhancer implements BeanPostProcessor {
-
-    @Autowired(required = false) Tracing tracing;
+  static class TracingSessionFactoryEnhancer  implements BeanPostProcessor, BeanFactoryAware {
+    /**
+     * Need this to resolve cyclic instantiation issue with spring when instantiating with tracing.
+     *
+     * <p>Ref: <a href="https://stackoverflow.com/a/19688634">Tracking down cause of Spring's "not
+     * eligible for auto-proxying"</a></p>
+     */
+    BeanFactory beanFactory;
 
     @Override public Object postProcessBeforeInitialization(Object bean, String beanName) {
       return bean;
     }
 
     @Override public Object postProcessAfterInitialization(Object bean, String beanName) {
-      if (tracing == null) return bean;
-      if (bean instanceof SessionFactory) {
+      if (bean instanceof SessionFactory && beanFactory.containsBean("tracing")) {
         SessionFactory delegate = (SessionFactory) bean;
+        Tracing tracing = beanFactory.getBean(Tracing.class);
         return (SessionFactory) storage -> TracingSession.create(tracing, delegate.create(storage));
       }
       return bean;
+    }
+
+    @Override public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+      this.beanFactory = beanFactory;
     }
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
@@ -47,7 +47,7 @@ import zipkin2.storage.StorageComponent;
 
 import static zipkin2.server.internal.elasticsearch.ZipkinElasticsearchStorageProperties.Ssl;
 
-@Configuration
+@Configuration(proxyBeanMethods=false)
 @EnableConfigurationProperties(ZipkinElasticsearchStorageProperties.class)
 @ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "elasticsearch")
 @ConditionalOnMissingBean(StorageComponent.class)

--- a/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfiguration.java
@@ -19,7 +19,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
@@ -30,7 +29,6 @@ import zipkin2.storage.StorageComponent;
  * This collector consumes a topic, decodes spans from thrift messages and stores them subject to
  * sampling policy.
  */
-@Configuration
 @ConditionalOnClass(KafkaCollector.class)
 @Conditional(ZipkinKafkaCollectorConfiguration.KafkaBootstrapServersSet.class)
 @EnableConfigurationProperties(ZipkinKafkaCollectorProperties.class)

--- a/zipkin-server/src/main/java/zipkin2/server/internal/mysql/ZipkinMySQLStorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/mysql/ZipkinMySQLStorageConfiguration.java
@@ -24,13 +24,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import zipkin2.storage.StorageComponent;
 import zipkin2.storage.mysql.v1.MySQLStorage;
 
-@Configuration
 @EnableConfigurationProperties(ZipkinMySQLStorageProperties.class)
 @ConditionalOnClass(MySQLStorage.class)
 @ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "mysql")

--- a/zipkin-server/src/main/java/zipkin2/server/internal/mysql/ZipkinSelfTracingMySQLStorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/mysql/ZipkinSelfTracingMySQLStorageConfiguration.java
@@ -25,13 +25,11 @@ import org.jooq.impl.DefaultExecuteListenerProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import zipkin2.server.internal.ConditionalOnSelfTracing;
 
 /** Sets up the MySQL tracing in Brave as an initialization. */
 @ConditionalOnSelfTracing
 @ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "mysql")
-@Configuration
 class ZipkinSelfTracingMySQLStorageConfiguration extends DefaultExecuteListener {
 
   @Autowired ZipkinMySQLStorageProperties mysql;

--- a/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
@@ -42,7 +42,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.util.StringUtils;
 
-@Configuration
+@Configuration(proxyBeanMethods=false)
 public class ZipkinPrometheusMetricsConfiguration {
   // from io.micrometer.spring.web.servlet.WebMvcTags
   private static final Tag URI_NOT_FOUND = Tag.of("uri", "NOT_FOUND");

--- a/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorConfiguration.java
@@ -22,7 +22,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
@@ -30,7 +29,6 @@ import zipkin2.collector.rabbitmq.RabbitMQCollector;
 import zipkin2.storage.StorageComponent;
 
 /** Auto-configuration for {@link RabbitMQCollector}. */
-@Configuration
 @ConditionalOnClass(RabbitMQCollector.class)
 @Conditional(ZipkinRabbitMQCollectorConfiguration.RabbitMQAddressesOrUriSet.class)
 @EnableConfigurationProperties(ZipkinRabbitMQCollectorProperties.class)

--- a/zipkin-server/src/main/java/zipkin2/server/internal/scribe/ZipkinScribeCollectorConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/scribe/ZipkinScribeCollectorConfiguration.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
 import zipkin2.collector.scribe.ScribeCollector;
@@ -28,7 +27,6 @@ import zipkin2.storage.StorageComponent;
  * a single span, which is TBinaryProtocol big-endian, then base64 encoded. Decoded spans are stored
  * asynchronously.
  */
-@Configuration
 @ConditionalOnClass(ScribeCollector.class)
 @ConditionalOnProperty(value = "zipkin.collector.scribe.enabled", havingValue = "true")
 public class ZipkinScribeCollectorConfiguration {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -46,7 +46,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
 import zipkin2.server.internal.JsonUtil;
@@ -76,7 +75,6 @@ import static zipkin2.server.internal.ui.ZipkinUiProperties.DEFAULT_BASEPATH;
  * Since index.html links to hashed resource names, any change to it will orphan old resources.
  * That's why hashed resource age can be 365 days.
  */
-@Configuration
 @EnableConfigurationProperties({ZipkinUiProperties.class, CompressionProperties.class})
 @ConditionalOnProperty(name = "zipkin.ui.enabled", matchIfMissing = true)
 public class ZipkinUiConfiguration {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
@@ -32,7 +32,7 @@ import zipkin.server.ZipkinServer;
 import zipkin2.Component;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesEncoder;
-import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.Reporter;
 import zipkin2.storage.InMemoryStorage;
 import zipkin2.storage.QueryRequest;
 
@@ -60,7 +60,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
 @RunWith(SpringRunner.class)
 public class ITZipkinSelfTracing {
   @Autowired TracingStorageComponent storage;
-  @Autowired AsyncReporter<Span> reporter;
+  @Autowired Reporter<Span> reporter;
   @Autowired Server server;
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -43,7 +43,7 @@ import static zipkin2.storage.cassandra.v1.InternalForTests.writeDependencyLinks
 class ITCassandraStorage {
 
   @RegisterExtension CassandraStorageExtension backend =
-    new CassandraStorageExtension("openzipkin/zipkin-cassandra:2.17.1");
+    new CassandraStorageExtension("openzipkin/zipkin-cassandra:2.18.2");
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<CassandraStorage> {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -45,7 +45,7 @@ import static zipkin2.storage.cassandra.InternalForTests.writeDependencyLinks;
 class ITCassandraStorage {
 
   @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
-    "openzipkin/zipkin-cassandra:2.17.1");
+    "openzipkin/zipkin-cassandra:2.18.2");
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<CassandraStorage> {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class ITElasticsearchStorageV6 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch6:2.17.1");
+    "openzipkin/zipkin-elasticsearch6:2.18.2");
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class ITElasticsearchStorageV7 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch7:2.17.1");
+    "openzipkin/zipkin-elasticsearch7:2.18.2");
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -34,7 +34,7 @@ import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinDependenc
 class ITMySQLStorage {
 
   @RegisterExtension MySQLStorageExtension backend = new MySQLStorageExtension(
-    "openzipkin/zipkin-mysql:2.17.1");
+    "openzipkin/zipkin-mysql:2.18.2");
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<MySQLStorage> {


### PR DESCRIPTION
`proxyBeanMethods` is disablable in Spring 5.2, shipped with Spring Boot 2.2

Fixes https://github.com/openzipkin/zipkin/issues/2863