### PR TITLE
Remove invocation of Bean methods.

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/JsonUtil.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/JsonUtil.java
@@ -1,0 +1,31 @@
+package zipkin2.server.internal;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Utilities for working with JSON.
+ */
+public final class JsonUtil {
+
+  static final JsonFactory JSON_FACTORY = new JsonFactory();
+  static final DefaultPrettyPrinter.Indenter TWOSPACES_LF_INDENTER =
+    new DefaultIndenter("  ", "\n");
+
+  /**
+   * Creates a new {@link JsonGenerator} with pretty-printing enabled forcing {@code '\n'}
+   * between lines, as opposed to Jackson's default which uses the system line separator.
+   */
+  public static JsonGenerator createGenerator(Writer writer) throws IOException {
+    JsonGenerator generator = JSON_FACTORY.createGenerator(writer);
+    DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+    prettyPrinter.indentArraysWith(TWOSPACES_LF_INDENTER);
+    prettyPrinter.indentObjectsWith(TWOSPACES_LF_INDENTER);
+    generator.setPrettyPrinter(prettyPrinter);
+    return generator;
+  }
+}

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
@@ -103,11 +103,11 @@ public class ZipkinSelfTracingConfiguration {
   }
 
   /** Controls aspects of tracing such as the name that shows up in the UI */
-  @Bean Tracing tracing(Reporter<Span> reporter) {
+  @Bean Tracing tracing(Reporter<Span> reporter, CurrentTraceContext currentTraceContext) {
     return Tracing.newBuilder()
       .localServiceName("zipkin-server")
       .sampler(Sampler.NEVER_SAMPLE) // don't sample traces at this abstraction
-      .currentTraceContext(currentTraceContext())
+      .currentTraceContext(currentTraceContext)
       // Reduce the impact on untraced downstream http services such as Elasticsearch
       .propagationFactory(B3SinglePropagation.FACTORY)
       .spanReporter(reporter)

--- a/zipkin-server/src/main/java/zipkin2/server/internal/health/ZipkinHealthController.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/health/ZipkinHealthController.java
@@ -13,7 +13,6 @@
  */
 package zipkin2.server.internal.health;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -26,14 +25,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import zipkin2.Component;
+import zipkin2.server.internal.JsonUtil;
 
 import static zipkin2.server.internal.ZipkinHttpConfiguration.MEDIA_TYPE_ACTUATOR;
 import static zipkin2.server.internal.health.ComponentHealth.STATUS_DOWN;
 import static zipkin2.server.internal.health.ComponentHealth.STATUS_UP;
 
 public class ZipkinHealthController {
-  static final JsonFactory JSON_FACTORY = new JsonFactory();
-
   final List<Component> components;
 
   ZipkinHealthController(List<Component> components) {
@@ -98,8 +96,7 @@ public class ZipkinHealthController {
 
   static String writeJsonError(String error) throws IOException {
     StringWriter writer = new StringWriter();
-    try (JsonGenerator generator = JSON_FACTORY.createGenerator(writer)) {
-      generator.useDefaultPrettyPrinter();
+    try (JsonGenerator generator = JsonUtil.createGenerator(writer)) {
       generator.writeStartObject();
       generator.writeStringField("status", STATUS_DOWN);
       generator.writeObjectFieldStart("zipkin");
@@ -115,8 +112,7 @@ public class ZipkinHealthController {
 
   static String writeJson(String overallStatus, List<ComponentHealth> healths) throws IOException {
     StringWriter writer = new StringWriter();
-    try (JsonGenerator generator = JSON_FACTORY.createGenerator(writer)) {
-      generator.useDefaultPrettyPrinter();
+    try (JsonGenerator generator = JsonUtil.createGenerator(writer)) {
       generator.writeStartObject();
       generator.writeStringField("status", overallStatus);
       generator.writeObjectFieldStart("zipkin");

--- a/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinMetricsController.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinMetricsController.java
@@ -13,7 +13,6 @@
  */
 package zipkin2.server.internal.prometheus;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -26,9 +25,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.prometheus.client.CollectorRegistry;
 import java.io.IOException;
 import java.io.StringWriter;
+import zipkin2.server.internal.JsonUtil;
 
 public class ZipkinMetricsController {
-  static final JsonFactory JSON_FACTORY = new JsonFactory();
 
   final MeterRegistry meterRegistry;
   final CollectorRegistry collectorRegistry;
@@ -42,8 +41,7 @@ public class ZipkinMetricsController {
   @Get("/metrics")
   public HttpResponse fetchMetricsFromMicrometer() throws IOException {
     StringWriter writer = new StringWriter();
-    JsonGenerator generator = JSON_FACTORY.createGenerator(writer);
-    generator.useDefaultPrettyPrinter();
+    JsonGenerator generator = JsonUtil.createGenerator(writer);
     generator.writeStartObject();
     // Get the Zipkin Custom meters for constructing the Metrics endpoint
     for (Meter meter : meterRegistry.getMeters()) {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
@@ -73,8 +73,9 @@ public class ZipkinPrometheusMetricsConfiguration {
     return new CollectorRegistry(true);
   }
 
-  @Bean @ConditionalOnMissingBean public PrometheusMeterRegistry prometheusMeterRegistry() {
-    return new PrometheusMeterRegistry(config(), registry(), clock());
+  @Bean @ConditionalOnMissingBean public PrometheusMeterRegistry prometheusMeterRegistry(
+    PrometheusConfig config, CollectorRegistry registry, Clock clock) {
+    return new PrometheusMeterRegistry(config, registry, clock);
   }
 
   // https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-spring-mvc

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
+import zipkin2.server.internal.JsonUtil;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static zipkin2.server.internal.ui.ZipkinUiProperties.DEFAULT_BASEPATH;
@@ -187,20 +188,20 @@ public class ZipkinUiConfiguration {
   // }
   static String writeConfig(ZipkinUiProperties ui) throws IOException {
     StringWriter writer = new StringWriter();
-    JsonGenerator generator = JSON_FACTORY.createGenerator(writer);
-    generator.useDefaultPrettyPrinter();
-    generator.writeStartObject();
-    generator.writeStringField("environment", ui.getEnvironment());
-    generator.writeBooleanField("suggestLens", ui.isSuggestLens());
-    generator.writeNumberField("queryLimit", ui.getQueryLimit());
-    generator.writeNumberField("defaultLookback", ui.getDefaultLookback());
-    generator.writeBooleanField("searchEnabled", ui.isSearchEnabled());
-    generator.writeObjectFieldStart("dependency");
-    generator.writeNumberField("lowErrorRate", ui.getDependency().getLowErrorRate());
-    generator.writeNumberField("highErrorRate", ui.getDependency().getHighErrorRate());
-    generator.writeEndObject(); // .dependency
-    generator.writeEndObject(); // .
-    generator.flush();
+    try (JsonGenerator generator = JsonUtil.createGenerator(writer)) {
+      generator.useDefaultPrettyPrinter();
+      generator.writeStartObject();
+      generator.writeStringField("environment", ui.getEnvironment());
+      generator.writeBooleanField("suggestLens", ui.isSuggestLens());
+      generator.writeNumberField("queryLimit", ui.getQueryLimit());
+      generator.writeNumberField("defaultLookback", ui.getDefaultLookback());
+      generator.writeBooleanField("searchEnabled", ui.isSearchEnabled());
+      generator.writeObjectFieldStart("dependency");
+      generator.writeNumberField("lowErrorRate", ui.getDependency().getLowErrorRate());
+      generator.writeNumberField("highErrorRate", ui.getDependency().getHighErrorRate());
+      generator.writeEndObject(); // .dependency
+      generator.writeEndObject(); // .
+    }
     return writer.toString();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.server.internal.prometheus;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.linecorp.armeria.server.Server;
@@ -40,7 +41,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.LOTS_OF_SPANS;
 import static zipkin2.server.internal.ITZipkinServer.url;
-import static zipkin2.server.internal.prometheus.ZipkinMetricsController.JSON_FACTORY;
 
 @SpringBootTest(
   classes = ZipkinServer.class,
@@ -203,7 +203,7 @@ public class ITZipkinMetrics {
 
   static Map<String, Integer> readJson(String json) throws Exception {
     Map<String, Integer> result = new LinkedHashMap<>();
-    JsonParser parser = JSON_FACTORY.createParser(json);
+    JsonParser parser = new JsonFactory().createParser(json);
     assertThat(parser.nextToken()).isEqualTo(JsonToken.START_OBJECT);
     String nextField;
     while ((nextField = parser.nextFieldName()) != null) {


### PR DESCRIPTION
Not allowed to invoke Bean methods when turning off proxying (being allowed to invoke them in the first place has always been a terrible feature of Spring anyways...).

I didn't take a detailed look at whether this fixes the failure in #2864 but not surprised if it does. Instead of examining and debugging failures, I just went through every reference in `@InternalZipkinConfiguration` and ctrl-clicked on `@Bean` methods to see if they have references.

Also overrides the pretty printer for Jackson so the output always uses `\n` so tests pass on Windows.