### PR TITLE
Workaround issue where docker-compose and docker won't share layers a…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,15 +12,22 @@
 # the License.
 #
 
+# We copy files from the context into a scratch container first to avoid a problem where docker and
+# docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
+# COPY --from= works around the issue.
+FROM scratch as scratch
+
+COPY . /code/
+
 #####
 # zipkin-builder - An image that caches build repositories (.m2, .npm) to speed up subsequent builds.
 #####
 
 FROM openzipkin/zipkin-builder as built
 
-WORKDIR /code
+COPY --from=scratch /code /code
 
-COPY . /code/
+WORKDIR /code
 
 RUN mvn -B --no-transfer-progress package -DskipTests=true -pl zipkin-server -am
 

--- a/docker/docker-compose-cassandra.yml
+++ b/docker/docker-compose-cassandra.yml
@@ -27,9 +27,9 @@ services:
   zipkin:
     build:
       context: ..
-      dockerfile: "${DOCKERFILE_PATH}"
+      dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH}"
+        version: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/docker-compose-elasticsearch6.yml
+++ b/docker/docker-compose-elasticsearch6.yml
@@ -27,9 +27,9 @@ services:
   zipkin:
     build:
       context: ..
-      dockerfile: "${DOCKERFILE_PATH}"
+      dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH}"
+        version: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/docker-compose-elasticsearch7.yml
+++ b/docker/docker-compose-elasticsearch7.yml
@@ -27,9 +27,9 @@ services:
   zipkin:
     build:
       context: ..
-      dockerfile: "${DOCKERFILE_PATH}"
+      dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH}"
+        version: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/docker-compose-slim-elasticsearch7.yml
+++ b/docker/docker-compose-slim-elasticsearch7.yml
@@ -27,9 +27,9 @@ services:
   zipkin-slim:
     build:
       context: ..
-      dockerfile: "${DOCKERFILE_PATH}"
+      dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH}"
+        version: "${SOURCE_BRANCH:-master}"
       target: zipkin-slim
     networks:
       default:

--- a/docker/docker-compose-ui.test.yml
+++ b/docker/docker-compose-ui.test.yml
@@ -22,7 +22,11 @@ services:
         aliases:
           - mysql
   zipkin:
-    image: "${IMAGE_NAME}"
+    build:
+      context: ..
+      dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
+      args:
+        version: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:
@@ -44,10 +48,10 @@ services:
   zipkin-ui:
     build:
       context: ..
-      dockerfile: "${DOCKERFILE_PATH}"
+      dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       target: zipkin-ui
       args:
-        version: "${SOURCE_BRANCH}"
+        version: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -22,7 +22,11 @@ services:
         aliases:
           - mysql
   zipkin:
-    image: "${IMAGE_NAME}"
+    build:
+      context: ..
+      dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
+      args:
+        version: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -49,9 +49,3 @@ for path in collector/kafka storage/cassandra storage/elasticsearch6 storage/ela
     docker tag "openzipkin/${image}:${TAGS[0]}" "openzipkin/${image}:$tag"
   done
 done
-
-if [[ "$DOCKER_TAG" == "master" ]]; then
-  # We rebuild the builder image on master push, not on release pushes.
-  echo Building zipkin-builder
-  docker build -f "$DOCKERFILE_PATH" -t openzipkin/zipkin-builder --target zipkin-builder .
-fi

--- a/docker/hooks/post_push
+++ b/docker/hooks/post_push
@@ -20,6 +20,9 @@ if [[ "$DOCKER_REPO" == "index.docker.io/openzipkin/zipkin" ]]; then
 
   if [[ "$DOCKER_TAG" == "master" ]]; then
     # We repush the builder image on master push, not on release pushes.
+    echo Building zipkin-builder
+    docker build -f "$DOCKERFILE_PATH" -t openzipkin/zipkin-builder --target zipkin-builder .
+
     echo Pushing zipkin-builder
     # zipkin-builder is just a cache of maven / npm dependencies, there's no need to version it
     # with docker tags.

--- a/docker/storage/cassandra/Dockerfile
+++ b/docker/storage/cassandra/Dockerfile
@@ -12,6 +12,16 @@
 # the License.
 #
 
+# We copy files from the context into a scratch container first to avoid a problem where docker and
+# docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
+# COPY --from= works around the issue.
+FROM scratch as scratch
+
+COPY zipkin-storage/cassandra/src/main/resources/*.cql /zipkin-schemas/
+COPY zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema.cql /zipkin-schemas/
+
+COPY docker/storage/cassandra/install.sh /usr/local/bin/install
+
 # Share the same base image to reduce layers used in testing
 FROM openzipkin/jre-full:1.8.0_212
 MAINTAINER OpenZipkin "http://zipkin.io/"
@@ -22,10 +32,9 @@ ENV CASSANDRA_VERSION=3.11.4 \
 
 WORKDIR /cassandra
 
-ADD zipkin-storage/cassandra/src/main/resources/*.cql /zipkin-schemas/
-ADD zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema.cql /zipkin-schemas/
+COPY --from=scratch /zipkin-schemas /zipkin-schemas
+COPY --from=scratch /usr/local/bin/install /usr/local/bin/install
 
-ADD docker/storage/cassandra/install.sh /usr/local/bin/install
 RUN /usr/local/bin/install
 
 # cassandra complains if run as root

--- a/docker/storage/mysql/Dockerfile
+++ b/docker/storage/mysql/Dockerfile
@@ -12,12 +12,19 @@
 # the License.
 #
 
+# We copy files from the context into a scratch container first to avoid a problem where docker and
+# docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
+# COPY --from= works around the issue.
+FROM scratch as scratch
+
+COPY docker/storage/mysql/*.sh /mysql/
+COPY zipkin-storage/mysql-v1/src/main/resources/mysql.sql /mysql/zipkin.sql
+
 FROM alpine
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 WORKDIR /mysql
-ADD docker/storage/mysql/*.sh /mysql/
-ADD zipkin-storage/mysql-v1/src/main/resources/mysql.sql /mysql/zipkin.sql
+COPY --from=scratch /mysql/* /mysql/
 
 RUN /mysql/install.sh
 


### PR DESCRIPTION
…nd build artifacts twice.

I found that docker-compose and docker repeat build steps if there are `COPY` or `ADD` instructions due to a bug that's hopefully fixed next year https://github.com/docker/docker-py/issues/998

Somehow I found a workaround by copying files into a scratch container first. It's a bit annoying, but on the flip side actually reduces layers on some of our images so maybe can be considered best practice anyways.

Also move rebuilding / pushing the builder cache to the end since it's lowest priority, and also shouldn't mess with other layer caches.