### PR TITLE
Move source_branch parsing into Dockerfile to allow it to work with b…

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -12,31 +12,35 @@
 # the License.
 #
 
-
 # Download artifact from bintray, where the artifact should have been published by now.
 
 FROM openzipkin/zipkin-builder as built
 
-ARG version
+ARG source_branch
 
+# source_branch is something like
+#
+#   master       - Building the master branch. This cut command will return 'master', and Dockerfiles will ignore it
+#   1.0.1        - Building a release image along with a new Zipkin server version. This cut command will return
+#                  '1.0.1' and Dockerfiles will use it to fetch the correct version of Zipkin.
+#   docker-1.0.1 - Building a release image, but not a new Zipkin server. This cut command will return
+#                  '1.0.1' and Dockerfiles will use it to fetch the correct version of Zipkin.
+
+RUN export version=$(echo "${source_branch}" | cut -d '-' -f 2) && \
 # Download jars using Maven. It will try to resolve the artifact from Maven Central, which might
 # not work right away if the sync is taking time, followed by bintray, which should always work
 # since it's where we publish to.
-
-RUN mvn org.apache.maven.plugins:maven-dependency-plugin:get \
-  -DremoteRepositories=bintray::::https://dl.bintray.com/openzipkin/maven -Dtransitive=false \
-  -Dartifact=io.zipkin:zipkin-server:${version}:jar:exec
-RUN mvn org.apache.maven.plugins:maven-dependency-plugin:get \
-  -DremoteRepositories=bintray::::https://dl.bintray.com/openzipkin/maven -Dtransitive=false \
-  -Dartifact=io.zipkin:zipkin-server:${version}:jar:slim
-
+  mvn org.apache.maven.plugins:maven-dependency-plugin:get \
+    -DremoteRepositories=bintray::::https://dl.bintray.com/openzipkin/maven -Dtransitive=false \
+    -Dartifact=io.zipkin:zipkin-server:${version}:jar:exec && \
+  mvn org.apache.maven.plugins:maven-dependency-plugin:get \
+    -DremoteRepositories=bintray::::https://dl.bintray.com/openzipkin/maven -Dtransitive=false \
+    -Dartifact=io.zipkin:zipkin-server:${version}:jar:slim && \
 # Extract the built out of the Maven repository
-
-RUN mkdir -p /zipkin && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar
-RUN mkdir -p /zipkin-slim && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
-
+  mkdir -p /zipkin && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar && \
+  mkdir -p /zipkin-slim && cp ~/.m2/repository/io/zipkin/zipkin-server/${version}/zipkin-server-${version}-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar && \
 # Extract zipkin-lens
-RUN mkdir -p /zipkin-lens && cp /zipkin/BOOT-INF/lib/zipkin-lens-${version}.jar /zipkin-lens && cd /zipkin-lens && jar xf *.jar && rm *.jar
+  mkdir -p /zipkin-lens && cp /zipkin/BOOT-INF/lib/zipkin-lens-${version}.jar /zipkin-lens && cd /zipkin-lens && jar xf *.jar && rm *.jar
 
 #####
 # zipkin-ui - An image containing the Zipkin web frontend only, served by NGINX

--- a/docker/docker-compose-cassandra.yml
+++ b/docker/docker-compose-cassandra.yml
@@ -29,7 +29,7 @@ services:
       context: ..
       dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH:-master}"
+        source_branch: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/docker-compose-elasticsearch6.yml
+++ b/docker/docker-compose-elasticsearch6.yml
@@ -29,7 +29,7 @@ services:
       context: ..
       dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH:-master}"
+        source_branch: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/docker-compose-elasticsearch7.yml
+++ b/docker/docker-compose-elasticsearch7.yml
@@ -29,7 +29,7 @@ services:
       context: ..
       dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH:-master}"
+        source_branch: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/docker-compose-slim-elasticsearch7.yml
+++ b/docker/docker-compose-slim-elasticsearch7.yml
@@ -29,7 +29,7 @@ services:
       context: ..
       dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH:-master}"
+        source_branch: "${SOURCE_BRANCH:-master}"
       target: zipkin-slim
     networks:
       default:

--- a/docker/docker-compose-ui.test.yml
+++ b/docker/docker-compose-ui.test.yml
@@ -26,7 +26,7 @@ services:
       context: ..
       dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH:-master}"
+        source_branch: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:
@@ -51,7 +51,7 @@ services:
       dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       target: zipkin-ui
       args:
-        version: "${SOURCE_BRANCH:-master}"
+        source_branch: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -26,7 +26,7 @@ services:
       context: ..
       dockerfile: "${DOCKERFILE_PATH:-docker/Dockerfile}"
       args:
-        version: "${SOURCE_BRANCH:-master}"
+        source_branch: "${SOURCE_BRANCH:-master}"
     networks:
       default:
         aliases:

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -9,17 +9,9 @@ set -v
 # to top level.
 cd ..
 
-# SOURCE_BRANCH is something like
-#
-#   master       - Building the master branch. This cut command will return 'master', and Dockerfiles will ignore it
-#   1.0.1        - Building a release image along with a new Zipkin server version. This cut command will return
-#                  '1.0.1' and Dockerfiles will use it to fetch the correct version of Zipkin.
-#   docker-1.0.1 - Building a release image, but not a new Zipkin server. This cut command will return
-#                  '1.0.1' and Dockerfiles will use it to fetch the correct version of Zipkin.
-VERSION=$(echo "$SOURCE_BRANCH" | cut -d '-' -f 2)
-echo "Building images for version $VERSION"
+echo "Building images for $SOURCE_BRANCH"
 
-docker build --build-arg version="$VERSION" -f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" .
+docker build --build-arg source_branch=${SOURCE_BRANCH} -f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" .
 
 IFS=',' read -ra TAGS <<< "$DOCKER_TAG"
 for tag in ${TAGS[@]}; do
@@ -28,14 +20,14 @@ done
 
 # We always build zipkin-slim
 echo Building zipkin-slim
-docker build --build-arg version="$VERSION" -f "$DOCKERFILE_PATH" -t "openzipkin/zipkin-slim:${TAGS[0]}" --target zipkin-slim .
+docker build --build-arg source_branch=${SOURCE_BRANCH} -f "$DOCKERFILE_PATH" -t "openzipkin/zipkin-slim:${TAGS[0]}" --target zipkin-slim .
 for tag in ${TAGS[@]:1}; do
   docker tag "openzipkin/zipkin-slim:${TAGS[0]}" "openzipkin/zipkin-slim:$tag"
 done
 
 # We always build test images formerly hosted on https://github.com/openzipkin/docker-zipkin
 echo Building zipkin-ui
-docker build --build-arg version="VERSION" -f "$DOCKERFILE_PATH" -t "openzipkin/zipkin-ui:${TAGS[0]}" --target zipkin-ui .
+docker build --build-arg source_branch=${SOURCE_BRANCH} -f "$DOCKERFILE_PATH" -t "openzipkin/zipkin-ui:${TAGS[0]}" --target zipkin-ui .
 for tag in ${TAGS[@]:1}; do
   docker tag "openzipkin/zipkin-ui:${TAGS[0]}" "openzipkin/zipkin-ui:$tag"
 done
@@ -44,7 +36,7 @@ done
 for path in collector/kafka storage/cassandra storage/elasticsearch6 storage/elasticsearch7 storage/mysql; do
   image=zipkin-$(basename ${path})
   echo Building ${image}
-  docker build --build-arg version="$VERSION" -f "docker/${path}/Dockerfile" -t "openzipkin/${image}:${TAGS[0]}" .
+  docker build --build-arg source_branch=${SOURCE_BRANCH} -f "docker/${path}/Dockerfile" -t "openzipkin/${image}:${TAGS[0]}" .
   for tag in ${TAGS[@]:1}; do
     docker tag "openzipkin/${image}:${TAGS[0]}" "openzipkin/${image}:$tag"
   done


### PR DESCRIPTION
…oth docker build and docker-compose

There isn't really a way to specify the variables available to the docker-compose tests, short of overriding the `test` hook completely. I think it's fine to move the logic for determining the version instead. This is so the `docker-*` tags can pass tests.