### PR TITLE
Adds final example assets formerly on docker-zipkin repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Once the server is running, you can view traces with the Zipkin UI at `http://yo
 
 If your applications aren't sending traces, yet, configure them with [Zipkin instrumentation](https://zipkin.io/pages/tracers_instrumentation) or try one of our [examples](https://github.com/openzipkin?utf8=%E2%9C%93&q=example).
 
-Check out the [`zipkin-server`](/zipkin-server) documentation for configuration details, or [`docker-zipkin`](https://github.com/openzipkin/docker-zipkin) for how to use docker-compose.
+Check out the [`zipkin-server`](/zipkin-server) documentation for configuration details, or [Docker examples](docker/examples) for how to use docker-compose.
 
 ## Core Library
 The [core library](zipkin/src/main/java/zipkin2) is used by both Zipkin instrumentation and the Zipkin server. Its minimum Java language level is 6, in efforts to support those writing agent instrumentation.
@@ -193,7 +193,7 @@ Releases are uploaded to [Bintray](https://bintray.com/openzipkin/maven/zipkin) 
 Snapshots are uploaded to [JFrog](https://oss.jfrog.org/artifactory/oss-snapshot-local) after commits to master.
 ### Docker Images
 Released versions of zipkin-server are published to Docker Hub as `openzipkin/zipkin`.
-See [docker-zipkin](https://github.com/openzipkin/docker-zipkin) for details.
+See [docker] for details.
 ### Javadocs
 https://zipkin.io/zipkin contains versioned folders with JavaDocs published on each (non-PR) build, as well
 as releases.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,16 +15,12 @@ in mind when choosing version numbers.
 
 1. **Wait for Travis CI**
 
-   This part is controlled by [`travis/publish.sh`](travis/publish.sh). It creates a bunch of new commits, bumps
-   the version, publishes artifacts, syncs to Maven Central, and publishes Javaocs to http://zipkin.io/zipkin
-   into a versioned subdirectory.
-   (Note: Javaocs are also published on all builds of master; due to versioning, it doesn't overwrite docs built
-   for releases.)
+   This part is controlled by [`travis/publish.sh`](travis/publish.sh). It creates a bunch of new
+   commits, bumps the version, publishes artifacts, syncs to Maven Central, invokes [docker] builds,
+   and publishes Javadocs to http://zipkin.io/zipkin into a versioned subdirectory.
+   (Note: Javadocs are also published on all builds of master; due to versioning, it doesn't
+   overwrite docs built for releases.)
 
-1. **Publish `docker-zipkin`**
-
-   Refer to [docker-zipkin/RELEASE.md](https://github.com/openzipkin/docker-zipkin/blob/master/RELEASE.md).
-   
 ## Credentials
 
 Credentials of various kind are needed for the release process to work. If you notice something
@@ -162,7 +158,7 @@ creating a couple commit, pushing a tag, and running deploy.
 
 Assuming you are on branch 2.4.x and you want to release 2.4.5.
 ```bash
-$ ./mvnw versions:set -DnewVersion=2.4.5 -DgenerateBackupPoms=false 
+$ ./mvnw versions:set -DnewVersion=2.4.5 -DgenerateBackupPoms=false
 # edit the pom and change <tag>HEAD</tag> to <tag>2.4.5</tag>
 $ git commit -am"prepare to release 2.4.5"
 $ git tag 2.4.5
@@ -187,7 +183,7 @@ release branch.
 
 Assuming you are on branch 2.4.x and you just released 2.4.5.
 ```bash
-$ ./mvnw versions:set -DnewVersion=2.4.6-SNAPSHOT -DgenerateBackupPoms=false 
+$ ./mvnw versions:set -DnewVersion=2.4.6-SNAPSHOT -DgenerateBackupPoms=false
 # edit the pom and change <tag>2.4.5</tag> to <tag>HEAD</tag>
 $ git commit -am"prepare next version"
 $ git push origin 2.4.x

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,18 +6,6 @@ The only Zipkin production images built here:
 * openzipkin/zipkin: The core server image that hosts the Zipkin UI, Api and Collector features.
 * openzipkin/zipkin-slim: The stripped server image that hosts the Zipkin UI and Api features, but only supports in-memory or Elasticsearch storage with HTTP or gRPC span collectors.
 
-To build `openzipkin/zipkin`, from the top level of the repository, run:
-
-```bash
-$ docker build -t openzipkin/zipkin:test -f docker/Dockerfile .
-```
-
-If you want the slim distribution instead, run:
-
-```bash
-$ docker build -t openzipkin/zipkin-slim:test -f docker/Dockerfile . --target zipkin-slim
-```
-
 ## Testing images
 
 We also provide a number images that are not for production, rather to simplify demos and
@@ -31,3 +19,72 @@ base layer `openzipkin/zipkin`, and setting up schema where relevant.
 * [openzipkin/zipkin-mysql](storage/mysql/README.md) - runs MySQL initialized with Zipkin's schema
 * [openzipkin/zipkin-ui](lens/README.md) - serves the (Lens) UI directly with NGINX
 
+## Getting started
+
+Zipkin has no dependencies, for example you can run an in-memory zipkin server like so:
+`docker run -d -p 9411:9411 openzipkin/zipkin-slim`
+
+See the ui at (docker ip):9411
+
+In the ui - click zipkin-server, then click "Find Traces".
+
+We also provide [example compose files](examples/README.md) that integrate collectors and storage,
+such as Kafka or Elasticsearch.
+
+## Configuration
+Configuration is via environment variables, defined by [zipkin-server](https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md). Notably, you'll want to look at the `STORAGE_TYPE` environment variables, which
+include "cassandra", "mysql" and "elasticsearch".
+
+Note: the `openzipkin/zipkin-slim` image only supports "elasticsearch" storage. To use other storage types, you must use the main image `openzipkin/zipkin`.
+
+When in docker, the following environment variables also apply
+
+* `JAVA_OPTS`: Use to set java arguments, such as heap size or trust store location.
+* `STORAGE_PORT_9042_TCP_ADDR` -- A Cassandra node listening on port 9042. This
+  environment variable is typically set by linking a container running
+  `zipkin-cassandra` as "storage" when you start the container.
+* `STORAGE_PORT_3306_TCP_ADDR` -- A MySQL node listening on port 3306. This
+  environment variable is typically set by linking a container running
+  `zipkin-mysql` as "storage" when you start the container.
+* `STORAGE_PORT_9200_TCP_ADDR` -- An Elasticsearch node listening on port 9200. This
+  environment variable is typically set by linking a container running
+  `zipkin-elasticsearch` as "storage" when you start the container. This is ignored
+  when `ES_HOSTS` or `ES_AWS_DOMAIN` are set.
+* `KAFKA_PORT_2181_TCP_ADDR` -- A zookeeper node listening on port 2181. This
+  environment variable is typically set by linking a container running
+  `zipkin-kafka` as "kafka" when you start the container.
+
+For example, to add debug logging, set JAVA_OPTS as shown in our [docker-compose](docker-compose.yml) file:
+```yaml
+      - JAVA_OPTS=-Dlogging.level.zipkin=DEBUG -Dlogging.level.zipkin2=DEBUG
+```
+
+## Runtime user
+The `openzipkin/zipkin` and `openzipkin/zipkin-slim` images run under a nologin
+user named 'zipkin' with a home directory of '/zipkin'. As this is a distroless
+image, you won't find many utilities installed, but you can browse contents
+with a shell like below:
+
+```bash
+$ docker run -it --rm --entrypoint /busybox/sh openzipkin/zipkin
+/zipkin $ ls
+BOOT-INF  META-INF  org       run.sh
+```
+
+## Notes
+
+If using an external MySQL server or image, ensure schema and other parameters match the [docs](https://github.com/openzipkin/zipkin/tree/master/zipkin-storage/mysql-v1#applying-the-schema).
+
+## Building images
+
+To build `openzipkin/zipkin`, from the top level of the repository, run:
+
+```bash
+$ docker build -t openzipkin/zipkin:test -f docker/Dockerfile .
+```
+
+If you want the slim distribution instead, run:
+
+```bash
+$ docker build -t openzipkin/zipkin-slim:test -f docker/Dockerfile . --target zipkin-slim
+```

--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -1,0 +1,114 @@
+# Zipkin Docker Examples
+
+This project is configured to run docker containers using
+[docker-compose](https://docs.docker.com/compose/). Note that the default
+configuration requires docker-compose 1.6.0+ and docker-engine 1.10.0+.
+
+To start the default docker-compose configuration, run:
+
+    $ docker-compose up
+
+View the web UI at $(docker ip):9411.
+
+To see specific traces in the UI, select "zipkin-server" in the dropdown and
+then click the "Find Traces" button.
+
+## Slim
+To start a smaller and faster distribution of zipkin, run:
+
+```bash
+$ docker-compose -f docker-compose-slim.yml up
+```
+
+This starts in-memory storage. The only other supported option for slim is Elasticsearch:
+
+```bash
+$ docker-compose -f docker-compose-slim.yml -f docker-compose-elasticsearch.yml up
+```
+
+## MySQL
+
+The default docker-compose configuration defined in `docker-compose.yml` is
+backed by [MySQL](../storage/mysql/README.md). This configuration starts `zipkin`, `zipkin-mysql`
+and `zipkin-dependencies` (cron job) in their own containers.
+
+## Cassandra
+
+The docker-compose configuration can be extended to use [Cassandra](../storage/cassandra/README.md)
+instead of MySQL, using the `docker-compose-cassandra.yml` file. That file employs
+[docker-compose overrides](https://docs.docker.com/compose/extends/#multiple-compose-files)
+to swap out one storage container for another.
+
+To start the Cassandra-backed configuration, run:
+
+    $ docker-compose -f docker-compose.yml -f docker-compose-cassandra.yml up
+
+## Elasticsearch
+
+The docker-compose configuration can be extended to use [Elasticsearch](../storage/elasticsearch7/README.md)
+instead of MySQL, using the `docker-compose-elasticsearch.yml` file. That file employs
+[docker-compose overrides](https://docs.docker.com/compose/extends/#multiple-compose-files)
+to swap out one storage container for another.
+
+To start the Elasticsearch-backed configuration, run:
+
+    $ docker-compose -f docker-compose.yml -f docker-compose-elasticsearch.yml up
+
+## Kafka
+
+The docker-compose configuration can be extended to host a test [Kafka broker](../collector/kafka/README.md)
+and activate the [Kafka collector](../../zipkin-collector/kafka) using the `docker-compose-kafka.yml`
+file. That file employs [docker-compose overrides](https://docs.docker.com/compose/extends/#multiple-compose-files)
+to add a Kafka+ZooKeeper container and relevant settings.
+
+To start the MySQL+Kafka configuration, run:
+
+    $ docker-compose -f docker-compose.yml -f docker-compose-kafka.yml up
+
+Then configure the [Kafka sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java) using a `bootstrapServers` value of `host.docker.internal:9092` if your application is inside the same docker network or `localhost:19092` if not, but running on the same host.
+
+In other words, if you are running a sample application on your laptop, you would use `localhost:19092` bootstrap server to send spans to the Kafka broker running in Docker.
+
+### Docker machine and Kafka
+
+If you are using Docker machine, adjust `KAFKA_ADVERTISED_HOST_NAME` in `docker-compose-kafka.yml`
+and the `bootstrapServers` configuration of the kafka sender to match your Docker host IP (ex. 192.168.99.100:19092).
+
+## UI
+
+The docker-compose configuration can be extended to host the [UI](../lens/README.md) on port 80
+using the `docker-compose-ui.yml` file. That file employs
+[docker-compose overrides](https://docs.docker.com/compose/extends/#multiple-compose-files)
+to add an NGINX container and relevant settings.
+
+To start the NGINX configuration, run:
+
+    $ docker-compose -f docker-compose.yml -f docker-compose-ui.yml up
+
+This container doubles as a skeleton for creating proxy configuration around
+Zipkin like authentication, dealing with CORS with zipkin-js apps, or
+terminating SSL.
+
+## Prometheus
+
+Zipkin comes with a built-in Prometheus metric exporter. The main
+`docker-compose.yml` file starts Prometheus configured to scrape Zipkin, exposes
+it on port `9090`. You can open `$DOCKER_HOST_IP:9090` and start exploring the
+metrics (which are available on the `/prometheus` endpoint of Zipkin).
+
+`docker-compose.yml` also starts a Grafana container with authentication
+disabled, exposing it on port 3000. On startup it's configured with the
+Prometheus instance started by `docker-compose` as a data source, and imports
+the dashboard published at https://grafana.com/dashboards/1598. This means that,
+after running `docker-compose up`, you can open
+`$DOCKER_IP:3000/dashboard/db/zipkin-prometheus` and play around with the
+dashboard.
+
+If you want to run the zipkin-ui standalone against a remote zipkin server, you
+need to set `ZIPKIN_BASE_URL` accordingly:
+
+```bash
+$ docker run -d -p 80:80 \
+  -e ZIPKIN_BASE_URL=http://myfavoritezipkin:9411 \
+  openzipkin/zipkin-ui
+```

--- a/docker/examples/docker-compose-cassandra.yml
+++ b/docker/examples/docker-compose-cassandra.yml
@@ -1,0 +1,33 @@
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml to run the
+# zipkin-cassandra container instead of the zipkin-mysql container.
+
+version: '2'
+
+services:
+  # Run Cassandra instead of MySQL
+  storage:
+    image: openzipkin/zipkin-cassandra
+    container_name: cassandra
+    # Uncomment to expose the storage port for testing
+    # ports:
+    #   - 9042:9042
+
+  # Switch storage type to Cassandra
+  zipkin:
+    environment:
+      - STORAGE_TYPE=cassandra3
+      # When using the test docker image, or have schema pre-installed, you don't need to re-install it
+      - CASSANDRA_ENSURE_SCHEMA=false
+      # When overriding this value, note the minimum supported version is 3.9
+      # If you you cannot run 3.9+, but can run 2.2+, set STORAGE_TYPE=cassandra
+      - CASSANDRA_CONTACT_POINTS=cassandra
+    depends_on:
+      - storage
+
+  dependencies:
+    environment:
+      - STORAGE_TYPE=cassandra3
+      - CASSANDRA_CONTACT_POINTS=cassandra

--- a/docker/examples/docker-compose-elasticsearch-aws.yml
+++ b/docker/examples/docker-compose-elasticsearch-aws.yml
@@ -1,0 +1,30 @@
+# This runs zipkin against an Amazon Elasticsearch Service
+#
+# Note that this file is meant for learning Zipkin, not production deployments.
+
+version: '2'
+
+services:
+  zipkin:
+    image: openzipkin/zipkin-aws
+    container_name: zipkin
+    environment:
+      - STORAGE_TYPE=elasticsearch
+      # This is an alternative to ES_HOSTS=https://search-zipkin-2rlyh66ibw43ftlk4342ceeewu.ap-southeast-1.es.amazonaws.com
+      - ES_AWS_DOMAIN=zipkin
+      # When ES backs up it doesn't always error, sometimes it will timeout
+      - ES_TIMEOUT=20000
+      # - ES_HTTP_LOGGING=HEADERS
+    volumes:
+      # Share your credentials with your docker image so it can access your Elasticsearch domain
+      - ~/.aws:/zipkin/.aws:ro
+    ports:
+      # Port used for the Zipkin UI and HTTP Api
+      - 9411:9411
+
+  # disable storage as we're using the cloud!
+  storage:
+    image: hello-world
+    container_name: storage-disabled
+    logging:
+      driver: none

--- a/docker/examples/docker-compose-elasticsearch.yml
+++ b/docker/examples/docker-compose-elasticsearch.yml
@@ -1,0 +1,30 @@
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml to run the
+# zipkin-elasticsearch container instead of the zipkin-mysql container.
+
+version: '2'
+
+services:
+  # Run Elasticsearch instead of MySQL
+  storage:
+    image: openzipkin/zipkin-elasticsearch7
+    container_name: elasticsearch
+    # Uncomment to expose the storage port for testing
+    # ports:
+    #   - 9200:9200
+
+  # Switch storage type to Elasticsearch
+  zipkin:
+    environment:
+      - STORAGE_TYPE=elasticsearch
+      # Point the zipkin at the storage backend
+      - ES_HOSTS=elasticsearch:9200
+      # Uncomment to see requests to and from elasticsearch
+      # - ES_HTTP_LOGGING=BODY
+
+  dependencies:
+    environment:
+      - STORAGE_TYPE=elasticsearch
+      - ES_HOSTS=elasticsearch

--- a/docker/examples/docker-compose-kafka.yml
+++ b/docker/examples/docker-compose-kafka.yml
@@ -1,0 +1,28 @@
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml to add a test
+# kafka server, which is used as a span transport.
+
+version: '2'
+
+services:
+  kafka-zookeeper:
+    image: openzipkin/zipkin-kafka
+    container_name: kafka-zookeeper
+    # If using docker machine, uncomment the below and set your bootstrap
+    # server list to 192.168.99.100:19092
+    # environment:
+      # - KAFKA_ADVERTISED_HOST_NAME=192.168.99.100
+    ports:
+      - 2181:2181
+      - 9092:9092
+      # port 19092 is listening on localhost by default. In normal Docker,
+      # you can set your bootstrap server list to localhost:19092
+      - 19092:19092
+
+  zipkin:
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka-zookeeper:9092
+    depends_on:
+      - kafka-zookeeper

--- a/docker/examples/docker-compose-mem.yml
+++ b/docker/examples/docker-compose-mem.yml
@@ -1,0 +1,28 @@
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# This runs the zipkin and zipkin-mysql containers, using docker-compose's
+# default networking to wire the containers together.
+#
+# Note that this file is meant for learning Zipkin, not production deployments.
+
+version: '2'
+
+services:
+  # The zipkin process services the UI, and also exposes a POST endpoint that
+  # instrumentation can send trace data to. Scribe is enabled by default.
+  zipkin:
+    image: openzipkin/zipkin
+    container_name: zipkin
+    # Environment settings are defined here https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md#environment-variables
+    environment:
+      - STORAGE_TYPE=mem
+      # Uncomment to disable scribe
+      # - SCRIBE_ENABLED=false
+      # Uncomment to enable self-tracing
+      # - SELF_TRACING_ENABLED=true
+      # Uncomment to enable debug logging
+      # - JAVA_OPTS=-Dlogging.level.zipkin=DEBUG
+    ports:
+      # Port used for the Zipkin UI and HTTP Api
+      - 9411:9411

--- a/docker/examples/docker-compose-slim.yml
+++ b/docker/examples/docker-compose-slim.yml
@@ -1,0 +1,38 @@
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# This runs the zipkin and zipkin-mysql containers, using docker-compose's
+# default networking to wire the containers together.
+#
+# Note that this file is meant for learning Zipkin, not production deployments.
+
+version: '2'
+
+services:
+  # The zipkin process services the UI, and also exposes a POST endpoint that
+  # instrumentation can send trace data to.
+  zipkin:
+    image: openzipkin/zipkin-slim
+    container_name: zipkin
+    # Environment settings are defined here https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md#environment-variables
+    environment:
+      - STORAGE_TYPE=mem
+      # Uncomment to enable self-tracing
+      # - SELF_TRACING_ENABLED=true
+      # Uncomment to enable debug logging
+      # - JAVA_OPTS=-Dorg.slf4j.simpleLogger.log.zipkin2=debug
+    ports:
+      # Port used for the Zipkin UI and HTTP Api
+      - 9411:9411
+    depends_on:
+      - storage
+
+  # Fake services allow us to compose with docker-compose-elasticsearch.yml
+  # BusyBox is pinned to prevent repetitive image pulls for no-op services
+  storage:
+    image: busybox:1.31.0
+    container_name: fake_storage
+
+  dependencies:
+    image: busybox:1.31.0
+    container_name: fake_dependencies

--- a/docker/examples/docker-compose-ui.yml
+++ b/docker/examples/docker-compose-ui.yml
@@ -1,0 +1,19 @@
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml, hosting the
+# ui on port 80 using NGINX
+
+version: '2'
+
+services:
+  zipkin-ui:
+    image: openzipkin/zipkin-ui
+    container_name: zipkin-ui
+    environment:
+      # Change this if connecting to a different zipkin server
+      - ZIPKIN_BASE_URL=http://zipkin:9411
+    ports:
+      - 80:80
+    depends_on:
+      - zipkin

--- a/docker/examples/docker-compose.yml
+++ b/docker/examples/docker-compose.yml
@@ -1,0 +1,92 @@
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# This runs the zipkin and zipkin-mysql containers, using docker-compose's
+# default networking to wire the containers together.
+#
+# Note that this file is meant for learning Zipkin, not production deployments.
+
+version: '2'
+
+services:
+  storage:
+    image: openzipkin/zipkin-mysql
+    container_name: mysql
+    # Uncomment to expose the storage port for testing
+    # ports:
+    #   - 3306:3306
+
+  # The zipkin process services the UI, and also exposes a POST endpoint that
+  # instrumentation can send trace data to. Scribe is disabled by default.
+  zipkin:
+    image: openzipkin/zipkin
+    container_name: zipkin
+    # Environment settings are defined here https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md#environment-variables
+    environment:
+      - STORAGE_TYPE=mysql
+      # Point the zipkin at the storage backend
+      - MYSQL_HOST=mysql
+      # Uncomment to enable scribe
+      # - SCRIBE_ENABLED=true
+      # Uncomment to enable self-tracing
+      # - SELF_TRACING_ENABLED=true
+      # Uncomment to enable debug logging
+      # - JAVA_OPTS=-Dlogging.level.zipkin2=DEBUG
+    ports:
+      # Port used for the Zipkin UI and HTTP Api
+      - 9411:9411
+      # Uncomment if you set SCRIBE_ENABLED=true
+      # - 9410:9410
+    depends_on:
+      - storage
+
+  # Adds a cron to process spans since midnight every hour, and all spans each day
+  # This data is served by http://192.168.99.100:8080/dependency
+  #
+  # For more details, see https://github.com/openzipkin/docker-zipkin-dependencies
+  dependencies:
+    image: openzipkin/zipkin-dependencies
+    container_name: dependencies
+    entrypoint: crond -f
+    environment:
+      - STORAGE_TYPE=mysql
+      - MYSQL_HOST=mysql
+      # Add the baked-in username and password for the zipkin-mysql image
+      - MYSQL_USER=zipkin
+      - MYSQL_PASS=zipkin
+      # Uncomment to see dependency processing logs
+      # - ZIPKIN_LOG_LEVEL=DEBUG
+      # Uncomment to adjust memory used by the dependencies job
+      # - JAVA_OPTS=-verbose:gc -Xms1G -Xmx1G
+    depends_on:
+      - storage
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - 9090:9090
+    depends_on:
+      - storage
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - 3000:3000
+    depends_on:
+      - prometheus
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+
+  setup_grafana_datasource:
+    image: appropriate/curl
+    container_name: setup_grafana_datasource
+    depends_on:
+      - grafana
+    volumes:
+      - ./prometheus/create-datasource-and-dashboard.sh:/create.sh:ro
+    command: /create.sh

--- a/docker/examples/prometheus/create-datasource-and-dashboard.sh
+++ b/docker/examples/prometheus/create-datasource-and-dashboard.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -xeuo pipefail
+
+if ! curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://grafana:3000/api/dashboards/name/prom; then
+    curl -sf -X POST -H "Content-Type: application/json" \
+         --data-binary '{"name":"prom","type":"prometheus","url":"http://prometheus:9090","access":"proxy","isDefault":true}' \
+         http://grafana:3000/api/datasources
+fi
+
+dashboard_id=1598
+last_revision=$(curl -sf https://grafana.com/api/dashboards/${dashboard_id}/revisions | grep '"revision":' | sed 's/ *"revision": \([0-9]*\),/\1/' | sort -n | tail -1)
+
+echo '{"dashboard": ' > data.json
+curl -s https://grafana.com/api/dashboards/${dashboard_id}/revisions/${last_revision}/download >> data.json
+echo ', "inputs": [{"name": "DS_PROMETHEUS", "pluginId": "prometheus", "type": "datasource", "value": "prom"}], "overwrite": false}' >> data.json
+curl --retry-connrefused --retry 5 --retry-delay 0 -sf \
+     -X POST -H "Content-Type: application/json" \
+     --data-binary @data.json \
+     http://grafana:3000/api/dashboards/import

--- a/docker/examples/prometheus/prometheus.yml
+++ b/docker/examples/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'zipkin'
+    scrape_interval: 5s
+    metrics_path: '/prometheus'
+    static_configs:
+      - targets: ['zipkin:9411']


### PR DESCRIPTION
This adds docker/examples directory, which hosts the docker-compose
files intended for end users. The docker-compose files in the docker/
directory are for DockerHub.