### PR TITLE
Fix Appbar's tab and Search bar overlap issue

### DIFF
--- a/zipkin-lens/src/components/GlobalSearch/GlobalSearchConditionKey.jsx
+++ b/zipkin-lens/src/components/GlobalSearch/GlobalSearchConditionKey.jsx
@@ -96,7 +96,7 @@ const GlobalSearchConditionKey = ({
       },
       cursor: 'pointer',
     }),
-    menuPortal: base => ({
+    menu: base => ({
       ...base,
       zIndex: 10000,
       width: '15rem',

--- a/zipkin-lens/src/components/GlobalSearch/conditions/DurationCondition.jsx
+++ b/zipkin-lens/src/components/GlobalSearch/conditions/DurationCondition.jsx
@@ -142,7 +142,7 @@ const DurationCondition = ({
       },
       cursor: 'pointer',
     }),
-    menuPortal: base => ({
+    menu: base => ({
       ...base,
       zIndex: 10000,
       width: '3rem',

--- a/zipkin-lens/src/components/GlobalSearch/conditions/NameCondition.jsx
+++ b/zipkin-lens/src/components/GlobalSearch/conditions/NameCondition.jsx
@@ -58,7 +58,7 @@ const NameCondition = ({
       },
       cursor: 'pointer',
     }),
-    menuPortal: base => ({
+    menu: base => ({
       ...base,
       zIndex: 10000,
       width: '18rem',


### PR DESCRIPTION
**Before**

<img width="480" alt="スクリーンショット 2019-10-23 14 32 15" src="https://user-images.githubusercontent.com/19551419/67360853-faeebb00-f5a1-11e9-8019-bd7cbad20458.png">
<img width="505" alt="スクリーンショット 2019-10-23 14 32 19" src="https://user-images.githubusercontent.com/19551419/67360859-fde9ab80-f5a1-11e9-80ef-ea7c21bd4214.png">


**After**

<img width="493" alt="スクリーンショット 2019-10-23 14 31 57" src="https://user-images.githubusercontent.com/19551419/67360874-02ae5f80-f5a2-11e9-97d6-80dd381f43f6.png">
<img width="546" alt="スクリーンショット 2019-10-23 14 32 04" src="https://user-images.githubusercontent.com/19551419/67360884-0641e680-f5a2-11e9-88e7-5544afb937b9.png">

@drolando Thank you for your report!!!