### PR TITLE
Enable license plugin on Travis.

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -168,7 +168,7 @@ if is_release_commit; then
   true
 else
   # Ensure no tests rely on the actuator library
-  MYSQL_USER=root ./mvnw verify -nsu -Dlicense.skip=true -DskipActuator
+  MYSQL_USER=root ./mvnw verify -nsu -DskipActuator
 fi
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install


### PR DESCRIPTION
License plugin is currently disabled on Travis. I guess this makes the plugin somewhat pointless as we've seen routinely checking in files without license.

The issue referenced that showed issues with Travis's shallow clone is quite old, and since it seems to work fine on Docker Hub, which also does a shallow clone, let's give it a try and see if this passes the build - if so it means the problem might not be there anymore.

Fixes #1512