### PR TITLE
Bump span name and autocomplete limit to 10k

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectAutocompleteValues.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectAutocompleteValues.java
@@ -56,7 +56,7 @@ final class SelectAutocompleteValues extends ResultSetFutureCall<ResultSet> {
   @Override protected ResultSetFuture newFuture() {
     return factory.session.executeAsync(factory.preparedStatement.bind()
       .setString("key", key)
-      .setInt("limit_", 1000)); // no one is ever going to browse so many tag values
+      .setInt("limit_", 10000));
   }
 
   @Override public ResultSet map(ResultSet input) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectSpanNames.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectSpanNames.java
@@ -59,7 +59,7 @@ final class SelectSpanNames extends ResultSetFutureCall<ResultSet> {
   @Override protected ResultSetFuture newFuture() {
     return factory.session.executeAsync(factory.preparedStatement.bind()
       .setString("service_name", service_name)
-      .setInt("limit_", 1000)); // no one is ever going to browse so many span names
+      .setInt("limit_", 10000));
   }
 
   @Override public ResultSet map(ResultSet input) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectAutocompleteValues.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectAutocompleteValues.java
@@ -57,7 +57,7 @@ final class SelectAutocompleteValues extends ResultSetFutureCall<ResultSet> {
   @Override protected ResultSetFuture newFuture() {
     return factory.session.executeAsync(factory.preparedStatement.bind()
       .setString("key", key)
-      .setInt("limit_", 1000)); // no one is ever going to browse so many tag values
+      .setInt("limit_", 10000));
   }
 
   @Override public ResultSet map(ResultSet input) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectRemoteServiceNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectRemoteServiceNames.java
@@ -61,7 +61,7 @@ final class SelectRemoteServiceNames extends ResultSetFutureCall<ResultSet> {
     return factory.session.executeAsync(factory.preparedStatement
       .bind()
       .setString("service", service)
-      .setInt("limit_", 1000)); // no one is ever going to browse so many span names
+      .setInt("limit_", 1000)); // no one is ever going to browse so many service names
   }
 
   @Override public ResultSet map(ResultSet input) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
@@ -60,7 +60,7 @@ final class SelectSpanNames extends ResultSetFutureCall<ResultSet> {
   @Override protected ResultSetFuture newFuture() {
     return factory.session.executeAsync(factory.preparedStatement.bind()
       .setString("service", service)
-      .setInt("limit_", 1000)); // no one is ever going to browse so many span names
+      .setInt("limit_", 10000));
   }
 
   @Override public ResultSet map(ResultSet input) {

--- a/zipkin-storage/cassandra/src/test/resources/autocomplete_tags-stress.yaml
+++ b/zipkin-storage/cassandra/src/test/resources/autocomplete_tags-stress.yaml
@@ -45,5 +45,5 @@ queries:
     cql: SELECT DISTINCT key FROM autocomplete_tags
     fields: samerow
    select_values:
-    cql: SELECT value FROM autocomplete_tags WHERE key = ? LIMIT 1000
+    cql: SELECT value FROM autocomplete_tags WHERE key = ? LIMIT 10000
     fields: samerow

--- a/zipkin-storage/cassandra/src/test/resources/span_by_service-stress.yaml
+++ b/zipkin-storage/cassandra/src/test/resources/span_by_service-stress.yaml
@@ -45,5 +45,5 @@ queries:
     cql: SELECT DISTINCT service FROM span_by_service
     fields: samerow
    select_spans:
-    cql: SELECT span FROM span_by_service WHERE service = ? LIMIT 1000
+    cql: SELECT span FROM span_by_service WHERE service = ? LIMIT 10000
     fields: samerow


### PR DESCRIPTION
The main monolith at Yelp has more than 1k span names. This is due to
several reasons, main one being that all mysql queries also have
"yelp-main" as localEndpoint.serviceName. Since we use the query
fingerprint as name, this causes us to have around 6k span names.