### PR TITLE
Loading indicators to discover page

### DIFF
--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
@@ -103,7 +103,7 @@ const useStyles = makeStyles(theme => ({
 
 const propTypes = {
   isLoading: PropTypes.bool.isRequired,
-  traces: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  traces: PropTypes.arrayOf(PropTypes.any).isRequired,
   lastQueryParams: PropTypes.shape({}).isRequired,
   conditions: globalSearchConditionsPropTypes.isRequired,
   lookbackCondition: globalSearchLookbackConditionPropTypes.isRequired,

--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
@@ -51,6 +51,21 @@ const propTypes = {
 };
 
 const useStyles = makeStyles(theme => ({
+  header: {
+    paddingRight: theme.spacing(3),
+    paddingLeft: theme.spacing(3),
+  },
+  titleRow: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  upperRightBox: {
+    paddingRight: theme.spacing(3),
+    display: 'flex',
+    alignItems: 'center',
+  },
   tabs: {
     color: theme.palette.text.primary,
     backgroundColor: theme.palette.common.white,
@@ -62,6 +77,16 @@ const useStyles = makeStyles(theme => ({
     minHeight: '2rem',
   },
   contentPaper: {
+    height: '100%',
+    marginTop: theme.spacing(2),
+    marginRight: theme.spacing(3),
+    marginBottom: theme.spacing(2),
+    marginLeft: theme.spacing(3),
+  },
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'auto',
     width: '100%',
     height: '100%',
   },
@@ -155,33 +180,23 @@ const DiscoverPage = ({ history, location }) => {
 
   return (
     <>
-      <Box pl={3} pr={3}>
-        <Box width="100%" display="flex" justifyContent="space-between">
-          <Box display="flex" alignItems="center">
-            <Typography variant="h5">
-              Discover
-            </Typography>
-          </Box>
-          <Box pr={3} display="flex" alignItems="center">
+      <Box className={classes.header}>
+        <Box className={classes.titleRow}>
+          <Typography variant="h5">
+            Discover
+          </Typography>
+          <Box className={classes.upperRightBox}>
             <TraceJsonUploader />
             <TraceIdSearchInput />
           </Box>
         </Box>
         <GlobalSearch findData={findTraces} />
       </Box>
-      <Box
-        flex="0 1 100%"
-        marginTop={1.5}
-        marginBottom={1}
-        marginRight={3}
-        marginLeft={3}
-      >
-        <Paper className={classes.contentPaper}>
-          <Box display="flex" flexDirection="column" overflow="auto" width="100%" height="100%">
-            <TracesTab />
-          </Box>
-        </Paper>
-      </Box>
+      <Paper className={classes.contentPaper}>
+        <Box className={classes.content}>
+          <TracesTab />
+        </Box>
+      </Paper>
     </>
   );
 };

--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
@@ -19,10 +19,11 @@ import moment from 'moment';
 import queryString from 'query-string';
 import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
-import { makeStyles } from '@material-ui/styles';
 import Box from '@material-ui/core/Box';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/styles';
 
 import TraceJsonUploader from '../Common/TraceJsonUploader';
 import TraceIdSearchInput from '../Common/TraceIdSearchInput';
@@ -42,6 +43,7 @@ import * as spansActionCreators from '../../actions/spans-action';
 import * as autocompleteKeysActionCreators from '../../actions/autocomplete-keys-action';
 import * as globalSearchActionCreators from '../../actions/global-search-action';
 import { globalSearchLookbackConditionPropTypes, globalSearchConditionsPropTypes } from '../../prop-types';
+import ExplainBox from './ExplainBox';
 
 const useStyles = makeStyles(theme => ({
   header: {
@@ -69,6 +71,20 @@ const useStyles = makeStyles(theme => ({
     height: '2rem',
     minHeight: '2rem',
   },
+  loadingIndicatorWrapper: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  explainBoxWrapper: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   contentPaper: {
     height: '100%',
     marginTop: theme.spacing(2),
@@ -87,6 +103,7 @@ const useStyles = makeStyles(theme => ({
 
 const propTypes = {
   isLoading: PropTypes.bool.isRequired,
+  traces: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   lastQueryParams: PropTypes.shape({}).isRequired,
   conditions: globalSearchConditionsPropTypes.isRequired,
   lookbackCondition: globalSearchLookbackConditionPropTypes.isRequired,
@@ -108,6 +125,7 @@ const propTypes = {
 
 const DiscoverPageImpl = ({
   isLoading,
+  traces,
   lastQueryParams,
   conditions,
   lookbackCondition,
@@ -203,6 +221,29 @@ const DiscoverPageImpl = ({
     }
   });
 
+  let content;
+  if (isLoading) {
+    content = (
+      <Box className={classes.loadingIndicatorWrapper} data-testid="loading-indicator">
+        <CircularProgress />
+      </Box>
+    );
+  } else if (traces.length === 0) {
+    content = (
+      <Box className={classes.explainBoxWrapper} data-testid="explain-box">
+        <ExplainBox />
+      </Box>
+    );
+  } else {
+    content = (
+      <Paper className={classes.contentPaper}>
+        <Box className={classes.content}>
+          <TracesTab />
+        </Box>
+      </Paper>
+    );
+  }
+
   return (
     <>
       <Box className={classes.header}>
@@ -217,11 +258,7 @@ const DiscoverPageImpl = ({
         </Box>
         <GlobalSearch findData={findTraces} />
       </Box>
-      <Paper className={classes.contentPaper}>
-        <Box className={classes.content}>
-          <TracesTab />
-        </Box>
-      </Paper>
+      {content}
     </>
   );
 };
@@ -229,6 +266,7 @@ const DiscoverPageImpl = ({
 DiscoverPageImpl.propTypes = propTypes;
 
 const mapStateToProps = state => ({
+  traces: state.traces.traces,
   isLoading: state.traces.isLoading,
   lastQueryParams: state.traces.lastQueryParams,
   conditions: state.globalSearch.conditions,

--- a/zipkin-lens/src/components/DiscoverPage/ExplainBox.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/ExplainBox.jsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/styles';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    color: theme.palette.text.secondary,
+  },
+  iconWrapper: {
+    fontSize: '10rem',
+    lineHeight: '1',
+  },
+  description: {
+    marginTop: theme.spacing(1.4),
+    textAlign: 'center',
+  },
+}));
+
+const ExplainBox = React.memo(() => {
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.root}>
+      <Box className={classes.iconWrapper}>
+        <Box className="fas fa-search" />
+      </Box>
+      <Typography variant="h4">
+        Search Traces
+      </Typography>
+      <Typography variant="body1" className={classes.description}>
+        Please select criteria in the search bar.
+        <br />
+        Then, click the search button.
+      </Typography>
+    </Box>
+  );
+});
+
+export default ExplainBox;

--- a/zipkin-lens/src/components/GlobalSearch/GlobalSearchConditionValue.jsx
+++ b/zipkin-lens/src/components/GlobalSearch/GlobalSearchConditionValue.jsx
@@ -40,11 +40,22 @@ const GlobalSearchConditionValue = ({
   onBlur,
 }) => {
   const dispatch = useDispatch();
-
-  const services = useSelector(state => state.services.services);
-  const remoteServices = useSelector(state => state.remoteServices.remoteServices);
-  const spans = useSelector(state => state.spans.spans);
-  const autocompleteValues = useSelector(state => state.autocompleteValues.autocompleteValues);
+  const {
+    services,
+    isLoading: isLoadingServices,
+  } = useSelector(state => state.services);
+  const {
+    remoteServices,
+    isLoading: isLoadingRemoteServices,
+  } = useSelector(state => state.remoteServices);
+  const {
+    spans,
+    isLoading: isLoadingSpans,
+  } = useSelector(state => state.spans);
+  const {
+    autocompleteValues,
+    isLoading: isLoadingAutocompleteValues,
+  } = useSelector(state => state.autocompleteValues);
   const conditions = useSelector(state => state.globalSearch.conditions);
 
   const { key: conditionKey, value: conditionValue } = conditions[conditionIndex];
@@ -72,13 +83,23 @@ const GlobalSearchConditionValue = ({
     case 'remoteServiceName':
     case 'spanName': {
       let opts;
+      let isLoading;
       switch (conditionKey) {
-        case 'serviceName': opts = services; break;
-        case 'remoteServiceName': opts = remoteServices; break;
-        case 'spanName': opts = spans; break;
+        case 'serviceName':
+          opts = services;
+          isLoading = isLoadingServices;
+          break;
+        case 'remoteServiceName':
+          opts = remoteServices;
+          isLoading = isLoadingRemoteServices;
+          break;
+        case 'spanName':
+          opts = spans;
+          isLoading = isLoadingSpans;
+          break;
         default: break;
       }
-      return (<NameCondition {...commonProps} options={opts} />);
+      return (<NameCondition {...commonProps} options={opts} isLoading={isLoading} />);
     }
     case 'minDuration':
     case 'maxDuration':
@@ -86,7 +107,13 @@ const GlobalSearchConditionValue = ({
     case 'tags':
       return (<TagCondition {...commonProps} />);
     default: // autocompleteTags
-      return (<NameCondition {...commonProps} options={autocompleteValues} />);
+      return (
+        <NameCondition
+          {...commonProps}
+          options={autocompleteValues}
+          isLoading={isLoadingAutocompleteValues}
+        />
+      );
   }
 };
 

--- a/zipkin-lens/src/components/GlobalSearch/conditions/NameCondition.jsx
+++ b/zipkin-lens/src/components/GlobalSearch/conditions/NameCondition.jsx
@@ -26,6 +26,7 @@ const propTypes = {
   isFocused: PropTypes.bool.isRequired,
   valueRef: PropTypes.shape({}).isRequired,
   addCondition: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -41,6 +42,7 @@ const NameCondition = ({
   onChange,
   valueRef,
   addCondition,
+  isLoading,
 }) => {
   const styles = useMemo(() => ({
     control: base => ({
@@ -87,6 +89,7 @@ const NameCondition = ({
       ref={valueRef}
       value={{ value, label: value }}
       options={options.map(opt => ({ value: opt, label: opt }))}
+      isLoading={isLoading}
       styles={styles}
       onFocus={onFocus}
       onBlur={onBlur}


### PR DESCRIPTION
## Summary

If users store a large amount of data, the data fetch time will be longer.
In this case, if the loading indicator is not displayed, the user may simply think that there is no data on zipkin-server.
This is a very big UX issue. we should fix it as soon as possible.

## Screenshots

![loading-services](https://user-images.githubusercontent.com/19551419/67825845-ff6d2380-fb0d-11e9-9c6a-b2c49b8a1967.gif)

![loading-traces](https://user-images.githubusercontent.com/19551419/67825853-05fb9b00-fb0e-11e9-812e-3645394eb071.gif)

