### PR TITLE
fix: add log4j2 metrics binder

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -515,7 +515,7 @@
               <classifier>slim</classifier>
               <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
               <excludeGroupIds>
-                com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
+                com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift
               </excludeGroupIds>
               <excludes>
                 <!-- Actuator -->

--- a/zipkin-server/src/it/slimjar/pom.xml
+++ b/zipkin-server/src/it/slimjar/pom.xml
@@ -59,6 +59,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.12.1</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>

--- a/zipkin-server/src/it/slimjar/pom.xml
+++ b/zipkin-server/src/it/slimjar/pom.xml
@@ -59,12 +59,6 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.12.1</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>

--- a/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
@@ -33,6 +33,7 @@ import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.logging.Log4j2Metrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
@@ -86,6 +87,7 @@ public class ZipkinPrometheusMetricsConfiguration {
     new JvmThreadMetrics().bindTo(meterRegistry);
     new ClassLoaderMetrics().bindTo(meterRegistry);
     new ProcessorMetrics().bindTo(meterRegistry);
+    new Log4j2Metrics().bindTo(meterRegistry);
     return meterRegistry;
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
@@ -141,7 +141,8 @@ public class ITZipkinMetrics {
         .contains("jvm_threads_live_threads")
         .contains("jvm_threads_states_threads")
         .contains("jvm_threads_peak_threads")
-        .contains("jvm_threads_daemon_threads");
+        .contains("jvm_threads_daemon_threads")
+        .contains("log4j2_events_total");
     // gc metrics are not tested as are not present during test running
   }
 


### PR DESCRIPTION
To complete restoring metrics missing in `/prometheus` endpoint, this PR adds Log4j2 metrics. 