### PR TITLE
Change span's bar color & search result's bar color when there are errors

### DIFF
--- a/zipkin-lens/src/colors/index.js
+++ b/zipkin-lens/src/colors/index.js
@@ -75,3 +75,25 @@ export const selectServiceTheme = (serviceName) => {
 export const selectServiceColor = serviceName => selectServiceTheme(
   serviceName,
 ).palette.primary.dark;
+
+export const selectColorByErrorType = (errorType) => {
+  switch (errorType) {
+    case 'transient':
+      return colors.red[500];
+    case 'critical':
+      return colors.red[500];
+    default:
+      return theme.palette.primary.main;
+  }
+};
+
+export const selectColorByInfoClass = (infoClass) => {
+  switch (infoClass) {
+    case 'trace-error-transient':
+      return selectColorByErrorType('transient');
+    case 'trace-error-critical':
+      return selectColorByErrorType('critical');
+    default:
+      return selectColorByErrorType('none');
+  }
+};

--- a/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
@@ -20,12 +20,11 @@ import { makeStyles } from '@material-ui/styles';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import grey from '@material-ui/core/colors/grey';
-import { fade } from '@material-ui/core/styles/colorManipulator';
 
 import ServiceBadge from '../../Common/ServiceBadge';
 import { getServiceName } from '../../../zipkin';
 import { traceSummaryPropTypes } from '../../../prop-types';
-import { theme } from '../../../colors';
+import { theme, selectColorByInfoClass } from '../../../colors';
 
 export function rootServiceAndSpanName(root) {
   const { span } = root;
@@ -61,7 +60,7 @@ const useStyles = makeStyles({
     borderBottom: `1px solid ${grey[200]}`,
   },
   durationBar: {
-    backgroundColor: fade(theme.palette.primary.light, 0.4),
+    opacity: 0.4,
   },
   dataCell: {
     display: 'flex',
@@ -111,6 +110,9 @@ export const TracesTableRowImpl = ({
           width={`${traceSummary.width}%`}
           height="100%"
           className={classes.durationBar}
+          style={{
+            backgroundColor: selectColorByInfoClass(traceSummary.infoClass),
+          }}
           data-test="duration-bar"
         />
         <Grid item xs={3} className={classes.dataCell}>

--- a/zipkin-lens/src/components/TracePage/TraceTimeline/TraceTimelineRow.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceTimeline/TraceTimelineRow.jsx
@@ -28,6 +28,7 @@ import {
   spanBarHeight,
 } from '../sizing';
 import { detailedSpanPropTypes } from '../../../prop-types';
+import { selectColorByErrorType } from '../../../colors';
 
 const minWidth = 0.25;
 
@@ -48,7 +49,6 @@ const style = theme => ({
   },
   bar: {
     opacity: 0.8,
-    fill: theme.palette.primary.main,
   },
   row: {
     opacity: 0,
@@ -125,6 +125,9 @@ const TraceTimelineRow = React.memo(({
         rx={4}
         ry={4}
         className={classes.bar}
+        style={{
+          fill: selectColorByErrorType(span.errorType),
+        }}
       />
       {
         isTextLeft ? (


### PR DESCRIPTION
This feature was in the classic UI and previous version lens.

The logics are same as these (https://github.com/openzipkin/zipkin/blob/0c4a71481c7021e2cf29d5aa5c7fd215cea0e3e3/zipkin-lens/src/util/color.js#L14-L34)

# BEFORE

<img width="1200" alt="スクリーンショット 2019-11-14 12 15 06" src="https://user-images.githubusercontent.com/19551419/68823880-71319980-06d8-11ea-8dd1-e444af082e1e.png">
<img width="1200" alt="スクリーンショット 2019-11-14 12 14 59" src="https://user-images.githubusercontent.com/19551419/68823890-77c01100-06d8-11ea-97ef-29629d5ad6c3.png">

# AFTER

<img width="1200" alt="スクリーンショット 2019-11-14 12 12 19" src="https://user-images.githubusercontent.com/19551419/68823795-3af41a00-06d8-11ea-90e5-091719071254.png">
<img width="1200" alt="スクリーンショット 2019-11-14 12 13 18" src="https://user-images.githubusercontent.com/19551419/68823805-40516480-06d8-11ea-96ab-b83f907e9840.png">
