### PR TITLE
Use Jackson to write names and write to pooled buffer to reduce garbage.

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
@@ -103,7 +103,7 @@ public class ZipkinSelfTracingConfiguration {
   /** Controls aspects of tracing such as the name that shows up in the UI */
   @Bean Tracing tracing(Reporter<Span> reporter, CurrentTraceContext currentTraceContext) {
     return Tracing.newBuilder()
-      .localServiceName("zipkin-\tserver")
+      .localServiceName("zipkin-server")
       .sampler(Sampler.NEVER_SAMPLE) // don't sample traces at this abstraction
       .currentTraceContext(currentTraceContext)
       // Reduce the impact on untraced downstream http services such as Elasticsearch

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
@@ -103,7 +103,7 @@ public class ZipkinSelfTracingConfiguration {
   /** Controls aspects of tracing such as the name that shows up in the UI */
   @Bean Tracing tracing(Reporter<Span> reporter, CurrentTraceContext currentTraceContext) {
     return Tracing.newBuilder()
-      .localServiceName("zipkin-server")
+      .localServiceName("zipkin-\tserver")
       .sampler(Sampler.NEVER_SAMPLE) // don't sample traces at this abstraction
       .currentTraceContext(currentTraceContext)
       // Reduce the impact on untraced downstream http services such as Elasticsearch

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -166,10 +166,6 @@ public class ITZipkinServer {
       .localEndpoint(FRONTEND.toBuilder().serviceName("foo\tbar").build())
       .build()))
       .execute();
-    storage.accept(Arrays.asList(CLIENT_SPAN.toBuilder()
-      .localEndpoint(FRONTEND.toBuilder().serviceName("foo bar").build())
-      .build()))
-      .execute();
     Response response = get("/api/v2/services");
     assertThat(response.isSuccessful()).isTrue();
     assertThat(response.body().string()).isEqualTo("[\"foo\\tbar\"]");


### PR DESCRIPTION
We have an optimization to write out names as a quoted list for names, but this doesn't really work due to JSON's escaping rules. So instead we should stick to using Jackson which escapes correctly. We can get some performance back in exchange though by writing into a pooled buffer to reduce garbage generation.

Fixes #2915