### PR TITLE
Fix a bug that graph is not rendered when timestamp is not set in span

### DIFF
--- a/zipkin-lens/src/prop-types/index.js
+++ b/zipkin-lens/src/prop-types/index.js
@@ -42,7 +42,7 @@ export const detailedSpanPropTypes = PropTypes.shape({
   childIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   serviceName: PropTypes.string.isRequired,
   serviceNames: PropTypes.arrayOf(PropTypes.string).isRequired,
-  timestamp: PropTypes.number.isRequired,
+  timestamp: PropTypes.number,
   duration: PropTypes.number,
   durationStr: PropTypes.string,
   tags: spanTagsPropTypes.isRequired,


### PR DESCRIPTION
resolves #2906 

### Before

<img width="787" alt="スクリーンショット 2019-11-19 15 11 46" src="https://user-images.githubusercontent.com/19551419/69121147-edfcb300-0ade-11ea-86ac-2b71ad74187b.png">

### After

<img width="786" alt="スクリーンショット 2019-11-19 15 11 28" src="https://user-images.githubusercontent.com/19551419/69121164-fc4acf00-0ade-11ea-9a80-32294cfdd17a.png">
