### PR TITLE
Only collect metrics for API endpoints.

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
@@ -25,7 +25,6 @@ import com.linecorp.armeria.server.file.HttpFileBuilder;
 import com.linecorp.armeria.server.metric.PrometheusExpositionService;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.config.MeterFilter;
 import io.prometheus.client.CollectorRegistry;
 import java.time.Duration;
 import java.util.Optional;

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
@@ -77,17 +77,6 @@ public class ZipkinHttpConfiguration {
       // and default to a slightly longer timeout on the server to be able to handle these with
       // better error messages where possible.
       sb.requestTimeout(Duration.ofSeconds(11));
-
-      // don't add metrics for admin endpoints
-      meterRegistry.ifPresent(m -> m.config().meterFilter(MeterFilter.deny(id -> {
-        String uri = id.getTag("uri");
-        return uri != null && (
-          uri.startsWith("/actuator")
-            || uri.startsWith("/health")
-            || uri.startsWith("/info")
-            || uri.startsWith("/metrics")
-            || uri.startsWith("/prometheus"));
-      })));
     };
   }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
@@ -91,8 +91,10 @@ public class ZipkinPrometheusMetricsConfiguration {
 
   // https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-spring-mvc
   @Bean ArmeriaServerConfigurator httpRequestDurationConfigurator(MeterRegistry registry) {
-    return serverBuilder -> serverBuilder.decorator(
-      s -> new MetricCollectingService<>(s, registry, metricName));
+    return serverBuilder -> serverBuilder.routeDecorator()
+      .pathPrefix("/zipkin/api")
+      .pathPrefix("/api")
+      .build(s -> new MetricCollectingService<>(s, registry, metricName));
   }
 
   // We need to make sure not-found requests are still handled by a service to be decorated for

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
@@ -82,25 +82,6 @@ public class ITZipkinMetrics {
       .doesNotContain("uri=\"/\"");
   }
 
-  @Test public void notFound_prometheus() throws Exception {
-    assertThat(get("/doo-wop").isSuccessful())
-      .isFalse();
-
-    assertThat(scrape())
-      .contains("uri=\"NOT_FOUND\"")
-      .doesNotContain("uri=\"/doo-wop");
-  }
-
-  @Test public void redirected_prometheus() throws Exception {
-    assertThat(get("/").isSuccessful())
-      .isTrue(); // follows redirects
-
-    assertThat(scrape())
-      .contains("uri=\"REDIRECTION\"")
-      .contains("uri=\"/zipkin/index.html\"")
-      .doesNotContain("uri=\"/\"");
-  }
-
   @Test public void apiTemplate_prometheus() throws Exception {
     List<Span> spans = asList(LOTS_OF_SPANS[0]);
     byte[] body = SpanBytesEncoder.JSON_V2.encodeList(spans);


### PR DESCRIPTION
Currently we attach metric collection to the entire server, with a currently insufficient blacklist that allows static resources to be recorded. Instead, we should just go ahead and whitelist to the API endpoints as that's what really matters for metrics and are in our grafana.

Fixes #2928 