### PR TITLE
Fix bug that webpack does not work on Windows

### DIFF
--- a/zipkin-lens/webpack.dev.config.js
+++ b/zipkin-lens/webpack.dev.config.js
@@ -49,7 +49,7 @@ module.exports = {
         loader: 'html-loader',
       },
       {
-        test: /webfonts\/.*\.(png|jpg|jpeg|gif|svg|woff|woff2|ttf|eot)(\?.*$|$)/,
+        test: /webfonts(\/|\\).*\.(png|jpg|jpeg|gif|svg|woff|woff2|ttf|eot)(\?.*$|$)/,
         loader: 'file-loader',
       },
       {


### PR DESCRIPTION
In Windows, path delimiters is `\`, not `/`... :sob: 