### PR TITLE
Release URL allocated with createObjectURL using revokeObjectURL

### DIFF
--- a/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
@@ -106,6 +106,7 @@ const TraceSummaryHeader = React.memo(({ traceSummary, rootSpanIndex }) => {
         a.href = window.URL.createObjectURL(blob);
         a.download = `${traceSummary.traceId}.json`;
         a.click();
+        window.URL.revokeObjectURL(a.href);
       });
   }, [traceSummary]);
 

--- a/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
@@ -106,7 +106,9 @@ const TraceSummaryHeader = React.memo(({ traceSummary, rootSpanIndex }) => {
         a.href = window.URL.createObjectURL(blob);
         a.download = `${traceSummary.traceId}.json`;
         a.click();
-        window.URL.revokeObjectURL(a.href);
+        setTimeout(() => {
+          window.URL.revokeObjectURL(a.href);
+        }, 100);
       });
   }, [traceSummary]);
 

--- a/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
@@ -106,6 +106,7 @@ const TraceSummaryHeader = React.memo(({ traceSummary, rootSpanIndex }) => {
         a.href = window.URL.createObjectURL(blob);
         a.download = `${traceSummary.traceId}.json`;
         a.click();
+        // See: https://stackoverflow.com/questions/30694453/blob-createobjecturl-download-not-working-in-firefox-but-works-when-debugging
         setTimeout(() => {
           window.URL.revokeObjectURL(a.href);
         }, 100);


### PR DESCRIPTION
Probably, blob URI which is allocated with createObjectURL will not be collected by GC...
We should revoke this explicitly.