### PR TITLE
Fix orphaned spans bug

### DIFF
--- a/zipkin-lens/src/components/TracePage/TraceSummary.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummary.jsx
@@ -82,21 +82,18 @@ const TraceSummary = React.memo(({ traceSummary }) => {
     return spans;
   }, [isRootedTrace, rootSpanIndex, traceSummary.spans]);
 
+  // shownTree is a list of spans excluding hidden spans from rerootedTree.
   const shownTree = useMemo(() => {
-    let depth = 0;
-    let skip = false;
-
-    return rerootedTree.reduce((acc, cur) => {
-      if (cur.depth > depth && skip) {
+    let childrenHiddenSpanDepth;
+    return rerootedTree.reduce((acc, span) => {
+      if (!!childrenHiddenSpanDepth && span.depth > childrenHiddenSpanDepth) {
         return acc;
       }
-      acc.push(cur);
-
-      depth = cur.depth;
-      skip = false;
-      const spanIndex = findSpanIndex(traceSummary.spans, cur.spanId);
+      childrenHiddenSpanDepth = null;
+      acc.push(span);
+      const spanIndex = findSpanIndex(traceSummary.spans, span.spanId);
       if (childrenHiddenSpanIndices[spanIndex]) {
-        skip = true;
+        childrenHiddenSpanDepth = span.depth;
       }
       return acc;
     }, []);


### PR DESCRIPTION
Fix an obvious bug pointed out in #2922 .

Mainly change the calculation method of `shownTree`.
Previously, **span ID** was used to calculate the span's parent-child relationship and Expand/Collapse buttons were implemented using that parent-child relationship.
This created the orphaned span problem pointed out in #2922 because orphaned spans don't have parent-child relationship using **span IDs**.

Please see here. Orphan spans are simply appended to the root span:
https://github.com/openzipkin/zipkin/blob/8a5609a44ea52fa85d5309d7e4e46bc70a4c3ca8/zipkin-lens/src/zipkin/span-node.js#L272-L276

This PR uses span indices to calculate parent-child relationship instead of span IDs.

p.s. TraceSummary component is fairly complex, so I wanted to create custom hooks and improve readability, but I'm not doing it now to minimize PR.

### Before

![before-orphaned](https://user-images.githubusercontent.com/19551419/71953945-0bb8df80-3227-11ea-84f0-5abbb9fb3a83.gif)

### After

![after-orphaned](https://user-images.githubusercontent.com/19551419/71954327-5129dc80-3228-11ea-99bd-dc64a919b3b9.gif)

