### PR TITLE
Addressed Zipkin server crashing issue

### DIFF
--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,6 +34,7 @@ public final class ActiveMQCollector extends CollectorComponent {
   public static final class Builder extends CollectorComponent.Builder {
     Collector.Builder delegate = Collector.newBuilder(ActiveMQCollector.class);
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
+    boolean asyncExecution = true;
     ActiveMQConnectionFactory connectionFactory;
     String queue = "zipkin";
     int concurrency = 1;
@@ -52,6 +53,12 @@ public final class ActiveMQCollector extends CollectorComponent {
       if (metrics == null) throw new NullPointerException("metrics == null");
       this.metrics = metrics.forTransport("activemq");
       this.delegate.metrics(this.metrics);
+      return this;
+    }
+
+    @Override
+    public Builder asyncExecution(boolean asyncExecution) {
+      this.asyncExecution = asyncExecution;
       return this;
     }
 

--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,7 +34,6 @@ public final class ActiveMQCollector extends CollectorComponent {
   public static final class Builder extends CollectorComponent.Builder {
     Collector.Builder delegate = Collector.newBuilder(ActiveMQCollector.class);
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
-    boolean asyncExecution = true;
     ActiveMQConnectionFactory connectionFactory;
     String queue = "zipkin";
     int concurrency = 1;
@@ -53,12 +52,6 @@ public final class ActiveMQCollector extends CollectorComponent {
       if (metrics == null) throw new NullPointerException("metrics == null");
       this.metrics = metrics.forTransport("activemq");
       this.delegate.metrics(this.metrics);
-      return this;
-    }
-
-    @Override
-    public Builder asyncExecution(boolean asyncExecution) {
-      this.asyncExecution = asyncExecution;
       return this;
     }
 

--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQSpanConsumer.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQSpanConsumer.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/ActiveMQSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -54,18 +54,16 @@ final class ActiveMQSpanConsumer implements TransportListener, MessageListener, 
 
   final Collector collector;
   final CollectorMetrics metrics;
-  final boolean asyncExecution;
 
   final ActiveMQConnection connection;
   final Map<QueueSession, QueueReceiver> sessionToReceiver = new LinkedHashMap<>();
 
   volatile CheckResult checkResult = CheckResult.OK;
 
-  ActiveMQSpanConsumer(Collector collector, CollectorMetrics metrics, ActiveMQConnection conn, boolean asyncExecution) {
+  ActiveMQSpanConsumer(Collector collector, CollectorMetrics metrics, ActiveMQConnection conn) {
     this.collector = collector;
     this.metrics = metrics;
     this.connection = conn;
-    this.asyncExecution = asyncExecution;
     connection.addTransportListener(this);
   }
 
@@ -117,7 +115,7 @@ final class ActiveMQSpanConsumer implements TransportListener, MessageListener, 
 
     metrics.incrementBytes(serialized.length);
     if (serialized.length == 0) return; // lenient on empty messages
-    collector.acceptSpans(serialized, NOOP, asyncExecution);
+    collector.acceptSpans(serialized, NOOP);
   }
 
   @Override public void close() {

--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/LazyInit.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/LazyInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/LazyInit.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/LazyInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,6 +28,7 @@ import static zipkin2.collector.activemq.ActiveMQCollector.uncheckedException;
 final class LazyInit {
   final Collector collector;
   final CollectorMetrics metrics;
+  final boolean asyncExecution;
   final ActiveMQConnectionFactory connectionFactory;
   final String queue;
   final int concurrency;
@@ -37,6 +38,7 @@ final class LazyInit {
   LazyInit(ActiveMQCollector.Builder builder) {
     collector = builder.delegate.build();
     metrics = builder.metrics;
+    asyncExecution = builder.asyncExecution;
     connectionFactory = builder.connectionFactory;
     queue = builder.queue;
     concurrency = builder.concurrency;
@@ -68,7 +70,7 @@ final class LazyInit {
     }
 
     try {
-      ActiveMQSpanConsumer result = new ActiveMQSpanConsumer(collector, metrics, connection);
+      ActiveMQSpanConsumer result = new ActiveMQSpanConsumer(collector, metrics, connection, asyncExecution);
 
       for (int i = 0; i < concurrency; i++) {
         result.registerInNewSession(connection, queue);

--- a/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/LazyInit.java
+++ b/zipkin-collector/activemq/src/main/java/zipkin2/collector/activemq/LazyInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,7 +28,6 @@ import static zipkin2.collector.activemq.ActiveMQCollector.uncheckedException;
 final class LazyInit {
   final Collector collector;
   final CollectorMetrics metrics;
-  final boolean asyncExecution;
   final ActiveMQConnectionFactory connectionFactory;
   final String queue;
   final int concurrency;
@@ -38,7 +37,6 @@ final class LazyInit {
   LazyInit(ActiveMQCollector.Builder builder) {
     collector = builder.delegate.build();
     metrics = builder.metrics;
-    asyncExecution = builder.asyncExecution;
     connectionFactory = builder.connectionFactory;
     queue = builder.queue;
     concurrency = builder.concurrency;
@@ -70,7 +68,7 @@ final class LazyInit {
     }
 
     try {
-      ActiveMQSpanConsumer result = new ActiveMQSpanConsumer(collector, metrics, connection, asyncExecution);
+      ActiveMQSpanConsumer result = new ActiveMQSpanConsumer(collector, metrics, connection);
 
       for (int i = 0; i < concurrency; i++) {
         result.registerInNewSession(connection, queue);

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
@@ -13,6 +13,12 @@
  */
 package zipkin2.collector;
 
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.Callback;
@@ -22,16 +28,8 @@ import zipkin2.codec.BytesDecoder;
 import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.storage.StorageComponent;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.Executor;
-import java.util.function.Supplier;
-
 import static java.lang.String.format;
+import static java.util.logging.Level.FINE;
 import static zipkin2.Call.propagateIfFatal;
 
 /**
@@ -108,18 +106,16 @@ public class Collector { // not final for mock
   }
 
   public void accept(List<Span> spans, Callback<Void> callback) {
-    accept(spans, callback, Runnable::run, true);
+    accept(spans, callback, Runnable::run);
   }
 
   /**
-   *  Based on the async indicator collect spans synchronously or asynchronously
-   *
-   * @param spans spans to store
-   * @param callback callback function to invoke on success or error
    * @param executor the executor used to enqueue the storage request.
-   * @param async indicator used to determine whether to collect spans async or sync
+   *
+   * <p>Calls to get the storage component could be blocking. This ensures requests that block
+   * callers (such as http or gRPC) do not add additional load during such events.
    */
-  public void accept(List<Span> spans, Callback<Void> callback, Executor executor, boolean async) {
+  public void accept(List<Span> spans, Callback<Void> callback, Executor executor) {
     if (spans.isEmpty()) {
       callback.onSuccess(null);
       return;
@@ -132,30 +128,20 @@ public class Collector { // not final for mock
       return;
     }
 
-    if (async) {
-      try {
-        // In order to ensure callers are not blocked, we swap callbacks when we get to the storage
-        // phase of this process. Here, we create a callback whose sole purpose is classifying later
-        // errors on this bundle of spans in the same log category. This allows people to only turn on
-        // debug logging in one place.
-        executor.execute(new AsyncStoreSpans(spans));
-        callback.onSuccess(null);
-      } catch (Throwable unexpected) { // ensure if a future is supplied we always set value or error
-        callback.onError(unexpected);
-        throw unexpected;
-      }
-    } else {
-      try {
-        new SyncStoreSpans(spans);
-        callback.onSuccess(null);
-      } catch (Throwable unexpected) {
-        callback.onError(unexpected);
-        throw unexpected;
-      }
+    // In order to ensure callers are not blocked, we swap callbacks when we get to the storage
+    // phase of this process. Here, we create a callback whose sole purpose is classifying later
+    // errors on this bundle of spans in the same log category. This allows people to only turn on
+    // debug logging in one place.
+    try {
+      executor.execute(new StoreSpans(sampledSpans));
+      callback.onSuccess(null);
+    } catch (Throwable unexpected) { // ensure if a future is supplied we always set value or error
+      callback.onError(unexpected);
+      throw unexpected;
     }
   }
 
-  /** Like {@link #acceptSpans(byte[], BytesDecoder, Callback, boolean)}, except using a byte buffer. */
+  /** Like {@link #acceptSpans(byte[], BytesDecoder, Callback)}, except using a byte buffer. */
   public void acceptSpans(ByteBuffer encoded, SpanBytesDecoder decoder, Callback<Void> callback,
     Executor executor) {
     List<Span> spans;
@@ -165,7 +151,7 @@ public class Collector { // not final for mock
       handleDecodeError(e, callback);
       return;
     }
-    accept(spans, callback, executor, true);
+    accept(spans, callback, executor);
   }
 
   /**
@@ -176,18 +162,6 @@ public class Collector { // not final for mock
    * @param serialized not empty message
    */
   public void acceptSpans(byte[] serialized, Callback<Void> callback) {
-    acceptSpans(serialized, callback, true);
-  }
-
-  /**
-   * Before calling this, call {@link CollectorMetrics#incrementMessages()}, and {@link
-   * CollectorMetrics#incrementBytes(int)}. Do not call any other metrics callbacks as those are
-   * handled internal to this method.
-   *
-   * @param serialized not empty message
-   * @param async indicator used to determine whether to collect spans async or sync
-   */
-  public void acceptSpans(byte[] serialized, Callback<Void> callback, boolean async) {
     BytesDecoder<Span> decoder;
     try {
       decoder = SpanBytesDecoderDetector.decoderForListMessage(serialized);
@@ -195,7 +169,7 @@ public class Collector { // not final for mock
       handleDecodeError(e, callback);
       return;
     }
-    acceptSpans(serialized, decoder, callback, async);
+    acceptSpans(serialized, decoder, callback);
   }
 
   /**
@@ -207,18 +181,6 @@ public class Collector { // not final for mock
    */
   public void acceptSpans(
     byte[] serializedSpans, BytesDecoder<Span> decoder, Callback<Void> callback) {
-      acceptSpans(serializedSpans, decoder, callback, true);
-  }
-
-  /**
-   * Before calling this, call {@link CollectorMetrics#incrementMessages()}, and {@link
-   * CollectorMetrics#incrementBytes(int)}. Do not call any other metrics callbacks as those are
-   * handled internal to this method.
-   *
-   * @param serializedSpans not empty message
-   * @param async indicator used to determine whether to collect spans async or sync
-   */
-  public void acceptSpans(byte[] serializedSpans, BytesDecoder<Span> decoder, Callback<Void> callback, boolean async) {
     List<Span> spans;
     try {
       spans = decodeList(decoder, serializedSpans);
@@ -226,13 +188,17 @@ public class Collector { // not final for mock
       handleDecodeError(e, callback);
       return;
     }
-    accept(spans, callback, Runnable::run, async);
+    accept(spans, callback);
   }
 
   List<Span> decodeList(BytesDecoder<Span> decoder, byte[] serialized) {
     List<Span> out = new ArrayList<>();
     decoder.decodeList(serialized, out);
     return out;
+  }
+
+  void store(List<Span> sampledSpans, Callback<Void> callback) {
+    storage.spanConsumer().accept(sampledSpans).enqueue(callback);
   }
 
   String idString(Span span) {
@@ -252,16 +218,16 @@ public class Collector { // not final for mock
     return sampled;
   }
 
-  class AsyncStoreSpans implements Callback<Void>, Runnable {
+  class StoreSpans implements Callback<Void>, Runnable {
     final List<Span> spans;
 
-    AsyncStoreSpans(List<Span> spans) {
+    StoreSpans(List<Span> spans) {
       this.spans = spans;
     }
 
     @Override public void run() {
       try {
-        storage.spanConsumer().accept(spans).enqueue(this);
+        store(spans, this);
       } catch (RuntimeException | Error e) {
         // While unexpected, invoking the storage command could raise an error synchronously. When
         // that's the case, we wouldn't have invoked callback.onSuccess, so we need to handle the
@@ -270,32 +236,11 @@ public class Collector { // not final for mock
       }
     }
 
-    @Override public void onSuccess(Void value) {}
+    @Override public void onSuccess(Void value) {
+    }
 
     @Override public void onError(Throwable t) {
       handleStorageError(spans, t, NOOP_CALLBACK);
-    }
-
-    @Override public String toString() {
-      return appendSpanIds(spans, new StringBuilder("StoreSpans(")) + ")";
-    }
-  }
-
-  class SyncStoreSpans implements Runnable {
-
-    final List<Span> spans;
-
-    SyncStoreSpans(List<Span> spans) {
-      this.spans = spans;
-    }
-
-    @Override public void run() {
-      try {
-        storage.spanConsumer().accept(spans).execute();
-      } catch (IOException e) {
-        handleStorageError(spans, e, NOOP_CALLBACK);
-        throw new UncheckedIOException(e.getMessage(), e);
-      }
     }
 
     @Override public String toString() {

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
@@ -176,14 +176,7 @@ public class Collector { // not final for mock
    * @param serialized not empty message
    */
   public void acceptSpans(byte[] serialized, Callback<Void> callback) {
-    BytesDecoder<Span> decoder;
-    try {
-      decoder = SpanBytesDecoderDetector.decoderForListMessage(serialized);
-    } catch (RuntimeException | Error e) {
-      handleDecodeError(e, callback);
-      return;
-    }
-    acceptSpans(serialized, decoder, callback);
+    acceptSpans(serialized, callback, true);
   }
 
   /**
@@ -214,14 +207,7 @@ public class Collector { // not final for mock
    */
   public void acceptSpans(
     byte[] serializedSpans, BytesDecoder<Span> decoder, Callback<Void> callback) {
-    List<Span> spans;
-    try {
-      spans = decodeList(decoder, serializedSpans);
-    } catch (RuntimeException | Error e) {
-      handleDecodeError(e, callback);
-      return;
-    }
-    accept(spans, callback);
+      acceptSpans(serializedSpans, decoder, callback, true);
   }
 
   /**
@@ -240,7 +226,7 @@ public class Collector { // not final for mock
       handleDecodeError(e, callback);
       return;
     }
-    accept(spans, callback, null, async);
+    accept(spans, callback, Runnable::run, async);
   }
 
   List<Span> decodeList(BytesDecoder<Span> decoder, byte[] serialized) {

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorComponent.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorComponent.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -51,6 +51,11 @@ public abstract class CollectorComponent extends Component {
      * storage system. Defaults to always sample.
      */
     public abstract Builder sampler(CollectorSampler sampler);
+
+    /**
+     * Execution mode for spans collector. Defaults to async.
+     */
+    public abstract Builder asyncExecution(boolean asyncExecution);
 
     public abstract CollectorComponent build();
   }

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorComponent.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -51,11 +51,6 @@ public abstract class CollectorComponent extends Component {
      * storage system. Defaults to always sample.
      */
     public abstract Builder sampler(CollectorSampler sampler);
-
-    /**
-     * Execution mode for spans collector. Defaults to async.
-     */
-    public abstract Builder asyncExecution(boolean asyncExecution);
 
     public abstract CollectorComponent build();
   }

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
@@ -90,7 +90,7 @@ public class CollectorTest {
     byte[] bytes = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
     collector.acceptSpans(bytes, callback);
 
-    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback, true);
+    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();
@@ -131,7 +131,7 @@ public class CollectorTest {
     byte[] bytes = new byte[] {'[', ']'};
     collector.acceptSpans(bytes, callback);
 
-    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V1, callback, true);
+    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V1, callback);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();
@@ -143,13 +143,13 @@ public class CollectorTest {
     Span span2 = CLIENT_SPAN.toBuilder().id("3").build();
     when(collector.idString(span2)).thenReturn("3");
 
-    assertThat(collector.new AsyncStoreSpans(asList(CLIENT_SPAN, span2)))
+    assertThat(collector.new StoreSpans(asList(CLIENT_SPAN, span2)))
       .hasToString("StoreSpans([1, 3])");
   }
 
   @Test
   public void storeSpansCallback_toStringIncludesSpanIds_noMoreThan3() {
-    assertThat(unprefixIdString(collector.new AsyncStoreSpans(TRACE).toString()))
+    assertThat(unprefixIdString(collector.new StoreSpans(TRACE).toString()))
       .hasToString("StoreSpans([1, 1, 2, ...])");
   }
 
@@ -157,7 +157,7 @@ public class CollectorTest {
   public void storeSpansCallback_onErrorWithNullMessage() {
     RuntimeException error = new RuntimeException();
 
-    Callback<Void> callback = collector.new AsyncStoreSpans(TRACE);
+    Callback<Void> callback = collector.new StoreSpans(TRACE);
     callback.onError(error);
 
     assertDebugLogIs("Cannot store spans [1, 1, 2, ...] due to RuntimeException()");
@@ -167,7 +167,7 @@ public class CollectorTest {
   @Test
   public void storeSpansCallback_onErrorWithMessage() {
     IllegalArgumentException error = new IllegalArgumentException("no beer");
-    Callback<Void> callback = collector.new AsyncStoreSpans(TRACE);
+    Callback<Void> callback = collector.new StoreSpans(TRACE);
     callback.onError(error);
 
     assertDebugLogIs("Cannot store spans [1, 1, 2, ...] due to IllegalArgumentException(no beer)");

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -68,7 +68,7 @@ public class CollectorTest {
       .storage(storage)
       .build();
 
-    collector.accept(TRACE, callback);
+    collector.accept(TRACE, callback, true);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();
@@ -79,7 +79,7 @@ public class CollectorTest {
 
   @Test
   public void errorDetectingFormat() {
-    collector.acceptSpans(new byte[] {'f', 'o', 'o'}, callback);
+    collector.acceptSpans(new byte[] {'f', 'o', 'o'}, callback, true);
 
     verify(callback).onError(any(RuntimeException.class));
     verify(metrics).incrementMessagesDropped();
@@ -88,9 +88,9 @@ public class CollectorTest {
   @Test
   public void acceptSpans_jsonV2() {
     byte[] bytes = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
-    collector.acceptSpans(bytes, callback);
+    collector.acceptSpans(bytes, callback, true);
 
-    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback);
+    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback, true);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();
@@ -101,7 +101,7 @@ public class CollectorTest {
   @Test
   public void acceptSpans_decodingError() {
     byte[] bytes = "[\"='".getBytes(UTF_8); // screwed up json
-    collector.acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback);
+    collector.acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback, true);
 
     verify(callback).onError(any(IllegalArgumentException.class));
     assertDebugLogIs("Malformed reading List<Span> from json");
@@ -118,7 +118,7 @@ public class CollectorTest {
       .storage(storage)
       .build();
 
-    collector.accept(TRACE, callback);
+    collector.accept(TRACE, callback, Runnable::run, true);
 
     verify(callback).onSuccess(null); // error is async
     assertDebugLogIs("Cannot store spans [1, 2, 2, ...] due to RuntimeException(storage disabled)");
@@ -129,9 +129,9 @@ public class CollectorTest {
   @Test
   public void acceptSpans_emptyMessageOk() {
     byte[] bytes = new byte[] {'[', ']'};
-    collector.acceptSpans(bytes, callback);
+    collector.acceptSpans(bytes, callback, true);
 
-    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V1, callback);
+    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V1, callback, true);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();
@@ -143,13 +143,13 @@ public class CollectorTest {
     Span span2 = CLIENT_SPAN.toBuilder().id("3").build();
     when(collector.idString(span2)).thenReturn("3");
 
-    assertThat(collector.new StoreSpans(asList(CLIENT_SPAN, span2)))
+    assertThat(collector.new AsyncStoreSpans(asList(CLIENT_SPAN, span2)))
       .hasToString("StoreSpans([1, 3])");
   }
 
   @Test
   public void storeSpansCallback_toStringIncludesSpanIds_noMoreThan3() {
-    assertThat(unprefixIdString(collector.new StoreSpans(TRACE).toString()))
+    assertThat(unprefixIdString(collector.new AsyncStoreSpans(TRACE).toString()))
       .hasToString("StoreSpans([1, 1, 2, ...])");
   }
 
@@ -157,7 +157,7 @@ public class CollectorTest {
   public void storeSpansCallback_onErrorWithNullMessage() {
     RuntimeException error = new RuntimeException();
 
-    Callback<Void> callback = collector.new StoreSpans(TRACE);
+    Callback<Void> callback = collector.new AsyncStoreSpans(TRACE);
     callback.onError(error);
 
     assertDebugLogIs("Cannot store spans [1, 1, 2, ...] due to RuntimeException()");
@@ -167,7 +167,7 @@ public class CollectorTest {
   @Test
   public void storeSpansCallback_onErrorWithMessage() {
     IllegalArgumentException error = new IllegalArgumentException("no beer");
-    Callback<Void> callback = collector.new StoreSpans(TRACE);
+    Callback<Void> callback = collector.new AsyncStoreSpans(TRACE);
     callback.onError(error);
 
     assertDebugLogIs("Cannot store spans [1, 1, 2, ...] due to IllegalArgumentException(no beer)");

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
@@ -90,7 +90,7 @@ public class CollectorTest {
     byte[] bytes = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
     collector.acceptSpans(bytes, callback);
 
-    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback);
+    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback, true);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();
@@ -131,7 +131,7 @@ public class CollectorTest {
     byte[] bytes = new byte[] {'[', ']'};
     collector.acceptSpans(bytes, callback);
 
-    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V1, callback);
+    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V1, callback, true);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -143,13 +143,13 @@ public class CollectorTest {
     Span span2 = CLIENT_SPAN.toBuilder().id("3").build();
     when(collector.idString(span2)).thenReturn("3");
 
-    assertThat(collector.new StoreSpans(asList(CLIENT_SPAN, span2)))
+    assertThat(collector.new AsyncStoreSpans(asList(CLIENT_SPAN, span2)))
       .hasToString("StoreSpans([1, 3])");
   }
 
   @Test
   public void storeSpansCallback_toStringIncludesSpanIds_noMoreThan3() {
-    assertThat(unprefixIdString(collector.new StoreSpans(TRACE).toString()))
+    assertThat(unprefixIdString(collector.new AsyncStoreSpans(TRACE).toString()))
       .hasToString("StoreSpans([1, 1, 2, ...])");
   }
 
@@ -157,7 +157,7 @@ public class CollectorTest {
   public void storeSpansCallback_onErrorWithNullMessage() {
     RuntimeException error = new RuntimeException();
 
-    Callback<Void> callback = collector.new StoreSpans(TRACE);
+    Callback<Void> callback = collector.new AsyncStoreSpans(TRACE);
     callback.onError(error);
 
     assertDebugLogIs("Cannot store spans [1, 1, 2, ...] due to RuntimeException()");
@@ -167,7 +167,7 @@ public class CollectorTest {
   @Test
   public void storeSpansCallback_onErrorWithMessage() {
     IllegalArgumentException error = new IllegalArgumentException("no beer");
-    Callback<Void> callback = collector.new StoreSpans(TRACE);
+    Callback<Void> callback = collector.new AsyncStoreSpans(TRACE);
     callback.onError(error);
 
     assertDebugLogIs("Cannot store spans [1, 1, 2, ...] due to IllegalArgumentException(no beer)");

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -68,7 +68,7 @@ public class CollectorTest {
       .storage(storage)
       .build();
 
-    collector.accept(TRACE, callback, true);
+    collector.accept(TRACE, callback);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();
@@ -79,7 +79,7 @@ public class CollectorTest {
 
   @Test
   public void errorDetectingFormat() {
-    collector.acceptSpans(new byte[] {'f', 'o', 'o'}, callback, true);
+    collector.acceptSpans(new byte[] {'f', 'o', 'o'}, callback);
 
     verify(callback).onError(any(RuntimeException.class));
     verify(metrics).incrementMessagesDropped();
@@ -88,9 +88,9 @@ public class CollectorTest {
   @Test
   public void acceptSpans_jsonV2() {
     byte[] bytes = SpanBytesEncoder.JSON_V2.encodeList(TRACE);
-    collector.acceptSpans(bytes, callback, true);
+    collector.acceptSpans(bytes, callback);
 
-    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback, true);
+    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();
@@ -101,7 +101,7 @@ public class CollectorTest {
   @Test
   public void acceptSpans_decodingError() {
     byte[] bytes = "[\"='".getBytes(UTF_8); // screwed up json
-    collector.acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback, true);
+    collector.acceptSpans(bytes, SpanBytesDecoder.JSON_V2, callback);
 
     verify(callback).onError(any(IllegalArgumentException.class));
     assertDebugLogIs("Malformed reading List<Span> from json");
@@ -118,7 +118,7 @@ public class CollectorTest {
       .storage(storage)
       .build();
 
-    collector.accept(TRACE, callback, Runnable::run, true);
+    collector.accept(TRACE, callback);
 
     verify(callback).onSuccess(null); // error is async
     assertDebugLogIs("Cannot store spans [1, 2, 2, ...] due to RuntimeException(storage disabled)");
@@ -129,9 +129,9 @@ public class CollectorTest {
   @Test
   public void acceptSpans_emptyMessageOk() {
     byte[] bytes = new byte[] {'[', ']'};
-    collector.acceptSpans(bytes, callback, true);
+    collector.acceptSpans(bytes, callback);
 
-    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V1, callback, true);
+    verify(collector).acceptSpans(bytes, SpanBytesDecoder.JSON_V1, callback);
 
     verify(callback).onSuccess(null);
     assertThat(testLogger.getLoggingEvents()).isEmpty();
@@ -143,13 +143,13 @@ public class CollectorTest {
     Span span2 = CLIENT_SPAN.toBuilder().id("3").build();
     when(collector.idString(span2)).thenReturn("3");
 
-    assertThat(collector.new AsyncStoreSpans(asList(CLIENT_SPAN, span2)))
+    assertThat(collector.new StoreSpans(asList(CLIENT_SPAN, span2)))
       .hasToString("StoreSpans([1, 3])");
   }
 
   @Test
   public void storeSpansCallback_toStringIncludesSpanIds_noMoreThan3() {
-    assertThat(unprefixIdString(collector.new AsyncStoreSpans(TRACE).toString()))
+    assertThat(unprefixIdString(collector.new StoreSpans(TRACE).toString()))
       .hasToString("StoreSpans([1, 1, 2, ...])");
   }
 
@@ -157,7 +157,7 @@ public class CollectorTest {
   public void storeSpansCallback_onErrorWithNullMessage() {
     RuntimeException error = new RuntimeException();
 
-    Callback<Void> callback = collector.new AsyncStoreSpans(TRACE);
+    Callback<Void> callback = collector.new StoreSpans(TRACE);
     callback.onError(error);
 
     assertDebugLogIs("Cannot store spans [1, 1, 2, ...] due to RuntimeException()");
@@ -167,7 +167,7 @@ public class CollectorTest {
   @Test
   public void storeSpansCallback_onErrorWithMessage() {
     IllegalArgumentException error = new IllegalArgumentException("no beer");
-    Callback<Void> callback = collector.new AsyncStoreSpans(TRACE);
+    Callback<Void> callback = collector.new StoreSpans(TRACE);
     callback.onError(error);
 
     assertDebugLogIs("Cannot store spans [1, 1, 2, ...] due to IllegalArgumentException(no beer)");

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -63,6 +63,7 @@ public final class KafkaCollector extends CollectorComponent {
     final Properties properties = new Properties();
     Collector.Builder delegate = Collector.newBuilder(KafkaCollector.class);
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
+    boolean asyncExecution = true;
     String topic = "zipkin";
     int streams = 1;
 
@@ -83,6 +84,12 @@ public final class KafkaCollector extends CollectorComponent {
       if (metrics == null) throw new NullPointerException("metrics == null");
       this.metrics = metrics.forTransport("kafka");
       delegate.metrics(this.metrics);
+      return this;
+    }
+
+    @Override
+    public Builder asyncExecution(boolean asyncExecution) {
+      this.asyncExecution = asyncExecution;
       return this;
     }
 

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -63,7 +63,6 @@ public final class KafkaCollector extends CollectorComponent {
     final Properties properties = new Properties();
     Collector.Builder delegate = Collector.newBuilder(KafkaCollector.class);
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
-    boolean asyncExecution = true;
     String topic = "zipkin";
     int streams = 1;
 
@@ -84,12 +83,6 @@ public final class KafkaCollector extends CollectorComponent {
       if (metrics == null) throw new NullPointerException("metrics == null");
       this.metrics = metrics.forTransport("kafka");
       delegate.metrics(this.metrics);
-      return this;
-    }
-
-    @Override
-    public Builder asyncExecution(boolean asyncExecution) {
-      this.asyncExecution = asyncExecution;
       return this;
     }
 

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -52,6 +52,7 @@ final class KafkaCollectorWorker implements Runnable {
   final List<String> topics;
   final Collector collector;
   final CollectorMetrics metrics;
+  final boolean asyncExecution;
   /** Kafka topic partitions currently assigned to this worker. List is not modifiable. */
   final AtomicReference<List<TopicPartition>> assignedPartitions =
       new AtomicReference<>(Collections.emptyList());
@@ -62,6 +63,7 @@ final class KafkaCollectorWorker implements Runnable {
     topics = Arrays.asList(builder.topic.split(","));
     collector = builder.delegate.build();
     metrics = builder.metrics;
+    asyncExecution = builder.asyncExecution;
   }
 
   @Override
@@ -103,9 +105,9 @@ final class KafkaCollectorWorker implements Runnable {
                 metrics.incrementMessagesDropped();
                 continue;
               }
-              collector.accept(Collections.singletonList(span), NOOP);
+              collector.accept(Collections.singletonList(span), NOOP, asyncExecution);
             } else {
-              collector.acceptSpans(bytes, NOOP);
+              collector.acceptSpans(bytes, NOOP, asyncExecution);
             }
           }
         }

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -52,7 +52,6 @@ final class KafkaCollectorWorker implements Runnable {
   final List<String> topics;
   final Collector collector;
   final CollectorMetrics metrics;
-  final boolean asyncExecution;
   /** Kafka topic partitions currently assigned to this worker. List is not modifiable. */
   final AtomicReference<List<TopicPartition>> assignedPartitions =
       new AtomicReference<>(Collections.emptyList());
@@ -63,7 +62,6 @@ final class KafkaCollectorWorker implements Runnable {
     topics = Arrays.asList(builder.topic.split(","));
     collector = builder.delegate.build();
     metrics = builder.metrics;
-    asyncExecution = builder.asyncExecution;
   }
 
   @Override
@@ -105,9 +103,9 @@ final class KafkaCollectorWorker implements Runnable {
                 metrics.incrementMessagesDropped();
                 continue;
               }
-              collector.accept(Collections.singletonList(span), NOOP, asyncExecution);
+              collector.accept(Collections.singletonList(span), NOOP);
             } else {
-              collector.acceptSpans(bytes, NOOP, asyncExecution);
+              collector.acceptSpans(bytes, NOOP);
             }
           }
         }

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -376,6 +376,7 @@ public class ITKafkaCollector {
         .topic(topic)
         .groupId(topic + "_group")
         .streams(streams)
+        .asyncExecution(true)
         .storage(buildStorage(consumer));
   }
 

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -376,7 +376,6 @@ public class ITKafkaCollector {
         .topic(topic)
         .groupId(topic + "_group")
         .streams(streams)
-        .asyncExecution(true)
         .storage(buildStorage(consumer));
   }
 

--- a/zipkin-collector/rabbitmq/README.md
+++ b/zipkin-collector/rabbitmq/README.md
@@ -11,6 +11,7 @@ The following configuration can be set for the RabbitMQ Collector.
 Property | Environment Variable | Description
 --- | --- | ---
 `zipkin.collector.rabbitmq.concurrency` | `RABBIT_CONCURRENCY` | Number of concurrent consumers. Defaults to `1`
+`zipkin.collector.rabbitmq.prefetchCount` | `RABBIT_PREFETCH_COUNT` | Channel prefetch count. Defaults to `0`
 `zipkin.collector.rabbitmq.connection-timeout` | `RABBIT_CONNECTION_TIMEOUT` | Milliseconds to wait establishing a connection. Defaults to `60000` (1 minute)
 `zipkin.collector.rabbitmq.queue` | `RABBIT_QUEUE` | Queue from which to collect span messages. Defaults to `zipkin`
 `zipkin.collector.rabbitmq.uri` | `RABBIT_URI` | [RabbitMQ URI spec](https://www.rabbitmq.com/uri-spec.html)-compliant URI, ex. `amqp://user:pass@host:10000/vhost`
@@ -58,7 +59,7 @@ $ RABBIT_ADDRESSES=localhost java -jar zipkin.jar
 ```json
 [{"traceId":"9032b04972e475c5","id":"9032b04972e475c5","kind":"SERVER","name":"get","timestamp":1505990621526000,"duration":612898,"localEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"192.168.1.113"},"remoteEndpoint":{"serviceName":"","ipv4":"127.0.0.1","port":60149},"tags":{"error":"500 Internal Server Error","http.path":"/a"}}]
 ```
-4. Publish them using the CLI 
+4. Publish them using the CLI
 ```bash
 $ rabbitmqadmin publish exchange=amq.default routing_key=zipkin < sample-spans.json
 ```

--- a/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
@@ -69,12 +69,6 @@ public final class RabbitMQCollector extends CollectorComponent {
       return this;
     }
 
-    @Override
-    public Builder asyncExecution(boolean asyncExecution) {
-      this.asyncExecution = asyncExecution;
-      return this;
-    }
-
     public Builder addresses(List<String> addresses) {
       this.addresses = convertAddresses(addresses);
       return this;
@@ -87,6 +81,11 @@ public final class RabbitMQCollector extends CollectorComponent {
 
     public Builder prefetchCount(int prefetchCount) {
       this.prefetchCount = prefetchCount;
+      return this;
+    }
+
+    public Builder asyncExecution(boolean asyncExecution) {
+      this.asyncExecution = asyncExecution;
       return this;
     }
 
@@ -202,7 +201,7 @@ public final class RabbitMQCollector extends CollectorComponent {
           Channel channel = connection.createChannel();
           channel.basicQos(builder.prefetchCount);
           RabbitMQSpanConsumer consumer = new RabbitMQSpanConsumer(channel, collector, metrics, builder.asyncExecution);
-          channel.basicConsume(builder.queue, true, consumerTag, consumer);
+          channel.basicConsume(builder.queue, false, consumerTag, consumer);
         } catch (IOException e) {
           throw new IllegalStateException("Failed to start RabbitMQ consumer " + consumerTag, e);
         }

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -36,6 +36,7 @@ public final class ScribeCollector extends CollectorComponent {
   public static final class Builder extends CollectorComponent.Builder {
     Collector.Builder delegate = Collector.newBuilder(ScribeCollector.class);
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
+    boolean asyncExecution = true;
     String category = "zipkin";
     int port = 9410;
 
@@ -53,6 +54,12 @@ public final class ScribeCollector extends CollectorComponent {
 
     @Override public Builder sampler(CollectorSampler sampler) {
       delegate.sampler(sampler);
+      return this;
+    }
+
+    @Override
+    public Builder asyncExecution(boolean asyncExecution) {
+      this.asyncExecution = asyncExecution;
       return this;
     }
 
@@ -78,7 +85,7 @@ public final class ScribeCollector extends CollectorComponent {
 
   ScribeCollector(Builder builder) {
     server = new NettyScribeServer(builder.port, new ScribeSpanConsumer(
-      builder.delegate.build(), builder.metrics, builder.category));
+      builder.delegate.build(), builder.metrics, builder.category, builder.asyncExecution));
   }
 
   /** Will throw an exception if the {@link Builder#port(int) port} is already in use. */

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -36,7 +36,6 @@ public final class ScribeCollector extends CollectorComponent {
   public static final class Builder extends CollectorComponent.Builder {
     Collector.Builder delegate = Collector.newBuilder(ScribeCollector.class);
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
-    boolean asyncExecution = true;
     String category = "zipkin";
     int port = 9410;
 
@@ -54,12 +53,6 @@ public final class ScribeCollector extends CollectorComponent {
 
     @Override public Builder sampler(CollectorSampler sampler) {
       delegate.sampler(sampler);
-      return this;
-    }
-
-    @Override
-    public Builder asyncExecution(boolean asyncExecution) {
-      this.asyncExecution = asyncExecution;
       return this;
     }
 
@@ -85,7 +78,7 @@ public final class ScribeCollector extends CollectorComponent {
 
   ScribeCollector(Builder builder) {
     server = new NettyScribeServer(builder.port, new ScribeSpanConsumer(
-      builder.delegate.build(), builder.metrics, builder.category, builder.asyncExecution));
+      builder.delegate.build(), builder.metrics, builder.category));
   }
 
   /** Will throw an exception if the {@link Builder#port(int) port} is already in use. */

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -31,11 +31,13 @@ final class ScribeSpanConsumer implements Scribe.AsyncIface {
   final Collector collector;
   final CollectorMetrics metrics;
   final String category;
+  final boolean asyncExecution;
 
-  ScribeSpanConsumer(Collector collector, CollectorMetrics metrics, String category) {
+  ScribeSpanConsumer(Collector collector, CollectorMetrics metrics, String category, boolean asyncExecution) {
     this.collector = collector;
     this.metrics = metrics;
     this.category = category;
+    this.asyncExecution = asyncExecution;
   }
 
   @Override
@@ -68,6 +70,6 @@ final class ScribeSpanConsumer implements Scribe.AsyncIface {
         Exception error = t instanceof Exception ? (Exception) t : new RuntimeException(t);
         resultHandler.onError(error);
       }
-    });
+    }, asyncExecution);
   }
 }

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -31,13 +31,11 @@ final class ScribeSpanConsumer implements Scribe.AsyncIface {
   final Collector collector;
   final CollectorMetrics metrics;
   final String category;
-  final boolean asyncExecution;
 
-  ScribeSpanConsumer(Collector collector, CollectorMetrics metrics, String category, boolean asyncExecution) {
+  ScribeSpanConsumer(Collector collector, CollectorMetrics metrics, String category) {
     this.collector = collector;
     this.metrics = metrics;
     this.category = category;
-    this.asyncExecution = asyncExecution;
   }
 
   @Override
@@ -70,6 +68,6 @@ final class ScribeSpanConsumer implements Scribe.AsyncIface {
         Exception error = t instanceof Exception ? (Exception) t : new RuntimeException(t);
         resultHandler.onError(error);
       }
-    }, asyncExecution);
+    });
   }
 }

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -55,11 +55,11 @@ public class ITScribeCollector {
       Callback<Void> callback = invocation.getArgument(1);
       callback.onSuccess(null);
       return null;
-    }).when(collector).accept(any(), any(), any());
+    }).when(collector).accept(any(), any());
 
     metrics = mock(CollectorMetrics.class);
 
-    server = new NettyScribeServer(0, new ScribeSpanConsumer(collector, metrics, "zipkin", true));
+    server = new NettyScribeServer(0, new ScribeSpanConsumer(collector, metrics, "zipkin"));
     server.start();
   }
 
@@ -89,7 +89,7 @@ public class ITScribeCollector {
       transport.close();
     }
 
-    verify(collector, times(2)).accept(eq(TestObjects.TRACE), any(), any());
+    verify(collector, times(2)).accept(eq(TestObjects.TRACE), any());
     verify(metrics, times(2)).incrementMessages();
   }
 

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -55,11 +55,11 @@ public class ITScribeCollector {
       Callback<Void> callback = invocation.getArgument(1);
       callback.onSuccess(null);
       return null;
-    }).when(collector).accept(any(), any());
+    }).when(collector).accept(any(), any(), any());
 
     metrics = mock(CollectorMetrics.class);
 
-    server = new NettyScribeServer(0, new ScribeSpanConsumer(collector, metrics, "zipkin"));
+    server = new NettyScribeServer(0, new ScribeSpanConsumer(collector, metrics, "zipkin", true));
     server.start();
   }
 
@@ -89,7 +89,7 @@ public class ITScribeCollector {
       transport.close();
     }
 
-    verify(collector, times(2)).accept(eq(TestObjects.TRACE), any());
+    verify(collector, times(2)).accept(eq(TestObjects.TRACE), any(), any());
     verify(metrics, times(2)).incrementMessages();
   }
 

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -249,6 +249,7 @@ public class ScribeSpanConsumerTest {
     return new ScribeSpanConsumer(
       builder.delegate.build(),
       builder.metrics,
-      builder.category);
+      builder.category,
+      builder.asyncExecution);
   }
 }

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -249,7 +249,6 @@ public class ScribeSpanConsumerTest {
     return new ScribeSpanConsumer(
       builder.delegate.build(),
       builder.metrics,
-      builder.category,
-      builder.asyncExecution);
+      builder.category);
   }
 }

--- a/zipkin-junit/src/main/java/zipkin2/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin2/junit/ZipkinDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-junit/src/main/java/zipkin2/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin2/junit/ZipkinDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -91,7 +91,7 @@ final class ZipkinDispatcher extends Dispatcher {
         String message = t.getMessage();
         result.setBody(message).setResponseCode(message.startsWith("Cannot store") ? 500 : 400);
       }
-    });
+    }, true);
     return result;
   }
 }

--- a/zipkin-junit/src/main/java/zipkin2/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin2/junit/ZipkinDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -91,7 +91,7 @@ final class ZipkinDispatcher extends Dispatcher {
         String message = t.getMessage();
         result.setBody(message).setResponseCode(message.startsWith("Cannot store") ? 500 : 400);
       }
-    }, true);
+    });
     return result;
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,9 +34,6 @@ class ZipkinActiveMQCollectorProperties {
 
   /** Number of concurrent span consumers */
   private Integer concurrency;
-
-  /** Execution mode for span collector */
-  private Boolean asyncExecution = true;
 
   /** Login user of the broker. */
   private String username;
@@ -84,14 +81,6 @@ class ZipkinActiveMQCollectorProperties {
     this.concurrency = concurrency;
   }
 
-  public Boolean getAsyncExecution() {
-    return asyncExecution;
-  }
-
-  public void setAsyncExecution(Boolean asyncExecution) {
-    this.asyncExecution = asyncExecution;
-  }
-
   public String getUsername() {
     return username;
   }
@@ -111,7 +100,6 @@ class ZipkinActiveMQCollectorProperties {
   public ActiveMQCollector.Builder toBuilder() {
     final ActiveMQCollector.Builder result = ActiveMQCollector.builder();
     if (concurrency != null) result.concurrency(concurrency);
-    if (asyncExecution != null) result.asyncExecution(asyncExecution);
     if (queue != null) result.queue(queue);
 
     ActiveMQConnectionFactory connectionFactory;

--- a/zipkin-server/src/main/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,6 +34,9 @@ class ZipkinActiveMQCollectorProperties {
 
   /** Number of concurrent span consumers */
   private Integer concurrency;
+
+  /** Execution mode for span collector */
+  private Boolean asyncExecution = true;
 
   /** Login user of the broker. */
   private String username;
@@ -81,6 +84,14 @@ class ZipkinActiveMQCollectorProperties {
     this.concurrency = concurrency;
   }
 
+  public Boolean getAsyncExecution() {
+    return asyncExecution;
+  }
+
+  public void setAsyncExecution(Boolean asyncExecution) {
+    this.asyncExecution = asyncExecution;
+  }
+
   public String getUsername() {
     return username;
   }
@@ -100,6 +111,7 @@ class ZipkinActiveMQCollectorProperties {
   public ActiveMQCollector.Builder toBuilder() {
     final ActiveMQCollector.Builder result = ActiveMQCollector.builder();
     if (concurrency != null) result.concurrency(concurrency);
+    if (asyncExecution != null) result.asyncExecution(asyncExecution);
     if (queue != null) result.queue(queue);
 
     ActiveMQConnectionFactory connectionFactory;

--- a/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,6 +28,8 @@ class ZipkinKafkaCollectorProperties {
   private String topic;
   /** Number of Kafka consumer threads to run. */
   private Integer streams;
+  /** Execution mode for span collector */
+  private Boolean asyncExecution = true;
   /** Additional Kafka consumer configuration. */
   private Map<String, String> overrides = new LinkedHashMap<>();
 
@@ -63,6 +65,14 @@ class ZipkinKafkaCollectorProperties {
     this.streams = streams;
   }
 
+  public Boolean getAsyncExecution() {
+    return asyncExecution;
+  }
+
+  public void setAsyncExecution(Boolean asyncExecution) {
+    this.asyncExecution = asyncExecution;
+  }
+
   public Map<String, String> getOverrides() {
     return overrides;
   }
@@ -77,6 +87,7 @@ class ZipkinKafkaCollectorProperties {
     if (groupId != null) result.groupId(groupId);
     if (topic != null) result.topic(topic);
     if (streams != null) result.streams(streams);
+    if (asyncExecution != null) result.asyncExecution(asyncExecution);
     if (overrides != null) result.overrides(overrides);
     return result;
   }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,8 +28,6 @@ class ZipkinKafkaCollectorProperties {
   private String topic;
   /** Number of Kafka consumer threads to run. */
   private Integer streams;
-  /** Execution mode for span collector */
-  private Boolean asyncExecution = true;
   /** Additional Kafka consumer configuration. */
   private Map<String, String> overrides = new LinkedHashMap<>();
 
@@ -65,14 +63,6 @@ class ZipkinKafkaCollectorProperties {
     this.streams = streams;
   }
 
-  public Boolean getAsyncExecution() {
-    return asyncExecution;
-  }
-
-  public void setAsyncExecution(Boolean asyncExecution) {
-    this.asyncExecution = asyncExecution;
-  }
-
   public Map<String, String> getOverrides() {
     return overrides;
   }
@@ -87,7 +77,6 @@ class ZipkinKafkaCollectorProperties {
     if (groupId != null) result.groupId(groupId);
     if (topic != null) result.topic(topic);
     if (streams != null) result.streams(streams);
-    if (asyncExecution != null) result.asyncExecution(asyncExecution);
     if (overrides != null) result.overrides(overrides);
     return result;
   }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/mysql/ZipkinMySQLStorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/mysql/ZipkinMySQLStorageConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -57,11 +57,22 @@ public class ZipkinMySQLStorageConfiguration {
     @Value("${zipkin.storage.strict-trace-id:true}") boolean strictTraceId,
     @Value("${zipkin.storage.search-enabled:true}") boolean searchEnabled,
     @Value("${zipkin.storage.autocomplete-keys:}") List<String> autocompleteKeys) {
+    if (mysql.isAsyncStorage()) {
+      return MySQLStorage.newBuilder()
+        .strictTraceId(strictTraceId)
+        .searchEnabled(searchEnabled)
+        .autocompleteKeys(autocompleteKeys)
+        .executor(mysqlExecutor)
+        .datasource(mysqlDataSource)
+        .listenerProvider(mysqlListener)
+        .build();
+    }
+
     return MySQLStorage.newBuilder()
       .strictTraceId(strictTraceId)
       .searchEnabled(searchEnabled)
       .autocompleteKeys(autocompleteKeys)
-      .executor(mysqlExecutor)
+      .executor(Runnable::run)
       .datasource(mysqlDataSource)
       .listenerProvider(mysqlListener)
       .build();

--- a/zipkin-server/src/main/java/zipkin2/server/internal/mysql/ZipkinMySQLStorageProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/mysql/ZipkinMySQLStorageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,6 +30,7 @@ class ZipkinMySQLStorageProperties implements Serializable { // for Spark jobs
   private String password;
   private String db = "zipkin";
   private int maxActive = 10;
+  private boolean asyncStorage = true;
   private boolean useSsl;
 
   public String getJdbcUrl() {
@@ -86,6 +87,14 @@ class ZipkinMySQLStorageProperties implements Serializable { // for Spark jobs
 
   public void setMaxActive(int maxActive) {
     this.maxActive = maxActive;
+  }
+
+  public boolean isAsyncStorage() {
+    return asyncStorage;
+  }
+
+  public void setAsyncStorage(boolean asyncStorage) {
+    this.asyncStorage = asyncStorage;
   }
 
   public boolean isUseSsl() {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
@@ -33,6 +33,8 @@ class ZipkinRabbitMQCollectorProperties {
   private Integer concurrency = 1;
   /** Channel prefetch count */
   private Integer prefetchCount = 0;
+  /** Execution mode for span collector */
+  private Boolean asyncExecution = true;
   /** TCP connection timeout in milliseconds */
   private Integer connectionTimeout;
   /** RabbitMQ user password */
@@ -73,6 +75,14 @@ class ZipkinRabbitMQCollectorProperties {
 
   public void setPrefetchCount(int prefetchCount) {
     this.prefetchCount = prefetchCount;
+  }
+
+  public Boolean getAsyncExecution() {
+    return asyncExecution;
+  }
+
+  public void setAsyncExecution(Boolean asyncExecution) {
+    this.asyncExecution = asyncExecution;
   }
 
   public Integer getConnectionTimeout() {
@@ -138,6 +148,7 @@ class ZipkinRabbitMQCollectorProperties {
     ConnectionFactory connectionFactory = new ConnectionFactory();
     if (concurrency != null) result.concurrency(concurrency);
     if (prefetchCount != null) result.prefetchCount(prefetchCount);
+    if (asyncExecution != null) result.asyncExecution(asyncExecution);
     if (connectionTimeout != null) connectionFactory.setConnectionTimeout(connectionTimeout);
     if (queue != null) result.queue(queue);
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
@@ -31,6 +31,8 @@ class ZipkinRabbitMQCollectorProperties {
   private List<String> addresses;
   /** Number of concurrent consumers */
   private Integer concurrency = 1;
+  /** Channel prefetch count */
+  private Integer prefetchCount = 0;
   /** TCP connection timeout in milliseconds */
   private Integer connectionTimeout;
   /** RabbitMQ user password */
@@ -63,6 +65,14 @@ class ZipkinRabbitMQCollectorProperties {
 
   public void setConcurrency(int concurrency) {
     this.concurrency = concurrency;
+  }
+
+  public int getPrefetchCount() {
+    return prefetchCount;
+  }
+
+  public void setPrefetchCount(int prefetchCount) {
+    this.prefetchCount = prefetchCount;
   }
 
   public Integer getConnectionTimeout() {
@@ -127,6 +137,7 @@ class ZipkinRabbitMQCollectorProperties {
     final RabbitMQCollector.Builder result = RabbitMQCollector.builder();
     ConnectionFactory connectionFactory = new ConnectionFactory();
     if (concurrency != null) result.concurrency(concurrency);
+    if (prefetchCount != null) result.prefetchCount(prefetchCount);
     if (connectionTimeout != null) connectionFactory.setConnectionTimeout(connectionTimeout);
     if (queue != null) result.queue(queue);
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
@@ -33,8 +33,6 @@ class ZipkinRabbitMQCollectorProperties {
   private Integer concurrency = 1;
   /** Channel prefetch count */
   private Integer prefetchCount = 0;
-  /** Execution mode for span collector */
-  private Boolean asyncExecution = true;
   /** TCP connection timeout in milliseconds */
   private Integer connectionTimeout;
   /** RabbitMQ user password */
@@ -75,14 +73,6 @@ class ZipkinRabbitMQCollectorProperties {
 
   public void setPrefetchCount(int prefetchCount) {
     this.prefetchCount = prefetchCount;
-  }
-
-  public Boolean getAsyncExecution() {
-    return asyncExecution;
-  }
-
-  public void setAsyncExecution(Boolean asyncExecution) {
-    this.asyncExecution = asyncExecution;
   }
 
   public Integer getConnectionTimeout() {
@@ -148,7 +138,6 @@ class ZipkinRabbitMQCollectorProperties {
     ConnectionFactory connectionFactory = new ConnectionFactory();
     if (concurrency != null) result.concurrency(concurrency);
     if (prefetchCount != null) result.prefetchCount(prefetchCount);
-    if (asyncExecution != null) result.asyncExecution(asyncExecution);
     if (connectionTimeout != null) connectionFactory.setConnectionTimeout(connectionTimeout);
     if (queue != null) result.queue(queue);
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/scribe/ZipkinScribeCollectorConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/scribe/ZipkinScribeCollectorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/scribe/ZipkinScribeCollectorConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/scribe/ZipkinScribeCollectorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -35,12 +35,14 @@ public class ZipkinScribeCollectorConfiguration {
   ScribeCollector scribe(
     @Value("${zipkin.collector.scribe.category:zipkin}") String category,
     @Value("${zipkin.collector.scribe.port:9410}") int port,
+    @Value("${zipkin.collector.scribe.asyncExecution:true}") boolean asyncExecution,
     CollectorSampler sampler,
     CollectorMetrics metrics,
     StorageComponent storage) {
     return ScribeCollector.newBuilder()
       .category(category)
       .port(port)
+      .asyncExecution(asyncExecution)
       .sampler(sampler)
       .metrics(metrics)
       .storage(storage)

--- a/zipkin-server/src/main/java/zipkin2/server/internal/scribe/ZipkinScribeCollectorConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/scribe/ZipkinScribeCollectorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -35,14 +35,12 @@ public class ZipkinScribeCollectorConfiguration {
   ScribeCollector scribe(
     @Value("${zipkin.collector.scribe.category:zipkin}") String category,
     @Value("${zipkin.collector.scribe.port:9410}") int port,
-    @Value("${zipkin.collector.scribe.asyncExecution:true}") boolean asyncExecution,
     CollectorSampler sampler,
     CollectorMetrics metrics,
     StorageComponent storage) {
     return ScribeCollector.newBuilder()
       .category(category)
       .port(port)
-      .asyncExecution(asyncExecution)
       .sampler(sampler)
       .metrics(metrics)
       .storage(storage)

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -21,8 +21,6 @@ zipkin:
       queue: ${ACTIVEMQ_QUEUE:zipkin}
       # Number of concurrent span consumers.
       concurrency: ${ACTIVEMQ_CONCURRENCY:1}
-      # Execution mode for span collector.
-      asyncExecution: ${ACTIVEMQ_ASYNC_EXECUTION:true}
       # Optional username to connect to the broker
       username: ${ACTIVEMQ_USERNAME:}
       # Optional password to connect to the broker
@@ -44,8 +42,6 @@ zipkin:
       group-id: ${KAFKA_GROUP_ID:zipkin}
       # Count of consumer threads consuming the topic
       streams: ${KAFKA_STREAMS:1}
-      # Execution mode for span collector.
-      asyncExecution: ${KAFKA_ASYNC_EXECUTION:true}
     rabbitmq:
       enabled: ${COLLECTOR_RABBITMQ_ENABLED:true}
       # RabbitMQ server address list (comma-separated list of host:port)
@@ -66,8 +62,6 @@ zipkin:
       enabled: ${COLLECTOR_SCRIBE_ENABLED:${SCRIBE_ENABLED:false}}
       category: ${SCRIBE_CATEGORY:zipkin}
       port: ${COLLECTOR_PORT:9410}
-      # Execution mode for span collector.
-      asyncExecution: ${SCRIBE_ASYNC_EXECUTION:true}
   query:
     enabled: ${QUERY_ENABLED:true}
     # Timeout for requests to the query API

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -21,6 +21,8 @@ zipkin:
       queue: ${ACTIVEMQ_QUEUE:zipkin}
       # Number of concurrent span consumers.
       concurrency: ${ACTIVEMQ_CONCURRENCY:1}
+      # Execution mode for span collector.
+      asyncExecution: ${ASYNC_EXECUTION:true}
       # Optional username to connect to the broker
       username: ${ACTIVEMQ_USERNAME:}
       # Optional password to connect to the broker
@@ -42,12 +44,16 @@ zipkin:
       group-id: ${KAFKA_GROUP_ID:zipkin}
       # Count of consumer threads consuming the topic
       streams: ${KAFKA_STREAMS:1}
+      # Execution mode for span collector.
+      asyncExecution: ${ASYNC_EXECUTION:true}
     rabbitmq:
       enabled: ${COLLECTOR_RABBITMQ_ENABLED:true}
       # RabbitMQ server address list (comma-separated list of host:port)
       addresses: ${RABBIT_ADDRESSES:}
       concurrency: ${RABBIT_CONCURRENCY:1}
       prefetchCount: ${RABBIT_PREFETCH_COUNT:0}
+      # Execution mode for span collector.
+      asyncExecution: ${ASYNC_EXECUTION:true}
       # TCP connection timeout in milliseconds
       connection-timeout: ${RABBIT_CONNECTION_TIMEOUT:60000}
       password: ${RABBIT_PASSWORD:guest}
@@ -60,6 +66,8 @@ zipkin:
       enabled: ${COLLECTOR_SCRIBE_ENABLED:${SCRIBE_ENABLED:false}}
       category: ${SCRIBE_CATEGORY:zipkin}
       port: ${COLLECTOR_PORT:9410}
+      # Execution mode for span collector.
+      asyncExecution: ${ASYNC_EXECUTION:true}
   query:
     enabled: ${QUERY_ENABLED:true}
     # Timeout for requests to the query API

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -47,6 +47,7 @@ zipkin:
       # RabbitMQ server address list (comma-separated list of host:port)
       addresses: ${RABBIT_ADDRESSES:}
       concurrency: ${RABBIT_CONCURRENCY:1}
+      prefetchCount: ${RABBIT_PREFETCH_COUNT:1}
       # TCP connection timeout in milliseconds
       connection-timeout: ${RABBIT_CONNECTION_TIMEOUT:60000}
       password: ${RABBIT_PASSWORD:guest}

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -47,7 +47,7 @@ zipkin:
       # RabbitMQ server address list (comma-separated list of host:port)
       addresses: ${RABBIT_ADDRESSES:}
       concurrency: ${RABBIT_CONCURRENCY:1}
-      prefetchCount: ${RABBIT_PREFETCH_COUNT:1}
+      prefetchCount: ${RABBIT_PREFETCH_COUNT:0}
       # TCP connection timeout in milliseconds
       connection-timeout: ${RABBIT_CONNECTION_TIMEOUT:60000}
       password: ${RABBIT_PASSWORD:guest}

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -48,8 +48,6 @@ zipkin:
       addresses: ${RABBIT_ADDRESSES:}
       concurrency: ${RABBIT_CONCURRENCY:1}
       prefetchCount: ${RABBIT_PREFETCH_COUNT:0}
-      # Execution mode for span collector.
-      asyncExecution: ${RABBIT_ASYNC_EXECUTION:true}
       # TCP connection timeout in milliseconds
       connection-timeout: ${RABBIT_CONNECTION_TIMEOUT:60000}
       password: ${RABBIT_PASSWORD:guest}
@@ -170,6 +168,7 @@ zipkin:
       password: ${MYSQL_PASS:}
       db: ${MYSQL_DB:zipkin}
       max-active: ${MYSQL_MAX_CONNECTIONS:10}
+      async-storage: ${MYSQL_ASYNC_STORAGE:true}
       use-ssl: ${MYSQL_USE_SSL:false}
   ui:
     enabled: ${QUERY_ENABLED:true}

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -22,7 +22,7 @@ zipkin:
       # Number of concurrent span consumers.
       concurrency: ${ACTIVEMQ_CONCURRENCY:1}
       # Execution mode for span collector.
-      asyncExecution: ${ASYNC_EXECUTION:true}
+      asyncExecution: ${ACTIVEMQ_ASYNC_EXECUTION:true}
       # Optional username to connect to the broker
       username: ${ACTIVEMQ_USERNAME:}
       # Optional password to connect to the broker
@@ -45,7 +45,7 @@ zipkin:
       # Count of consumer threads consuming the topic
       streams: ${KAFKA_STREAMS:1}
       # Execution mode for span collector.
-      asyncExecution: ${ASYNC_EXECUTION:true}
+      asyncExecution: ${KAFKA_ASYNC_EXECUTION:true}
     rabbitmq:
       enabled: ${COLLECTOR_RABBITMQ_ENABLED:true}
       # RabbitMQ server address list (comma-separated list of host:port)
@@ -53,7 +53,7 @@ zipkin:
       concurrency: ${RABBIT_CONCURRENCY:1}
       prefetchCount: ${RABBIT_PREFETCH_COUNT:0}
       # Execution mode for span collector.
-      asyncExecution: ${ASYNC_EXECUTION:true}
+      asyncExecution: ${RABBIT_ASYNC_EXECUTION:true}
       # TCP connection timeout in milliseconds
       connection-timeout: ${RABBIT_CONNECTION_TIMEOUT:60000}
       password: ${RABBIT_PASSWORD:guest}
@@ -67,7 +67,7 @@ zipkin:
       category: ${SCRIBE_CATEGORY:zipkin}
       port: ${COLLECTOR_PORT:9410}
       # Execution mode for span collector.
-      asyncExecution: ${ASYNC_EXECUTION:true}
+      asyncExecution: ${SCRIBE_ASYNC_EXECUTION:true}
   query:
     enabled: ${QUERY_ENABLED:true}
     # Timeout for requests to the query API


### PR DESCRIPTION
**Environment:** 
Platform: Pivotal Cloud Foundry
Memory: 1GB
Span Collector: RabbitMQ
Storage: MySQL

**Issue:**
Server crashes with resources exhausted error, when RabbitMQ queue has couple thousand messages.

**Cause:**
RabbitMQ broker delivers messages to consumer channel as soon as they are published to a queue. Since, Zipkin RabbitMQ collector utilizes auto acknowledgment feature, broker continuously deliver incoming messages through consumer channel, it doesn’t wait for an ack for a previously delivered message.

**Solution:**
Use channel prefetch count with manual acknowledgement to limit number of inflight/unacknowledged deliveries permitted on a consumer channel. Message consumption rate can be tuned through concurrency and synchronous span collection execution mode configurations.