### PR TITLE
Add View Logs link to lens.

### DIFF
--- a/zipkin-lens/src/components/TracePage/TracePage.jsx
+++ b/zipkin-lens/src/components/TracePage/TracePage.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -75,7 +75,7 @@ export const TracePageImpl = React.memo(({
       <>
         <TraceSummaryHeader />
         <Box width="100%" display="flex" justifyContent="center">
-          <CircularProgress />
+          <CircularProgress data-testid="progress-indicator" />
         </Box>
       </>
     );

--- a/zipkin-lens/src/components/TracePage/TracePage.test.jsx
+++ b/zipkin-lens/src/components/TracePage/TracePage.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -12,16 +12,20 @@
  * the License.
  */
 import React from 'react';
-import { shallow } from 'enzyme';
-import CircularProgress from '@material-ui/core/CircularProgress';
+
+import render from '../../test/util/render-with-default-settings';
 
 import { TracePageImpl } from './TracePage';
 import TraceSummary from './TraceSummary';
-import MessageBar from './MessageBar';
+
+jest.mock("./TraceSummary", () => () => (<div data-testid="trace-summary">TraceSummary</div>));
+afterAll(() => {
+  jest.restoreAllMocks();
+});
 
 describe('<TracePage />', () => {
   it('should render an error message when the page is traceViewer and malformed file is loaded', () => {
-    const wrapper = shallow(
+    const { getByText } = render(
       <TracePageImpl
         isTraceViewerPage
         isMalformedFile
@@ -29,50 +33,45 @@ describe('<TracePage />', () => {
         errorMessage="This is an error message"
       />,
     );
-    expect(wrapper.find(MessageBar).first().prop('message')).toBe(
-      'This is an error message',
-    );
+
+    expect(getByText('This is an error message')).toBeInTheDocument();
   });
 
   it('should render a loading indicator when the page is trace page and is loading trace', () => {
-    const wrapper = shallow(
+    const { getByTestId } = render(
       <TracePageImpl
         isTraceViewerPage={false}
         isLoading
         loadTrace={jest.fn()}
       />,
     );
-    expect(wrapper.find(CircularProgress).first().length).toBe(1);
+    expect(getByTestId('progress-indicator')).toBeInTheDocument();
   });
 
   it('should render an info message when the page is traceViewer and the trace has not loaded yet', () => {
-    const wrapper = shallow(
+    const { getByText } = render(
       <TracePageImpl
         isTraceViewerPage
         isMalformedFile={false}
         loadTrace={jest.fn()}
       />,
     );
-    expect(wrapper.find(MessageBar).first().prop('message')).toBe(
-      'You need to upload JSON...',
-    );
+    expect(getByText('You need to upload JSON...')).toBeInTheDocument();
   });
 
   it('should render an error message when the page is trace page and the trace is null', () => {
-    const wrapper = shallow(
+    const { getByText } = render(
       <TracePageImpl
         isTraceViewerPage={false}
         isLoading={false}
         loadTrace={jest.fn()}
       />,
     );
-    expect(wrapper.find(MessageBar).first().prop('message')).toBe(
-      'Trace not found',
-    );
+    expect(getByText('Trace not found')).toBeInTheDocument();
   });
 
   it('should render TraceSummary when the page is traceViewer and the trace has been loaded', () => {
-    const wrapper = shallow(
+    const { getByTestId } = render(
       <TracePageImpl
         isTraceViewerPage
         isMalformedFile={false}
@@ -90,11 +89,11 @@ describe('<TracePage />', () => {
         }}
       />,
     );
-    expect(wrapper.find(TraceSummary).first().length).toBe(1);
+    expect(getByTestId('trace-summary')).toBeInTheDocument();
   });
 
   it('should render TraceSummary when the page is trace page and the trace has been loaded', () => {
-    const wrapper = shallow(
+    const { getByTestId } = render(
       <TracePageImpl
         isTraceViewerPage={false}
         isLoading={false}
@@ -112,6 +111,6 @@ describe('<TracePage />', () => {
         }}
       />,
     );
-    expect(wrapper.find(TraceSummary).first().length).toBe(1);
+    expect(getByTestId('trace-summary')).toBeInTheDocument();
   });
 });

--- a/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
@@ -13,13 +13,16 @@
  */
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
-import { faDownload } from '@fortawesome/free-solid-svg-icons';
+import { faDownload, faFileAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { makeStyles } from '@material-ui/styles';
 import Box from '@material-ui/core/Box';
+import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { useUiConfig } from '../UiConfig';
 
 import TraceIdSearchInput from '../Common/TraceIdSearchInput';
 import TraceJsonUploader from '../Common/TraceJsonUploader';
@@ -65,8 +68,6 @@ const useStyles = makeStyles(theme => ({
     paddingRight: theme.spacing(4),
   },
   lowerBox: {
-    display: 'flex',
-    justifyContent: 'space-between',
     marginTop: theme.spacing(0.5),
     marginBottom: theme.spacing(0.5),
   },
@@ -86,11 +87,11 @@ const useStyles = makeStyles(theme => ({
     fontWeight: 'bold',
     marginLeft: theme.spacing(0.8),
   },
-  saveButton: {
+  actionButton: {
     fontSize: '0.5rem',
     lineHeight: 0.8,
   },
-  saveButtonIcon: {
+  actionButtonIcon: {
     marginRight: theme.spacing(1),
   },
 }));
@@ -98,6 +99,11 @@ const useStyles = makeStyles(theme => ({
 const TraceSummaryHeader = React.memo(({ traceSummary, rootSpanIndex }) => {
   const classes = useStyles();
   const intl = useIntl();
+  const config = useUiConfig();
+
+  const logsUrl = (config.logsUrl && traceSummary)
+    ? config.logsUrl.replace('{traceId}', traceSummary.traceId)
+    : undefined;
 
   const handleSaveButtonClick = useCallback(() => {
     if (!traceSummary || !traceSummary.traceId) {
@@ -167,13 +173,27 @@ const TraceSummaryHeader = React.memo(({ traceSummary, rootSpanIndex }) => {
           <TraceIdSearchInput />
         </Box>
       </Box>
-      <Box className={classes.lowerBox}>
-        {traceInfo}
-        <Button variant="outlined" className={classes.saveButton} onClick={handleSaveButtonClick}>
-          <FontAwesomeIcon icon={faDownload} className={classes.saveButtonIcon} />
-          Download JSON
-        </Button>
-      </Box>
+      <Grid container className={classes.lowerBox} justify="space-between">
+        <Grid item xs={8}>
+          {traceInfo}
+        </Grid>
+        <Grid container item xs={4} justify="flex-end" spacing={1}>
+          <Grid item>
+            <Button variant="outlined" className={classes.actionButton} onClick={handleSaveButtonClick}>
+              <FontAwesomeIcon icon={faDownload} className={classes.actionButtonIcon} />
+              <FormattedMessage {...messages.downloadJson} />
+            </Button>
+          </Grid>
+          {logsUrl && (
+            <Grid item>
+              <Button variant="outlined" className={classes.actionButton} href={logsUrl} target="_blank" rel="noopener" data-testid="view-logs-link">
+                <FontAwesomeIcon icon={faFileAlt} className={classes.actionButtonIcon} />
+                <FormattedMessage {...messages.viewLogs} />
+              </Button>
+            </Grid>
+          )}
+        </Grid>
+      </Grid>
     </Box>
   );
 });

--- a/zipkin-lens/src/components/TracePage/TraceSummaryHeader.test.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummaryHeader.test.jsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+
+import render from '../../test/util/render-with-default-settings';
+
+import TraceSummaryHeader from './TraceSummaryHeader';
+
+describe('<TraceSummaryHeader />', () => {
+  it('does not render View Logs link with default config', () => {
+    const { queryByTestId } = render(
+      <TraceSummaryHeader
+        traceSummary={{
+          traceId: '1',
+          spans: [],
+          serviceNameAndSpanCounts: [],
+          duration: 1,
+          durationStr: '1μs',
+          rootSpan: {
+            serviceName: 'service-A',
+            spanName: 'span-A',
+          }}}
+      />);
+    expect(queryByTestId('view-logs-link')).not.toBeInTheDocument();
+  });
+
+  it('does render View Logs link when logs URL in config', () => {
+    const { queryByTestId } = render(
+      <TraceSummaryHeader
+        traceSummary={{
+          traceId: '1',
+          spans: [],
+          serviceNameAndSpanCounts: [],
+          duration: 1,
+          durationStr: '1μs',
+          rootSpan: {
+            serviceName: 'service-A',
+            spanName: 'span-A',
+          }}}
+      />,
+      { uiConfig: { logsUrl: 'http://zipkin.io/logs={traceId}' }});
+    const logsLink = queryByTestId('view-logs-link');
+    expect(logsLink).toBeInTheDocument();
+    expect(logsLink.href).toEqual('http://zipkin.io/logs=1');
+    // Make sure the link opens in a new tab
+    expect(logsLink.target).toEqual('_blank');
+    expect(logsLink.rel).toEqual('noopener');
+  });
+});

--- a/zipkin-lens/src/components/TracePage/messages.js
+++ b/zipkin-lens/src/components/TracePage/messages.js
@@ -14,8 +14,10 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
+  downloadJson: 'Download JSON',
   duration: 'Duration',
   services: 'Services',
   depth: 'Depth',
   totalSpans: 'Total Spans',
+  viewLogs: 'View Logs',
 });

--- a/zipkin-lens/src/components/UiConfig/UiConfig.jsx
+++ b/zipkin-lens/src/components/UiConfig/UiConfig.jsx
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { UI_CONFIG } from '../../constants/api';
 import fetchResource from '../../util/fetch-resource';
@@ -31,3 +31,5 @@ export const UiConfig = ({ children }) => {
 
 export const UiConfigContext = ConfigContext;
 export const UiConfigConsumer = ConfigContext.Consumer;
+
+export const useUiConfig = () => useContext(UiConfigContext);

--- a/zipkin-lens/src/components/UiConfig/UiConfig.test.jsx
+++ b/zipkin-lens/src/components/UiConfig/UiConfig.test.jsx
@@ -45,29 +45,31 @@ const UiConfig = () => {
   );
 };
 
-test('fetches config and suspends', async () => {
-  const configPromise = new Promise(() => undefined);
-  fetchMock.mock('*', configPromise);
+describe('<UiConfig />', () => {
+  it('fetches config and suspends', async () => {
+    const configPromise = new Promise(() => undefined);
+    fetchMock.once(UI_CONFIG, configPromise, { overwriteRoutes: true });
 
-  const { getByText } = render(<UiConfig />);
-  expect(getByText('Suspended')).toBeInTheDocument();
+    const { getByText } = render(<UiConfig />);
+    expect(getByText('Suspended')).toBeInTheDocument();
 
-  fetchMock.called(UI_CONFIG);
-});
+    fetchMock.called(UI_CONFIG);
+  });
 
-test('provides config when resolved', async () => {
-  const config = { defaultLookback: 100 };
-  fetchMock.once('*', config);
+  it('provides config when resolved', async () => {
+    const config = { defaultLookback: 100 };
+    fetchMock.once(UI_CONFIG, config, { overwriteRoutes: true });
 
-  const { getByText, rerender } = render(<UiConfig />);
-  expect(getByText('Suspended')).toBeInTheDocument();
+    const { getByText, rerender } = render(<UiConfig />);
+    expect(getByText('Suspended')).toBeInTheDocument();
 
-  // We need to get off the processing loop to allow the promise to complete and resolve the
-  // config.
-  await new Promise(resolve => setTimeout(resolve, 1));
+    // We need to get off the processing loop to allow the promise to complete and resolve the
+    // config.
+    await new Promise(resolve => setTimeout(resolve, 1));
 
-  rerender(<UiConfig />);
-  expect(getByText(JSON.stringify(config))).toBeInTheDocument();
+    rerender(<UiConfig />);
+    expect(getByText(JSON.stringify(config))).toBeInTheDocument();
 
-  fetchMock.called(UI_CONFIG);
+    fetchMock.called(UI_CONFIG);
+  });
 });

--- a/zipkin-lens/src/setup-test.js
+++ b/zipkin-lens/src/setup-test.js
@@ -43,10 +43,6 @@ beforeEach(() => {
   Object.defineProperty(window.navigator, 'language', { value: 'en-US', configurable: true });
 });
 
-afterEach(() => {
-  fetchMock.restore();
-});
-
 afterAll(() => {
   // Restore overrides for good measure.
   Object.defineProperty(window.navigator, 'language', { value: language, configurable: true });

--- a/zipkin-lens/src/setup-test.js
+++ b/zipkin-lens/src/setup-test.js
@@ -15,11 +15,17 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
 import '@testing-library/jest-dom';
+import fetchMock from 'fetch-mock';
+
+import { UI_CONFIG } from './constants/api';
 
 const Enzyme = require('enzyme');
 const EnzymeAdapter = require('enzyme-adapter-react-16');
 
 Enzyme.configure({ adapter: new EnzymeAdapter() });
+
+// Mock out UI Config fetch with an empty config as a baseline, tests can remock as needed.
+fetchMock.mock(UI_CONFIG, {});
 
 // Mock out browser refresh.
 const { reload } = window.location;
@@ -35,6 +41,10 @@ beforeAll(() => {
 beforeEach(() => {
   // Set english as browser locale by default.
   Object.defineProperty(window.navigator, 'language', { value: 'en-US', configurable: true });
+});
+
+afterEach(() => {
+  fetchMock.restore();
 });
 
 afterAll(() => {

--- a/zipkin-lens/src/test/util/render-with-default-settings.jsx
+++ b/zipkin-lens/src/test/util/render-with-default-settings.jsx
@@ -21,6 +21,8 @@ import MomentUtils from '@date-io/moment';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
+import { UiConfigContext } from '../../components/UiConfig';
+
 import { theme } from '../../colors';
 import configureStore from '../../store/configure-store';
 
@@ -28,6 +30,7 @@ export default (ui, {
   route = '/',
   history = createMemoryHistory({ initialEntries: [route] }),
   locale = 'en',
+  uiConfig = {},
 } = {}) => {
   const store = configureStore({});
 
@@ -37,7 +40,9 @@ export default (ui, {
         <Router history={history}>
           <MuiPickersUtilsProvider utils={MomentUtils}>
             <ThemeProvider theme={theme}>
-              {children}
+              <UiConfigContext.Provider value={uiConfig}>
+                {children}
+              </UiConfigContext.Provider>
             </ThemeProvider>
           </MuiPickersUtilsProvider>
         </Router>

--- a/zipkin-lens/src/translations/en.json
+++ b/zipkin-lens/src/translations/en.json
@@ -13,7 +13,9 @@
   "src.components.GlobalSearch.limit": "Limit",
   "src.components.GlobalSearch.pleaseSelectCriteria": "Please select the criteria for your trace lookup",
   "src.components.TracePage.depth": "Depth",
+  "src.components.TracePage.downloadJson": "Download JSON",
   "src.components.TracePage.duration": "Duration",
   "src.components.TracePage.services": "Services",
-  "src.components.TracePage.totalSpans": "Total Spans"
+  "src.components.TracePage.totalSpans": "Total Spans",
+  "src.components.TracePage.viewLogs": "View Logs"
 }

--- a/zipkin-lens/src/translations/zh-cn.json
+++ b/zipkin-lens/src/translations/zh-cn.json
@@ -13,7 +13,9 @@
   "src.components.GlobalSearch.limit": "数量",
   "src.components.GlobalSearch.pleaseSelectCriteria": "",
   "src.components.TracePage.depth": "深度",
+  "src.components.TracePage.downloadJson": "",
   "src.components.TracePage.duration": "持续时间",
   "src.components.TracePage.services": "服务",
-  "src.components.TracePage.totalSpans": "Span总数"
+  "src.components.TracePage.totalSpans": "Span总数",
+  "src.components.TracePage.viewLogs": ""
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -15,29 +15,21 @@ package zipkin2.server.internal.ui;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ServerCacheControl;
 import com.linecorp.armeria.common.ServerCacheControlBuilder;
-import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.RedirectService;
-import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.file.HttpFileBuilder;
 import com.linecorp.armeria.server.file.HttpFileServiceBuilder;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
-import io.netty.handler.codec.http.cookie.Cookie;
-import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -129,7 +121,6 @@ public class ZipkinUiConfiguration {
     };
   }
 
-  // TODO: This is not read by lens https://github.com/openzipkin/zipkin/issues/2969
   //
   // environment: '',
   // queryLimit: 10,
@@ -148,6 +139,7 @@ public class ZipkinUiConfiguration {
       generator.writeNumberField("queryLimit", ui.getQueryLimit());
       generator.writeNumberField("defaultLookback", ui.getDefaultLookback());
       generator.writeBooleanField("searchEnabled", ui.isSearchEnabled());
+      generator.writeStringField("logsUrl", ui.getLogsUrl());
       generator.writeObjectFieldStart("dependency");
       generator.writeNumberField("lowErrorRate", ui.getDependency().getLowErrorRate());
       generator.writeNumberField("highErrorRate", ui.getDependency().getHighErrorRate());

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -114,6 +114,16 @@ public class ITZipkinUiConfiguration {
       .isEqualTo("gzip");
   }
 
+  /**
+   * The test sets the property {@code zipkin.ui.base-path=/foozipkin}, which should reflect in
+   * index.html
+   */
+  @Test public void replacesBaseTag() throws Exception {
+    assertThat(get("/zipkin/index.html").body().string())
+      .isEqualToIgnoringWhitespace(stringFromClasspath(getClass(), "zipkin-lens/index.html")
+        .replace("<base href=\"/\" />", "<base href=\"/foozipkin/\" />"));
+  }
+
   /** index.html is served separately. This tests other content is also loaded from the classpath. */
   @Test public void servesOtherContentFromClasspath() throws Exception {
     assertThat(get("/zipkin/test.txt").body().string())

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -58,6 +58,7 @@ public class ITZipkinUiConfiguration {
       + "  \"queryLimit\" : 10,\n"
       + "  \"defaultLookback\" : 900000,\n"
       + "  \"searchEnabled\" : true,\n"
+      + "  \"logsUrl\" : null,\n"
       + "  \"dependency\" : {\n"
       + "    \"lowErrorRate\" : 0.5,\n"
       + "    \"highErrorRate\" : 0.75\n"
@@ -111,16 +112,6 @@ public class ITZipkinUiConfiguration {
       .isNull(); // too small to compress
     assertThat(getContentEncodingFromRequestThatAcceptsGzip("/zipkin/config.json"))
       .isEqualTo("gzip");
-  }
-
-  /**
-   * The test sets the property {@code zipkin.ui.base-path=/foozipkin}, which should reflect in
-   * index.html
-   */
-  @Test public void replacesBaseTag() throws Exception {
-    assertThat(get("/zipkin/index.html").body().string())
-      .isEqualToIgnoringWhitespace(stringFromClasspath(getClass(), "zipkin-lens/index.html")
-        .replace("<base href=\"/\" />", "<base href=\"/foozipkin/\" />"));
   }
 
   /** index.html is served separately. This tests other content is also loaded from the classpath. */


### PR DESCRIPTION
I've mentioned considering `Grid` for layout before and did it here - I find it much simpler to layout items on a page only with markup instead of context-switching with the CSS any time a new item is added.

Fixes #2491

With logsUrl set
![image](https://user-images.githubusercontent.com/198344/75223845-adea5200-57ea-11ea-8fca-bdce52b0caaa.png)

Without logsUrl set (unchanged)
![image](https://user-images.githubusercontent.com/198344/75223985-f73aa180-57ea-11ea-8883-1c67da14df09.png)
