### PR TITLE
Read base tag in zipkin-lens to allow reverse proxies.

### DIFF
--- a/zipkin-lens/src/components/App/App.jsx
+++ b/zipkin-lens/src/components/App/App.jsx
@@ -30,6 +30,8 @@ import { theme } from '../../colors';
 import { useDocumentTitle } from '../../hooks';
 import { DEFAULT_LOCALE, getLocale } from '../../util/locale';
 
+import { BASE_PATH } from '../../constants/api';
+
 const translations = {
   en: require('../../translations/en.json'),
   'zh-cn': require('../../translations/zh-cn.json'),
@@ -53,21 +55,21 @@ const App = () => {
                     messages={messages}
                     defaultLocale={DEFAULT_LOCALE}
                   >
-                    <BrowserRouter>
+                    <BrowserRouter basename={BASE_PATH}>
                       <Layout>
                         <Route
                           exact
-                          path="/zipkin"
+                          path="/"
                           component={DiscoverPage}
                         />
                         <Route
                           exact
-                          path="/zipkin/dependency"
+                          path="/dependency"
                           component={DependenciesPage}
                         />
                         <Route
                           exact
-                          path={['/zipkin/traces/:traceId', '/zipkin/traceViewer']}
+                          path={['/traces/:traceId', '/traceViewer']}
                           component={TracePage}
                         />
                       </Layout>

--- a/zipkin-lens/src/components/App/Layout.jsx
+++ b/zipkin-lens/src/components/App/Layout.jsx
@@ -81,8 +81,8 @@ const Layout = ({ children }) => {
             <Logo className={classes.zipkinLogo} />
           </Box>
           <List>
-            <SidebarMenu title="Discover Page" path="/zipkin" icon={faSearch} />
-            <SidebarMenu title="Dependencies Page" path="/zipkin/dependency" icon={faProjectDiagram} />
+            <SidebarMenu title="Discover Page" path="/" icon={faSearch} />
+            <SidebarMenu title="Dependencies Page" path="/dependency" icon={faProjectDiagram} />
           </List>
         </Box>
         <List>

--- a/zipkin-lens/src/components/App/SidebarMenu.jsx
+++ b/zipkin-lens/src/components/App/SidebarMenu.jsx
@@ -20,6 +20,8 @@ import { makeStyles } from '@material-ui/styles';
 import ListItem from '@material-ui/core/ListItem';
 import Tooltip from '@material-ui/core/Tooltip';
 
+import { BASE_PATH } from '../../constants/api';
+
 const propTypes = {
   title: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
@@ -56,8 +58,10 @@ export const SidebarMenuImpl = React.forwardRef(({
     <Tooltip title={title} placement="right">
       <ListItem
         button
+        // TODO(anuraaga): Replace with react-router-dom Link for more smoothness after fixing state
+        // management. We need to make sure to clear traces when returning to the discovery page.
         component="a"
-        href={path}
+        href={`${BASE_PATH}${path}`}
         ref={ref}
         className={
           classNames(

--- a/zipkin-lens/src/components/Common/TraceIdSearchInput.jsx
+++ b/zipkin-lens/src/components/Common/TraceIdSearchInput.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -42,7 +42,7 @@ const TraceIdSearchInput = ({ history }) => {
   const handleKeyDown = useCallback((event) => {
     if (event.key === 'Enter') {
       history.push({
-        pathname: `/zipkin/traces/${traceId}`,
+        pathname: `/traces/${traceId}`,
       });
     }
   }, [history, traceId]);

--- a/zipkin-lens/src/components/Common/TraceJsonUploader.jsx
+++ b/zipkin-lens/src/components/Common/TraceJsonUploader.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -53,7 +53,7 @@ const TraceJsonUploader = ({ history }) => {
     const fileReader = new FileReader();
 
     const goToTraceViewerPage = () => {
-      history.push({ pathname: '/zipkin/traceViewer' });
+      history.push({ pathname: '/traceViewer' });
     };
 
     fileReader.onload = () => {

--- a/zipkin-lens/src/components/DependenciesPage/DependenciesPage.jsx
+++ b/zipkin-lens/src/components/DependenciesPage/DependenciesPage.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -129,7 +129,7 @@ export const DependenciesPageImpl = React.memo(({
     const lookback = endTs - startTs;
     fetchDependencies({ lookback, endTs });
     history.push({
-      pathname: '/zipkin/dependency',
+      pathname: '/dependency',
       search: buildQueryParameters({ startTs, endTs }),
     });
   }, [fetchDependencies, timeRange, history]);

--- a/zipkin-lens/src/components/DependenciesPage/NodeDetail.jsx
+++ b/zipkin-lens/src/components/DependenciesPage/NodeDetail.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -106,7 +106,7 @@ const NodeDetail = React.memo(({
 
   const handleSearchTracesButtonClick = useCallback(() => {
     history.push({
-      pathname: '/zipkin',
+      pathname: '/',
       search: buildQueryParameters({
         serviceName,
         startTs: startTime.valueOf(),

--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
@@ -155,7 +155,7 @@ const DiscoverPageImpl = ({
       limitCondition,
       currentTs,
     ));
-    history.push({ pathname: '/zipkin', search: queryParameters });
+    history.push({ search: queryParameters });
     loadTraces(buildTracesApiQueryParameters(
       conditions,
       lookbackCondition,

--- a/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -99,7 +99,7 @@ export const TracesTableRowImpl = ({
   const { spanName, serviceName } = rootServiceAndSpanName(correctedTrace);
 
   const handleClick = useCallback(() => {
-    history.push(`/zipkin/traces/${traceSummary.traceId}`);
+    history.push(`/traces/${traceSummary.traceId}`);
   }, [history, traceSummary.traceId]);
 
   return (

--- a/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.test.js
+++ b/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -145,7 +145,7 @@ describe('<TracesTableRow />', () => {
     item.simulate('click');
     expect(history.push.mock.calls.length).toBe(1);
     expect(history.push.mock.calls[0][0]).toBe(
-      '/zipkin/traces/12345',
+      '/traces/12345',
     );
   });
 });

--- a/zipkin-lens/src/components/TracePage/TracePage.jsx
+++ b/zipkin-lens/src/components/TracePage/TracePage.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-lens/src/components/TracePage/TracePage.jsx
+++ b/zipkin-lens/src/components/TracePage/TracePage.jsx
@@ -110,7 +110,7 @@ TracePageImpl.defaultProps = defaultProps;
 const mapStateToProps = (state, ownProps) => {
   const { location, match } = ownProps;
 
-  const isTraceViewerPage = location.pathname === '/zipkin/traceViewer';
+  const isTraceViewerPage = location.pathname === '/traceViewer';
 
   const props = {};
 

--- a/zipkin-lens/src/constants/api.js
+++ b/zipkin-lens/src/constants/api.js
@@ -13,8 +13,19 @@
  */
 const { API_BASE } = process.env;
 
-export const ZIPKIN_API = `${API_BASE || ''}/zipkin/api/v2`;
-export const UI_CONFIG = `${API_BASE || ''}/zipkin/config.json`;
+const extractBasePath = () => {
+  const base = document.getElementsByTagName('base');
+  if (base.length === 0) {
+    return '/zipkin';
+  }
+  return base[0].getAttribute('href').replace(/\/+$/, '');
+};
+
+export const BASE_PATH = extractBasePath();
+export const ZIPKIN_BASE = `${API_BASE || ''}${BASE_PATH}`;
+
+export const ZIPKIN_API = `${ZIPKIN_BASE}/api/v2`;
+export const UI_CONFIG = `${ZIPKIN_BASE}/config.json`;
 export const SERVICES = `${ZIPKIN_API}/services`;
 export const REMOTE_SERVICES = `${ZIPKIN_API}/remoteServices`;
 export const SPANS = `${ZIPKIN_API}/spans`;

--- a/zipkin-lens/src/constants/api.test.js
+++ b/zipkin-lens/src/constants/api.test.js
@@ -12,6 +12,8 @@
  * the License.
  */
 
+/* eslint-disable global-require */
+
 describe('BASE_PATH', () => {
   afterEach(() => {
     jest.resetModules();

--- a/zipkin-lens/src/constants/api.test.js
+++ b/zipkin-lens/src/constants/api.test.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+describe('BASE_PATH', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('defaults to /zipkin with no base tag', () => {
+    expect(require('./api').BASE_PATH).toEqual('/zipkin');
+  });
+
+  it('is set to base tag when present', () => {
+    const base = document.createElement('base');
+    base.setAttribute('href', '/coolzipkin/');
+    document.head.append(base);
+    expect(require('./api').BASE_PATH).toEqual('/coolzipkin');
+  });
+});

--- a/zipkin-lens/static/index.html
+++ b/zipkin-lens/static/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015-2019 The OpenZipkin Authors
+    Copyright 2015-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <base href="/" />
+    <base href="/zipkin/">
     <meta charset="utf-8">
   </head>
   <body>

--- a/zipkin-lens/webpack.dev.config.js
+++ b/zipkin-lens/webpack.dev.config.js
@@ -22,6 +22,7 @@ module.exports = {
   entry: path.join(__dirname, './src/index.js'),
   output: {
     filename: 'bundle.js',
+    publicPath: '/zipkin',
   },
   module: {
     rules: [

--- a/zipkin-lens/webpack.prod.config.js
+++ b/zipkin-lens/webpack.prod.config.js
@@ -28,7 +28,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, '/target/classes/zipkin-lens/'),
     filename: 'app-[hash].min.js',
-    publicPath: '/zipkin/',
+    publicPath: '',
   },
   optimization: {
     minimize: true,

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -15,29 +15,21 @@ package zipkin2.server.internal.ui;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ServerCacheControl;
 import com.linecorp.armeria.common.ServerCacheControlBuilder;
-import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.RedirectService;
-import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.file.HttpFileBuilder;
 import com.linecorp.armeria.server.file.HttpFileServiceBuilder;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
-import io.netty.handler.codec.http.cookie.Cookie;
-import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -176,8 +168,10 @@ public class ZipkinUiConfiguration {
       if (DEFAULT_BASEPATH.equals(basePath)) return content;
 
       String baseTagValue = "/".equals(basePath) ? "/" : basePath + "/";
+      // html-webpack-plugin seems to strip out quotes from the base tag when compiling so be
+      // careful with this matcher.
       return content.replaceAll(
-        "base href=\"[^\"]+\"", "base href=\"" + baseTagValue + "\""
+        "<base href=[^>]+>", "<base href=\"" + baseTagValue + "\">"
       );
     }
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -120,7 +120,7 @@ public class ITZipkinUiConfiguration {
   @Test public void replacesBaseTag() throws Exception {
     assertThat(get("/zipkin/index.html").body().string())
       .isEqualToIgnoringWhitespace(stringFromClasspath(getClass(), "zipkin-lens/index.html")
-        .replace("<base href=\"/\" />", "<base href=\"/foozipkin/\" />"));
+        .replace("<base href=\"/\" />", "<base href=\"/foozipkin/\">"));
   }
 
   /** index.html is served separately. This tests other content is also loaded from the classpath. */

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
@@ -139,7 +139,7 @@ public class ZipkinUiConfigurationTest {
     context = createContextWithOverridenProperty("zipkin.ui.basepath:/foo/bar");
 
     assertThat(serveIndex().contentUtf8())
-      .contains("<base href=\"/foo/bar/\" />");
+      .contains("<base href=\"/foo/bar/\">");
   }
 
   @Test
@@ -155,7 +155,7 @@ public class ZipkinUiConfigurationTest {
     context = createContextWithOverridenProperty("zipkin.ui.basepath:/");
 
     assertThat(serveIndex().contentUtf8())
-      .contains("<base href=\"/\" />");
+      .contains("<base href=\"/\">");
   }
 
   AggregatedHttpResponse serveIndex(Cookie... cookies) {


### PR DESCRIPTION
I was tricked that #2982 works because dev server returns bundles fine regardless of URL but realized that for the actual build the base tag is important for loading bundles.

This extracts base path from the base tag like before and sets up routing with it as the basename. This allows all links in the site to just have the subpath, without /zipkin.

I have verified with @jorgheymans apache configuration that it works.

Fixes #2519 

Note URL bar:

![image](https://user-images.githubusercontent.com/198344/75316364-7fcb4780-58a8-11ea-82f8-edf9aa372756.png)
