### PR TITLE
Fix docker examples prevents creating zipkin dashboard on grafana

### DIFF
--- a/docker/examples/prometheus/create-datasource-and-dashboard.sh
+++ b/docker/examples/prometheus/create-datasource-and-dashboard.sh
@@ -15,7 +15,7 @@
 
 set -xeuo pipefail
 
-if ! curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://grafana:3000/api/dashboards/name/prom; then
+if ! curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://grafana:3000/api/datasources/name/prom; then
     curl -sf -X POST -H "Content-Type: application/json" \
          --data-binary '{"name":"prom","type":"prometheus","url":"http://prometheus:9090","access":"proxy","isDefault":true}' \
          http://grafana:3000/api/datasources


### PR DESCRIPTION
docker examples fail to create datasource for zipkin on grafana. Wrong URL changed to correct one which fixes the problem