### PR TITLE
Remove flexbox from top level app container to prevent flickering.

### DIFF
--- a/zipkin-lens/src/components/App/Layout.jsx
+++ b/zipkin-lens/src/components/App/Layout.jsx
@@ -57,8 +57,6 @@ const useStyles = makeStyles(theme => ({
     },
   },
   childrenWrapper: {
-    display: 'flex',
-    flexDirection: 'column',
     width: '100%',
     height: '100vh',
     overflow: 'auto',

--- a/zipkin-lens/webpack.dev.config.js
+++ b/zipkin-lens/webpack.dev.config.js
@@ -22,7 +22,7 @@ module.exports = {
   entry: path.join(__dirname, './src/index.js'),
   output: {
     filename: 'bundle.js',
-    publicPath: '/zipkin',
+    publicPath: '/zipkin/',
   },
   module: {
     rules: [
@@ -87,6 +87,10 @@ module.exports = {
     port: 9000,
     host: '0.0.0.0',
     disableHostCheck: true,
-    historyApiFallback: true,
+    historyApiFallback: {
+      rewrites: [
+        { from: /.*/, to: '/zipkin/index.html' },
+      ],
+    },
   },
 };


### PR DESCRIPTION
I found this mostly by opening up inspector and randomly disabling CSS styles. But intuitively it does seem incorrect to apply flexbox and overflow: auto to the same element - both automatically reflow the content (flexbox by nature, overflow to compensate for a scroll bar) and probably are fighting each other in our flickeroo scenario.

From an encapsulation standpoint, it also seems fishy to have flexbox in the top level of the app since children can't rely lay themselves out correctly in such a case unless they are flexbox-aware themselves, hence encapsulation gets broken.

And when I remove this and open discover page, search for traces, go to trace, and open dependency page, I don't see any layout issues so it seems the flexbox isn't being used.

Fixes #2973 