### PR TITLE
Use react-router link in side menu for SPA-type navigation and clear …

### DIFF
--- a/zipkin-lens/src/actions/traces-action.js
+++ b/zipkin-lens/src/actions/traces-action.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,6 +20,10 @@ import {
   traceSummary as buildTraceSummary,
   traceSummaries as buildTraceSummaries,
 } from '../zipkin';
+
+export const clearTraces = () => ({
+  type: types.CLEAR_TRACES,
+});
 
 export const loadTracesRequest = () => ({
   type: types.TRACES_LOAD_REQUEST,

--- a/zipkin-lens/src/actions/traces-action.test.js
+++ b/zipkin-lens/src/actions/traces-action.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -90,5 +90,12 @@ describe('traces async actions', () => {
     })).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
+  });
+
+  it('clearTraces dispatches action', () => {
+    const store = mockStore({});
+
+    store.dispatch(actions.clearTraces());
+    expect(store.getActions()).toEqual([{ type: types.CLEAR_TRACES }]);
   });
 });

--- a/zipkin-lens/src/components/App/LanguageSelector.test.jsx
+++ b/zipkin-lens/src/components/App/LanguageSelector.test.jsx
@@ -19,52 +19,54 @@ import { getLocale } from '../../util/locale';
 
 import LanguageSelector, { LANGUAGES } from './LanguageSelector';
 
-test('loads and displays button and no popover', async () => {
-  const { queryByTestId } = render(<LanguageSelector />);
+describe('<LanguageSelector />', () => {
+  it('loads and displays button and no popover', async () => {
+    const { container, queryByTestId } = render(<LanguageSelector />);
 
-  const changeLanguageButton = queryByTestId('change-language-button');
-  const languageList = queryByTestId('language-list');
+    const changeLanguageButton = queryByTestId('change-language-button');
+    const languageList = queryByTestId('language-list');
 
-  expect(changeLanguageButton).toBeInTheDocument();
-  expect(changeLanguageButton).toHaveAttribute('title', 'Change Language');
+    expect(changeLanguageButton).toBeInTheDocument();
+    expect(changeLanguageButton).toHaveAttribute('title', 'Change Language');
 
-  expect(languageList).not.toBeInTheDocument();
+    expect(languageList).not.toBeInTheDocument();
 
-  expect(getLocale()).toEqual('en');
-});
+    expect(getLocale()).toEqual('en');
+  });
 
-test('click displays popover', async () => {
-  const { queryByTestId } = render(<LanguageSelector />);
+  it('click displays popover', async () => {
+    const { queryByTestId } = render(<LanguageSelector />);
 
-  const changeLanguageButton = queryByTestId('change-language-button');
+    const changeLanguageButton = queryByTestId('change-language-button');
 
-  expect(changeLanguageButton).toBeInTheDocument();
+    expect(changeLanguageButton).toBeInTheDocument();
 
-  fireEvent.click(changeLanguageButton);
+    fireEvent.click(changeLanguageButton);
 
-  const languageList = await waitForElement(() => queryByTestId('language-list'));
+    const languageList = await waitForElement(() => queryByTestId('language-list'));
 
-  expect(changeLanguageButton).toBeInTheDocument();
-  expect(languageList).toBeInTheDocument();
-  expect(languageList.children).toHaveLength(LANGUAGES.length);
+    expect(changeLanguageButton).toBeInTheDocument();
+    expect(languageList).toBeInTheDocument();
+    expect(languageList.children).toHaveLength(LANGUAGES.length);
 
-  expect(getLocale()).toEqual('en');
-});
+    expect(getLocale()).toEqual('en');
+  });
 
-test('language select changes locale and refreshes', async () => {
-  const { queryByTestId } = render(<LanguageSelector />);
+  it('language select changes locale and refreshes', async () => {
+    const { queryByTestId } = render(<LanguageSelector />);
 
-  const changeLanguageButton = queryByTestId('change-language-button');
+    const changeLanguageButton = queryByTestId('change-language-button');
 
-  expect(changeLanguageButton).toBeInTheDocument();
+    expect(changeLanguageButton).toBeInTheDocument();
 
-  fireEvent.click(changeLanguageButton);
+    fireEvent.click(changeLanguageButton);
 
-  await waitForElement(() => queryByTestId('language-list'));
+    await waitForElement(() => queryByTestId('language-list'));
 
-  fireEvent.click(queryByTestId('language-list-item-zh-cn'));
+    fireEvent.click(queryByTestId('language-list-item-zh-cn'));
 
-  await expect(window.location.reload).toHaveBeenCalled();
+    await expect(window.location.reload).toHaveBeenCalled();
 
-  expect(getLocale()).toEqual('zh-cn');
+    expect(getLocale()).toEqual('zh-cn');
+  });
 });

--- a/zipkin-lens/src/components/App/SidebarMenu.jsx
+++ b/zipkin-lens/src/components/App/SidebarMenu.jsx
@@ -13,14 +13,12 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { useLocation } from 'react-router';
+import { Link, useLocation } from 'react-router-dom';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { makeStyles } from '@material-ui/styles';
 import ListItem from '@material-ui/core/ListItem';
 import Tooltip from '@material-ui/core/Tooltip';
-
-import { BASE_PATH } from '../../constants/api';
 
 const propTypes = {
   title: PropTypes.string.isRequired,
@@ -54,14 +52,22 @@ export const SidebarMenuImpl = React.forwardRef(({
   const classes = useStyles();
   const location = useLocation();
 
+  const listItemProps = {};
+  if (path.startsWith('https://')) {
+    listItemProps.component = 'a'
+    listItemProps.href = path;
+    listItemProps.target = '_blank';
+    listItemProps.rel = 'no-opener';
+  } else {
+    listItemProps.component = Link;
+    listItemProps.to = path;
+  }
+
   return (
     <Tooltip title={title} placement="right">
       <ListItem
+        {...listItemProps}
         button
-        // TODO(anuraaga): Replace with react-router-dom Link for more smoothness after fixing state
-        // management. We need to make sure to clear traces when returning to the discovery page.
-        component="a"
-        href={`${BASE_PATH}${path}`}
         ref={ref}
         className={
           classNames(

--- a/zipkin-lens/src/components/App/SidebarMenu.test.jsx
+++ b/zipkin-lens/src/components/App/SidebarMenu.test.jsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { faHome } from '@fortawesome/free-solid-svg-icons';
+import React from 'react';
+
+import render from '../../test/util/render-with-default-settings';
+
+import SidebarMenu from './SidebarMenu';
+
+describe('<SidebarMenu />', () => {
+  it('renders relative link to be non-external', () => {
+    const { getByTestId } = render(
+      <SidebarMenu title="tooltip" path="/traces" icon={faHome} data-testid="sidebar-menu-link" />);
+    const link = getByTestId('sidebar-menu-link');
+    expect(link.href).toEqual('http://localhost/traces');
+    expect(link.target).toBeFalsy();
+  });
+
+  it('renders absolute link to be external', () => {
+    const { getByTestId } = render(
+      <SidebarMenu title="tooltip" path="https://github.com/openzipkin" icon={faHome} data-testid="sidebar-menu-link" />
+    );
+    const link = getByTestId('sidebar-menu-link');
+    expect(link.href).toEqual('https://github.com/openzipkin');
+    expect(link.target).toEqual('_blank');
+    expect(link.rel).toEqual('no-opener');
+  })
+});

--- a/zipkin-lens/src/components/DependenciesPage/DependenciesPage.test.jsx
+++ b/zipkin-lens/src/components/DependenciesPage/DependenciesPage.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
@@ -141,6 +141,7 @@ const DiscoverPageImpl = ({
   fetchRemoteServices,
   fetchSpans,
   fetchAutocompleteKeys,
+  clearTraces,
   setConditions,
   setLookbackCondition,
   setLimitCondition,
@@ -227,6 +228,12 @@ const DiscoverPageImpl = ({
     }
   });
 
+  if (!location.search && traces.length > 0) {
+    // Previously loaded traces but now back to the beginning, reset state and re-render.
+    clearTraces();
+    return null;
+  }
+
   let content;
   if (isLoading) {
     content = (
@@ -283,6 +290,9 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   loadTraces: params => dispatch(
     tracesActionCreators.loadTraces(params),
+  ),
+  clearTraces: parms => dispatch(
+    tracesActionCreators.clearTraces(),
   ),
   fetchServices: () => dispatch(
     servicesActionCreators.fetchServices(),

--- a/zipkin-lens/src/constants/action-types.js
+++ b/zipkin-lens/src/constants/action-types.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -32,6 +32,7 @@ export const TRACE_LOAD_FAILURE = 'TRACE_LOAD_FAILURE';
 export const TRACES_LOAD_REQUEST = 'TRACES_LOAD_REQUEST';
 export const TRACES_LOAD_SUCCESS = 'TRACES_LOAD_SUCCESS';
 export const TRACES_LOAD_FAILURE = 'TRACES_LOAD_FAILURE';
+export const CLEAR_TRACES = 'TRACES_RESET';
 
 export const FETCH_DEPENDENCIES_REQUEST = 'FETCH_DEPENDENCIES_REQUEST';
 export const FETCH_DEPENDENCIES_SUCCESS = 'FETCH_DEPENDENCIES_SUCCESS';

--- a/zipkin-lens/src/reducers/traces.js
+++ b/zipkin-lens/src/reducers/traces.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 import * as types from '../constants/action-types';
 
-const initialState = {
+export const initialState = {
   isLoading: false,
   traces: [],
   traceSummaries: [],
@@ -23,6 +23,8 @@ const initialState = {
 
 const traces = (state = initialState, action) => {
   switch (action.type) {
+    case types.CLEAR_TRACES:
+      return initialState;
     case types.TRACES_LOAD_REQUEST:
       return {
         ...state,

--- a/zipkin-lens/src/reducers/traces.test.js
+++ b/zipkin-lens/src/reducers/traces.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import reducer from './traces';
+import reducer, { initialState } from './traces';
 import * as types from '../constants/action-types';
 
 describe('traces reducer', () => {
@@ -120,5 +120,20 @@ describe('traces reducer', () => {
       correctedTraceMap: {},
       lastQueryParams: {},
     });
+  });
+
+  it('should handle CLEAR_TRACES', () => {
+    expect(reducer({
+      isLoading: true,
+      traces: [
+        [
+          {
+            traceId: 'c020e0d52326cf84',
+          },
+        ],
+      ],
+    }, {
+      type: types.CLEAR_TRACES,
+    })).toEqual(initialState);
   });
 });


### PR DESCRIPTION
…discover page when navigating back to it from another page.

Also fixes the absolute URL issue in the sidebar.

This allows all the navigation to be in the SPA, currently only search results are.