### PR TITLE
Allows lens to open traces in a new tab

### DIFF
--- a/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
@@ -102,7 +102,7 @@ export const TracesTableRowImpl = ({
   const { spanName, serviceName } = rootServiceAndSpanName(correctedTrace);
 
   return (
-    <Box className={classes.root} data-test="root">
+    <Box className={classes.root}>
       <Link to={`/traces/${traceSummary.traceId}`} className={classes.anchor}>
         <Grid container spacing={0} className={classes.data}>
           <Box
@@ -110,16 +110,14 @@ export const TracesTableRowImpl = ({
             width={`${traceSummary.width}%`}
             height="100%"
             className={classes.durationBar}
-            style={{
-              backgroundColor: selectColorByInfoClass(traceSummary.infoClass),
-            }}
-            data-test="duration-bar"
+            style={{ backgroundColor: selectColorByInfoClass(traceSummary.infoClass) }}
+            data-testid="duration-bar"
           />
           <Grid item xs={3} className={classes.dataCell}>
-            <Box className={classes.serviceName} data-test="service-name">
+            <Box className={classes.serviceName} data-testid="service-name">
               {`${serviceName}`}
             </Box>
-            <Box className={classes.subInfo} data-test="span-name">
+            <Box className={classes.subInfo} data-testid="span-name">
               {`(${spanName})`}
             </Box>
           </Grid>

--- a/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
@@ -20,7 +20,6 @@ import moment from 'moment';
 import { makeStyles } from '@material-ui/styles';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
-import grey from '@material-ui/core/colors/grey';
 
 import ServiceBadge from '../../Common/ServiceBadge';
 import { getServiceName } from '../../../zipkin';
@@ -52,7 +51,7 @@ const useStyles = makeStyles(theme => ({
   root: {
     cursor: 'pointer',
     '&:hover': {
-      backgroundColor: grey[100],
+      backgroundColor: theme.palette.grey[100],
     },
   },
   anchor: {
@@ -62,7 +61,7 @@ const useStyles = makeStyles(theme => ({
   },
   data: {
     position: 'relative',
-    borderBottom: `1px solid ${grey[200]}`,
+    borderBottom: `1px solid ${theme.palette.grey[200]}`,
   },
   durationBar: {
     opacity: 0.4,
@@ -79,7 +78,7 @@ const useStyles = makeStyles(theme => ({
     paddingRight: '1rem',
     paddingTop: '0.6rem',
     paddingBottom: '0.6rem',
-    borderBottom: `1px solid ${grey[300]}`,
+    borderBottom: `1px solid ${theme.palette.grey[300]}`,
   },
   serviceName: {
     textTransform: 'uppercase',

--- a/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
@@ -12,9 +12,10 @@
  * the License.
  */
 import PropTypes from 'prop-types';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
+import { Link } from 'react-router-dom';
 import moment from 'moment';
 import { makeStyles } from '@material-ui/styles';
 import Box from '@material-ui/core/Box';
@@ -44,7 +45,6 @@ export function rootServiceAndSpanName(root) {
 const propTypes = {
   traceSummary: traceSummaryPropTypes.isRequired,
   onAddFilter: PropTypes.func.isRequired,
-  history: PropTypes.shape({ push: PropTypes.func.isRequired }).isRequired,
   correctedTraceMap: PropTypes.shape({}).isRequired,
 };
 
@@ -88,7 +88,6 @@ const useStyles = makeStyles({
 export const TracesTableRowImpl = ({
   traceSummary,
   onAddFilter,
-  history,
   correctedTraceMap,
 }) => {
   const classes = useStyles();
@@ -98,46 +97,44 @@ export const TracesTableRowImpl = ({
   const correctedTrace = correctedTraceMap[traceSummary.traceId];
   const { spanName, serviceName } = rootServiceAndSpanName(correctedTrace);
 
-  const handleClick = useCallback(() => {
-    history.push(`/traces/${traceSummary.traceId}`);
-  }, [history, traceSummary.traceId]);
-
   return (
-    <Box className={classes.root} onClick={handleClick} data-test="root">
-      <Grid container spacing={0} className={classes.data}>
-        <Box
-          position="absolute"
-          width={`${traceSummary.width}%`}
-          height="100%"
-          className={classes.durationBar}
-          style={{
-            backgroundColor: selectColorByInfoClass(traceSummary.infoClass),
-          }}
-          data-test="duration-bar"
-        />
-        <Grid item xs={3} className={classes.dataCell}>
-          <Box className={classes.serviceName} data-test="service-name">
-            {`${serviceName}`}
-          </Box>
-          <Box className={classes.subInfo} data-test="span-name">
-            {`(${spanName})`}
-          </Box>
+    <Box className={classes.root} data-test="root">
+      <Link to={`/traces/${traceSummary.traceId}`}>
+        <Grid container spacing={0} className={classes.data}>
+          <Box
+            position="absolute"
+            width={`${traceSummary.width}%`}
+            height="100%"
+            className={classes.durationBar}
+            style={{
+              backgroundColor: selectColorByInfoClass(traceSummary.infoClass),
+            }}
+            data-test="duration-bar"
+          />
+          <Grid item xs={3} className={classes.dataCell}>
+            <Box className={classes.serviceName} data-test="service-name">
+              {`${serviceName}`}
+            </Box>
+            <Box className={classes.subInfo} data-test="span-name">
+              {`(${spanName})`}
+            </Box>
+          </Grid>
+          <Grid item xs={3} className={classes.dataCell}>
+            {traceSummary.traceId}
+          </Grid>
+          <Grid item xs={3} className={classes.dataCell}>
+            <Box>
+              {startTime.format('MM/DD HH:mm:ss:SSS')}
+            </Box>
+            <Box className={classes.subInfo}>
+              {`(${startTime.fromNow()})`}
+            </Box>
+          </Grid>
+          <Grid item xs={3} className={classes.dataCell}>
+            {traceSummary.durationStr}
+          </Grid>
         </Grid>
-        <Grid item xs={3} className={classes.dataCell}>
-          {traceSummary.traceId}
-        </Grid>
-        <Grid item xs={3} className={classes.dataCell}>
-          <Box>
-            {startTime.format('MM/DD HH:mm:ss:SSS')}
-          </Box>
-          <Box className={classes.subInfo}>
-            {`(${startTime.fromNow()})`}
-          </Box>
-        </Grid>
-        <Grid item xs={3} className={classes.dataCell}>
-          {traceSummary.durationStr}
-        </Grid>
-      </Grid>
+      </Link>
       <Box display="flex" flexWrap="wrap" className={classes.badgeRow}>
         {
           traceSummary.serviceSummaries.map(serviceSummary => (

--- a/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/TracesTab/TracesTableRow.jsx
@@ -25,7 +25,7 @@ import grey from '@material-ui/core/colors/grey';
 import ServiceBadge from '../../Common/ServiceBadge';
 import { getServiceName } from '../../../zipkin';
 import { traceSummaryPropTypes } from '../../../prop-types';
-import { theme, selectColorByInfoClass } from '../../../colors';
+import { selectColorByInfoClass } from '../../../colors';
 
 export function rootServiceAndSpanName(root) {
   const { span } = root;
@@ -48,12 +48,17 @@ const propTypes = {
   correctedTraceMap: PropTypes.shape({}).isRequired,
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
     cursor: 'pointer',
     '&:hover': {
       backgroundColor: grey[100],
     },
+  },
+  anchor: {
+    color: theme.palette.text.primary,
+    textDecoration: 'none',
+    outline: 'none',
   },
   data: {
     position: 'relative',
@@ -83,7 +88,7 @@ const useStyles = makeStyles({
     marginLeft: '0.6rem',
     color: theme.palette.text.hint,
   },
-});
+}));
 
 export const TracesTableRowImpl = ({
   traceSummary,
@@ -99,7 +104,7 @@ export const TracesTableRowImpl = ({
 
   return (
     <Box className={classes.root} data-test="root">
-      <Link to={`/traces/${traceSummary.traceId}`}>
+      <Link to={`/traces/${traceSummary.traceId}`} className={classes.anchor}>
         <Grid container spacing={0} className={classes.data}>
           <Box
             position="absolute"
@@ -135,6 +140,8 @@ export const TracesTableRowImpl = ({
           </Grid>
         </Grid>
       </Link>
+      {/* In HTML5, anchor tag including interactive content is invalid.
+          So ServiceBadge which has onClick callback cannot be surrounded by Link. */}
       <Box display="flex" flexWrap="wrap" className={classes.badgeRow}>
         {
           traceSummary.serviceSummaries.map(serviceSummary => (


### PR DESCRIPTION
fixes #2998 

I think basically there are two ways to move pages, using `history.push` and using an `<a/>` tag.
However, when using `history.push`, the page cannot be displayed in a new tab as pointed out #2998 .

So this PR use `<a/>` tag (Strictly speaking `<Link/>` component of react-router-dom) instead of `history.push`.