### PR TITLE
Add benchmark for XRay UDP.

### DIFF
--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Because UDP doesn't need to actually be received, we can reuse our current benchmark infrastructure quite easily for checking XRay.

0.20.0 result
```
Benchmark complete, wrk output:
Running 2m test @ http://frontend:8081
  4 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   435.43ms  267.10ms   1.99s    73.54%
    Req/Sec    77.72     38.55   232.00     69.05%
  Latency Distribution
     50%  396.07ms
     75%  562.31ms
     90%  774.00ms
     99%    1.33s 
  30387 requests in 1.67m, 4.12MB read
  Socket errors: connect 0, read 0, write 0, timeout 43
Requests/sec:    303.57
Transfer/sec:     42.14KB

Messages received: 168
Spans received: 91545
Spans dropped: 0
Memory quantiles:
jvm_memory_used_bytes{area="heap"}[0.0] = 3145728
jvm_memory_used_bytes{area="heap"}[0.25] = 7340032
jvm_memory_used_bytes{area="heap"}[0.5] = 11534336
jvm_memory_used_bytes{area="heap"}[0.75] = 29074432
jvm_memory_used_bytes{area="heap"}[1.0] = 46614528
jvm_memory_used_bytes{area="nonheap"}[0.0] = 1227776
jvm_memory_used_bytes{area="nonheap"}[0.25] = 2374016
jvm_memory_used_bytes{area="nonheap"}[0.5] = 5751624
jvm_memory_used_bytes{area="nonheap"}[0.75] = 11454976
jvm_memory_used_bytes{area="nonheap"}[1.0] = 47086632
Total GC time (s): 
Number of GCs: 
POST Spans latency (s)
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans"}[0.5] = 0.02164802035483871
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans"}[0.9] = 0.050471456125000015
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans"}[0.99] = 0.08567564942999996
```