### PR TITLE
Try disabling shallow clone to see if it fixes license plugin flakiness.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@
 sudo: required
 dist: trusty
 
+# Don't do a shallow clone to allow license plugin to correctly read git history.
+git:
+  depth: false
+
 cache:
   directories:
   # zipkin-lens gets dependencies via NPM
@@ -37,7 +41,7 @@ before_install:
   - git config credential.helper "store --file=.git/credentials"
   - echo "https://$GH_TOKEN:@github.com" > .git/credentials
 
-# Override default travis to use the maven wrapper; skip license on travis due to #1512
+# Override default travis to use the maven wrapper
 install: ./mvnw install -DskipTests=true -Dlicense.skip=true -Dmaven.javadoc.skip=true -B -V
 script: ./travis/publish.sh
 

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -168,7 +168,7 @@ if is_release_commit; then
   true
 else
   # Ensure no tests rely on the actuator library
-  MYSQL_USER=root ./mvnw verify -nsu -Dlicense.skip=true -DskipActuator
+  MYSQL_USER=root ./mvnw verify -nsu -DskipActuator
 fi
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
@@ -191,7 +191,6 @@ elif is_travis_branch_master; then
 # If we are on a release tag, the following will update any version references and push a version tag for deployment.
 elif build_started_by_tag; then
   safe_checkout_master
-  # skip license on travis due to #1512
   ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests -Dlicense.skip=true" release:prepare
 fi
 


### PR DESCRIPTION
I removed the comments about license skipping since I think `skipTests` is essentially the same. I could add something like `Disable all checks since we do it in the mvn verify step of publish.sh` to them all instead though if that seems helpful though.

This causes `git clone` to take much longer than before - meaning a couple of seconds now takes a few seconds and has very little impact on the entire build so shouldn't be an issue.

Might fix #1512 