### PR TITLE
Add Archive Trace button

### DIFF
--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -10496,6 +10496,17 @@
         }
       }
     },
+    "notistack": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-0.9.9.tgz",
+      "integrity": "sha512-C783KedXtgCWfd/wD4qzKEF4bP/sVF9cAveVpWAFhzypYo0q6l3xLcaLVtUnOBUXZY7KWfvg+lv4XSOiofXeTA==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "hoist-non-react-statics": "^3.3.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -35,8 +35,8 @@
     "@types/react-dom": "^16.9.5",
     "@types/react-redux": "^7.1.7",
     "@types/react-router-dom": "^5.1.3",
-    "@typescript-eslint/parser": "^2.23.0",
     "@typescript-eslint/eslint-plugin": "^2.23.0",
+    "@typescript-eslint/parser": "^2.23.0",
     "chart.js": "^2.7.2",
     "classnames": "^2.2.6",
     "enzyme": "^3.7.0",
@@ -55,6 +55,7 @@
     "moment": "^2.24.0",
     "mvy": "0.2.1",
     "node-fetch": "^2.3.0",
+    "notistack": "^0.9.9",
     "prettier": "^1.19.1",
     "prop-types": "^15.6.2",
     "query-string": "^6.1.0",
@@ -64,6 +65,7 @@
     "react-dom": "^16.13.0",
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.0.1",
+    "react-scripts": "3.4.0",
     "react-select": "^2.0.0",
     "react-table": "^6.8.6",
     "react-transition-group": "^2.4.0",
@@ -72,10 +74,9 @@
     "redux": "^4.0.0",
     "redux-mock-store": "^1.5.3",
     "redux-thunk": "^2.3.0",
-    "react-scripts": "3.4.0",
     "shortid": "^2.2.14",
-    "vizceral-react": "^4.6.5",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5",
+    "vizceral-react": "^4.6.5"
   },
   "scripts": {
     "compile": "lingui compile --namespace es",

--- a/zipkin-lens/src/components/App/App.jsx
+++ b/zipkin-lens/src/components/App/App.jsx
@@ -19,6 +19,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import { ThemeProvider } from '@material-ui/styles';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import MomentUtils from '@date-io/moment';
+import { SnackbarProvider } from 'notistack';
 
 import Layout from './Layout';
 import DiscoverPage from '../DiscoverPage';
@@ -39,29 +40,32 @@ const App = () => {
       <UiConfig>
         <MuiPickersUtilsProvider utils={MomentUtils}>
           <ThemeProvider theme={theme}>
-            <UiConfigConsumer>
-              {(config) => (
-                <Provider store={configureStore(config)}>
-                  <I18nProvider i18n={i18n}>
-                    <BrowserRouter basename={BASE_PATH}>
-                      <Layout>
-                        <Route exact path="/" component={DiscoverPage} />
-                        <Route
-                          exact
-                          path="/dependency"
-                          component={DependenciesPage}
-                        />
-                        <Route
-                          exact
-                          path={['/traces/:traceId', '/traceViewer']}
-                          component={TracePage}
-                        />
-                      </Layout>
-                    </BrowserRouter>
-                  </I18nProvider>
-                </Provider>
-              )}
-            </UiConfigConsumer>
+            {/* Snackbar is used to provide popup alerts to the user */}
+            <SnackbarProvider>
+              <UiConfigConsumer>
+                {(config) => (
+                  <Provider store={configureStore(config)}>
+                    <I18nProvider i18n={i18n}>
+                      <BrowserRouter basename={BASE_PATH}>
+                        <Layout>
+                          <Route exact path="/" component={DiscoverPage} />
+                          <Route
+                            exact
+                            path="/dependency"
+                            component={DependenciesPage}
+                          />
+                          <Route
+                            exact
+                            path={['/traces/:traceId', '/traceViewer']}
+                            component={TracePage}
+                          />
+                        </Layout>
+                      </BrowserRouter>
+                    </I18nProvider>
+                  </Provider>
+                )}
+              </UiConfigConsumer>
+            </SnackbarProvider>
           </ThemeProvider>
         </MuiPickersUtilsProvider>
       </UiConfig>

--- a/zipkin-lens/src/components/TracePage/TraceSummaryHeader.test.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummaryHeader.test.jsx
@@ -91,4 +91,44 @@ describe('<TraceSummaryHeader />', () => {
       'http://zipkin.io/logs=1&moreLogs=1',
     );
   });
+
+  it('does not render Archive Trace link with default config', () => {
+    const { queryByTestId } = render(
+      <TraceSummaryHeader
+        traceSummary={{
+          traceId: '1',
+          spans: [],
+          serviceNameAndSpanCounts: [],
+          duration: 1,
+          durationStr: '1μs',
+          rootSpan: {
+            serviceName: 'service-A',
+            spanName: 'span-A',
+          },
+        }}
+      />,
+    );
+    expect(queryByTestId('archive-trace-link')).not.toBeInTheDocument();
+  });
+
+  it('does render Archive Trace link when logs URL in config', () => {
+    const { queryByTestId } = render(
+      <TraceSummaryHeader
+        traceSummary={{
+          traceId: '1',
+          spans: [],
+          serviceNameAndSpanCounts: [],
+          duration: 1,
+          durationStr: '1μs',
+          rootSpan: {
+            serviceName: 'service-A',
+            spanName: 'span-A',
+          },
+        }}
+      />,
+      { uiConfig: { archivePostUrl: 'http://localhost:9411/api/v2/spans' } },
+    );
+    const logsLink = queryByTestId('archive-trace-link');
+    expect(logsLink).toBeInTheDocument();
+  });
 });

--- a/zipkin-lens/src/test/util/render-with-default-settings.tsx
+++ b/zipkin-lens/src/test/util/render-with-default-settings.tsx
@@ -21,6 +21,7 @@ import { createMemoryHistory, History } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
+import { SnackbarProvider } from 'notistack';
 
 import { UiConfigContext } from '../../components/UiConfig';
 
@@ -67,9 +68,11 @@ export default (
         <Router history={history}>
           <MuiPickersUtilsProvider utils={MomentUtils}>
             <ThemeProvider theme={theme}>
-              <UiConfigContext.Provider value={filledConfig}>
-                {children}
-              </UiConfigContext.Provider>
+              <SnackbarProvider>
+                <UiConfigContext.Provider value={filledConfig}>
+                  {children}
+                </UiConfigContext.Provider>
+              </SnackbarProvider>
             </ThemeProvider>
           </MuiPickersUtilsProvider>
         </Router>

--- a/zipkin-lens/src/translations/en/messages.json
+++ b/zipkin-lens/src/translations/en/messages.json
@@ -36,6 +36,7 @@
   "Trace ID": "",
   "Upload JSON": "",
   "View Logs": "",
+  "Archive Trace": "",
   "Zipkin Home": "",
   "hide annotations": "",
   "show all annotations": "",

--- a/zipkin-lens/src/translations/es/messages.json
+++ b/zipkin-lens/src/translations/es/messages.json
@@ -36,7 +36,7 @@
   "Trace ID": "ID de Traza",
   "Upload JSON": "Subir JSON",
   "View Logs": "Ver Logs",
-  "Archive Trace": "",
+  "Archive Trace": "Archivar Traza",
   "Zipkin Home": "Zipkin Inicio",
   "hide annotations": "ocultar anotaciones",
   "show all annotations": "mostrar todas las anotaciones",

--- a/zipkin-lens/src/translations/es/messages.json
+++ b/zipkin-lens/src/translations/es/messages.json
@@ -36,6 +36,7 @@
   "Trace ID": "ID de Traza",
   "Upload JSON": "Subir JSON",
   "View Logs": "Ver Logs",
+  "Archive Trace": "",
   "Zipkin Home": "Zipkin Inicio",
   "hide annotations": "ocultar anotaciones",
   "show all annotations": "mostrar todas las anotaciones",

--- a/zipkin-lens/src/translations/zh-cn/messages.json
+++ b/zipkin-lens/src/translations/zh-cn/messages.json
@@ -36,6 +36,7 @@
   "Trace ID": "",
   "Upload JSON": "",
   "View Logs": "",
+  "Archive Trace": "",
   "Zipkin Home": "",
   "hide annotations": "",
   "show all annotations": "",

--- a/zipkin-lens/src/zipkin/trace.js
+++ b/zipkin-lens/src/zipkin/trace.js
@@ -291,12 +291,7 @@ function addLayoutDetails(
   }
 }
 
-export function detailedTraceSummary(
-  root,
-  logsUrl,
-  archivePostUrl,
-  archiveUrl,
-) {
+export function detailedTraceSummary(root) {
   const serviceNameToCount = {};
   let queue = root.queueRootMostSpans();
   const modelview = {
@@ -385,9 +380,6 @@ export function detailedTraceSummary(
 
   modelview.duration = duration;
   modelview.durationStr = mkDurationStr(duration);
-  if (logsUrl) modelview.logsUrl = logsUrl;
-  if (archivePostUrl) modelview.archivePostUrl = archivePostUrl;
-  if (archiveUrl) modelview.archiveUrl = archiveUrl;
 
   return modelview;
 }

--- a/zipkin-lens/src/zipkin/trace.js
+++ b/zipkin-lens/src/zipkin/trace.js
@@ -291,7 +291,12 @@ function addLayoutDetails(
   }
 }
 
-export function detailedTraceSummary(root, logsUrl) {
+export function detailedTraceSummary(
+  root,
+  logsUrl,
+  archivePostUrl,
+  archiveUrl,
+) {
   const serviceNameToCount = {};
   let queue = root.queueRootMostSpans();
   const modelview = {
@@ -381,6 +386,8 @@ export function detailedTraceSummary(root, logsUrl) {
   modelview.duration = duration;
   modelview.durationStr = mkDurationStr(duration);
   if (logsUrl) modelview.logsUrl = logsUrl;
+  if (archivePostUrl) modelview.archivePostUrl = archivePostUrl;
+  if (archiveUrl) modelview.archiveUrl = archiveUrl;
 
   return modelview;
 }

--- a/zipkin-lens/src/zipkin/trace.test.js
+++ b/zipkin-lens/src/zipkin/trace.test.js
@@ -362,11 +362,6 @@ describe('totalDuration', () => {
 const cleanedNetflixTrace = treeCorrectedForClockSkew(netflixTrace);
 
 describe('detailedTraceSummary', () => {
-  it('should show logsUrl', () => {
-    const { logsUrl } = detailedTraceSummary(cleanedHttpTrace, 'http/url.com');
-    expect(logsUrl).toBe('http/url.com');
-  });
-
   it('should derive summary info', () => {
     const {
       traceId,

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -186,6 +186,14 @@ basePath | zipkin.ui.basepath | path prefix placed into the <base> tag in the UI
 To map properties to environment variables, change them to upper-underscore case format. For
 example, if using docker you can set `ZIPKIN_UI_QUERY_LIMIT=100` to affect `$.queryLimit` in `/config.json`.
 
+### Trace archival
+Most production Zipkin clusters store traces with a limited TTL. This makes it a bit inconvenient to
+share a trace, as the link to it will expire after a few days.
+
+The "archive a trace" feature helps with this. Launch a second zipkin server pointing to a storage with a longer
+TTL than the regular one and set the archivePostUrl and archiveUrl UI configs pointing to this second server.
+Once archivePostUrl is set, a new "Archive Trace" button will appear on the trace view page.
+
 ## Storage
 
 ### In-Memory Storage

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -177,6 +177,8 @@ queryLimit | zipkin.ui.query-limit | Default limit for Find Traces. Defaults to 
 instrumented | zipkin.ui.instrumented | Which sites this Zipkin UI covers. Regex syntax. e.g. `http:\/\/example.com\/.*` Defaults to match all websites (`.*`).
 logsUrl | zipkin.ui.logs-url | Logs query service url pattern. If specified, a button will appear on the trace page and will replace {traceId} in the url by the traceId. Not required.
 supportUrl / zipkin.ui.support-url / A URL where a user can ask for support. If specified, a link will be placed in the side menu to this URL, for example a page to file support tickets. Not required.
+archivePostUrl | zipkin.ui.archive-post-url | Url to POST the current trace in Zipkin v2 json format. e.g. 'https://longterm/api/v2/spans'. If specified, a button will appear on the trace page accordingly. Not required.
+archiveUrl | zipkin.ui.archive-url | Url to a web application serving an archived trace, templated by '{traceId}'. e.g. https://longterm/zipkin/trace/{traceId}'. This is shown in a confirmation message after a trace is successfully POSTed to the `archivePostUrl`. Not required.
 dependency.lowErrorRate | zipkin.ui.dependency.low-error-rate | The rate of error calls on a dependency link that turns it yellow. Defaults to 0.5 (50%) set to >1 to disable.
 dependency.highErrorRate | zipkin.ui.dependency.high-error-rate | The rate of error calls on a dependency link that turns it red. Defaults to 0.75 (75%) set to >1 to disable.
 basePath | zipkin.ui.basepath | path prefix placed into the <base> tag in the UI HTML; useful when running behind a reverse proxy. Default "/zipkin"

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -141,6 +141,8 @@ public class ZipkinUiConfiguration {
       generator.writeBooleanField("searchEnabled", ui.isSearchEnabled());
       generator.writeStringField("logsUrl", ui.getLogsUrl());
       generator.writeStringField("supportUrl", ui.getSupportUrl());
+      generator.writeStringField("archivePostUrl", ui.getArchivePostUrl());
+      generator.writeStringField("archiveUrl", ui.getArchiveUrl());
       generator.writeObjectFieldStart("dependency");
       generator.writeNumberField("lowErrorRate", ui.getDependency().getLowErrorRate());
       generator.writeNumberField("highErrorRate", ui.getDependency().getHighErrorRate());

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiProperties.java
@@ -28,6 +28,8 @@ class ZipkinUiProperties {
   private String instrumented = ".*";
   private String logsUrl = null;
   private String supportUrl = null;
+  private String archivePostUrl = null;
+  private String archiveUrl = null;
   private String basepath = DEFAULT_BASEPATH;
   private boolean searchEnabled = true;
   private Dependency dependency = new Dependency();
@@ -68,6 +70,15 @@ class ZipkinUiProperties {
     return logsUrl;
   }
 
+  public String getArchivePostUrl() {
+    return archivePostUrl;
+  }
+
+
+  public String getArchiveUrl() {
+    return archiveUrl;
+  }
+
   public void setLogsUrl(String logsUrl) {
     if (!StringUtils.isEmpty(logsUrl)) {
       this.logsUrl = logsUrl;
@@ -81,6 +92,19 @@ class ZipkinUiProperties {
   public void setSupportUrl(String supportUrl) {
     if (!StringUtils.isEmpty(supportUrl)) {
       this.supportUrl = supportUrl;
+    }
+
+  }
+
+  public void setArchivePostUrl(String archivePostUrl) {
+    if (!StringUtils.isEmpty(archivePostUrl)) {
+      this.archivePostUrl = archivePostUrl;
+    }
+  }
+
+  public void setArchiveUrl(String archiveUrl) {
+    if (!StringUtils.isEmpty(archiveUrl)) {
+      this.archiveUrl = archiveUrl;
     }
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -60,6 +60,8 @@ public class ITZipkinUiConfiguration {
       + "  \"searchEnabled\" : true,\n"
       + "  \"logsUrl\" : null,\n"
       + "  \"supportUrl\" : null,\n"
+      + "  \"archivePostUrl\" : null,\n"
+      + "  \"archiveUrl\" : null,\n"
       + "  \"dependency\" : {\n"
       + "    \"lowErrorRate\" : 0.5,\n"
       + "    \"highErrorRate\" : 0.75\n"

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
@@ -83,6 +83,22 @@ public class ZipkinUiConfigurationTest {
   }
 
   @Test
+  public void canOverrideProperty_archivePostUrl() {
+    final String url = "http://zipkin.archive.com/api/v2/spans";
+    context = createContextWithOverridenProperty("zipkin.ui.archive-post-url:" + url);
+
+    assertThat(context.getBean(ZipkinUiProperties.class).getArchivePostUrl()).isEqualTo(url);
+  }
+
+  @Test
+  public void canOverrideProperty_archiveUrl() {
+    final String url = "http://zipkin.archive.com/zipkin/traces/{traceId}";
+    context = createContextWithOverridenProperty("zipkin.ui.archive-url:" + url);
+
+    assertThat(context.getBean(ZipkinUiProperties.class).getArchiveUrl()).isEqualTo(url);
+  }
+
+  @Test
   public void canOverrideProperty_supportUrl() {
     final String url = "http://mycompany.com/file-a-bug";
     context = createContextWithOverridenProperty("zipkin.ui.support-url:" + url);


### PR DESCRIPTION
This button lets you easily reupload the current trace to a different
server.

The main motivation for having this is that you can have the
archival server have a very long retention period and use it as very
long term storage for traces that you care about. For example when
sharing a trace in a jira ticket since otherwise the link would expire
after 1 week.

Design doc explaining the reason behind this in more details and why we
went with this implementation: https://github.com/openzipkin/openzipkin.github.io/wiki/Favorite-trace