### PR TITLE
Fixes incorrect handling of getTrace and IT access modifiers

### DIFF
--- a/zipkin-junit/src/main/java/zipkin2/junit/ZipkinRule.java
+++ b/zipkin-junit/src/main/java/zipkin2/junit/ZipkinRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -126,14 +126,17 @@ public final class ZipkinRule implements TestRule {
     return storage.spanStore().getTraces();
   }
 
-  /** Retrieves a trace by ID which zipkin server has received, or null if not present. */
+  /** Retrieves a trace by ID which Zipkin server has received, or null if not present. */
   @Nullable
   public List<Span> getTrace(String traceId) {
+    List<Span> result;
     try {
-      return storage.traces().getTrace(traceId).execute();
+      result = storage.traces().getTrace(traceId).execute();
     } catch (IOException e) {
       throw Platform.get().assertionError("I/O exception in in-memory storage", e);
     }
+    // Note: this is a different behavior than Traces.getTrace() which is not nullable!
+    return result.isEmpty() ? null : result;
   }
 
   /** Retrieves all service links between traces this zipkin server has received. */

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -153,7 +153,7 @@ public class ZipkinQueryApiV2 {
   public AggregatedHttpResponse getTrace(@Param("traceId") String traceId) throws IOException {
     traceId = Span.normalizeTraceId(traceId);
     List<Span> trace = storage.traces().getTrace(traceId).execute();
-    if (trace == null) {
+    if (trace.isEmpty()) {
       return AggregatedHttpResponse.of(NOT_FOUND, ANY_TEXT_TYPE, traceId + " not found");
     }
     return jsonResponse(SpanBytesEncoder.JSON_V2.encodeList(trace));

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -74,6 +74,14 @@ public class ITZipkinServer {
       .containsExactly(SpanBytesEncoder.JSON_V2.encodeList(TRACE));
   }
 
+  @Test public void getTrace_notFound() throws Exception {
+    Response response = get("/api/v2/trace/" + TRACE.get(0).traceId());
+    assertThat(response.code()).isEqualTo(404);
+
+    assertThat(response.body().string())
+      .isEqualTo(TRACE.get(0).traceId() + " not found");
+  }
+
   @Test public void getTrace_malformed() throws Exception {
     storage.accept(TRACE).execute();
 
@@ -161,7 +169,8 @@ public class ITZipkinServer {
       .isEqualTo(200);
   }
 
-  @Test public void remoteServiceNameReturnsCorrectJsonForEscapedWhitespaceInName() throws Exception {
+  @Test public void remoteServiceNameReturnsCorrectJsonForEscapedWhitespaceInName()
+    throws Exception {
     storage.accept(Arrays.asList(CLIENT_SPAN.toBuilder()
       .localEndpoint(FRONTEND.toBuilder().serviceName("foo\tbar").build())
       .build()))

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITAutocompleteTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -33,7 +33,7 @@ public abstract class ITAutocompleteTags<T extends StorageComponent> extends ITS
     storage.autocompleteKeys(asList("http.host"));
   }
 
-  @Test void Should_not_store_when_key_not_in_autocompleteTags() throws IOException {
+  @Test protected void should_not_store_when_key_not_in_autocompleteTags() throws IOException {
     accept(TestObjects.LOTS_OF_SPANS[0].toBuilder()
       .timestamp(Instant.now().toEpochMilli())
       .putTag("http.method", "GET")
@@ -44,7 +44,7 @@ public abstract class ITAutocompleteTags<T extends StorageComponent> extends ITS
     assertThat(storage.autocompleteTags().getValues("http.method").execute()).isEmpty();
   }
 
-  @Test void getTagsAndValues() throws IOException {
+  @Test protected void getTagsAndValues() throws IOException {
     for (int i = 0; i < 2; i++) {
       accept(TestObjects.LOTS_OF_SPANS[i].toBuilder()
         .putTag("http.method", "GET")

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITSearchEnabledFalse.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITSearchEnabledFalse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -31,7 +31,7 @@ public abstract class ITSearchEnabledFalse<T extends StorageComponent> extends I
     storage.searchEnabled(false);
   }
 
-  @Test void getTraces_indexDataReturnsNothing() throws Exception {
+  @Test protected void getTraces_indexDataReturnsNothing() throws Exception {
     accept(CLIENT_SPAN);
 
     assertThat(store().getTraces(requestBuilder()
@@ -54,19 +54,19 @@ public abstract class ITSearchEnabledFalse<T extends StorageComponent> extends I
       .build()).execute()).isEmpty();
   }
 
-  @Test void getServiceNames_isEmpty() throws Exception {
+  @Test protected void getServiceNames_isEmpty() throws Exception {
     accept(CLIENT_SPAN);
 
     assertThat(names().getServiceNames().execute()).isEmpty();
   }
 
-  @Test void getRemoteServiceNames_isEmpty() throws Exception {
+  @Test protected void getRemoteServiceNames_isEmpty() throws Exception {
     accept(CLIENT_SPAN);
 
     assertThat(names().getRemoteServiceNames(CLIENT_SPAN.localServiceName()).execute()).isEmpty();
   }
 
-  @Test void getSpanNames_isEmpty() throws Exception {
+  @Test protected void getSpanNames_isEmpty() throws Exception {
     accept(CLIENT_SPAN);
 
     assertThat(names().getSpanNames(CLIENT_SPAN.localServiceName()).execute()).isEmpty();

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITServiceAndSpanNames.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITServiceAndSpanNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -36,7 +36,7 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
     // Defaults are fine.
   }
 
-  @Test void getLocalServiceNames_includesLocalServiceName() throws Exception {
+  @Test protected void getLocalServiceNames_includesLocalServiceName() throws Exception {
     assertThat(names().getServiceNames().execute())
       .isEmpty();
 
@@ -46,13 +46,13 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
       .containsOnly("frontend");
   }
 
-  @Test void getLocalServiceNames_noServiceName() throws IOException {
+  @Test protected void getLocalServiceNames_noServiceName() throws IOException {
     accept(Span.newBuilder().traceId("a").id("a").build());
 
     assertThat(names().getServiceNames().execute()).isEmpty();
   }
 
-  @Test void getRemoteServiceNames() throws Exception {
+  @Test protected void getRemoteServiceNames() throws Exception {
     assertThat(names().getRemoteServiceNames("frontend").execute())
       .isEmpty();
 
@@ -65,7 +65,7 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
       .contains(CLIENT_SPAN.remoteServiceName());
   }
 
-  @Test void getRemoteServiceNames_allReturned() throws IOException {
+  @Test protected void getRemoteServiceNames_allReturned() throws IOException {
     // Assure a default store limit isn't hit by assuming if 50 are returned, all are returned
     List<Span> spans = IntStream.rangeClosed(0, 50)
       .mapToObj(i -> {
@@ -83,7 +83,7 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
   }
 
   /** Ensures the service name index returns distinct results */
-  @Test void getRemoteServiceNames_dedupes() throws IOException {
+  @Test protected void getRemoteServiceNames_dedupes() throws IOException {
     List<Span> spans = IntStream.rangeClosed(0, 50)
       .mapToObj(i -> CLIENT_SPAN.toBuilder().id(i + 1).build())
       .collect(Collectors.toList());
@@ -93,27 +93,27 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
       .containsExactly(CLIENT_SPAN.remoteServiceName());
   }
 
-  @Test void getRemoteServiceNames_noRemoteServiceName() throws IOException {
+  @Test protected void getRemoteServiceNames_noRemoteServiceName() throws IOException {
     accept(Span.newBuilder().traceId("a").id("a").localEndpoint(FRONTEND).build());
 
     assertThat(names().getRemoteServiceNames("frontend").execute()).isEmpty();
   }
 
-  @Test void getRemoteServiceNames_serviceNameGoesLowercase() throws IOException {
+  @Test protected void getRemoteServiceNames_serviceNameGoesLowercase() throws IOException {
     accept(CLIENT_SPAN);
 
     assertThat(names().getRemoteServiceNames("FrOnTeNd").execute())
       .containsExactly(CLIENT_SPAN.remoteServiceName());
   }
 
-  @Test void getSpanNames_doesNotMapNameToRemoteServiceName() throws Exception {
+  @Test protected void getSpanNames_doesNotMapNameToRemoteServiceName() throws Exception {
     accept(CLIENT_SPAN);
 
     assertThat(names().getSpanNames(CLIENT_SPAN.remoteServiceName()).execute())
       .isEmpty();
   }
 
-  @Test void getSpanNames() throws Exception {
+  @Test protected void getSpanNames() throws Exception {
     assertThat(names().getSpanNames("frontend").execute())
       .isEmpty();
 
@@ -126,7 +126,7 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
       .contains(CLIENT_SPAN.name());
   }
 
-  @Test void getSpanNames_allReturned() throws IOException {
+  @Test protected void getSpanNames_allReturned() throws IOException {
     // Assure a default store limit isn't hit by assuming if 50 are returned, all are returned
     List<Span> spans = IntStream.rangeClosed(0, 50)
       .mapToObj(i -> {
@@ -141,7 +141,7 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
   }
 
   /** Ensures the span name index returns distinct results */
-  @Test void getSpanNames_dedupes() throws IOException {
+  @Test protected void getSpanNames_dedupes() throws IOException {
     List<Span> spans = IntStream.rangeClosed(0, 50)
       .mapToObj(i -> CLIENT_SPAN.toBuilder().id(i + 1).build())
       .collect(Collectors.toList());
@@ -151,13 +151,13 @@ public abstract class ITServiceAndSpanNames<T extends StorageComponent> extends 
       .containsExactly(CLIENT_SPAN.name());
   }
 
-  @Test void getSpanNames_noSpanName() throws IOException {
+  @Test protected void getSpanNames_noSpanName() throws IOException {
     accept(Span.newBuilder().traceId("a").id("a").localEndpoint(FRONTEND).build());
 
     assertThat(names().getSpanNames("frontend").execute()).isEmpty();
   }
 
-  @Test void getSpanNames_serviceNameGoesLowercase() throws IOException {
+  @Test protected void getSpanNames_serviceNameGoesLowercase() throws IOException {
     accept(CLIENT_SPAN);
 
     assertThat(names().getSpanNames("FrOnTeNd").execute()).containsExactly("get");

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITStrictTraceIdFalse.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITStrictTraceIdFalse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,11 +41,11 @@ public abstract class ITStrictTraceIdFalse<T extends StorageComponent> extends I
   }
 
   /** Ensures we can still lookup fully 128-bit traces when strict trace ID id disabled */
-  @Test void getTraces_128BitTraceId() throws IOException {
+  @Test protected void getTraces_128BitTraceId() throws IOException {
     getTraces_128BitTraceId(accept128BitTrace(storage));
   }
 
-  @Test void getTraces_128BitTraceId_mixed() throws IOException {
+  @Test protected void getTraces_128BitTraceId_mixed() throws IOException {
     getTraces_128BitTraceId(acceptMixedTrace());
   }
 
@@ -66,13 +66,13 @@ public abstract class ITStrictTraceIdFalse<T extends StorageComponent> extends I
       .containsExactly(trace);
   }
 
-  @Test void getTrace_retrievesBy64Or128BitTraceId() throws IOException {
+  @Test protected void getTrace_retrievesBy64Or128BitTraceId() throws IOException {
     List<Span> trace = accept128BitTrace(storage);
 
     retrievesBy64Or128BitTraceId(trace);
   }
 
-  @Test void getTrace_retrievesBy64Or128BitTraceId_mixed() throws IOException {
+  @Test protected void getTrace_retrievesBy64Or128BitTraceId_mixed() throws IOException {
     List<Span> trace = acceptMixedTrace();
 
     retrievesBy64Or128BitTraceId(trace);
@@ -83,9 +83,9 @@ public abstract class ITStrictTraceIdFalse<T extends StorageComponent> extends I
     String traceId = trace.get(trace.size() - 1).traceId();
 
     assertThat(traces().getTrace(traceId.substring(16)).execute())
-      .containsOnlyElementsOf(trace);
+      .containsExactlyInAnyOrderElementsOf(trace);
     assertThat(traces().getTrace(traceId).execute())
-      .containsOnlyElementsOf(trace);
+      .containsExactlyInAnyOrderElementsOf(trace);
   }
 
   protected List<Span> accept128BitTrace(StorageComponent storage) throws IOException {
@@ -121,7 +121,7 @@ public abstract class ITStrictTraceIdFalse<T extends StorageComponent> extends I
     .traceId("ffffffffffffffff").id("2").timestamp(TODAY * 1000).build();
 
   /** current implementation cannot return exact form reported */
-  @Test void getTraces_retrievesBy64Or128BitTraceId() throws Exception {
+  @Test protected void getTraces_retrievesBy64Or128BitTraceId() throws Exception {
     accept(with128BitId1, with64BitId1, with128BitId2, with64BitId2, with128BitId3, with64BitId3);
 
     List<List<Span>> trace1And3 = asList(

--- a/zipkin-tests/src/main/java/zipkin2/storage/ITTraces.java
+++ b/zipkin-tests/src/main/java/zipkin2/storage/ITTraces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,7 +34,7 @@ public abstract class ITTraces<T extends StorageComponent> extends ITStorage<T> 
     // Defaults are fine.
   }
 
-  @Test void getTrace_returnsEmptyOnNotFound() throws IOException {
+  @Test protected void getTrace_returnsEmptyOnNotFound() throws IOException {
     assertThat(traces().getTrace(CLIENT_SPAN.traceId()).execute())
       .isEmpty();
 
@@ -48,7 +48,7 @@ public abstract class ITTraces<T extends StorageComponent> extends ITStorage<T> 
   }
 
 
-  @Test void getTraces_onlyReturnsTracesThatMatch() throws IOException {
+  @Test protected void getTraces_onlyReturnsTracesThatMatch() throws IOException {
     List<String> traceIds = asList(LOTS_OF_SPANS[0].traceId(), LOTS_OF_SPANS[1].traceId());
 
     assertThat(traces().getTraces(traceIds).execute())
@@ -64,7 +64,7 @@ public abstract class ITTraces<T extends StorageComponent> extends ITStorage<T> 
       .isEmpty();
   }
 
-  @Test void getTraces_returnsEmptyOnNotFound() throws IOException {
+  @Test protected void getTraces_returnsEmptyOnNotFound() throws IOException {
     List<String> traceIds = asList(LOTS_OF_SPANS[0].traceId(), LOTS_OF_SPANS[1].traceId());
 
     assertThat(traces().getTraces(traceIds).execute())
@@ -86,7 +86,7 @@ public abstract class ITTraces<T extends StorageComponent> extends ITStorage<T> 
    * exists, it is known not all backends will be able to cheaply make it pass. In other words, it
    * is optional.
    */
-  @Test public void getTrace_deduplicates() throws IOException {
+  @Test protected void getTrace_deduplicates() throws IOException {
     // simulate a re-processed message
     accept(LOTS_OF_SPANS[0]);
     accept(LOTS_OF_SPANS[0]);

--- a/zipkin/src/main/java/zipkin2/internal/TracesAdapter.java
+++ b/zipkin/src/main/java/zipkin2/internal/TracesAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -67,7 +67,7 @@ public final class TracesAdapter implements Traces {
     }
 
     @Override protected void append(List<Span> input, List<List<Span>> output) {
-      output.add(input);
+      if (!input.isEmpty()) output.add(input);
     }
 
     @Override protected boolean isEmpty(List<List<Span>> output) {
@@ -80,6 +80,6 @@ public final class TracesAdapter implements Traces {
   }
 
   @Override public String toString() {
-    return "TraceReader{" + delegate + "}";
+    return "TracesAdapter{" + delegate + "}";
   }
 }

--- a/zipkin/src/main/java/zipkin2/storage/InMemoryStorage.java
+++ b/zipkin/src/main/java/zipkin2/storage/InMemoryStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -369,7 +369,7 @@ public final class InMemoryStorage extends StorageComponent implements SpanStore
   @Override public synchronized Call<List<Span>> getTrace(String traceId) {
     traceId = Span.normalizeTraceId(traceId);
     List<Span> spans = spansByTraceId(lowTraceId(traceId));
-    if (spans == null || spans.isEmpty()) return Call.emptyList();
+    if (spans.isEmpty()) return Call.emptyList();
     if (!strictTraceId) return Call.create(spans);
 
     List<Span> filtered = new ArrayList<>(spans);

--- a/zipkin/src/test/java/zipkin2/internal/TracesAdapterTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/TracesAdapterTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.internal;
+
+import org.junit.jupiter.api.Test;
+import zipkin2.TestObjects;
+import zipkin2.storage.InMemoryStorage;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TracesAdapterTest {
+  InMemoryStorage storage = InMemoryStorage.newBuilder().build();
+  TracesAdapter adapter = new TracesAdapter(storage);
+
+  /**
+   * The contract for {@link zipkin2.storage.SpanStore#getTrace(java.lang.String)} is to return
+   * empty on not found. This ensures a list of results aren't padded with empty ones.
+   */
+  @Test void getTraces_doesntReturnEmptyElements() throws Exception {
+    storage.accept(TestObjects.TRACE).execute();
+
+    assertThat(adapter.getTraces(asList("1", TestObjects.TRACE.get(0).traceId(), "3")).execute())
+      .containsExactly(TestObjects.TRACE);
+  }
+}


### PR DESCRIPTION
I noticed porting zipkin-voltdb to latest, that we incorrectly handled
getTrace in some places. Basically, we treated a non-nullable result as
nullable. This fixes that and also corrects method protection so that
subclasses of the IT can override (ex to ignore).