### PR TITLE
Fix quote bug in DiscoverPage

### DIFF
--- a/zipkin-lens/.eslintrc
+++ b/zipkin-lens/.eslintrc
@@ -9,6 +9,7 @@
     "react/no-array-index-key": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
+    "react/no-unescaped-entities": ["error", {"forbid": [">", "}"]}],
     "no-console": 0,
     "no-underscore-dangle": ["off"],
     "no-continue": ["off"],

--- a/zipkin-lens/.eslintrc
+++ b/zipkin-lens/.eslintrc
@@ -9,7 +9,7 @@
     "react/no-array-index-key": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "react/no-unescaped-entities": ["error", {"forbid": [">", "}"]}],
+    "react/no-unescaped-entities": "off",
     "no-console": 0,
     "no-underscore-dangle": ["off"],
     "no-continue": ["off"],

--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+/* eslint-disable react/no-unescaped-entities */
 import { Trans } from '@lingui/macro';
 import PropTypes from 'prop-types';
 import React, { useEffect, useCallback } from 'react';
@@ -294,11 +295,9 @@ const DiscoverPageImpl = (props) => {
         <Box className={classes.explainBoxWrapper}>
           <Typography variant="body1">
             <Trans>
-              {
-                'Searching has been disabled via the searchEnabled property.'
-                  + 'You can still view specific traces of which you know the trace id'
-                  + 'by entering it in the "trace id..." textbox on the top-right.'
-              }
+              Searching has been disabled via the searchEnabled property.
+              You can still view specific traces of which you know the trace id
+              by entering it in the "trace id..." textbox on the top-right.
             </Trans>
           </Typography>
         </Box>

--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
@@ -11,7 +11,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/* eslint-disable react/no-unescaped-entities */
 import { Trans } from '@lingui/macro';
 import PropTypes from 'prop-types';
 import React, { useEffect, useCallback } from 'react';

--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.jsx
@@ -294,9 +294,11 @@ const DiscoverPageImpl = (props) => {
         <Box className={classes.explainBoxWrapper}>
           <Typography variant="body1">
             <Trans>
-              Searching has been disabled via the searchEnabled property.
-              You can still view specific traces of which you know the trace id
-              by entering it in the &quot;trace id...&quot; textbox on the top-right.
+              {
+                'Searching has been disabled via the searchEnabled property.'
+                  + 'You can still view specific traces of which you know the trace id'
+                  + 'by entering it in the "trace id..." textbox on the top-right.'
+              }
             </Trans>
           </Typography>
         </Box>


### PR DESCRIPTION
While fixing lint errors, I escaped double quotes.
But it did not seem to work correctly in React.

Before: 
<img width="1062" alt="スクリーンショット 2020-03-11 18 50 57" src="https://user-images.githubusercontent.com/19551419/76404222-74f4d480-63c9-11ea-92a0-44ebb9acf1ba.png">

After:
<img width="1061" alt="スクリーンショット 2020-03-11 18 50 44" src="https://user-images.githubusercontent.com/19551419/76404235-7aeab580-63c9-11ea-877d-79b55a46f361.png">

