### PR TITLE
Use blocking executor for delegating span collection in scribe collec…

### DIFF
--- a/zipkin-collector/scribe/pom.xml
+++ b/zipkin-collector/scribe/pom.xml
@@ -61,6 +61,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/NettyScribeServer.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/NettyScribeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/NettyScribeServer.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/NettyScribeServer.java
@@ -20,6 +20,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import java.net.InetSocketAddress;
 
 import static zipkin2.Call.propagateIfFatal;
@@ -46,7 +47,9 @@ final class NettyScribeServer {
         .channel(EventLoopGroups.serverChannelType(bossGroup))
         .childHandler(new ChannelInitializer<SocketChannel>() {
           @Override protected void initChannel(SocketChannel ch) {
-            ch.pipeline().addLast(new ScribeInboundHandler(scribe));
+            ch.pipeline()
+              .addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4))
+              .addLast(new ScribeInboundHandler(scribe));
           }
         })
         .bind(port)

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeInboundHandler.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeInboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeInboundHandler.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeInboundHandler.java
@@ -24,10 +24,8 @@ import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.ServiceRequestContextBuilder;
 import com.linecorp.armeria.server.thrift.THttpService;
-import com.linecorp.armeria.unsafe.ByteBufHttpData;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
-import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
@@ -62,71 +60,14 @@ final class ScribeInboundHandler extends ChannelInboundHandlerAdapter {
     scribeService = THttpService.of(scribe);
   }
 
-  enum ReadState {
-    HEADER,
-    PAYLOAD
-  }
-
-  CompositeByteBuf pending;
-  ReadState state;
-  int nextFrameSize;
-
   Map<Integer, ByteBuf> pendingResponses = new HashMap<>();
   int nextResponseIndex = 0;
   int previouslySentResponseIndex = -1;
 
-  @Override public void channelActive(ChannelHandlerContext ctx) {
-    pending = ctx.alloc().compositeBuffer();
-    state = ReadState.HEADER;
-  }
-
-  @Override public void channelRead(final ChannelHandlerContext ctx, Object msg) {
-    if (pending == null) return; // Already closed (probably due to an exception).
-
-    assert msg instanceof ByteBuf;
-    ByteBuf buf = (ByteBuf) msg;
-    pending.addComponent(true, buf);
-
-    switch (state) {
-      case HEADER:
-        maybeReadHeader(ctx);
-        break;
-      case PAYLOAD:
-        maybeReadPayload(ctx);
-        break;
-    }
-  }
-
-  @Override public void channelInactive(ChannelHandlerContext ctx) {
-    release();
-  }
-
-  @Override public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-    Exceptions.logIfUnexpected(logger, ctx.channel(), cause);
-
-    release();
-    closeOnFlush(ctx.channel());
-  }
-
-  void maybeReadHeader(ChannelHandlerContext ctx) {
-    if (pending.readableBytes() < 4) return;
-
-    nextFrameSize = pending.readInt();
-    state = ReadState.PAYLOAD;
-    maybeReadPayload(ctx);
-  }
-
-  void maybeReadPayload(ChannelHandlerContext ctx) {
-    if (pending.readableBytes() < nextFrameSize) return;
-
-    ByteBuf payload = ctx.alloc().buffer(nextFrameSize);
-    pending.readBytes(payload, nextFrameSize);
-    pending.discardSomeReadBytes();
-
-    state = ReadState.HEADER;
-
-    HttpRequest request = HttpRequest.of(THRIFT_HEADERS, new ByteBufHttpData(payload, true));
-    ServiceRequestContextBuilder requestContextBuilder = ServiceRequestContextBuilder.of(request)
+  @Override public void channelRead(ChannelHandlerContext ctx, Object payload) {
+    assert payload instanceof ByteBuf;
+    HttpRequest request = HttpRequest.of(THRIFT_HEADERS, HttpData.wrap((ByteBuf) payload));
+    ServiceRequestContextBuilder requestContextBuilder = ServiceRequestContext.builder(request)
       .service(scribeService)
       .alloc(ctx.alloc());
 
@@ -181,6 +122,17 @@ final class ScribeInboundHandler extends ChannelInboundHandlerAdapter {
     });
   }
 
+  @Override public void channelInactive(ChannelHandlerContext ctx) {
+    release();
+  }
+
+  @Override public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    Exceptions.logIfUnexpected(logger, ctx.channel(), cause);
+
+    release();
+    closeOnFlush(ctx.channel());
+  }
+
   void flushResponses(ChannelHandlerContext ctx) {
     while (!pendingResponses.isEmpty()) {
       ByteBuf response = pendingResponses.remove(previouslySentResponseIndex + 1);
@@ -194,11 +146,6 @@ final class ScribeInboundHandler extends ChannelInboundHandlerAdapter {
   }
 
   void release() {
-    if (pending != null) {
-      pending.release();
-      pending = null;
-    }
-
     pendingResponses.values().forEach(ByteBuf::release);
     pendingResponses.clear();
   }

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin2/collector/scribe/ScribeSpanConsumer.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.collector.scribe;
 
+import com.linecorp.armeria.common.CommonPools;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -68,6 +69,7 @@ final class ScribeSpanConsumer implements Scribe.AsyncIface {
         Exception error = t instanceof Exception ? (Exception) t : new RuntimeException(t);
         resultHandler.onError(error);
       }
-    });
+    // Collectors may not be asynchronous so switch to blocking executor here.
+    }, CommonPools.blockingTaskExecutor());
   }
 }

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
@@ -34,14 +34,12 @@ import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.scribe.generated.LogEntry;
 import zipkin2.collector.scribe.generated.ResultCode;
 import zipkin2.collector.scribe.generated.Scribe;
-import zipkin2.storage.InMemoryStorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ITScribeCollector.java
@@ -47,15 +47,18 @@ import static org.mockito.Mockito.verify;
 
 public class ITScribeCollector {
 
-  private static InMemoryStorage storage;
   private static Collector collector;
   private static CollectorMetrics metrics;
 
   private static NettyScribeServer server;
 
   @BeforeClass public static void startServer() {
-    storage = InMemoryStorage.newBuilder().build();
-    collector = spy(Collector.newBuilder(ITScribeCollector.class).storage(storage).build());
+    collector = mock(Collector.class);
+    doAnswer(invocation -> {
+      Callback<Void> callback = invocation.getArgument(1);
+      callback.onSuccess(null);
+      return null;
+    }).when(collector).accept(any(), any(), any());
 
     metrics = mock(CollectorMetrics.class);
 

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
…tor.

Also cleans up code by using Netty to handle deframing, functionality I found recently.

Fixes #3028 