### PR TITLE
Smaller span bars - bigger download buttons

### DIFF
--- a/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
@@ -87,8 +87,8 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: theme.spacing(0.8),
   },
   actionButton: {
-    fontSize: '0.5rem',
-    lineHeight: 0.8,
+    fontSize: '0.7rem',
+    lineHeight: 1.0,
   },
   actionButtonIcon: {
     marginRight: theme.spacing(1),

--- a/zipkin-lens/src/components/TracePage/TraceTimeline/TraceTimelineRow.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceTimeline/TraceTimelineRow.jsx
@@ -43,7 +43,7 @@ const propTypes = {
 
 const useStyles = makeStyles((theme) => ({
   line: {
-    stroke: theme.palette.grey[400],
+    stroke: theme.palette.grey[300],
     strokeWidth: '1px',
   },
   bar: {

--- a/zipkin-lens/src/components/TracePage/TraceTimeline/TraceTree.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceTimeline/TraceTree.jsx
@@ -218,7 +218,7 @@ const propTypes = {
 
 const useStyles = makeStyles((theme) => ({
   line: {
-    stroke: theme.palette.grey[400],
+    stroke: theme.palette.grey[300],
     strokeWidth: '1px',
   },
   spanToggleButton: {

--- a/zipkin-lens/src/components/TracePage/sizing.js
+++ b/zipkin-lens/src/components/TracePage/sizing.js
@@ -34,13 +34,13 @@ export const timelineRightMarginPercent = 2; // %
 export const timelineWidthPercent =
   100 -
   (spanTreeWidthPercent + serviceNameWidthPercent + timelineRightMarginPercent);
-export const spanBarRowHeight = 40; // px
+export const spanBarRowHeight = 30; // px
 export const spanBarHeight = spanBarRowHeight - 4; // px;
 
 export const spanTreeLineWidthPercentPerDepth = (depth) =>
   spanTreeWidthPercent / (depth + 1); // %
 export const serviceNameBadgeWidth = serviceNameWidthPercent - 2;
-export const serviceNameBadgeHeight = 24;
+export const serviceNameBadgeHeight = 20;
 export const serviceNameBadgeTranslate = `translate(16,${-serviceNameBadgeHeight /
   2})`; // px
 export const spanToggleButtonLengthOfSide = 16; // px


### PR DESCRIPTION
I've changed the size of a few element. In particular:
- span rows are now less tall, to help with traces with 1k+ spans
- the View Logs, Archive Trace, Download JSON buttons are bigger and
  more visible
- the background lines showing the call tree are now a lighter gray,
  since I found them too visible and distracting.

These are just suggestions, feel free to comment or discard the PR if
you don't agree.

cc @tacigar @anuraaga 

Current version:
![image](https://user-images.githubusercontent.com/3317638/76707840-ce9e1d00-66af-11ea-99bf-fb5964d26a37.png)

After my changes:
![image](https://user-images.githubusercontent.com/3317638/76707857-ee354580-66af-11ea-826c-09f5dcda1da5.png)
