### PR TITLE
Replace all instances of {traceId} in logs URL instead of just first.

### DIFF
--- a/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummaryHeader.jsx
@@ -102,7 +102,7 @@ const TraceSummaryHeader = React.memo(({ traceSummary, rootSpanIndex }) => {
 
   const logsUrl =
     config.logsUrl && traceSummary
-      ? config.logsUrl.replace('{traceId}', traceSummary.traceId)
+      ? config.logsUrl.replace(/{traceId}/g, traceSummary.traceId)
       : undefined;
 
   const handleSaveButtonClick = useCallback(() => {

--- a/zipkin-lens/src/components/TracePage/TraceSummaryHeader.test.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummaryHeader.test.jsx
@@ -57,9 +57,38 @@ describe('<TraceSummaryHeader />', () => {
     );
     const logsLink = queryByTestId('view-logs-link');
     expect(logsLink).toBeInTheDocument();
-    expect(logsLink.href).toEqual('http://zipkin.io/logs=1');
+    expect(logsLink).toHaveAttribute('href', 'http://zipkin.io/logs=1');
     // Make sure the link opens in a new tab
-    expect(logsLink.target).toEqual('_blank');
-    expect(logsLink.rel).toEqual('noopener');
+    expect(logsLink).toHaveAttribute('target', '_blank');
+    expect(logsLink).toHaveAttribute('rel', 'noopener');
+  });
+
+  it('does replace multiple instances of {traceId} in logsUrl', () => {
+    const { queryByTestId } = render(
+      <TraceSummaryHeader
+        traceSummary={{
+          traceId: '1',
+          spans: [],
+          serviceNameAndSpanCounts: [],
+          duration: 1,
+          durationStr: '1μs',
+          rootSpan: {
+            serviceName: 'service-A',
+            spanName: 'span-A',
+          },
+        }}
+      />,
+      {
+        uiConfig: {
+          logsUrl: 'http://zipkin.io/logs={traceId}&moreLogs={traceId}',
+        },
+      },
+    );
+    const logsLink = queryByTestId('view-logs-link');
+    expect(logsLink).toBeInTheDocument();
+    expect(logsLink).toHaveAttribute(
+      'href',
+      'http://zipkin.io/logs=1&moreLogs=1',
+    );
   });
 });


### PR DESCRIPTION
I originally thought this is a bug in lens but realized classic only replaced one too

https://github.com/openzipkin-attic/zipkin-classic/blob/bad04931779d6486b4fb7efd64c1c90965f79fcd/js/component_data/trace.js#L9

But it seems simple enough to just replace them all if it helps.

Fixes #3033 