### PR TITLE
Silence the Flags and DocStringExtractor during startup

### DIFF
--- a/zipkin-server/src/main/resources/simplelogger.properties
+++ b/zipkin-server/src/main/resources/simplelogger.properties
@@ -5,3 +5,8 @@ org.slf4j.simpleLogger.defaultLogLevel=info
 org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS
 org.slf4j.simpleLogger.showShortLogName=true
+
+# this mirrors the logging configuration applied in zipkin-server-shared.yml , logging.level
+org.slf4j.simpleLogger.log.com.linecorp.armeria.client.HttpResponseDecoder=OFF
+org.slf4j.simpleLogger.log.com.linecorp.armeria.common.Flags=OFF
+org.slf4j.simpleLogger.log.com.linecorp.armeria.server.docs.DocStringExtractor=OFF

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -251,6 +251,8 @@ logging:
     # Silence ResponseTimeoutException in the Armeria framework since we log it anyways in HTTP
     # logging when enabled. https://github.com/line/armeria/issues/2000
     com.linecorp.armeria.client.HttpResponseDecoder: 'OFF'
+    com.linecorp.armeria.common.Flags: 'OFF'
+    com.linecorp.armeria.server.docs.DocStringExtractor: 'OFF'
 #     # investigate /api/v2/dependencies
 #     zipkin2.internal.DependencyLinker: 'DEBUG'
 #     # log cassandra queries (DEBUG is without values)


### PR DESCRIPTION
Before (using slim)
```
:: version 2.21.1-SNAPSHOT :: commit bc7a2ca ::

2020-04-09 12:00:59:720 [main] INFO ZipkinServer - Starting ZipkinServer on heymjo-xps-13-9370 with PID 15556 (/home/heymjo/src/zipkin/zipkin-server/target/zipkin-server-2.21.1-SNAPSHOT-slim.jar started by heymjo in /home/heymjo/src/zipkin)
2020-04-09 12:00:59:722 [main] INFO ZipkinServer - The following profiles are active: shared
2020-04-09 12:01:00:680 [main] INFO Flags - com.linecorp.armeria.verboseExceptions: rate-limit=10 (default)
2020-04-09 12:01:00:687 [main] INFO Flags - com.linecorp.armeria.verboseSocketExceptions: false (default)
2020-04-09 12:01:00:688 [main] INFO Flags - com.linecorp.armeria.verboseResponses: false (default)
2020-04-09 12:01:00:751 [main] INFO Flags - com.linecorp.armeria.useEpoll: true (default)
2020-04-09 12:01:00:753 [main] INFO Flags - com.linecorp.armeria.maxNumConnections: 2147483647 (default)
2020-04-09 12:01:00:753 [main] INFO Flags - com.linecorp.armeria.numCommonWorkers: 16 (default)
2020-04-09 12:01:00:754 [main] INFO Flags - com.linecorp.armeria.numCommonBlockingTaskThreads: 200 (default)
2020-04-09 12:01:00:755 [main] INFO Flags - com.linecorp.armeria.defaultMaxRequestLength: 10485760 (default)
2020-04-09 12:01:00:756 [main] INFO Flags - com.linecorp.armeria.defaultMaxResponseLength: 10485760 (default)
2020-04-09 12:01:00:756 [main] INFO Flags - com.linecorp.armeria.defaultRequestTimeoutMillis: 10000 (default)
2020-04-09 12:01:00:757 [main] INFO Flags - com.linecorp.armeria.defaultResponseTimeoutMillis: 15000 (default)
2020-04-09 12:01:00:757 [main] INFO Flags - com.linecorp.armeria.defaultConnectTimeoutMillis: 3200 (default)
2020-04-09 12:01:00:758 [main] INFO Flags - com.linecorp.armeria.defaultWriteTimeoutMillis: 1000 (default)
2020-04-09 12:01:00:758 [main] INFO Flags - com.linecorp.armeria.defaultServerIdleTimeoutMillis: 15000 (default)
2020-04-09 12:01:00:759 [main] INFO Flags - com.linecorp.armeria.defaultClientIdleTimeoutMillis: 10000 (default)
2020-04-09 12:01:00:759 [main] INFO Flags - com.linecorp.armeria.defaultHttp2PingTimeoutMillis: 0 (default)
2020-04-09 12:01:00:760 [main] INFO Flags - com.linecorp.armeria.defaultHttp2InitialConnectionWindowSize: 1048576 (default)
2020-04-09 12:01:00:760 [main] INFO Flags - com.linecorp.armeria.defaultHttp2InitialStreamWindowSize: 1048576 (default)
2020-04-09 12:01:00:761 [main] INFO Flags - com.linecorp.armeria.defaultHttp2MaxFrameSize: 16384 (default)
2020-04-09 12:01:00:761 [main] INFO Flags - com.linecorp.armeria.defaultHttp2MaxStreamsPerConnection: 2147483647 (default)
2020-04-09 12:01:00:761 [main] INFO Flags - com.linecorp.armeria.defaultHttp2MaxHeaderListSize: 8192 (default)
2020-04-09 12:01:00:762 [main] INFO Flags - com.linecorp.armeria.defaultHttp1MaxInitialLineLength: 4096 (default)
2020-04-09 12:01:00:762 [main] INFO Flags - com.linecorp.armeria.defaultHttp1MaxHeaderSize: 8192 (default)
2020-04-09 12:01:00:763 [main] INFO Flags - com.linecorp.armeria.defaultHttp1MaxChunkSize: 8192 (default)
2020-04-09 12:01:00:763 [main] INFO Flags - com.linecorp.armeria.defaultUseHttp2Preface: true (default)
2020-04-09 12:01:00:763 [main] INFO Flags - com.linecorp.armeria.defaultUseHttp1Pipelining: false (default)
2020-04-09 12:01:00:763 [main] INFO Flags - com.linecorp.armeria.defaultUseHttp2PingWhenNoActiveStreams: false (default)
2020-04-09 12:01:00:764 [main] INFO Flags - com.linecorp.armeria.defaultBackoffSpec: exponential=200:10000,jitter=0.2 (default)
2020-04-09 12:01:00:764 [main] INFO Flags - com.linecorp.armeria.defaultMaxTotalAttempts: 10 (default)
2020-04-09 12:01:00:765 [main] INFO Flags - com.linecorp.armeria.routeCache: maximumSize=4096 (default)
2020-04-09 12:01:00:765 [main] INFO Flags - com.linecorp.armeria.routeDecoratorCache: maximumSize=4096 (default)
2020-04-09 12:01:00:765 [main] INFO Flags - com.linecorp.armeria.compositeServiceCache: maximumSize=256 (default)
2020-04-09 12:01:00:766 [main] INFO Flags - com.linecorp.armeria.parsedPathCache: maximumSize=4096 (default)
2020-04-09 12:01:00:766 [main] INFO Flags - com.linecorp.armeria.headerValueCache: maximumSize=4096 (default)
2020-04-09 12:01:00:766 [main] INFO Flags - com.linecorp.armeria.fileServiceCache: maximumSize=1024 (default)
2020-04-09 12:01:00:767 [main] INFO Flags - com.linecorp.armeria.cachedHeaders: :authority,:scheme,:method,accept-encoding,content-type (default)
2020-04-09 12:01:00:769 [main] INFO Flags - com.linecorp.armeria.annotatedServiceExceptionVerbosity: unhandled (default)
2020-04-09 12:01:00:771 [main] INFO Flags - com.linecorp.armeria.useJdkDnsResolver: false (default)
2020-04-09 12:01:00:771 [main] INFO Flags - com.linecorp.armeria.reportBlockedEventLoop: true (default)
2020-04-09 12:01:00:771 [main] INFO Flags - com.linecorp.armeria.validateHeaders: true (default)
2020-04-09 12:01:00:771 [main] INFO Flags - com.linecorp.armeria.useLegacyMeterNames: false (default)
2020-04-09 12:01:00:771 [main] INFO Flags - Using /dev/epoll
2020-04-09 12:01:01:562 [main] INFO SystemInfo - Hostname: heymjo-xps-13-9370 (from /proc/sys/kernel/hostname)
2020-04-09 12:01:02:140 [armeria-boss-http-*:9411] INFO Server - Serving HTTP at /0:0:0:0:0:0:0:0%0:9411 - http://127.0.0.1:9411/
2020-04-09 12:01:02:141 [main] INFO ArmeriaAutoConfiguration - Armeria server started at ports: {/0:0:0:0:0:0:0:0%0:9411=ServerPort(/0:0:0:0:0:0:0:0%0:9411, [http])}
2020-04-09 12:01:02:186 [main] INFO ZipkinServer - Started ZipkinServer in 3.24 seconds (JVM running for 4.52)
```

After
```
:: version 2.21.1-SNAPSHOT :: commit bc7a2ca ::

2020-04-09 12:10:08:023 [main] INFO ZipkinServer - Starting ZipkinServer on heymjo-xps-13-9370 with PID 16149 (/home/heymjo/src/zipkin/zipkin-server/target/zipkin-server-2.21.1-SNAPSHOT-slim.jar started by heymjo in /home/heymjo/src/zipkin/zipkin-server)
2020-04-09 12:10:08:025 [main] INFO ZipkinServer - The following profiles are active: shared
2020-04-09 12:10:09:754 [main] INFO SystemInfo - Hostname: heymjo-xps-13-9370 (from /proc/sys/kernel/hostname)
2020-04-09 12:10:10:241 [armeria-boss-http-*:9411] INFO Server - Serving HTTP at /0:0:0:0:0:0:0:0%0:9411 - http://127.0.0.1:9411/
2020-04-09 12:10:10:242 [main] INFO ArmeriaAutoConfiguration - Armeria server started at ports: {/0:0:0:0:0:0:0:0%0:9411=ServerPort(/0:0:0:0:0:0:0:0%0:9411, [http])}
2020-04-09 12:10:10:278 [main] INFO ZipkinServer - Started ZipkinServer in 2.97 seconds (JVM running for 3.615)
```