### PR TITLE
Fix #3052

### DIFF
--- a/zipkin-lens/src/components/DependenciesPage/DependenciesPageHeader.jsx
+++ b/zipkin-lens/src/components/DependenciesPage/DependenciesPageHeader.jsx
@@ -90,6 +90,21 @@ const DependenciesPageHeader = React.memo(
     const classes = useStyles();
     const { i18n } = useLingui();
 
+    const dateTimePickerCommonProps = React.useMemo(
+      () => ({
+        inputVariant: 'outlined',
+        className: classes.dateTimePicker,
+        InputProps: {
+          // See: https://github.com/openzipkin/zipkin/issues/3052
+          // DateTimePicker's input is not very useful, so disable it and
+          // let users use a calendar dialog instead.
+          disabled: true,
+          classes: { input: classes.dateTimePickerInput },
+        },
+      }),
+      [classes.dateTimePicker, classes.dateTimePickerInput],
+    );
+
     return (
       <Box className={classes.root}>
         <Box className={classes.upperBox}>
@@ -104,26 +119,16 @@ const DependenciesPageHeader = React.memo(
         <Box className={classes.searchBox}>
           <KeyboardDateTimePicker
             label={i18n._(t`Start Time`)}
-            inputVariant="outlined"
             value={startTime}
             onChange={onStartTimeChange}
-            className={classes.dateTimePicker}
-            InputProps={{
-              disabled: true,
-              classes: { input: classes.dateTimePickerInput },
-            }}
+            {...dateTimePickerCommonProps}
           />
           -
           <KeyboardDateTimePicker
             label={i18n._(t`End Time`)}
-            inputVariant="outlined"
             value={endTime}
             onChange={onEndTimeChange}
-            className={classes.dateTimePicker}
-            InputProps={{
-              disabled: true,
-              classes: { input: classes.dateTimePickerInput },
-            }}
+            {...dateTimePickerCommonProps}
           />
           <Button
             color="primary"

--- a/zipkin-lens/src/components/DependenciesPage/DependenciesPageHeader.jsx
+++ b/zipkin-lens/src/components/DependenciesPage/DependenciesPageHeader.jsx
@@ -90,20 +90,14 @@ const DependenciesPageHeader = React.memo(
     const classes = useStyles();
     const { i18n } = useLingui();
 
-    const dateTimePickerCommonProps = React.useMemo(
-      () => ({
-        inputVariant: 'outlined',
-        className: classes.dateTimePicker,
-        InputProps: {
-          // See: https://github.com/openzipkin/zipkin/issues/3052
-          // DateTimePicker's input is not very useful, so disable it and
-          // let users use a calendar dialog instead.
-          disabled: true,
-          classes: { input: classes.dateTimePickerInput },
-        },
-      }),
-      [classes.dateTimePicker, classes.dateTimePickerInput],
-    );
+    const dateTimePickerCommonProps = {
+      inputVariant: 'outlined',
+      className: classes.dateTimePicker,
+      InputProps: {
+        classes: { input: classes.dateTimePickerInput },
+      },
+      format: 'MM/DD/YYYY HH:mm:ss',
+    };
 
     return (
       <Box className={classes.root}>

--- a/zipkin-lens/src/components/DependenciesPage/DependenciesPageHeader.jsx
+++ b/zipkin-lens/src/components/DependenciesPage/DependenciesPageHeader.jsx
@@ -60,6 +60,9 @@ const useStyles = makeStyles((theme) => ({
     fontSize: '1rem',
     height: '1.6rem',
     padding: '0.4rem 0.6rem',
+    '&:disabled': {
+      color: theme.palette.text.primary,
+    },
   },
   findButton: {
     fontSize: '1.2rem',
@@ -105,7 +108,10 @@ const DependenciesPageHeader = React.memo(
             value={startTime}
             onChange={onStartTimeChange}
             className={classes.dateTimePicker}
-            InputProps={{ classes: { input: classes.dateTimePickerInput } }}
+            InputProps={{
+              disabled: true,
+              classes: { input: classes.dateTimePickerInput },
+            }}
           />
           -
           <KeyboardDateTimePicker
@@ -114,7 +120,10 @@ const DependenciesPageHeader = React.memo(
             value={endTime}
             onChange={onEndTimeChange}
             className={classes.dateTimePicker}
-            InputProps={{ classes: { input: classes.dateTimePickerInput } }}
+            InputProps={{
+              disabled: true,
+              classes: { input: classes.dateTimePickerInput },
+            }}
           />
           <Button
             color="primary"


### PR DESCRIPTION
Fix #3052

As pointed out #3052 , when something is put to the input of DateTimePicker, it will often barf.
So disable input and force users to enter the date time using a calendar dialog.
Probably this is better UX.