### PR TITLE
Adds parameter to disable the dependencies screen

### DIFF
--- a/zipkin-lens/src/components/App/App.jsx
+++ b/zipkin-lens/src/components/App/App.jsx
@@ -49,11 +49,13 @@ const App = () => {
                       <BrowserRouter basename={BASE_PATH}>
                         <Layout>
                           <Route exact path="/" component={DiscoverPage} />
-                          <Route
-                            exact
-                            path="/dependency"
-                            component={DependenciesPage}
-                          />
+                          {config.dependency.enabled && (
+                            <Route
+                              exact
+                              path="/dependency"
+                              component={DependenciesPage}
+                            />
+                          )}
                           <Route
                             exact
                             path={['/traces/:traceId', '/traceViewer']}

--- a/zipkin-lens/src/components/App/Layout.jsx
+++ b/zipkin-lens/src/components/App/Layout.jsx
@@ -104,11 +104,13 @@ const Layout = ({ children }) => {
               path="/"
               icon={faSearch}
             />
-            <SidebarMenu
-              title={i18n._(t`Dependencies Page`)}
-              path="/dependency"
-              icon={faProjectDiagram}
-            />
+            {config.dependency.enabled && (
+              <SidebarMenu
+                title={i18n._(t`Dependencies Page`)}
+                path="/dependency"
+                icon={faProjectDiagram}
+              />
+            )}
           </List>
         </Box>
         <List>

--- a/zipkin-lens/src/components/App/Layout.test.jsx
+++ b/zipkin-lens/src/components/App/Layout.test.jsx
@@ -31,7 +31,7 @@ describe('<Layout />', () => {
 
   it('does render help link when defined', () => {
     // children is required so avoid warning by passing dummy children
-    const { getByTitle } = render(
+    const { queryByTitle } = render(
       <Layout>
         <span>Test</span>
         <span>Test</span>
@@ -42,12 +42,12 @@ describe('<Layout />', () => {
         },
       },
     );
-    const helpLink = getByTitle('Support');
+    const helpLink = queryByTitle('Support');
     expect(helpLink).toBeInTheDocument();
     expect(helpLink.href).toEqual('https://gitter.im/openzipkin/zipkin');
   });
 
-  it('does render Dependencies with default config', () => {
+  it('does render Dependencies Page with default config', () => {
     // children is required so avoid warning by passing dummy children
     const { queryByTitle } = render(
       <Layout>
@@ -55,12 +55,12 @@ describe('<Layout />', () => {
         <span>Test</span>
       </Layout>,
     );
-    expect(queryByTitle('Dependencies')).toBeInTheDocument();
+    expect(queryByTitle('Dependencies Page')).toBeInTheDocument();
   });
 
-  it('does not render Dependencies link when disabled', () => {
+  it('does not render Dependencies Page when disabled', () => {
     // children is required so avoid warning by passing dummy children
-    const { getByTitle } = render(
+    const { queryByTitle } = render(
       <Layout>
         <span>Test</span>
         <span>Test</span>
@@ -73,6 +73,6 @@ describe('<Layout />', () => {
         },
       },
     );
-    expect(queryByTitle('Dependencies')).not.toBeInTheDocument();
+    expect(queryByTitle('Dependencies Page')).not.toBeInTheDocument();
   });
 });

--- a/zipkin-lens/src/components/App/Layout.test.jsx
+++ b/zipkin-lens/src/components/App/Layout.test.jsx
@@ -46,4 +46,33 @@ describe('<Layout />', () => {
     expect(helpLink).toBeInTheDocument();
     expect(helpLink.href).toEqual('https://gitter.im/openzipkin/zipkin');
   });
+
+  it('does render Dependencies with default config', () => {
+    // children is required so avoid warning by passing dummy children
+    const { queryByTitle } = render(
+      <Layout>
+        <span>Test</span>
+        <span>Test</span>
+      </Layout>,
+    );
+    expect(queryByTitle('Dependencies')).toBeInTheDocument();
+  });
+
+  it('does not render Dependencies link when disabled', () => {
+    // children is required so avoid warning by passing dummy children
+    const { getByTitle } = render(
+      <Layout>
+        <span>Test</span>
+        <span>Test</span>
+      </Layout>,
+      {
+        uiConfig: {
+          dependency: {
+            'enabled': false,
+          },
+        },
+      },
+    );
+    expect(queryByTitle('Dependencies')).not.toBeInTheDocument();
+  });
 });

--- a/zipkin-lens/src/components/App/Layout.test.jsx
+++ b/zipkin-lens/src/components/App/Layout.test.jsx
@@ -68,7 +68,7 @@ describe('<Layout />', () => {
       {
         uiConfig: {
           dependency: {
-            'enabled': false,
+            enabled: false,
           },
         },
       },

--- a/zipkin-lens/src/test/util/render-with-default-settings.tsx
+++ b/zipkin-lens/src/test/util/render-with-default-settings.tsx
@@ -56,6 +56,7 @@ export default (
     defaultLookback: 15 * 60 * 1000,
     searchEnabled: true,
     dependency: {
+      enabled: true,
       lowErrorRate: 0.5,
       highErrorRate: 0.75,
     },

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -174,13 +174,14 @@ Attribute | Property | Description
 --- | --- | ---
 environment | zipkin.ui.environment | The value here becomes a label in the top-right corner. Not required.
 defaultLookback | zipkin.ui.default-lookback | Default duration in millis to look back when finding traces. Affects the "Start time" element in the UI. Defaults to 900000 (15 minutes in millis).
-searchEnabled | zipkin.ui.search-enabled | If the Find Traces screen is enabled. Defaults to true.
+searchEnabled | zipkin.ui.search-enabled | If the Discover screen is enabled. Defaults to true.
 queryLimit | zipkin.ui.query-limit | Default limit for Find Traces. Defaults to 10.
 instrumented | zipkin.ui.instrumented | Which sites this Zipkin UI covers. Regex syntax. e.g. `http:\/\/example.com\/.*` Defaults to match all websites (`.*`).
 logsUrl | zipkin.ui.logs-url | Logs query service url pattern. If specified, a button will appear on the trace page and will replace {traceId} in the url by the traceId. Not required.
 supportUrl | zipkin.ui.support-url | A URL where a user can ask for support. If specified, a link will be placed in the side menu to this URL, for example a page to file support tickets. Not required.
 archivePostUrl | zipkin.ui.archive-post-url | Url to POST the current trace in Zipkin v2 json format. e.g. 'https://longterm/api/v2/spans'. If specified, a button will appear on the trace page accordingly. Not required.
 archiveUrl | zipkin.ui.archive-url | Url to a web application serving an archived trace, templated by '{traceId}'. e.g. https://longterm/zipkin/trace/{traceId}'. This is shown in a confirmation message after a trace is successfully POSTed to the `archivePostUrl`. Not required.
+dependency.enabled | zipkin.ui.dependency.enabled | If the Dependencies screen is enabled. Defaults to true.
 dependency.lowErrorRate | zipkin.ui.dependency.low-error-rate | The rate of error calls on a dependency link that turns it yellow. Defaults to 0.5 (50%) set to >1 to disable.
 dependency.highErrorRate | zipkin.ui.dependency.high-error-rate | The rate of error calls on a dependency link that turns it red. Defaults to 0.75 (75%) set to >1 to disable.
 basePath | zipkin.ui.basepath | path prefix placed into the <base> tag in the UI HTML; useful when running behind a reverse proxy. Default "/zipkin"

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -127,6 +127,7 @@ public class ZipkinUiConfiguration {
   // defaultLookback: 15 * 60 * 1000, // 15 minutes
   // searchEnabled: true,
   // dependency: {
+  //   enabled: true,
   //   lowErrorRate: 0.5, // 50% of calls in error turns line yellow
   //   highErrorRate: 0.75 // 75% of calls in error turns line red
   // }
@@ -144,6 +145,7 @@ public class ZipkinUiConfiguration {
       generator.writeStringField("archivePostUrl", ui.getArchivePostUrl());
       generator.writeStringField("archiveUrl", ui.getArchiveUrl());
       generator.writeObjectFieldStart("dependency");
+      generator.writeBooleanField("enabled", ui.getDependency().isEnabled());
       generator.writeNumberField("lowErrorRate", ui.getDependency().getLowErrorRate());
       generator.writeNumberField("highErrorRate", ui.getDependency().getHighErrorRate());
       generator.writeEndObject(); // .dependency

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiProperties.java
@@ -133,8 +133,17 @@ class ZipkinUiProperties {
   }
 
   public static class Dependency {
+    private boolean enabled = true;
     private float lowErrorRate = 0.5f; // 50% of calls in error turns line yellow
     private float highErrorRate = 0.75f; // 75% of calls in error turns line red
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
 
     public float getLowErrorRate() {
       return lowErrorRate;

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -180,7 +180,7 @@ zipkin:
     # Default duration to look back when finding traces.
     # Affects the "Start time" element in the UI. 15 minutes in millis
     default-lookback: 900000
-    # When false, disables the "find a trace" screen
+    # When false, disables the "Discover" screen
     search-enabled: ${SEARCH_ENABLED:true}
     # Which sites this Zipkin UI covers. Regex syntax. (e.g. http:\/\/example.com\/.*)
     # Multiple sites can be specified, e.g.

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -63,6 +63,7 @@ public class ITZipkinUiConfiguration {
       + "  \"archivePostUrl\" : null,\n"
       + "  \"archiveUrl\" : null,\n"
       + "  \"dependency\" : {\n"
+      + "    \"enabled\" : true,\n"
       + "    \"lowErrorRate\" : 0.5,\n"
       + "    \"highErrorRate\" : 0.75\n"
       + "  }\n"

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
@@ -135,6 +135,13 @@ public class ZipkinUiConfigurationTest {
   }
 
   @Test
+  public void canOverridesProperty_dependenciesEnabled() {
+    context = createContextWithOverridenProperty("zipkin.ui.dependency.enabled:false");
+
+    assertThat(context.getBean(ZipkinUiProperties.class).getDependency().isEnabled()).isFalse();
+  }
+
+  @Test
   public void canOverrideProperty_dependencyLowErrorRate() {
     context = createContextWithOverridenProperty("zipkin.ui.dependency.low-error-rate:0.1");
 


### PR DESCRIPTION
zipkin.ui.dependency.enabled now controls whether or not the
Dependencies screen is visible. Like all other UI props, this can also
be set as an env variable.

```bash
ZIPKIN_UI_DEPENDENCY_ENABLED=false
```

The naming choice was made to match other UI config for Dependencies
vs creating a different convention just for this.

Fixes #3056