### PR TITLE
add trace.trim()

### DIFF
--- a/zipkin/src/main/java/zipkin2/Span.java
+++ b/zipkin/src/main/java/zipkin2/Span.java
@@ -641,7 +641,7 @@ public final class Span implements Serializable { // for Spark and Flink jobs
    */
   public static String normalizeTraceId(String traceId) {
     if (traceId == null) throw new NullPointerException("traceId == null");
-    int length = traceId.length();
+    int length = traceId.trim().length();
     if (length == 0) throw new IllegalArgumentException("traceId is empty");
     if (length > 32) throw new IllegalArgumentException("traceId.length > 32");
     int zeros = validateHexAndReturnZeroPrefix(traceId);


### PR DESCRIPTION
when use "@get("/api/v2/trace/{traceId}")"
here is the code traceId = Span.normalizeTraceId(traceId);
if trace with space , it will doesnt work.
1、 in SPAN.JAVA ,we add trace.trim();
2、in ZipkinQueryApiV2, we add this “ traceId = traceId != null ? traceId.trim() :null; ”

i choiced the first one