### PR TITLE
Bump Kafka versions to 2.5.0

### DIFF
--- a/docker/collector/kafka/Dockerfile
+++ b/docker/collector/kafka/Dockerfile
@@ -15,8 +15,7 @@
 FROM alpine
 
 ENV SCALA_VERSION 2.12
-ENV KAFKA_VERSION 2.4.1
-ENV ZOOKEEPER_VERSION 3.5.7
+ENV KAFKA_VERSION 2.5.0
 
 WORKDIR /kafka
 ADD docker/collector/kafka/install.sh /kafka/install

--- a/docker/collector/kafka/install.sh
+++ b/docker/collector/kafka/install.sh
@@ -20,10 +20,6 @@ apk add --update --no-cache jq curl
 
 APACHE_MIRROR=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
 
-curl -sSL $APACHE_MIRROR/zookeeper/zookeeper-$ZOOKEEPER_VERSION/apache-zookeeper-$ZOOKEEPER_VERSION.tar.gz | tar xz
-mkdir zookeeper
-mv apache-zookeeper-$ZOOKEEPER_VERSION/conf zookeeper/
-
 # download kafka binaries
 curl -sSL $APACHE_MIRROR/kafka/$KAFKA_VERSION/kafka_$SCALA_VERSION-$KAFKA_VERSION.tgz | tar xz
 mv kafka_$SCALA_VERSION-$KAFKA_VERSION/* .

--- a/docker/collector/kafka/install.sh
+++ b/docker/collector/kafka/install.sh
@@ -38,7 +38,4 @@ EOF
 
 mkdir /kafka/logs
 
-echo "*** Cleaning Up"
-rm -rf apache-zookeeper-$ZOOKEEPER_VERSION
-
 echo "*** Image build complete"

--- a/docker/collector/kafka/start.sh
+++ b/docker/collector/kafka/start.sh
@@ -15,7 +15,7 @@
 
 
 echo Starting Zookeeper
-/busybox/sh /kafka/bin/kafka-run-class.sh -Dlog4j.configuration=file:/kafka/config/log4j.properties org.apache.zookeeper.server.quorum.QuorumPeerMain /kafka/zookeeper/conf/zoo_sample.cfg &
+/busybox/sh /kafka/bin/kafka-run-class.sh -Dlog4j.configuration=file:/kafka/config/log4j.properties org.apache.zookeeper.server.quorum.QuorumPeerMain /kafka/config/zookeeper.properties &
 /busybox/sh /kafka/bin/wait-for-zookeeper.sh
 
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then

--- a/docker/collector/kafka/start.sh
+++ b/docker/collector/kafka/start.sh
@@ -1,6 +1,6 @@
 #!/busybox/sh
 #
-# Copyright 2015-2019 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -29,7 +29,10 @@
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- when changing this, a change to the version of kafka-junit is likely needed, too -->
-    <kafka.version>2.4.1</kafka.version>
+    <kafka.version>2.5.0</kafka.version>
+    <!-- This version is tightly coupled to the version of kafka-clients being used.
+     https://github.com/charithe/kafka-junit -->
+    <kafka-junit.version>4.1.9</kafka-junit.version>
   </properties>
 
   <dependencies>
@@ -48,9 +51,7 @@
     <dependency>
       <groupId>com.github.charithe</groupId>
       <artifactId>kafka-junit</artifactId>
-      <!-- This version is tightly coupled to the version of kafka-clients being used.
-       https://github.com/charithe/kafka-junit -->
-      <version>4.1.8</version>
+      <version>${kafka-junit.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Btw, if https://github.com/openzipkin-contrib/zipkin-storage-kafka/pull/70 is successful, we could evaluate replacing kafka-junit with Testcontainers :)