### PR TITLE
Stops looking for local RabbitMQ connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jdk: openjdk13
 
 services:
   - docker
-  - rabbitmq
 
 before_install:
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <assertj.version>3.15.0</assertj.version>
     <awaitility.version>4.0.2</awaitility.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <testcontainers.version>1.14.0</testcontainers.version>
+    <testcontainers.version>1.14.2</testcontainers.version>
     <okhttp.version>4.5.0</okhttp.version>
 
     <auto-value.version>1.7</auto-value.version>

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/main/java/zipkin2/collector/rabbitmq/RabbitMQCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -124,6 +124,7 @@ public final class RabbitMQCollector extends CollectorComponent {
   @Override
   public CheckResult check() {
     try {
+      start();
       CheckResult failure = connection.failure.get();
       if (failure != null) return failure;
       return CheckResult.OK;

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/ITRabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/ITRabbitMQCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,151 +15,120 @@ package zipkin2.collector.rabbitmq;
 
 import com.rabbitmq.client.Channel;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import zipkin2.Component;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesEncoder;
-import zipkin2.collector.CollectorMetrics;
+import zipkin2.collector.InMemoryCollectorMetrics;
 import zipkin2.storage.InMemoryStorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.LOTS_OF_SPANS;
 import static zipkin2.TestObjects.UTF_8;
+import static zipkin2.codec.SpanBytesEncoder.JSON_V2;
 import static zipkin2.codec.SpanBytesEncoder.THRIFT;
-import static zipkin2.collector.rabbitmq.RabbitMQCollector.builder;
 
 public class ITRabbitMQCollector {
   List<Span> spans = Arrays.asList(LOTS_OF_SPANS[0], LOTS_OF_SPANS[1]);
 
-  @ClassRule
-  public static RabbitMQCollectorRule rabbit = new RabbitMQCollectorRule("rabbitmq:3.7-alpine");
+  @ClassRule public static RabbitMQCollectorRule rabbit = new RabbitMQCollectorRule();
 
-  @After
-  public void clear() {
-    rabbit.metrics.clear();
-    rabbit.storage.clear();
-  }
+  InMemoryStorage storage = InMemoryStorage.newBuilder().build();
+  InMemoryCollectorMetrics metrics = new InMemoryCollectorMetrics();
+  InMemoryCollectorMetrics rabbitmqMetrics = metrics.forTransport("rabbitmq");
+  RabbitMQCollector collector = rabbit.tryToInitializeCollector(newCollectorBuilder()).start();
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
-  @Test
-  public void checkPasses() {
-    assertThat(rabbit.collector.check().ok()).isTrue();
-  }
-
-  @Test
-  public void startFailsWithInvalidRabbitMqServer() throws Exception {
-    // we can be pretty certain RabbitMQ isn't running on localhost port 80
-    String notRabbitMqAddress = "localhost:80";
-    try (RabbitMQCollector collector =
-        builder().addresses(Collections.singletonList(notRabbitMqAddress)).build()) {
-      thrown.expect(UncheckedIOException.class);
-      thrown.expectMessage("Unable to establish connection to RabbitMQ server: Connection refused");
-      collector.start();
-    }
+  @After public void after() throws Exception {
+    collector.close();
   }
 
   /** Ensures list encoding works: a json encoded list of spans */
-  @Test
-  public void messageWithMultipleSpans_json() throws Exception {
+  @Test public void messageWithMultipleSpans_json() throws Exception {
     messageWithMultipleSpans(SpanBytesEncoder.JSON_V1);
   }
 
   /** Ensures list encoding works: a version 2 json list of spans */
-  @Test
-  public void messageWithMultipleSpans_json2() throws Exception {
+  @Test public void messageWithMultipleSpans_json2() throws Exception {
     messageWithMultipleSpans(SpanBytesEncoder.JSON_V2);
   }
 
   /** Ensures list encoding works: proto3 ListOfSpans */
-  @Test
-  public void messageWithMultipleSpans_proto3() throws Exception {
+  @Test public void messageWithMultipleSpans_proto3() throws Exception {
     messageWithMultipleSpans(SpanBytesEncoder.PROTO3);
   }
 
   void messageWithMultipleSpans(SpanBytesEncoder encoder) throws Exception {
     byte[] message = encoder.encodeList(spans);
-    rabbit.publish(message);
+    publish(message);
 
-    Thread.sleep(1000);
-    assertThat(rabbit.storage.acceptedSpanCount()).isEqualTo(spans.size());
+    Thread.sleep(200L);
+    assertThat(storage.acceptedSpanCount()).isEqualTo(spans.size());
 
-    assertThat(rabbit.rabbitmqMetrics.messages()).isEqualTo(1);
-    assertThat(rabbit.rabbitmqMetrics.messagesDropped()).isZero();
-    assertThat(rabbit.rabbitmqMetrics.bytes()).isEqualTo(message.length);
-    assertThat(rabbit.rabbitmqMetrics.spans()).isEqualTo(spans.size());
-    assertThat(rabbit.rabbitmqMetrics.spansDropped()).isZero();
+    assertThat(rabbitmqMetrics.messages()).isEqualTo(1);
+    assertThat(rabbitmqMetrics.messagesDropped()).isZero();
+    assertThat(rabbitmqMetrics.bytes()).isEqualTo(message.length);
+    assertThat(rabbitmqMetrics.spans()).isEqualTo(spans.size());
+    assertThat(rabbitmqMetrics.spansDropped()).isZero();
   }
 
   /** Ensures malformed spans don't hang the collector */
-  @Test
-  public void skipsMalformedData() throws Exception {
+  @Test public void skipsMalformedData() throws Exception {
     byte[] malformed1 = "[\"='".getBytes(UTF_8); // screwed up json
     byte[] malformed2 = "malformed".getBytes(UTF_8);
-    rabbit.publish(THRIFT.encodeList(spans));
-    rabbit.publish(new byte[0]);
-    rabbit.publish(malformed1);
-    rabbit.publish(malformed2);
-    rabbit.publish(THRIFT.encodeList(spans));
+    publish(THRIFT.encodeList(spans));
+    publish(new byte[0]);
+    publish(malformed1);
+    publish(malformed2);
+    publish(THRIFT.encodeList(spans));
 
-    Thread.sleep(1000);
+    Thread.sleep(200L);
 
-    assertThat(rabbit.rabbitmqMetrics.messages()).isEqualTo(5);
-    assertThat(rabbit.rabbitmqMetrics.messagesDropped()).isEqualTo(2); // only malformed, not empty
-    assertThat(rabbit.rabbitmqMetrics.bytes())
+    assertThat(rabbitmqMetrics.messages()).isEqualTo(5);
+    assertThat(rabbitmqMetrics.messagesDropped()).isEqualTo(2); // only malformed, not empty
+    assertThat(rabbitmqMetrics.bytes())
       .isEqualTo(THRIFT.encodeList(spans).length * 2 + malformed1.length + malformed2.length);
-    assertThat(rabbit.rabbitmqMetrics.spans()).isEqualTo(spans.size() * 2);
-    assertThat(rabbit.rabbitmqMetrics.spansDropped()).isZero();
+    assertThat(rabbitmqMetrics.spans()).isEqualTo(spans.size() * 2);
+    assertThat(rabbitmqMetrics.spansDropped()).isZero();
   }
 
   /** See GitHub issue #2068 */
   @Test
-  public void startsWhenConfiguredQueueAlreadyExists() throws IOException, TimeoutException {
-    Channel channel = rabbit.collector.connection.get().createChannel();
-    // make a queue with non-default properties
-    channel.queueDeclare("zipkin-test2", true, false, false, Collections.singletonMap("x-message-ttl", 36000000));
-    try {
-      RabbitMQCollector.builder()
-        .storage(InMemoryStorage.newBuilder().build())
-        .metrics(CollectorMetrics.NOOP_METRICS)
-        .queue("zipkin-test2")
-        .addresses(Collections.singletonList(rabbit.address())).build()
-        .start().close();
-    } finally {
-      channel.queueDelete("zipkin-test2");
-      channel.close();
-    }
-  }
+  public void startsWhenConfiguredQueueAlreadyExists() throws Exception {
+    String differentQueue = "zipkin-test2";
 
-  /**
-   * The {@code toString()} of {@link Component} implementations appear in health check endpoints.
-   * Since these are likely to be exposed in logs and other monitoring tools, care should be taken
-   * to ensure {@code toString()} output is a reasonable length and does not contain sensitive
-   * information.
-   */
-  @Test public void toStringContainsOnlySummaryInformation() {
-    assertThat(rabbit.collector).hasToString(
-      String.format("RabbitMQCollector{addresses=[%s], queue=%s}", rabbit.address(), rabbit.queue)
-    );
+    rabbit.declareQueue(differentQueue);
+    collector.close();
+    collector = rabbit.tryToInitializeCollector(newCollectorBuilder().queue(differentQueue)).start();
+
+    publish(JSON_V2.encodeList(spans));
+
+    Thread.sleep(200L);
+    assertThat(storage.acceptedSpanCount()).isEqualTo(spans.size());
   }
 
   /** Guards against errors that leak from storage, such as InvalidQueryException */
-  @Test
-  public void skipsOnSpanConsumerException() {
+  @Test public void skipsOnSpanConsumerException() {
     // TODO: reimplement
   }
 
-  @Test
-  public void messagesDistributedAcrossMultipleThreadsSuccessfully() {
+  @Test public void messagesDistributedAcrossMultipleThreadsSuccessfully() {
     // TODO: reimplement
+  }
+
+  RabbitMQCollector.Builder newCollectorBuilder() {
+    return rabbit.newCollectorBuilder().storage(storage).metrics(metrics);
+  }
+
+  void publish(byte[] message) throws IOException, TimeoutException {
+    Channel channel = collector.connection.get().createChannel();
+    try {
+      channel.basicPublish("", collector.queue, null, message);
+    } finally {
+      channel.close();
+    }
   }
 }

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorRule.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,114 +13,98 @@
  */
 package zipkin2.collector.rabbitmq;
 
-import com.rabbitmq.client.Channel;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.concurrent.TimeoutException;
+import java.time.Duration;
 import org.junit.AssumptionViolatedException;
+import org.junit.ClassRule;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import zipkin2.CheckResult;
-import zipkin2.collector.InMemoryCollectorMetrics;
-import zipkin2.storage.InMemoryStorage;
 
+import static java.util.Arrays.asList;
+import static zipkin2.Call.propagateIfFatal;
+
+/** This should be used as a {@link ClassRule} as it takes a very long time to start-up. */
 class RabbitMQCollectorRule extends ExternalResource {
   static final Logger LOGGER = LoggerFactory.getLogger(RabbitMQCollectorRule.class);
+  static final String IMAGE = "rabbitmq:3.7-management-alpine";
+  static final String QUEUE = "zipkin-test1";
   static final int RABBIT_PORT = 5672;
 
-  final InMemoryStorage storage = InMemoryStorage.newBuilder().build();
-  final InMemoryCollectorMetrics metrics = new InMemoryCollectorMetrics();
-  final InMemoryCollectorMetrics rabbitmqMetrics = metrics.forTransport("rabbitmq");
-
-  final String image;
-  final String queue = "zipkin-test";
-  GenericContainer container;
-  RabbitMQCollector collector;
-
-  RabbitMQCollectorRule(String image) {
-    this.image = image;
-  }
-
-  @Override
-  protected void before() {
-    if (!"true".equals(System.getProperty("docker.skip"))) {
-      try {
-        LOGGER.info("Starting docker image " + image);
-        container = new GenericContainer(image).withExposedPorts(RABBIT_PORT);
-        container.start();
-      } catch (RuntimeException e) {
-        LOGGER.warn("Couldn't start docker image " + image + ": " + e.getMessage(), e);
-      }
-    } else {
-      LOGGER.info("Skipping startup of docker " + image);
-    }
-
-    try {
-      this.collector = tryToInitializeCollector();
-    } catch (RuntimeException | Error e) {
-      if (container == null) throw e;
-      LOGGER.warn("Couldn't connect to docker image " + image + ": " + e.getMessage(), e);
-      container.stop();
-      container = null; // try with local connection instead
-      this.collector = tryToInitializeCollector();
+  static final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
+    RabbitMQContainer(String image) {
+      super(image);
+      addExposedPorts(RABBIT_PORT);
+      this.waitStrategy = Wait.forLogMessage(".*Server startup complete.*", 1)
+          .withStartupTimeout(Duration.ofSeconds(60));
     }
   }
 
-  RabbitMQCollector tryToInitializeCollector() {
-    RabbitMQCollector result = computeCollectorBuilder().build();
-    try {
-      result.start();
-    } catch (RuntimeException e) {
-      throw new AssumptionViolatedException(e.getMessage(), e);
+  RabbitMQContainer container;
+
+  @Override protected void before() {
+    if ("true".equals(System.getProperty("docker.skip"))) {
+      throw new AssumptionViolatedException("Skipping startup of docker " + IMAGE);
     }
 
-    CheckResult check = result.check();
+    try {
+      LOGGER.info("Starting docker image " + IMAGE);
+      container = new RabbitMQContainer(IMAGE);
+      container.start();
+    } catch (Throwable e) {
+      throw new AssumptionViolatedException(
+          "Couldn't start docker image " + IMAGE + ": " + e.getMessage(), e);
+    }
+
+    declareQueue(QUEUE);
+  }
+
+  RabbitMQCollector tryToInitializeCollector(RabbitMQCollector.Builder collectorBuilder) {
+    RabbitMQCollector result = collectorBuilder.build();
+
+    CheckResult check;
+    try {
+      check = result.check();
+    } catch (Throwable e) {
+      propagateIfFatal(e);
+      throw new AssertionError("collector.check shouldn't propagate errors", e);
+    }
+
     if (!check.ok()) {
-      throw new AssumptionViolatedException(check.error().getMessage(), check.error());
+      throw new AssumptionViolatedException(
+          "Couldn't connect to docker container " + container + ": " +
+              check.error().getMessage(), check.error());
     }
+
     return result;
   }
 
-  RabbitMQCollector.Builder computeCollectorBuilder() {
-    return RabbitMQCollector.builder()
-        .storage(storage)
-        .metrics(metrics)
-        .queue(queue)
-        .addresses(Arrays.asList(address()));
+  RabbitMQCollector.Builder newCollectorBuilder() {
+    return RabbitMQCollector.builder().queue(QUEUE).addresses(
+        asList(container.getContainerIpAddress() + ":" + container.getMappedPort(RABBIT_PORT)));
   }
 
-  String address() {
-    if (container != null && container.isRunning()) {
-      return String.format(
-          "%s:%d", container.getContainerIpAddress(), container.getMappedPort(RABBIT_PORT));
-    } else {
-      // Use localhost if we failed to start a container (i.e. Docker is not available)
-      return "localhost:" + RABBIT_PORT;
+  void declareQueue(String queue) {
+    ExecResult result;
+    try {
+      result = container.execInContainer("rabbitmqadmin", "declare", "queue", "name=" + queue);
+    } catch (Throwable e) {
+      propagateIfFatal(e);
+      throw new AssumptionViolatedException(
+          "Couldn't declare queue " + queue + ": " + e.getMessage(), e);
+    }
+    if (result.getExitCode() != 0) {
+      throw new AssumptionViolatedException("Couldn't declare queue " + queue + ": " + result);
     }
   }
 
-  void publish(byte[] message) throws IOException, TimeoutException {
-    Channel channel = collector.connection.get().createChannel();
-    try {
-      channel.basicPublish("", collector.queue, null, message);
-    } finally {
-      channel.close();
-    }
-  }
-
-  @Override
-  protected void after() {
-    try {
-      if (collector != null) collector.close();
-    } catch (IOException e) {
-      LOGGER.warn("error closing collector " + e.getMessage(), e);
-    } finally {
-      if (container != null) {
-        LOGGER.info("Stopping docker image " + image);
-        container.stop();
-      }
+  @Override protected void after() {
+    if (container != null) {
+      LOGGER.info("Stopping docker container " + container);
+      container.stop();
     }
   }
 }

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorTest.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorTest.java
@@ -23,7 +23,6 @@ import zipkin2.Component;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static zipkin2.TestObjects.CLIENT_SPAN;
 
 public class RabbitMQCollectorTest {
 
@@ -40,15 +39,14 @@ public class RabbitMQCollectorTest {
   @Test public void checkFalseWhenRabbitMQIsDown() {
     CheckResult check = collector.check();
     assertThat(check.ok()).isFalse();
-    assertThat(check.error())
-        .isInstanceOf(RuntimeException.class);
+    assertThat(check.error()).isInstanceOf(UncheckedIOException.class);
   }
 
   @Test public void startFailsWhenRabbitMQIsDown() {
     // NOTE.. This is probably not good as it can crash on transient failure..
     assertThatThrownBy(collector::start)
         .isInstanceOf(UncheckedIOException.class)
-        .hasMessage("Unable to establish connection to RabbitMQ server: Connection refused");
+        .hasMessageStartingWith("Unable to establish connection to RabbitMQ server");
   }
 
   /**

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorTest.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.collector.rabbitmq;
+
+import com.rabbitmq.client.ConnectionFactory;
+import java.io.UncheckedIOException;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.CheckResult;
+import zipkin2.Component;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+
+public class RabbitMQCollectorTest {
+
+  RabbitMQCollector collector;
+
+  @Before public void before() {
+    ConnectionFactory connectionFactory = new ConnectionFactory();
+    connectionFactory.setConnectionTimeout(100);
+    // We can be pretty certain RabbitMQ isn't running on localhost port 80
+    collector = RabbitMQCollector.builder()
+        .connectionFactory(connectionFactory).addresses(asList("localhost:80")).build();
+  }
+
+  @Test public void checkFalseWhenRabbitMQIsDown() {
+    CheckResult check = collector.check();
+    assertThat(check.ok()).isFalse();
+    assertThat(check.error())
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test public void startFailsWhenRabbitMQIsDown() {
+    // NOTE.. This is probably not good as it can crash on transient failure..
+    assertThatThrownBy(collector::start)
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessage("Unable to establish connection to RabbitMQ server: Connection refused");
+  }
+
+  /**
+   * The {@code toString()} of {@link Component} implementations appear in health check endpoints.
+   * Since these are likely to be exposed in logs and other monitoring tools, care should be taken
+   * to ensure {@code toString()} output is a reasonable length and does not contain sensitive
+   * information.
+   */
+  @Test public void toStringContainsOnlySummaryInformation() {
+    assertThat(collector).hasToString(
+        "RabbitMQCollector{addresses=[localhost:80], queue=zipkin}"
+    );
+  }
+}

--- a/zipkin-collector/rabbitmq/src/test/resources/simplelogger.properties
+++ b/zipkin-collector/rabbitmq/src/test/resources/simplelogger.properties
@@ -5,6 +5,5 @@ org.slf4j.simpleLogger.defaultLogLevel=warn
 org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS
 
-org.slf4j.simpleLogger.log.zipkin2.collector.rabbitmq=debug
 # stop huge spam
 org.slf4j.simpleLogger.log.org.testcontainers.dockerclient=off

--- a/zipkin/src/test/java/zipkin2/internal/JsonEscaperTest.java
+++ b/zipkin/src/test/java/zipkin2/internal/JsonEscaperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,7 +21,7 @@ import static zipkin2.internal.JsonEscaper.jsonEscapedSizeInBytes;
 
 public class JsonEscaperTest {
 
-  @Test public void testJjsonEscapedSizeInBytes() {
+  @Test public void testJsonEscapedSizeInBytes() {
     assertThat(jsonEscapedSizeInBytes(new String(new char[] {0, 'a', 1})))
       .isEqualTo(13);
     assertThat(jsonEscapedSizeInBytes(new String(new char[] {'"', '\\', '\t', '\b'})))


### PR DESCRIPTION
This improves the Docker based RabbitMQ tests in the same manner as
https://github.com/openzipkin/zipkin-reporter-java/pull/176

This notably stops looking for a local RabbitMQ install. It also reduces
flakes by using the CLI and not sharing static collector resources in
instance-level tests.

Fixes #1748