### PR TITLE
Tests zipkin-server/README.md instructions for building server on each pull request

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -31,8 +31,8 @@ jobs:
         with:
          path: .mvn/wrapper/maven-wrapper.jar
          key: mvn-wrapper
-      - name: Execute Build Server
-        run: ./mvnw -DskipTests --also-make -pl zipkin-server clean install
+      - name: Execute Server Build
+        run: ./mvnw --batch-mode -DskipTests --also-make -pl zipkin-server clean install
         shell: bash
         env:
           CI: true

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -20,17 +20,17 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.npm
-          key: npm-packages
+          key: npm-packages-${{ runner.os }}-${{ hashFiles('zipkin-lens/package-lock.json') }}
       - name: Cache Maven Modules
         uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: m2-repository
+          key: m2-repository-${{ hashFiles('**/pom.xml') }}
       - name: Cache Maven Wrapper
         uses: actions/cache@v1
         with:
-         path: .mvn/wrapper/maven-wrapper.jar
-         key: mvn-wrapper
+         path: .mvn/wrapper
+         key: mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
       - name: Execute Server Build
         run: ./mvnw --batch-mode -DskipTests --also-make -pl zipkin-server clean install
         shell: bash

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -1,0 +1,38 @@
+name: Continuous Build Server
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build Server
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 10
+      - name: Cache NPM Packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: npm-packages
+      - name: Cache Maven Modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: m2-repository
+      - name: Cache Maven Wrapper
+        uses: actions/cache@v1
+        with:
+         path: .mvn/wrapper/maven-wrapper.jar
+         key: mvn-wrapper
+      - name: Execute Build Server
+        run: ./mvnw -DskipTests --also-make -pl zipkin-server clean install
+        shell: bash
+        env:
+          CI: true

--- a/pom.xml
+++ b/pom.xml
@@ -632,6 +632,7 @@
               </mapping>
               <excludes>
                 <exclude>**/simplelogger.properties</exclude>
+                <exclude>**/continuous-build.yml</exclude>
                 <exclude>.travis.yml</exclude>
                 <exclude>**/*.dockerignore</exclude>
                 <exclude>.editorconfig</exclude>

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -598,7 +598,7 @@ See [docker-zipkin](https://github.com/openzipkin/docker-zipkin) for details.
 To build and run the server from the currently checked out source, enter the following.
 ```bash
 # Build the server and also make its dependencies
-$ ./mvnw -DskipTests --also-make -pl zipkin-server clean install
+$ ./mvnw --batch-mode -DskipTests --also-make -pl zipkin-server clean install
 # Run the server
 $ java -jar ./zipkin-server/target/zipkin-server-*exec.jar
 # or Run the slim server


### PR DESCRIPTION
We still get questions about windows not building properly. This
uses GitHub actions to help ensure we don't break by accident, or at least
so we automatically know if at least one windows environment works.

Thanks to curiostack for the reference! https://github.com/curioswitch/curiostack/blob/master/.github/workflows/continuous-build.yml

See #1501