### PR TITLE
Updates docker images to JRE 13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ CMD ["/usr/local/bin/nginx.sh"]
 # zipkin-slim - An image containing the slim distribution of Zipkin server.
 #####
 
-FROM openzipkin/jre-full:11.0.7-11.39.15 as zipkin-slim
+FROM openzipkin/jre-full:13.0.3-13.31.11 as zipkin-slim
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.
@@ -114,7 +114,7 @@ ENTRYPOINT ["/busybox/sh", "run.sh"]
 # zipkin-server - An image containing the full distribution of Zipkin server.
 #####
 
-FROM openzipkin/jre-full:11.0.7-11.39.15 as zipkin-server
+FROM openzipkin/jre-full:13.0.3-13.31.11 as zipkin-server
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -66,7 +66,7 @@ CMD ["/usr/local/bin/nginx.sh"]
 # zipkin-slim - An image containing the slim distribution of Zipkin server.
 #####
 
-FROM openzipkin/jre-full:11.0.7-11.39.15 as zipkin-slim
+FROM openzipkin/jre-full:13.0.3-13.31.11 as zipkin-slim
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.
@@ -89,7 +89,7 @@ ENTRYPOINT ["/busybox/sh", "run.sh"]
 # zipkin-server - An image containing the full distribution of Zipkin server.
 #####
 
-FROM openzipkin/jre-full:11.0.7-11.39.15 as zipkin-server
+FROM openzipkin/jre-full:13.0.3-13.31.11 as zipkin-server
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.

--- a/docker/collector/kafka/Dockerfile
+++ b/docker/collector/kafka/Dockerfile
@@ -25,7 +25,7 @@ ADD docker/collector/kafka/wait-for-zookeeper.sh /kafka/bin
 ADD docker/collector/kafka/start.sh /kafka/bin
 
 # Share the same base image to reduce layers used in testing
-FROM openzipkin/jre-full:11.0.7-11.39.15
+FROM openzipkin/jre-full:13.0.3-13.31.11
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 WORKDIR /kafka

--- a/docker/storage/elasticsearch6/Dockerfile
+++ b/docker/storage/elasticsearch6/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -sSL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch
 
 COPY docker/storage/elasticsearch6/config /elasticsearch/config
 
-FROM openzipkin/jre-full:11.0.7-11.39.15
+FROM openzipkin/jre-full:13.0.3-13.31.11
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # https://github.com/elastic/elasticsearch/pull/31003 was closed won't fix

--- a/docker/storage/elasticsearch7/Dockerfile
+++ b/docker/storage/elasticsearch7/Dockerfile
@@ -30,7 +30,7 @@ COPY docker/storage/elasticsearch7/config /elasticsearch/config
 # Overwrite environment script to fix parse failures when run with busybox.
 COPY docker/storage/elasticsearch7/elasticsearch-env /elasticsearch/bin/elasticsearch-env
 
-FROM openzipkin/jre-full:11.0.7-11.39.15
+FROM openzipkin/jre-full:13.0.3-13.31.11
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # https://github.com/elastic/elasticsearch/pull/31003 was closed won't fix

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinActuatorImporter.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinActuatorImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,7 +30,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
  * This type helps load the actuator functionality we currently support without a compilation
  * dependency on actuator, and without relying on auto-configuration being enabled.
  *
- * <p><h3>Implementation note</h3>*
+ * <p><h3>Implementation note</h3>
  * <p>It may be possible to re-implement this as {@link ImportSelector} to provide {@link
  * #ACTUATOR_IMPL_CLASS} and the endpoint configuration types from {@link
  * #PROPERTY_NAME_ACTUATOR_INCLUDE}.


### PR DESCRIPTION
The rationale is this.. Even though LTS is 11, there are JRE features that move ahead meanwhile. 

Waiting until the next LTS (17 estimated next September) will block folks from accessing improvements not backported to JRE 11. Also, Zulu has a different support policy than Oracle anyway.

This chooses the JRE matching what we test against: 13