### PR TITLE
Fixes lens crash when trace data lacks localEndpoint.serviceName

### DIFF
--- a/zipkin-lens/src/components/DiscoverPage/TracesTab/util.js
+++ b/zipkin-lens/src/components/DiscoverPage/TracesTab/util.js
@@ -39,9 +39,6 @@ export const sortTraceSummaries = (traceSummaries, sortingMethod) => {
 export const extractAllServiceNames = (traceSummaries) => {
   const result = [];
   traceSummaries.forEach((traceSummary) => {
-    if (!traceSummary.serviceSummaries) {
-      return;
-    }
     traceSummary.serviceSummaries.forEach((serviceSummary) => {
       result.push(serviceSummary.serviceName);
     });

--- a/zipkin-lens/src/zipkin/trace.js
+++ b/zipkin-lens/src/zipkin/trace.js
@@ -215,6 +215,8 @@ export function traceSummaries(serviceName, summaries, utc = false) {
             10,
           );
         }
+      } else {
+        res.serviceSummaries = [];
       }
 
       if (t.errorType !== 'none') res.infoClass = `trace-error-${t.errorType}`;

--- a/zipkin-lens/src/zipkin/trace.test.js
+++ b/zipkin-lens/src/zipkin/trace.test.js
@@ -94,8 +94,63 @@ const httpTrace = [
   },
 ];
 
+const missingLocalEndpointTrace = [
+  {
+    traceId: '0b3ba16a811130ed',
+    parentId: '0b3ba16a811130ed',
+    id: '37c9d5cfc985592b',
+    kind: 'SERVER',
+    name: 'get',
+    timestamp: 1587434790009238,
+    duration: 10803,
+    remoteEndpoint: {
+      ipv4: '127.0.0.1',
+      port: 64529,
+    },
+    tags: {
+      'http.method': 'GET',
+      'http.path': '/api',
+      'mvc.controller.class': 'Backend',
+    },
+    shared: true,
+  },
+  {
+    traceId: '0b3ba16a811130ed',
+    parentId: '0b3ba16a811130ed',
+    id: '37c9d5cfc985592b',
+    kind: 'CLIENT',
+    name: 'get',
+    timestamp: 1587434789956001,
+    duration: 74362,
+    tags: {
+      'http.method': 'GET',
+      'http.path': '/api',
+    },
+  },
+  {
+    traceId: '0b3ba16a811130ed',
+    id: '0b3ba16a811130ed',
+    kind: 'SERVER',
+    name: 'get',
+    timestamp: 1587434789934510,
+    duration: 103410,
+    remoteEndpoint: {
+      ipv6: '::1',
+      port: 64528,
+    },
+    tags: {
+      'http.method': 'GET',
+      'http.path': '/',
+      'mvc.controller.class': 'Frontend',
+    },
+  },
+];
+
 // renders data into a tree for traceMustache
 const cleanedHttpTrace = treeCorrectedForClockSkew(httpTrace);
+const cleanedMissingLocalEndpointTrace = treeCorrectedForClockSkew(
+  missingLocalEndpointTrace,
+);
 
 describe('traceSummary', () => {
   it('should classify durations local to the endpoint', () => {
@@ -180,6 +235,13 @@ describe('traceSummariesToMustache', () => {
   it('should convert duration from micros to millis', () => {
     const model = traceSummaries(null, [summary]);
     expect(model[0].duration).toBe(168.731);
+  });
+
+  it('should render empty serviceSummaries when spans lack localEndpoint', () => {
+    const model = traceSummaries(null, [
+      traceSummary(cleanedMissingLocalEndpointTrace),
+    ]);
+    expect(model[0].serviceSummaries).toEqual([]);
   });
 
   it('should get service summaries, ordered descending by max span duration', () => {


### PR DESCRIPTION
This fixes a small but mighty bug!

Fixes #3072