### PR TITLE
Adds ES_SSL_NO_VERIFY for test environments

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -287,6 +287,9 @@ The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
                                          credentials. Any errors reading the credentials file occur in logs at this rate.
     * `ES_HTTP_LOGGING`: When set, controls the volume of HTTP logging of the Elasticsearch API.
                          Options are BASIC, HEADERS, BODY
+    * `ES_SSL_NO_VERIFY`: When true, disables the verification of server's key certificate chain.
+                          This is not appropriate for production. Defaults to false.
+
 Example usage:
 
 To connect normally:

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfiguration.java
@@ -88,12 +88,13 @@ public class ZipkinElasticsearchStorageConfiguration {
     MeterRegistry meterRegistry) throws Exception {
     ClientFactoryBuilder builder = ClientFactory.builder();
 
-    // Allow use of a custom KeyStore or TrustStore when connecting to Elasticsearch
     Ssl ssl = es.getSsl();
+    if (ssl.isNoVerify()) builder.tlsNoVerify();
+    // Allow use of a custom KeyStore or TrustStore when connecting to Elasticsearch
     if (ssl.getKeyStore() != null || ssl.getTrustStore() != null) configureSsl(builder, ssl);
 
     // Elasticsearch 7 never returns a response when receiving an HTTP/2 preface instead of the more
-    // valid behavior of returning a bad request response, so we can't use the preface.\
+    // valid behavior of returning a bad request response, so we can't use the preface.
     // TODO: find or raise a bug with Elastic
     return builder.useHttp2Preface(false)
       .connectTimeoutMillis(es.getTimeout())
@@ -223,7 +224,6 @@ public class ZipkinElasticsearchStorageConfiguration {
   static ClientFactoryBuilder configureSsl(ClientFactoryBuilder builder, Ssl ssl) throws Exception {
     final KeyManagerFactory keyManagerFactory = SslUtil.getKeyManagerFactory(ssl);
     final TrustManagerFactory trustManagerFactory = SslUtil.getTrustManagerFactory(ssl);
-
     return builder.tlsCustomizer(sslContextBuilder -> {
       sslContextBuilder.keyManager(keyManagerFactory);
       sslContextBuilder.trustManager(trustManagerFactory);

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -73,6 +73,8 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
     private String trustStorePassword =
       emptyToNull(System.getProperty("javax.net.ssl.trustStorePassword"));
     private String trustStoreType = emptyToNull(System.getProperty("javax.net.ssl.trustStoreType"));
+    /** Disables the verification of server's key certificate chain. */
+    boolean noVerify = false;
 
     public String getKeyStore() {
       return keyStore;
@@ -120,6 +122,14 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
 
     public void setTrustStoreType(String trustStoreType) {
       this.trustStoreType = trustStoreType;
+    }
+
+    public boolean isNoVerify() {
+      return noVerify;
+    }
+
+    public void setNoVerify(boolean noVerify) {
+      this.noVerify = noVerify;
     }
   }
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -159,6 +159,8 @@ zipkin:
       credentials-file: ${ES_CREDENTIALS_FILE:}
       credentials-refresh-interval: ${ES_CREDENTIALS_REFRESH_INTERVAL:5}
       http-logging: ${ES_HTTP_LOGGING:}
+      ssl:
+        no-verify: ${ES_SSL_NO_VERIFY:false}
       health-check:
         enabled: ${ES_HEALTH_CHECK_ENABLED:true}
         interval: ${ES_HEALTH_CHECK_INTERVAL:3s}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchNoVerify.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchNoVerify.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.elasticsearch;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.testing.junit.server.mock.MockWebServerExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin2.elasticsearch.ElasticsearchStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.server.internal.elasticsearch.TestResponses.VERSION_RESPONSE;
+import static zipkin2.server.internal.elasticsearch.TestResponses.YELLOW_RESPONSE;
+
+class ITElasticsearchNoVerify {
+  @RegisterExtension
+  static MockWebServerExtension server = new MockWebServerExtension();
+
+  AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+  ElasticsearchStorage storage;
+
+  @BeforeEach void init() {
+    TestPropertyValues.of(
+        "spring.config.name=zipkin-server",
+        "zipkin.storage.type=elasticsearch",
+        "zipkin.storage.elasticsearch.ensure-templates=false",
+        "zipkin.storage.elasticsearch.hosts=https://localhost:" + server.httpsPort(),
+        "zipkin.storage.elasticsearch.ssl.no-verify=true")
+        .applyTo(context);
+    Access.registerElasticsearch(context);
+    context.refresh();
+    storage = context.getBean(ElasticsearchStorage.class);
+  }
+
+  @AfterEach void close() {
+    storage.close();
+  }
+
+  @Test void healthcheck_no_tls_verify() {
+    server.enqueue(VERSION_RESPONSE.toHttpResponse());
+    server.enqueue(YELLOW_RESPONSE.toHttpResponse());
+
+    assertThat(storage.check().ok()).isTrue();
+  }
+
+  @Test void service_no_tls_verify() throws Exception {
+    server.enqueue(
+        AggregatedHttpResponse.of(ResponseHeaders.of(HttpStatus.OK), HttpData.ofUtf8("{}")));
+
+    assertThat(storage.serviceAndSpanNames().getServiceNames().execute()).isEmpty();
+  }
+}


### PR DESCRIPTION
This allows a user to set `ES_SSL_NO_VERIFY=false` to trust anything.
This is named SSL_NO_VERIFY not TLS_NO_VERIFY (after the Armeria
setting) because "ssl" is already a sub-configuration of Elasticsearch.

Fixes #3079