### PR TITLE
Fixes small drift in bench

### DIFF
--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -314,6 +314,8 @@ class ServerIntegratedBenchmark {
       }
       zipkin.withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("java"));
       zipkin.setCommand("-cp", String.join(":", classpath), "zipkin.server.ZipkinServer");
+      // Don't fail on classpath problem from missing lens, as we don't use it.
+      env.put("ZIPKIN_UI_ENABLED", "false");
     } else {
       zipkin = new GenericContainer<>("openzipkin/zipkin:" + RELEASED_ZIPKIN_VERSION);
     }


### PR DESCRIPTION
ran it and noticed when we reconfigured lens it slightly busted the "current checkout" variant.

works again.. behold the fury of my overloaded laptop!

```
Benchmark started.
Container gcr.io/distroless/java:11-debug ports exposed at {9411=http://localhost:32844}
Container openzipkin/zipkin-elasticsearch7:latest ports exposed at {9200=http://localhost:32837}
Container openzipkin/example-sleuth-webmvc:latest ports exposed at {9000=http://localhost:32840}
Container openzipkin/example-sleuth-webmvc:latest ports exposed at {8081=http://localhost:32841}
Container prom/prometheus:latest ports exposed at {9090=http://localhost:32842}
Container grafana/grafana:latest ports exposed at {3000=http://localhost:32839}
Benchmark complete, wrk output:
Running 2m test @ http://frontend:8081
  4 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   691.24ms  396.33ms   2.00s    67.66%
    Req/Sec    47.01     24.89   170.00     67.53%
  Latency Distribution
     50%  662.76ms
     75%  942.02ms
     90%    1.22s 
     99%    1.78s 
  18273 requests in 1.67m, 4.03MB read
  Socket errors: connect 0, read 0, write 0, timeout 204
Requests/sec:    182.84
Transfer/sec:     41.27KB

Messages received: 161
Spans received: 55200
Spans dropped: 0
Memory quantiles:
jvm_memory_used_bytes{area="heap"}[0.0] = 1048576
jvm_memory_used_bytes{area="heap"}[0.25] = 3145728
jvm_memory_used_bytes{area="heap"}[0.5] = 5242880
jvm_memory_used_bytes{area="heap"}[0.75] = 93759696
jvm_memory_used_bytes{area="heap"}[1.0] = 182276512
jvm_memory_used_bytes{area="nonheap"}[0.0] = 1282816
jvm_memory_used_bytes{area="nonheap"}[0.25] = 3719680
jvm_memory_used_bytes{area="nonheap"}[0.5] = 6521112
jvm_memory_used_bytes{area="nonheap"}[0.75] = 14276736
jvm_memory_used_bytes{area="nonheap"}[1.0] = 55783488
Total GC time (s): 1.543
Number of GCs: 84
POST Spans latency (s)
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans"}[0.5] = 0.018796695583333335
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans"}[0.9] = 0.06962544636250002
http_server_requests_seconds_bucket{method="POST",status="202",uri="/api/v2/spans"}[0.99] = 0.16531150018999968
```