### PR TITLE
Fixes glitch where root spans were ambiguous

### DIFF
--- a/zipkin-lens/src/zipkin/span-cleaner.js
+++ b/zipkin-lens/src/zipkin/span-cleaner.js
@@ -288,8 +288,8 @@ export function mergeV2ById(spans) {
   // Look to see if there is a root span, in case we need to correct its shared flag
   if (sorted[0].parentId || !sorted[0].shared) return sorted;
 
-  // Sorting puts root spans first. If there's only one root, and it has shared flag, remove it.
-  if (sorted.length === 1 || !sorted[1].shared) {
+  // Sorting puts root spans first. If there's only one root, remove any shared flag.
+  if (sorted.length === 1 || sorted[1].parentId) {
     delete sorted[0].shared;
   }
 


### PR DESCRIPTION
There was a scenario where we thought we were removing accidental shared
flag on the root but, but weren't. cc @drolando 

Fixes #3001

Before
![Screenshot 2020-06-18 at 4 18 42 PM](https://user-images.githubusercontent.com/64215/85024687-00d88280-b1a9-11ea-891e-5a75457e9dac.png)

After
![Screenshot 2020-06-18 at 9 10 16 PM](https://user-images.githubusercontent.com/64215/85024668-fb7b3800-b1a8-11ea-88ff-757e8cb83764.png)