### PR TITLE
Adds undocumented property to log Elasticsearch health check requests

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/LazyHttpClientImpl.java
@@ -96,7 +96,8 @@ final class LazyHttpClientImpl implements LazyHttpClient {
         .useGet(true)
         .clientFactory(factory.clientFactory)
         .withClientOptions(options -> {
-          factory.configureOptionsExceptLogging(options);
+          factory.configureHttpLogging(healthCheck.getHttpLogging(), options);
+          factory.configureOptionsExceptHttpLogging(options);
           options.decorator(MetricCollectingClient.newDecorator(
             MeterIdPrefixFunction.ofDefault("elasticsearch-healthcheck")));
           options.decorator((delegate, ctx, req) -> {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -48,6 +48,7 @@ import zipkin2.elasticsearch.ElasticsearchStorage.LazyHttpClient;
  *     trust-store-type: PKCS12
  *   health-check:
  *     enabled: true
+ *     http-logging: HEADERS
  *     interval: 3s
  * }</pre>
  */
@@ -139,6 +140,8 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
   public static class HealthCheck {
     /** Indicates health checking is enabled. */
     private boolean enabled = true;
+    /** When set, controls the volume of HTTP logging of the Elasticsearch API. */
+    private HttpLogging httpLogging = HttpLogging.NONE;
 
     /** The time to wait between sending health check requests. */
     @DurationUnit(ChronoUnit.MILLIS)
@@ -150,6 +153,14 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
 
     public void setEnabled(boolean enabled) {
       this.enabled = enabled;
+    }
+
+    public HttpLogging getHttpLogging() {
+      return httpLogging;
+    }
+
+    public void setHttpLogging(HttpLogging httpLogging) {
+      this.httpLogging = httpLogging;
     }
 
     public Duration getInterval() {
@@ -190,9 +201,9 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
   private String credentialsFile;
   /** Credentials refresh interval (in seconds) */
   private Integer credentialsRefreshInterval = 1;
-  /** When set, controls the volume of HTTP logging of the Elasticsearch Api. */
+  /** When set, controls the volume of HTTP logging of the Elasticsearch API. */
   private HttpLogging httpLogging = HttpLogging.NONE;
-  /** Connect, read and write socket timeouts (in milliseconds) for Elasticsearch Api requests. */
+  /** Connect, read and write socket timeouts (in milliseconds) for Elasticsearch API requests. */
   private Integer timeout = 10_000;
   /** Overrides ssl configuration relating to the Elasticsearch client connection. */
   private Ssl ssl = new Ssl();

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
@@ -72,6 +72,8 @@ public class ITElasticsearchHealthCheck {
       "zipkin.storage.elasticsearch.ensure-templates=false",
       "zipkin.storage.elasticsearch.timeout=200",
       "zipkin.storage.elasticsearch.health-check.enabled=true",
+      // uncomment (and also change log4j2.properties) to see health-checks requests in the console
+      //"zipkin.storage.elasticsearch.health-check.http-logging=headers",
       "zipkin.storage.elasticsearch.health-check.interval=100ms",
       "zipkin.storage.elasticsearch.hosts=" + hosts)
       .applyTo(context);

--- a/zipkin-server/src/test/resources/log4j2.properties
+++ b/zipkin-server/src/test/resources/log4j2.properties
@@ -1,0 +1,13 @@
+# Maven configuration conflicts on simplelogger vs Log4J2, but IntelliJ unit tests use Log4J2
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT
+
+# uncomment to see outbound client connections (useful in Elasticsearch troubleshooting)
+#logger.client.name=com.linecorp.armeria.client
+#logger.client.level=info


### PR DESCRIPTION
This adds the below property, but doesn't assign an ENV variable as it
is mostly useful for our own tests:

```
zipkin.storage.elasticsearch.health-check.http-logging=headers
```

This also comments out in tests how to enable it temporarily. Ex to
troubleshoot #3130