### PR TITLE
Removes guava dep in preparation of Datastax Driver 4.x

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -36,11 +36,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
     <!-- for codec benchmarks -->
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -114,7 +109,6 @@
       <groupId>${project.groupId}.zipkin2</groupId>
       <artifactId>zipkin-storage-cassandra</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>

--- a/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/CodecBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,8 +13,6 @@
  */
 package zipkin2.codec;
 
-import com.google.common.io.ByteStreams;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +32,9 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import zipkin2.Span;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static zipkin2.storage.cassandra.internal.Resources.resourceToString;
+
 /**
  * The {@link SpanBytesEncoder bundled java codec} aims to be both small in size (i.e. does not
  * significantly increase the size of zipkin's jar), and efficient. It may not always be fastest,
@@ -52,7 +53,7 @@ import zipkin2.Span;
 @State(Scope.Thread)
 @Threads(1)
 public class CodecBenchmarks {
-  static final byte[] clientSpanJsonV2 = read("/zipkin2-client.json");
+  static final byte[] clientSpanJsonV2 = resourceToString("/zipkin2-client.json").getBytes(UTF_8);
   static final Span clientSpan = SpanBytesDecoder.JSON_V2.decodeOne(clientSpanJsonV2);
   static final byte[] clientSpanJsonV1 = SpanBytesEncoder.JSON_V1.encode(clientSpan);
   static final byte[] clientSpanProto3 = SpanBytesEncoder.PROTO3.encode(clientSpan);
@@ -110,7 +111,7 @@ public class CodecBenchmarks {
     return SpanBytesEncoder.JSON_V2.encodeList(tenClientSpans);
   }
 
-  static final byte[] chineseSpanJsonV2 = read("/zipkin2-chinese.json");
+  static final byte[] chineseSpanJsonV2 = resourceToString("/zipkin2-chinese.json").getBytes(UTF_8);
   static final Span chineseSpan = SpanBytesDecoder.JSON_V2.decodeOne(chineseSpanJsonV2);
   static final byte[] chineseSpanProto3 = SpanBytesEncoder.PROTO3.encode(chineseSpan);
   static final byte[] chineseSpanJsonV1 = SpanBytesEncoder.JSON_V1.encode(chineseSpan);
@@ -164,13 +165,5 @@ public class CodecBenchmarks {
       .build();
 
     new Runner(opt).run();
-  }
-
-  static byte[] read(String resource) {
-    try {
-      return ByteStreams.toByteArray(CodecBenchmarks.class.getResourceAsStream(resource));
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
   }
 }

--- a/benchmarks/src/main/java/zipkin2/codec/JsonCodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/JsonCodecBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,10 +13,8 @@
  */
 package zipkin2.codec;
 
-import com.google.common.io.Resources;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +35,9 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import zipkin2.Span;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static zipkin2.storage.cassandra.internal.Resources.resourceToString;
+
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 10, time = 1)
 @Fork(3)
@@ -47,7 +48,7 @@ import zipkin2.Span;
 public class JsonCodecBenchmarks {
   static final MoshiSpanDecoder MOSHI = MoshiSpanDecoder.create();
 
-  static final byte[] clientSpanJsonV2 = read("/zipkin2-client.json");
+  static final byte[] clientSpanJsonV2 = resourceToString("/zipkin2-client.json").getBytes(UTF_8);
   static final Span clientSpan = SpanBytesDecoder.JSON_V2.decodeOne(clientSpanJsonV2);
 
   // Assume a message is 1000 spans (which is a high number for as this is per-node-second)
@@ -97,13 +98,5 @@ public class JsonCodecBenchmarks {
       .build();
 
     new Runner(opt).run();
-  }
-
-  static byte[] read(String resource) {
-    try {
-      return Resources.toByteArray(Resources.getResource(CodecBenchmarks.class, resource));
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
   }
 }

--- a/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/codec/ProtoCodecBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,10 +13,8 @@
  */
 package zipkin2.codec;
 
-import com.google.common.io.Resources;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +35,9 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import zipkin2.Span;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static zipkin2.storage.cassandra.internal.Resources.resourceToString;
+
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 10, time = 1)
 @Fork(3)
@@ -46,7 +47,7 @@ import zipkin2.Span;
 @Threads(1)
 public class ProtoCodecBenchmarks {
 
-  static final byte[] clientSpanJsonV2 = read("/zipkin2-client.json");
+  static final byte[] clientSpanJsonV2 = resourceToString("/zipkin2-client.json").getBytes(UTF_8);
   static final Span clientSpan = SpanBytesDecoder.JSON_V2.decodeOne(clientSpanJsonV2);
 
   // Assume a message is 1000 spans (which is a high number for as this is per-node-second)
@@ -104,13 +105,5 @@ public class ProtoCodecBenchmarks {
       .build();
 
     new Runner(opt).run();
-  }
-
-  static byte[] read(String resource) {
-    try {
-      return Resources.toByteArray(Resources.getResource(CodecBenchmarks.class, resource));
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
     <!-- This allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>0.99.8</armeria.version>
-    <!-- This should only be used in tests, and be careful to avoid >= v20 apis -->
-    <guava.version>28.1-jre</guava.version>
+    <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
+    <netty.version>4.1.50.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
     <jackson.version>2.11.1</jackson.version>
@@ -150,8 +150,16 @@
     <system>Github</system>
     <url>https://github.com/openzipkin/zipkin/issues</url>
   </issueManagement>
+
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>

--- a/zipkin-storage/cassandra-v1/pom.xml
+++ b/zipkin-storage/cassandra-v1/pom.xml
@@ -65,12 +65,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-guava</artifactId>
-      <version>3.2.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package zipkin2.storage.cassandra.v1;
 
 import com.datastax.driver.core.Session;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilderSpec;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -143,8 +142,7 @@ final class CassandraSpanConsumer implements SpanConsumer {
     return calls.isEmpty() ? Call.create(null) : AggregateCall.newVoidCall(calls);
   }
 
-  /** Clears any caches */
-  @VisibleForTesting
+  /** For testing only: Clears any caches */
   void clear() {
     if (insertServiceName != null) insertServiceName.clear();
     if (insertRemoteServiceName != null) insertRemoteServiceName.clear();

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -31,8 +31,6 @@ import zipkin2.storage.StorageComponent;
 import zipkin2.storage.Traces;
 import zipkin2.storage.cassandra.internal.call.DeduplicatingVoidCallFactory;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * CQL3 implementation of zipkin storage.
@@ -117,13 +115,15 @@ public class CassandraStorage extends StorageComponent { // not final for mockin
 
     /** Override to control how sessions are created. */
     public Builder sessionFactory(SessionFactory sessionFactory) {
-      this.sessionFactory = checkNotNull(sessionFactory, "sessionFactory");
+      if (sessionFactory == null) throw new NullPointerException("sessionFactory == null");
+      this.sessionFactory = sessionFactory;
       return this;
     }
 
     /** Keyspace to store span and index data. Defaults to "zipkin" */
     public Builder keyspace(String keyspace) {
-      this.keyspace = checkNotNull(keyspace, "keyspace");
+      if (keyspace == null) throw new NullPointerException("keyspace == null");
+      this.keyspace = keyspace;
       return this;
     }
 
@@ -132,7 +132,8 @@ public class CassandraStorage extends StorageComponent { // not final for mockin
      * custom port with 'host:port'. Defaults to localhost on port 9042 *
      */
     public Builder contactPoints(String contactPoints) {
-      this.contactPoints = checkNotNull(contactPoints, "contactPoints");
+      if (contactPoints == null) throw new NullPointerException("contactPoints == null");
+      this.contactPoints = contactPoints;
       return this;
     }
 

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraUtil.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraUtil.java
@@ -13,7 +13,6 @@
  */
 package zipkin2.storage.cassandra.v1;
 
-import com.google.common.collect.ImmutableList;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -39,12 +38,11 @@ import zipkin2.internal.Nullable;
 import zipkin2.internal.Platform;
 import zipkin2.storage.QueryRequest;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static zipkin2.internal.Platform.SHORT_STRING_LENGTH;
 
 final class CassandraUtil {
-  static final ImmutableList<String> CORE_ANNOTATIONS =
-    ImmutableList.of("cs", "cr", "ss", "sr", "ms", "mr", "ws", "wr");
+  static final List<String> CORE_ANNOTATIONS =
+    Arrays.asList("cs", "cr", "ss", "sr", "ms", "mr", "ws", "wr");
 
   private static final ThreadLocal<CharsetEncoder> UTF8_ENCODER =
     ThreadLocal.withInitial(StandardCharsets.UTF_8::newEncoder);
@@ -89,7 +87,9 @@ final class CassandraUtil {
 
   static List<String> annotationKeys(QueryRequest request) {
     if (request.annotationQuery().isEmpty()) return Collections.emptyList();
-    checkArgument(request.serviceName() != null, "serviceName needed with annotation query");
+    if (request.serviceName() == null) {
+      throw new IllegalArgumentException("serviceName needed with annotation query");
+    }
     Set<String> annotationKeys = new LinkedHashSet<>();
     for (Map.Entry<String, String> e : request.annotationQuery().entrySet()) {
       if (e.getValue().isEmpty()) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CompositeIndexer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CompositeIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,7 @@ package zipkin2.storage.cassandra.v1;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.collect.ImmutableSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
@@ -32,14 +32,14 @@ final class CompositeIndexer {
   CompositeIndexer(CassandraStorage storage, CacheBuilderSpec spec, int indexTtl) {
     this.sharedState = CacheBuilder.from(spec).<PartitionKeyToTraceId, Pair>build().asMap();
     Indexer.Factory factory = new Indexer.Factory(storage.session(), indexTtl, sharedState);
-    ImmutableSet.Builder<Indexer> indexers = ImmutableSet.builder();
+    Set<Indexer> indexers = new LinkedHashSet<>();
     indexers.add(factory.create(new InsertTraceIdByServiceName(storage.bucketCount)));
     if (storage.metadata().hasRemoteService) {
       indexers.add(factory.create(new InsertTraceIdByRemoteServiceName()));
     }
     indexers.add(factory.create(new InsertTraceIdBySpanName()));
     indexers.add(factory.create(new InsertTraceIdByAnnotation(storage.bucketCount)));
-    this.indexers = indexers.build();
+    this.indexers = indexers;
   }
 
   void index(Span span, List<Call<Void>> calls) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
@@ -17,14 +17,10 @@ import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.Session;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static zipkin2.storage.cassandra.internal.Resources.resourceToString;
 import static zipkin2.storage.cassandra.v1.Tables.AUTOCOMPLETE_TAGS;
 import static zipkin2.storage.cassandra.v1.Tables.REMOTE_SERVICE_NAMES;
@@ -144,15 +140,11 @@ final class Schema {
   }
 
   static void applyCqlFile(String keyspace, Session session, String resource) {
-    try (Reader reader = new InputStreamReader(Schema.class.getResourceAsStream(resource), UTF_8)) {
-      for (String cmd : resourceToString(resource).split(";", 100)) {
-        cmd = cmd.trim().replace(" zipkin", " " + keyspace);
-        if (!cmd.isEmpty()) {
-          session.execute(cmd);
-        }
+    for (String cmd : resourceToString(resource).split(";", 100)) {
+      cmd = cmd.trim().replace(" zipkin", " " + keyspace);
+      if (!cmd.isEmpty()) {
+        session.execute(cmd);
       }
-    } catch (IOException ex) {
-      LOG.error(ex.getMessage(), ex);
     }
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.Session;
-import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -26,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static zipkin2.storage.cassandra.internal.Resources.resourceToString;
 import static zipkin2.storage.cassandra.v1.Tables.AUTOCOMPLETE_TAGS;
 import static zipkin2.storage.cassandra.v1.Tables.REMOTE_SERVICE_NAMES;
 
@@ -145,7 +145,7 @@ final class Schema {
 
   static void applyCqlFile(String keyspace, Session session, String resource) {
     try (Reader reader = new InputStreamReader(Schema.class.getResourceAsStream(resource), UTF_8)) {
-      for (String cmd : CharStreams.toString(reader).split(";", 100)) {
+      for (String cmd : resourceToString(resource).split(";", 100)) {
         cmd = cmd.trim().replace(" zipkin", " " + keyspace);
         if (!cmd.isEmpty()) {
           session.execute(cmd);

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectRemoteServiceNames.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectRemoteServiceNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,11 +19,10 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import java.util.List;
+import java.util.Locale;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 final class SelectRemoteServiceNames extends ResultSetFutureCall<ResultSet> {
 
@@ -43,7 +42,7 @@ final class SelectRemoteServiceNames extends ResultSetFutureCall<ResultSet> {
 
     Call<List<String>> create(String serviceName) {
       if (serviceName == null || serviceName.isEmpty()) return Call.emptyList();
-      String service = checkNotNull(serviceName, "serviceName").toLowerCase();
+      String service = serviceName.toLowerCase(Locale.ROOT); // service names are always lowercase!
       return new SelectRemoteServiceNames(this, service).flatMap(remoteServiceNames);
     }
   }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectSpanNames.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectSpanNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,11 +19,10 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import java.util.List;
+import java.util.Locale;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 final class SelectSpanNames extends ResultSetFutureCall<ResultSet> {
 
@@ -43,7 +42,7 @@ final class SelectSpanNames extends ResultSetFutureCall<ResultSet> {
 
     Call<List<String>> create(String serviceName) {
       if (serviceName == null || serviceName.isEmpty()) return Call.emptyList();
-      String service = checkNotNull(serviceName, "serviceName").toLowerCase();
+      String service = serviceName.toLowerCase(Locale.ROOT); // service names are always lowercase!
       return new SelectSpanNames(this, service).flatMap(spanNames);
     }
   }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceRemoteServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceRemoteServiceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,8 +23,6 @@ import com.google.auto.value.AutoValue;
 import java.util.Set;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 final class SelectTraceIdTimestampFromServiceRemoteServiceName
   extends ResultSetFutureCall<ResultSet> {
@@ -58,9 +56,9 @@ final class SelectTraceIdTimestampFromServiceRemoteServiceName
 
     Call<Set<Pair>> newCall(
       String serviceName, String remoteServiceName, long endTs, long lookback, int limit) {
-      checkArgument(serviceName != null, "serviceName required on remote_serviceName query");
-      checkArgument(remoteServiceName != null,
-        "remoteServiceName required on remoteServiceName query");
+      // These are checked before calling, but verify pre-conditions as otherwise bugs are subtle
+      if (serviceName == null) throw new NullPointerException("serviceName == null");
+      if (remoteServiceName == null) throw new NullPointerException("remoteServiceName == null");
       String serviceSpanName = serviceName + "." + remoteServiceName;
       long startTs = Math.max(endTs - lookback, 0); // >= 1970
       Input input = new AutoValue_SelectTraceIdTimestampFromServiceRemoteServiceName_Input(

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceSpanName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceSpanName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,8 +23,6 @@ import com.google.auto.value.AutoValue;
 import java.util.Set;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 final class SelectTraceIdTimestampFromServiceSpanName extends ResultSetFutureCall<ResultSet> {
   @AutoValue
@@ -61,8 +59,9 @@ final class SelectTraceIdTimestampFromServiceSpanName extends ResultSetFutureCal
 
     Call<Set<Pair>> newCall(
         String serviceName, String spanName, long endTs, long lookback, int limit) {
-      checkArgument(serviceName != null, "serviceName required on spanName query");
-      checkArgument(spanName != null, "spanName required on spanName query");
+      // These are checked before calling, but verify pre-conditions as otherwise bugs are subtle
+      if (serviceName == null) throw new NullPointerException("serviceName == null");
+      if (spanName == null) throw new NullPointerException("spanName == null");
       String serviceSpanName = serviceName + "." + spanName;
       long startTs = Math.max(endTs - lookback, 0); // >= 1970
       Input input =

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SessionFactory.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SessionFactory.java
@@ -22,11 +22,9 @@ import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.LatencyAwarePolicy;
 import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
-import com.google.common.collect.Sets;
-import com.google.common.io.Closer;
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import zipkin2.storage.cassandra.internal.HostAndPort;
@@ -47,24 +45,22 @@ public interface SessionFactory {
      */
     @Override
     public Session create(CassandraStorage cassandra) {
-      Closer closer = Closer.create();
+      Cluster cluster = null;
+      Session session = null;
       try {
-        Cluster cluster = closer.register(buildCluster(cassandra));
+        cluster = buildCluster(cassandra);
         cluster.register(new QueryLogger.Builder().build());
         if (cassandra.ensureSchema) {
-          Session session = closer.register(cluster.connect());
+          session = cluster.connect();
           Schema.ensureExists(cassandra.keyspace, session);
           session.execute("USE " + cassandra.keyspace);
           return session;
         } else {
           return cluster.connect(cassandra.keyspace);
         }
-      } catch (RuntimeException e) {
-        try {
-          closer.close();
-        } catch (IOException ignored) {
-          throw e;
-        }
+      } catch (RuntimeException e) { // don't leak on unexpected exception!
+        if (session != null) session.close();
+        if (cluster != null) cluster.close();
         throw e;
       }
     }
@@ -109,7 +105,7 @@ public interface SessionFactory {
 
     /** Returns the consistent port across all contact points or 9042 */
     static int findConnectPort(List<InetSocketAddress> contactPoints) {
-      Set<Integer> ports = Sets.newLinkedHashSet();
+      Set<Integer> ports = new LinkedHashSet<>();
       for (InetSocketAddress contactPoint : contactPoints) {
         ports.add(contactPoint.getPort());
       }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraUtilTest.java
@@ -14,21 +14,18 @@
 package zipkin2.storage.cassandra.v1;
 
 import java.util.Date;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import zipkin2.Span;
 import zipkin2.internal.DateUtil;
 import zipkin2.storage.QueryRequest;
 
 import static java.util.concurrent.TimeUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.FRONTEND;
 
 public class CassandraUtilTest {
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
   QueryRequest request = QueryRequest.newBuilder().endTs(1).limit(1).lookback(1).build();
 
   @Test
@@ -38,9 +35,10 @@ public class CassandraUtilTest {
 
   @Test
   public void annotationKeys_serviceNameRequired() {
-    thrown.expect(IllegalArgumentException.class);
+    request = request.toBuilder().parseAnnotationQuery("error").build();
 
-    CassandraUtil.annotationKeys(request.toBuilder().parseAnnotationQuery("sr").build());
+    assertThatThrownBy(() -> CassandraUtil.annotationKeys(request))
+      .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -15,12 +15,10 @@ package zipkin2.storage.cassandra.v1;
 
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.Session;
-import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -43,7 +41,7 @@ import static zipkin2.storage.cassandra.v1.InternalForTests.writeDependencyLinks
 class ITCassandraStorage {
 
   @RegisterExtension CassandraStorageExtension backend =
-    new CassandraStorageExtension("openzipkin/zipkin-cassandra:2.21.4");
+    new CassandraStorageExtension("openzipkin/zipkin-cassandra:2.21.5");
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<CassandraStorage> {
@@ -312,7 +310,12 @@ class ITCassandraStorage {
     while (true) {
       for (Host host : state.getConnectedHosts()) {
         if (state.getInFlightQueries(host) > 0) {
-          Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+          try {
+            Thread.sleep(100);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+          }
           state = storage.session().getState();
           continue refresh;
         }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/IndexerTest.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/IndexerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,11 +14,11 @@
 package zipkin2.storage.cassandra.v1;
 
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Maps;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.junit.Test;
 
-import static org.assertj.guava.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.storage.cassandra.v1.Tables.SERVICE_NAME_INDEX;
 import static zipkin2.storage.cassandra.v1.Tables.SERVICE_SPAN_NAME_INDEX;
 
@@ -26,7 +26,7 @@ public class IndexerTest {
 
   @Test
   public void entriesThatIncreaseGap_filtersEntriesWithinTraceInterval() {
-    ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState = Maps.newConcurrentMap();
+    ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState = new ConcurrentHashMap<>();
 
     ImmutableSetMultimap<PartitionKeyToTraceId, Long> parsed = // intentionally shuffled
         ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
@@ -42,8 +42,8 @@ public class IndexerTest {
             .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", "a"), 1467676800025L)
             .build();
 
-    assertThat(Indexer.entriesThatIncreaseGap(sharedState, parsed))
-        .hasSameEntriesAs(
+    assertThat(Indexer.entriesThatIncreaseGap(sharedState, parsed).asMap())
+        .isEqualTo(
             ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
                 .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "a"), 1467676800050L)
                 .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app", "a"), 1467676800150L)
@@ -52,7 +52,7 @@ public class IndexerTest {
                 .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "db", "a"), 1467676800150L)
                 .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", "a"), 1467676800000L)
                 .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "web", "a"), 1467676800050L)
-                .build());
+                .build().asMap());
   }
 
   /**
@@ -63,7 +63,7 @@ public class IndexerTest {
    */
   @Test
   public void entriesThatIncreaseGap_treatsIndexesSeparately() {
-    ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState = Maps.newConcurrentMap();
+    ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState = new ConcurrentHashMap<>();
 
     // If indexes were not implemented properly, the span index app.foo would be mistaken as the
     // first service index
@@ -75,14 +75,14 @@ public class IndexerTest {
             .put(new PartitionKeyToTraceId(SERVICE_SPAN_NAME_INDEX, "app.foo", "a"), 1467676800000L)
             .build();
 
-    assertThat(Indexer.entriesThatIncreaseGap(sharedState, parsed))
-        .hasSameEntriesAs(
+    assertThat(Indexer.entriesThatIncreaseGap(sharedState, parsed).asMap())
+        .isEqualTo(
             ImmutableSetMultimap.<PartitionKeyToTraceId, Long>builder()
                 .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", "a"), 1467676800050L)
                 .put(new PartitionKeyToTraceId(SERVICE_NAME_INDEX, "app.foo", "a"), 1467676800125L)
                 .put(
                     new PartitionKeyToTraceId(SERVICE_SPAN_NAME_INDEX, "app.foo", "a"),
                     1467676800000L)
-                .build());
+                .build().asMap());
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/AnnotationUDT.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/AnnotationUDT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra;
+
+import com.datastax.driver.mapping.annotations.UDT;
+import java.io.Serializable;
+import zipkin2.Annotation;
+
+@UDT(name = "annotation")
+final class AnnotationUDT implements Serializable { // for Spark jobs
+  static final long serialVersionUID = 0L;
+
+  long ts;
+  String v;
+
+  AnnotationUDT() {
+    this.ts = 0;
+    this.v = null;
+  }
+
+  AnnotationUDT(Annotation annotation) {
+    this.ts = annotation.timestamp();
+    this.v = annotation.value();
+  }
+
+  public long getTs() {
+    return ts;
+  }
+
+  public String getV() {
+    return v;
+  }
+
+  public void setTs(long ts) {
+    this.ts = ts;
+  }
+
+  public void setV(String v) {
+    this.v = v;
+  }
+
+  Annotation toAnnotation() {
+    return Annotation.create(ts, v);
+  }
+
+  @Override public String toString() {
+    return "AnnotationUDT{SpanBytesDecoderts=" + ts + ", v=" + v + "}";
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraUtil.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraUtil.java
@@ -15,6 +15,8 @@ package zipkin2.storage.cassandra;
 
 import com.datastax.driver.core.LocalDate;
 import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -23,6 +25,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import zipkin2.Annotation;
 import zipkin2.Call;
 import zipkin2.Span;
@@ -34,6 +38,8 @@ import zipkin2.storage.QueryRequest;
 import static zipkin2.internal.Platform.SHORT_STRING_LENGTH;
 
 final class CassandraUtil {
+  static final Logger LOG = LoggerFactory.getLogger(CassandraUtil.class);
+
   /**
    * Time window covered by a single bucket of the {@link Schema#TABLE_TRACE_BY_SERVICE_SPAN} and
    * {@link Schema#TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE}, in seconds. Default: 1 day
@@ -125,5 +131,14 @@ final class CassandraUtil {
       result.add(LocalDate.fromMillisSinceEpoch(epochMillis));
     }
     return result;
+  }
+
+  @Nullable static InetAddress InetAddressOrNull(@Nullable String string, @Nullable byte[] bytes) {
+    try {
+      return bytes == null ? null : InetAddress.getByAddress(bytes);
+    } catch (UnknownHostException e) {
+      LOG.debug("InetAddress.getByAddress failed with input {}: {}", string, e.getMessage());
+      return null;
+    }
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraUtil.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraUtil.java
@@ -133,7 +133,7 @@ final class CassandraUtil {
     return result;
   }
 
-  @Nullable static InetAddress InetAddressOrNull(@Nullable String string, @Nullable byte[] bytes) {
+  @Nullable static InetAddress inetAddressOrNull(@Nullable String string, @Nullable byte[] bytes) {
     try {
       return bytes == null ? null : InetAddress.getByAddress(bytes);
     } catch (UnknownHostException e) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/EndpointUDT.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/EndpointUDT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra;
+
+import com.datastax.driver.mapping.annotations.UDT;
+import java.io.Serializable;
+import java.net.InetAddress;
+import zipkin2.Endpoint;
+import zipkin2.internal.Nullable;
+
+import static zipkin2.storage.cassandra.CassandraUtil.InetAddressOrNull;
+
+@UDT(name = "endpoint")
+final class EndpointUDT implements Serializable { // for Spark jobs
+  static final long serialVersionUID = 0L;
+
+  @Nullable static EndpointUDT create(@Nullable Endpoint endpoint) {
+    if (endpoint == null) return null;
+    EndpointUDT result = new EndpointUDT();
+    result.service = endpoint.serviceName();
+    result.ipv4 = InetAddressOrNull(endpoint.ipv4(), endpoint.ipv4Bytes());
+    result.ipv6 = InetAddressOrNull(endpoint.ipv6(), endpoint.ipv6Bytes());
+    result.port = endpoint.portAsInt();
+    return result;
+  }
+
+  String service;
+  InetAddress ipv4;
+  InetAddress ipv6;
+  int port;
+
+  EndpointUDT() {
+    this.service = null;
+    this.ipv4 = null;
+    this.ipv6 = null;
+    this.port = 0;
+  }
+
+  public String getService() {
+    return service;
+  }
+
+  public InetAddress getIpv4() {
+    return ipv4;
+  }
+
+  public InetAddress getIpv6() {
+    return ipv6;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setService(String service) {
+    this.service = service;
+  }
+
+  public void setIpv4(InetAddress ipv4) {
+    this.ipv4 = ipv4;
+  }
+
+  public void setIpv6(InetAddress ipv6) {
+    this.ipv6 = ipv6;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  Endpoint toEndpoint() {
+    Endpoint.Builder builder = Endpoint.newBuilder().serviceName(service).port(port);
+    builder.parseIp(ipv4);
+    builder.parseIp(ipv6);
+    return builder.build();
+  }
+
+  @Override public String toString() {
+    return "EndpointUDT{"
+      + "service=" + service + ", "
+      + "ipv4=" + ipv4 + ", "
+      + "ipv6=" + ipv6 + ", "
+      + "port=" + port
+      + "}";
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/EndpointUDT.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/EndpointUDT.java
@@ -19,7 +19,7 @@ import java.net.InetAddress;
 import zipkin2.Endpoint;
 import zipkin2.internal.Nullable;
 
-import static zipkin2.storage.cassandra.CassandraUtil.InetAddressOrNull;
+import static zipkin2.storage.cassandra.CassandraUtil.inetAddressOrNull;
 
 @UDT(name = "endpoint")
 final class EndpointUDT implements Serializable { // for Spark jobs
@@ -29,8 +29,8 @@ final class EndpointUDT implements Serializable { // for Spark jobs
     if (endpoint == null) return null;
     EndpointUDT result = new EndpointUDT();
     result.service = endpoint.serviceName();
-    result.ipv4 = InetAddressOrNull(endpoint.ipv4(), endpoint.ipv4Bytes());
-    result.ipv6 = InetAddressOrNull(endpoint.ipv6(), endpoint.ipv6Bytes());
+    result.ipv4 = inetAddressOrNull(endpoint.ipv4(), endpoint.ipv4Bytes());
+    result.ipv6 = inetAddressOrNull(endpoint.ipv6(), endpoint.ipv6Bytes());
     result.port = endpoint.portAsInt();
     return result;
   }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,8 +28,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import zipkin2.Call;
 import zipkin2.internal.Nullable;
-import zipkin2.storage.cassandra.Schema.AnnotationUDT;
-import zipkin2.storage.cassandra.Schema.EndpointUDT;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
 import static zipkin2.storage.cassandra.Schema.TABLE_SPAN;
@@ -133,8 +131,8 @@ final class InsertSpan extends ResultSetFutureCall<Void> {
           span.name(),
           span.timestampAsLong(),
           span.durationAsLong(),
-          span.localEndpoint() != null ? new EndpointUDT(span.localEndpoint()) : null,
-          span.remoteEndpoint() != null ? new EndpointUDT(span.remoteEndpoint()) : null,
+          EndpointUDT.create(span.localEndpoint()),
+          EndpointUDT.create(span.remoteEndpoint()),
           annotations,
           span.tags(),
           annotation_query,

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -19,15 +19,11 @@ import com.datastax.driver.core.Host;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.VersionNumber;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.internal.Nullable;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static zipkin2.storage.cassandra.internal.Resources.resourceToString;
 
 final class Schema {
@@ -157,15 +153,11 @@ final class Schema {
   }
 
   static void applyCqlFile(String keyspace, Session session, String resource) {
-    try (Reader reader = new InputStreamReader(Schema.class.getResourceAsStream(resource), UTF_8)) {
-      for (String cmd : resourceToString(resource).split(";", 100)) {
-        cmd = cmd.trim().replace(" " + DEFAULT_KEYSPACE, " " + keyspace);
-        if (!cmd.isEmpty()) {
-          session.execute(cmd);
-        }
+    for (String cmd : resourceToString(resource).split(";", 100)) {
+      cmd = cmd.trim().replace(" " + DEFAULT_KEYSPACE, " " + keyspace);
+      if (!cmd.isEmpty()) {
+        session.execute(cmd);
       }
-    } catch (IOException ex) {
-      LOG.error(ex.getMessage(), ex);
     }
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,26 +19,19 @@ import com.datastax.driver.core.Host;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.VersionNumber;
-import com.datastax.driver.mapping.annotations.UDT;
-import com.google.common.io.CharStreams;
-import com.google.common.net.InetAddresses;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.Serializable;
-import java.net.InetAddress;
-import java.nio.charset.Charset;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import zipkin2.Annotation;
-import zipkin2.Endpoint;
+import zipkin2.internal.Nullable;
 
-import static com.google.common.base.Preconditions.checkState;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static zipkin2.storage.cassandra.internal.Resources.resourceToString;
 
 final class Schema {
   static final Logger LOG = LoggerFactory.getLogger(Schema.class);
-  static final Charset UTF_8 = Charset.forName("UTF-8");
 
   static final String TABLE_SPAN = "span";
   static final String TABLE_TRACE_BY_SERVICE_SPAN = "trace_by_service_span";
@@ -70,8 +63,9 @@ final class Schema {
       ConsistencyLevel cl =
         session.getCluster().getConfiguration().getQueryOptions().getConsistencyLevel();
 
-      checkState(
-        ConsistencyLevel.ONE == cl, "Do not define `local_dc` and use SimpleStrategy");
+      if (cl != ConsistencyLevel.ONE) {
+        throw new IllegalArgumentException("Do not define `local_dc` and use SimpleStrategy");
+      }
     }
     String compactionClass =
       keyspaceMetadata.getTable("span").getOptions().getCompaction().get("class");
@@ -116,14 +110,17 @@ final class Schema {
     return keyspaceMetadata;
   }
 
-  static KeyspaceMetadata getKeyspaceMetadata(Session session, String keyspace) {
+  @Nullable static KeyspaceMetadata getKeyspaceMetadata(Session session, String keyspace) {
     Cluster cluster = session.getCluster();
     com.datastax.driver.core.Metadata metadata = cluster.getMetadata();
-    for (Host host : metadata.getAllHosts()) {
-      checkState(
-        0 >= VersionNumber.parse("3.11.3").compareTo(host.getCassandraVersion()),
-        "Host %s is running Cassandra %s, but minimum version is 3.11.3",
-        host.getHostId(), host.getCassandraVersion());
+    for (Host node : metadata.getAllHosts()) {
+      VersionNumber version = node.getCassandraVersion();
+      if (version == null) throw new RuntimeException("node had no version: " + node);
+      if (VersionNumber.parse("3.11.3").compareTo(version) > 0) {
+        throw new RuntimeException(String.format(
+          "Host %s is running Cassandra %s, but minimum version is 3.11.3",
+          node.getHostId(), node.getCassandraVersion()));
+      }
     }
     return metadata.getKeyspace(keyspace);
   }
@@ -161,7 +158,7 @@ final class Schema {
 
   static void applyCqlFile(String keyspace, Session session, String resource) {
     try (Reader reader = new InputStreamReader(Schema.class.getResourceAsStream(resource), UTF_8)) {
-      for (String cmd : CharStreams.toString(reader).split(";", 100)) {
+      for (String cmd : resourceToString(resource).split(";", 100)) {
         cmd = cmd.trim().replace(" " + DEFAULT_KEYSPACE, " " + keyspace);
         if (!cmd.isEmpty()) {
           session.execute(cmd);
@@ -169,120 +166,6 @@ final class Schema {
       }
     } catch (IOException ex) {
       LOG.error(ex.getMessage(), ex);
-    }
-  }
-
-  @UDT(name = "endpoint")
-  static final class EndpointUDT implements Serializable { // for Spark jobs
-    static final long serialVersionUID = 0L;
-
-    String service;
-    InetAddress ipv4;
-    InetAddress ipv6;
-    int port;
-
-    EndpointUDT() {
-      this.service = null;
-      this.ipv4 = null;
-      this.ipv6 = null;
-      this.port = 0;
-    }
-
-    EndpointUDT(Endpoint endpoint) {
-      this.service = endpoint.serviceName();
-      this.ipv4 = endpoint.ipv4() == null ? null : InetAddresses.forString(endpoint.ipv4());
-      this.ipv6 = endpoint.ipv6() == null ? null : InetAddresses.forString(endpoint.ipv6());
-      this.port = endpoint.portAsInt();
-    }
-
-    public String getService() {
-      return service;
-    }
-
-    public InetAddress getIpv4() {
-      return ipv4;
-    }
-
-    public InetAddress getIpv6() {
-      return ipv6;
-    }
-
-    public int getPort() {
-      return port;
-    }
-
-    public void setService(String service) {
-      this.service = service;
-    }
-
-    public void setIpv4(InetAddress ipv4) {
-      this.ipv4 = ipv4;
-    }
-
-    public void setIpv6(InetAddress ipv6) {
-      this.ipv6 = ipv6;
-    }
-
-    public void setPort(int port) {
-      this.port = port;
-    }
-
-    Endpoint toEndpoint() {
-      Endpoint.Builder builder = Endpoint.newBuilder().serviceName(service).port(port);
-      builder.parseIp(ipv4);
-      builder.parseIp(ipv6);
-      return builder.build();
-    }
-
-    @Override public String toString() {
-      return "EndpointUDT{"
-        + "service=" + service + ", "
-        + "ipv4=" + ipv4 + ", "
-        + "ipv6=" + ipv6 + ", "
-        + "port=" + port
-        + "}";
-    }
-  }
-
-  @UDT(name = "annotation")
-  static final class AnnotationUDT implements Serializable { // for Spark jobs
-    static final long serialVersionUID = 0L;
-
-    long ts;
-    String v;
-
-    AnnotationUDT() {
-      this.ts = 0;
-      this.v = null;
-    }
-
-    AnnotationUDT(Annotation annotation) {
-      this.ts = annotation.timestamp();
-      this.v = annotation.value();
-    }
-
-    public long getTs() {
-      return ts;
-    }
-
-    public String getV() {
-      return v;
-    }
-
-    public void setTs(long ts) {
-      this.ts = ts;
-    }
-
-    public void setV(String v) {
-      this.v = v;
-    }
-
-    Annotation toAnnotation() {
-      return Annotation.create(ts, v);
-    }
-
-    @Override public String toString() {
-      return "AnnotationUDT{SpanBytesDecoderts=" + ts + ", v=" + v + "}";
     }
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectFromSpan.java
@@ -38,7 +38,6 @@ import zipkin2.storage.StrictTraceId;
 import zipkin2.storage.cassandra.internal.call.AccumulateAllResults;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static zipkin2.storage.cassandra.Schema.TABLE_SPAN;
 
 final class SelectFromSpan extends ResultSetFutureCall<ResultSet> {
@@ -81,7 +80,6 @@ final class SelectFromSpan extends ResultSetFutureCall<ResultSet> {
     }
 
     Call<List<Span>> newCall(String hexTraceId) {
-      checkNotNull(hexTraceId, "hexTraceId");
       // Unless we are strict, truncate the trace ID to 64bit (encoded as 16 characters)
       Set<String> traceIds;
       if (!strictTraceId && hexTraceId.length() == 32) {
@@ -221,10 +219,10 @@ final class SelectFromSpan extends ResultSetFutureCall<ResultSet> {
           }
         }
         if (!row.isNull("l_ep")) {
-          builder.localEndpoint(row.get("l_ep", Schema.EndpointUDT.class).toEndpoint());
+          builder.localEndpoint(row.get("l_ep", EndpointUDT.class).toEndpoint());
         }
         if (!row.isNull("r_ep")) {
-          builder.remoteEndpoint(row.get("r_ep", Schema.EndpointUDT.class).toEndpoint());
+          builder.remoteEndpoint(row.get("r_ep", EndpointUDT.class).toEndpoint());
         }
         if (!row.isNull("shared")) {
           builder.shared(row.getBool("shared"));
@@ -232,7 +230,7 @@ final class SelectFromSpan extends ResultSetFutureCall<ResultSet> {
         if (!row.isNull("debug")) {
           builder.shared(row.getBool("debug"));
         }
-        for (Schema.AnnotationUDT udt : row.getList("annotations", Schema.AnnotationUDT.class)) {
+        for (AnnotationUDT udt : row.getList("annotations", AnnotationUDT.class)) {
           builder.addAnnotation(udt.toAnnotation().timestamp(), udt.toAnnotation().value());
         }
         for (Map.Entry<String, String> tag :

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectRemoteServiceNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectRemoteServiceNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,11 +19,11 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import java.util.List;
+import java.util.Locale;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_REMOTE_SERVICES;
 
 final class SelectRemoteServiceNames extends ResultSetFutureCall<ResultSet> {
@@ -43,7 +43,7 @@ final class SelectRemoteServiceNames extends ResultSetFutureCall<ResultSet> {
 
     Call<List<String>> create(String serviceName) {
       if (serviceName == null || serviceName.isEmpty()) return Call.emptyList();
-      String service = checkNotNull(serviceName, "serviceName").toLowerCase();
+      String service = serviceName.toLowerCase(Locale.ROOT); // service names are always lowercase!
       return new SelectRemoteServiceNames(this, service).flatMap(remoteServices);
     }
   }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,11 +19,11 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import java.util.List;
+import java.util.Locale;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_SPANS;
 
 final class SelectSpanNames extends ResultSetFutureCall<ResultSet> {
@@ -44,7 +44,7 @@ final class SelectSpanNames extends ResultSetFutureCall<ResultSet> {
 
     Call<List<String>> create(String serviceName) {
       if (serviceName == null || serviceName.isEmpty()) return Call.emptyList();
-      String service = checkNotNull(serviceName, "serviceName").toLowerCase();
+      String service = serviceName.toLowerCase(Locale.ROOT); // service names are always lowercase!
       return new SelectSpanNames(this, service).flatMap(spans);
     }
   }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/Resources.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/Resources.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra.internal;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public final class Resources {
+  public static String resourceToString(String resource) {
+    try (
+      Reader reader = new InputStreamReader(Resources.class.getResourceAsStream(resource), UTF_8)) {
+      char[] buf = new char[2048];
+      StringBuilder builder = new StringBuilder();
+      int read;
+      while ((read = reader.read(buf)) != -1) {
+        builder.append(buf, 0, read);
+      }
+      return builder.toString();
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  Resources() {
+  }
+}

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraUtilTest.java
@@ -14,12 +14,11 @@
 package zipkin2.storage.cassandra;
 
 import com.datastax.driver.core.LocalDate;
-import com.google.common.collect.ImmutableMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import zipkin2.Span;
 import zipkin2.TestObjects;
 import zipkin2.internal.DateUtil;
@@ -30,9 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.TODAY;
 
 public class CassandraUtilTest {
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
   @Test
   public void annotationKeys_emptyRequest() {
     assertThat(
@@ -134,13 +130,12 @@ public class CassandraUtilTest {
 
   @Test
   public void traceIdsSortedByDescTimestamp_doesntCollideOnSameTimestamp() {
-    Set<String> sortedTraceIds =
-        CassandraUtil.traceIdsSortedByDescTimestamp()
-            .map(
-                ImmutableMap.of(
-                    "a", 1L,
-                    "b", 1L,
-                    "c", 2L));
+    Map<String, Long> input = new LinkedHashMap<>();
+    input.put("a", 1L);
+    input.put("b", 1L);
+    input.put("c", 2L);
+
+    Set<String> sortedTraceIds = CassandraUtil.traceIdsSortedByDescTimestamp().map(input);
 
     try {
       assertThat(sortedTraceIds).containsExactly("c", "b", "a");

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -56,14 +56,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- For HttpCallTest -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>${armeria.groupId}</groupId>
       <artifactId>armeria-junit5</artifactId>

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class ITElasticsearchStorageV6 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch6:2.21.4");
+    "openzipkin/zipkin-elasticsearch6:2.21.5");
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class ITElasticsearchStorageV7 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch7:2.21.0"); // TODO: update when 2.21.5+
+    "openzipkin/zipkin-elasticsearch7:2.21.5");
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/BulkCallBuilderTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/BulkCallBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,35 +13,32 @@
  */
 package zipkin2.elasticsearch.internal;
 
-import java.io.IOException;
 import java.util.concurrent.RejectedExecutionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static zipkin2.elasticsearch.internal.BulkCallBuilder.CHECK_FOR_ERRORS;
 import static zipkin2.elasticsearch.internal.JsonSerializers.JSON_FACTORY;
 
 public class BulkCallBuilderTest {
-  @Rule public ExpectedException expectedException = ExpectedException.none();
-
-  @Test public void throwsRejectedExecutionExceptionWhenOverCapacity() throws IOException {
+  @Test public void throwsRejectedExecutionExceptionWhenOverCapacity()  {
     String response =
       "{\"took\":0,\"errors\":true,\"items\":[{\"index\":{\"_index\":\"dev-zipkin:span-2019.04.18\",\"_type\":\"span\",\"_id\":\"2511\",\"status\":429,\"error\":{\"type\":\"es_rejected_execution_exception\",\"reason\":\"rejected execution of org.elasticsearch.transport.TransportService$7@7ec1ea93 on EsThreadPoolExecutor[bulk, queue capacity = 200, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@621571ba[Running, pool size = 4, active threads = 4, queued tasks = 200, completed tasks = 3838534]]\"}}}]}";
 
-    expectedException.expect(RejectedExecutionException.class);
-    expectedException.expectMessage(
-      "rejected execution of org.elasticsearch.transport.TransportService$7@7ec1ea93 on EsThreadPoolExecutor[bulk, queue capacity = 200, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@621571ba[Running, pool size = 4, active threads = 4, queued tasks = 200, completed tasks = 3838534]]");
-    CHECK_FOR_ERRORS.convert(JSON_FACTORY.createParser(response), () -> response);
+    assertThatThrownBy(
+      () -> CHECK_FOR_ERRORS.convert(JSON_FACTORY.createParser(response), () -> response))
+      .isInstanceOf(RejectedExecutionException.class)
+      .hasMessage(
+        "rejected execution of org.elasticsearch.transport.TransportService$7@7ec1ea93 on EsThreadPoolExecutor[bulk, queue capacity = 200, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@621571ba[Running, pool size = 4, active threads = 4, queued tasks = 200, completed tasks = 3838534]]");
   }
 
-  @Test public void throwsRuntimeExceptionAsReasonWhenPresent() throws IOException {
+  @Test public void throwsRuntimeExceptionAsReasonWhenPresent() {
     String response =
       "{\"error\":{\"root_cause\":[{\"type\":\"illegal_argument_exception\",\"reason\":\"Fielddata is disabled on text fields by default. Set fielddata=true on [spanName] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.\"}],\"type\":\"search_phase_execution_exception\",\"reason\":\"all shards failed\",\"phase\":\"query\",\"grouped\":true,\"failed_shards\":[{\"shard\":0,\"index\":\"zipkin-2017-05-14\",\"node\":\"IqceAwZnSvyv0V0xALkEnQ\",\"reason\":{\"type\":\"illegal_argument_exception\",\"reason\":\"Fielddata is disabled on text fields by default. Set fielddata=true on [spanName] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.\"}}]},\"status\":400}";
 
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage(
-      "Fielddata is disabled on text fields by default. Set fielddata=true on [spanName] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.");
-    CHECK_FOR_ERRORS.convert(JSON_FACTORY.createParser(response), () -> response);
+    assertThatThrownBy(
+      () -> CHECK_FOR_ERRORS.convert(JSON_FACTORY.createParser(response), () -> response))
+      .isInstanceOf(RuntimeException.class)
+      .hasMessage("Fielddata is disabled on text fields by default. Set fielddata=true on [spanName] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.");
   }
 }

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -36,7 +36,7 @@ import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinDependenc
 class ITMySQLStorage {
 
   @RegisterExtension MySQLStorageExtension backend = new MySQLStorageExtension(
-    "openzipkin/zipkin-mysql:2.21.4");
+    "openzipkin/zipkin-mysql:2.21.5");
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<MySQLStorage> {


### PR DESCRIPTION
We only needed guava for Cassandra. Removing it here makes migration easier.

Note: there's still a guava left in cassandra-v1 which is too complex to undo
in this PR (Table and Cache apis).