### PR TITLE
Refactors DelayLimiter in preparation of re-use in cassandra v1

### DIFF
--- a/benchmarks/src/main/java/zipkin2/internal/DelayLimiterBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/internal/DelayLimiterBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -40,7 +40,10 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 public class DelayLimiterBenchmarks {
 
   final Random rng = new Random();
-  final DelayLimiter<Long> limiter = DelayLimiter.create();
+  final DelayLimiter<Long> limiter = DelayLimiter.newBuilder()
+    .ttl(1L, TimeUnit.HOURS) // legacy default from Cassandra
+    .cardinality(5 * 4000) // Ex. 5 site tags with cardinality 4000 each
+    .build();
 
   @Benchmark public boolean shouldInvoke_randomData() {
     return limiter.shouldInvoke(rng.nextLong());

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumer.java
@@ -14,7 +14,6 @@
 package zipkin2.storage.cassandra.v1;
 
 import com.datastax.driver.core.Session;
-import com.google.common.cache.CacheBuilderSpec;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -43,7 +42,7 @@ final class CassandraSpanConsumer implements SpanConsumer {
   @Nullable final CompositeIndexer indexer;
   @Nullable final InsertAutocompleteValue.Factory insertAutocompleteValue;
 
-  CassandraSpanConsumer(CassandraStorage storage, CacheBuilderSpec indexCacheSpec) {
+  CassandraSpanConsumer(CassandraStorage storage) {
     Session session = storage.session();
     Schema.Metadata metadata = storage.metadata();
     searchEnabled = storage.searchEnabled;
@@ -69,7 +68,7 @@ final class CassandraSpanConsumer implements SpanConsumer {
       insertRemoteServiceName = null;
     }
     insertSpanName = new InsertSpanName.Factory(storage, indexTtl);
-    indexer = new CompositeIndexer(storage, indexCacheSpec, indexTtl);
+    indexer = new CompositeIndexer(storage, indexTtl);
     if (metadata.hasAutocompleteTags && !storage.autocompleteKeys.isEmpty()) {
       insertAutocompleteValue = new InsertAutocompleteValue.Factory(storage, indexTtl);
     } else {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CompositeIndexer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CompositeIndexer.java
@@ -14,11 +14,11 @@
 package zipkin2.storage.cassandra.v1;
 
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheBuilderSpec;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import zipkin2.Call;
 import zipkin2.Span;
 
@@ -27,19 +27,21 @@ final class CompositeIndexer {
   private final Set<Indexer> indexers;
   // Shared across all threads as updates can come from any thread.
   // Shared for all indexes to make data management easier (ex. maximumSize)
-  private final ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState;
+  private final Map<PartitionKeyToTraceId, Pair> sharedState;
 
-  CompositeIndexer(CassandraStorage storage, CacheBuilderSpec spec, int indexTtl) {
-    this.sharedState = CacheBuilder.from(spec).<PartitionKeyToTraceId, Pair>build().asMap();
+  CompositeIndexer(CassandraStorage storage, int indexTtl) {
+    sharedState = CacheBuilder.newBuilder()
+      .maximumSize(storage.indexCacheMax)
+      .expireAfterWrite(storage.indexCacheTtl, TimeUnit.SECONDS)
+      .<PartitionKeyToTraceId, Pair>build().asMap();
     Indexer.Factory factory = new Indexer.Factory(storage.session(), indexTtl, sharedState);
-    Set<Indexer> indexers = new LinkedHashSet<>();
+    indexers = new LinkedHashSet<>();
     indexers.add(factory.create(new InsertTraceIdByServiceName(storage.bucketCount)));
     if (storage.metadata().hasRemoteService) {
       indexers.add(factory.create(new InsertTraceIdByRemoteServiceName()));
     }
     indexers.add(factory.create(new InsertTraceIdBySpanName()));
     indexers.add(factory.create(new InsertTraceIdByAnnotation(storage.bucketCount)));
-    this.indexers = indexers;
   }
 
   void index(Span span, List<Call<Void>> calls) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Indexer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Indexer.java
@@ -28,7 +28,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.Call;
@@ -56,12 +55,12 @@ final class Indexer {
    * Shared across all threads, as updates to indexes can come from any thread. Null disables
    * optimization.
    */
-  @Nullable final ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState;
+  @Nullable final Map<PartitionKeyToTraceId, Pair> sharedState;
 
   Indexer(
       Session session,
       int indexTtl,
-      @Nullable ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState,
+      @Nullable Map<PartitionKeyToTraceId, Pair> sharedState,
       IndexSupport index) {
     this.index = index;
     Insert insert =
@@ -162,7 +161,7 @@ final class Indexer {
   }
 
   static SetMultimap<PartitionKeyToTraceId, Long> entriesThatIncreaseGap(
-      ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState,
+      Map<PartitionKeyToTraceId, Pair> sharedState,
       SetMultimap<PartitionKeyToTraceId, Long> updates) {
     Set<PartitionKeyToTraceId> toUpdate = new LinkedHashSet<>();
 
@@ -225,12 +224,12 @@ final class Indexer {
   static class Factory {
     final Session session;
     final int indexTtl;
-    final ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState;
+    final Map<PartitionKeyToTraceId, Pair> sharedState;
 
     public Factory(
         Session session,
         int indexTtl,
-        @Nullable ConcurrentMap<PartitionKeyToTraceId, Pair> sharedState) {
+        @Nullable Map<PartitionKeyToTraceId, Pair> sharedState) {
       this.session = session;
       this.indexTtl = indexTtl;
       this.sharedState = sharedState;

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumerTest.java
@@ -14,7 +14,6 @@
 package zipkin2.storage.cassandra.v1;
 
 import com.datastax.driver.core.ProtocolVersion;
-import com.google.common.cache.CacheBuilderSpec;
 import java.util.Collections;
 import java.util.List;
 import org.assertj.core.api.AbstractListAssert;
@@ -135,6 +134,6 @@ public class CassandraSpanConsumerTest {
       spy(builder.sessionFactory(mock(SessionFactory.class, Mockito.RETURNS_MOCKS)).build());
     doReturn(new Schema.Metadata(ProtocolVersion.V4, "", true, true, true))
       .when(storage).metadata();
-    return new CassandraSpanConsumer(storage, CacheBuilderSpec.parse(""));
+    return new CassandraSpanConsumer(storage);
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/DeduplicatingVoidCallFactory.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/call/DeduplicatingVoidCallFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package zipkin2.storage.cassandra.internal.call;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import zipkin2.Call;
 import zipkin2.Callback;
 import zipkin2.internal.DelayLimiter;
@@ -23,7 +24,8 @@ public abstract class DeduplicatingVoidCallFactory<I> {
   final DelayLimiter<I> delayLimiter;
 
   protected DeduplicatingVoidCallFactory(int ttl, int cardinality) {
-    delayLimiter = DelayLimiter.newBuilder().ttl(ttl).cardinality(cardinality).build();
+    delayLimiter =
+      DelayLimiter.newBuilder().ttl(ttl, TimeUnit.MILLISECONDS).cardinality(cardinality).build();
   }
 
   protected abstract Call<Void> newCall(I input);


### PR DESCRIPTION
This refactors code relating to DelayLimiter so that it is easier to
reuse later. What will happen in a separate PR (or what will be
attempted) is change the limiter so that it can run a predicate instead
of an exact match. For example Cassandra v1's Indexer currently mutes
index insertions which are logically equivalent to data already written.

Concretely, a service name that appears 3 times in the same trace,
results in two writes (earliest and latest). If it appears again, and
between those timestamps, that write is muted as it is redundant.