### PR TITLE
Split dropped metrics to sampled out and storage error

### DIFF
--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
@@ -149,6 +149,7 @@ public class ITActiveMQCollector {
       .isEqualTo(THRIFT.encodeList(spans).length * 2 + malformed1.length + malformed2.length);
     assertThat(activemqMetrics.spans()).isEqualTo(spans.size() * 2);
     assertThat(activemqMetrics.spansDropped()).isZero();
+    assertThat(activemqMetrics.spansSampledOut()).isZero();
   }
 
   /** Guards against errors that leak from storage, such as InvalidQueryException */

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/Collector.java
@@ -214,7 +214,7 @@ public class Collector { // not final for mock
       }
     }
     int dropped = input.size() - sampled.size();
-    if (dropped > 0) metrics.incrementSpansDropped(dropped);
+    if (dropped > 0) metrics.incrementSpansSampledOut(dropped);
     return sampled;
   }
 

--- a/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorMetrics.java
+++ b/zipkin-collector/core/src/main/java/zipkin2/collector/CollectorMetrics.java
@@ -48,7 +48,7 @@ import zipkin2.storage.SpanConsumer;
  * messages sent from instrumentation.</li>
  * <li>Stored spans &lt;= {@link #incrementSpans(int) Accepted spans} - {@link
  * #incrementSpansDropped(int) Dropped spans}. Alert when this drops below the
- * {@link CollectorSampler#isSampled(long, boolean) collection-tier sample rate}.
+ * {@link CollectorSampler#isSampled(String, boolean) collection-tier sample rate}.
  * </li>
  * </ul>
  * </pre>
@@ -93,8 +93,13 @@ public interface CollectorMetrics {
   void incrementBytes(int quantity);
 
   /**
-   * Increments the count of spans dropped for any reason. For example, failure queueing to storage
+   * Increments the count of spans dropped by collector sampler.
    * or sampling decisions.
+   */
+  void incrementSpansSampledOut(int quantity);
+
+  /**
+   * Increments the count of spans dropped by storage error. For example, failure queueing to storage.
    */
   void incrementSpansDropped(int quantity);
 
@@ -120,6 +125,9 @@ public interface CollectorMetrics {
 
         @Override
         public void incrementSpansDropped(int quantity) {}
+
+        @Override
+        public void incrementSpansSampledOut(int quantity) {}
 
         @Override
         public String toString() {

--- a/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin2/collector/scribe/ScribeSpanConsumerTest.java
@@ -115,6 +115,7 @@ class ScribeSpanConsumerTest {
     assertThat(scribeMetrics.bytes()).isEqualTo(bytes.length);
     assertThat(scribeMetrics.spans()).isEqualTo(1);
     assertThat(scribeMetrics.spansDropped()).isZero();
+    assertThat(scribeMetrics.spansSampledOut()).isZero();
   }
 
   @Test void entriesWithoutSpansAreSkipped() throws Exception {


### PR DESCRIPTION
Motivation: Currently we don't know whether spans are dropped by error or sampled out