### PR TITLE
Correct Docker health check

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,7 +106,7 @@ EXPOSE 9411
 # report to https://gitter.im/openzipkin/zipkin including the values of the
 # /health and /info endpoints as this would be unexpected.
 #
-HEALTHCHECK --interval=5s --start-period=30s --timeout=5s CMD wget --quiet http://localhost:9411/health || exit 1
+HEALTHCHECK --interval=5s --start-period=30s --timeout=5s CMD wget -qO- http://localhost:9411/health &> /dev/null || exit 1
 
 ENTRYPOINT ["/busybox/sh", "run.sh"]
 
@@ -159,6 +159,6 @@ EXPOSE 9410 9411
 # report to https://gitter.im/openzipkin/zipkin including the values of the
 # /health and /info endpoints as this would be unexpected.
 #
-HEALTHCHECK --interval=5s --start-period=30s --timeout=5s CMD wget --quiet http://localhost:9411/health || exit 1
+HEALTHCHECK --interval=5s --start-period=30s --timeout=5s CMD wget -qO- http://localhost:9411/health &> /dev/null || exit 1
 
 ENTRYPOINT ["/busybox/sh", "run.sh"]


### PR DESCRIPTION
The existing health check leaves a file behind, "health", which will fail due to `wget: can't open 'health': File exists\n` on consecutive invocations.

This PR pipes the file to /dev/null but still relies on the exit code from `wget`.