### PR TITLE
Cleans up Cassandra Session logic in preparation of Driver v4

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/LazySession.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/LazySession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -45,6 +45,7 @@ final class LazySession {
 
   void close() {
     Session maybeSession = session;
-    if (maybeSession != null) maybeSession.close();
+    // The resource to close in Datastax Java Driver v3 is the cluster. In v4, it only session
+    if (maybeSession != null) maybeSession.getCluster().close();
   }
 }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/Access.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/Access.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.cassandra;
+
+import com.datastax.driver.core.Session;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** opens package access for testing */
+public final class Access {
+
+  // Builds a session without trying to use a namespace or init UDTs
+  public static Session tryToInitializeSession(String contactPoint) {
+    CassandraStorage storage = CassandraStorage.newBuilder()
+      .contactPoints(contactPoint)
+      .maxConnections(1)
+      .keyspace("test_cassandra_v1").build();
+    Session session = null;
+    try {
+      session = DefaultSessionFactory.buildSession(storage);
+      session.execute("SELECT now() FROM system.local");
+    } catch (Throwable e) {
+      if (session != null) session.getCluster().close();
+      assumeTrue(false, e.getMessage());
+    }
+    return session;
+  }
+}

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageExtension.java
@@ -13,12 +13,9 @@
  */
 package zipkin2.storage.cassandra.v1;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.HostDistance;
-import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.Session;
-import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -27,26 +24,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
-
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import zipkin2.storage.cassandra.Access;
 
 public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCallback {
   static final Logger LOGGER = LoggerFactory.getLogger(CassandraStorageExtension.class);
   static final int CASSANDRA_PORT = 9042;
   final String image;
   CassandraContainer container;
-  Cluster cluster;
-  Session session;
+  Session globalSession;
 
   CassandraStorageExtension(String image) {
     this.image = image;
   }
 
-  Session session() {
-    return session;
-  }
-
-  @Override public void beforeAll(ExtensionContext context) throws Exception {
+  @Override public void beforeAll(ExtensionContext context) {
     if (context.getRequiredTestClass().getEnclosingClass() != null) {
       // Only run once in outermost scope.
       return;
@@ -65,42 +56,35 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
     }
 
     try {
-      tryToInitializeSession();
+      globalSession = Access.tryToInitializeSession(contactPoint());
     } catch (RuntimeException | Error e) {
       if (container == null) throw e;
       LOGGER.warn("Couldn't connect to docker image " + image + ": " + e.getMessage(), e);
       container.stop();
       container = null; // try with local connection instead
-      tryToInitializeSession();
+      globalSession = Access.tryToInitializeSession(contactPoint());
     }
   }
 
-  void tryToInitializeSession() {
-    try {
-      cluster = getCluster(contactPoint());
-      session = cluster.newSession();
-      session.execute("SELECT now() FROM system.local");
-    } catch (RuntimeException e) { // don't leak on unexpected exception!
-      if (session != null) session.close();
-      if (cluster != null) cluster.close();
-      assumeTrue(false, e.getMessage());
-    }
-  }
-
-  CassandraStorage.Builder computeStorageBuilder() {
-    InetSocketAddress contactPoint = contactPoint();
+  CassandraStorage.Builder newStorageBuilder(TestInfo testInfo) {
     return CassandraStorage.newBuilder()
-      .contactPoints(contactPoint.getHostString() + ":" + contactPoint.getPort())
-      .ensureSchema(true)
-      .keyspace("test_cassandra3");
+      .contactPoints(contactPoint())
+      .maxConnections(1)
+      .keyspace(InternalForTests.keyspace(testInfo));
   }
 
-  InetSocketAddress contactPoint() {
+  static CassandraStorage.Builder newStorageBuilder(String contactPoint) {
+    return CassandraStorage.newBuilder()
+      .contactPoints(contactPoint)
+      .maxConnections(1)
+      .keyspace("test_cassandra_v1");
+  }
+
+  String contactPoint() {
     if (container != null && container.isRunning()) {
-      return new InetSocketAddress(
-        container.getContainerIpAddress(), container.getMappedPort(CASSANDRA_PORT));
+      return container.getContainerIpAddress() + ":" + container.getMappedPort(CASSANDRA_PORT);
     } else {
-      return new InetSocketAddress("127.0.0.1", CASSANDRA_PORT);
+      return "127.0.0.1:" + CASSANDRA_PORT;
     }
   }
 
@@ -109,18 +93,7 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
       // Only run once in outermost scope.
       return;
     }
-
-    try {
-      if (session != null) session.close();
-      if (cluster != null) cluster.close();
-    } catch (Exception | Error e) {
-      LOGGER.warn("error closing session " + e.getMessage(), e);
-    } finally {
-      if (container != null) {
-        LOGGER.info("Stopping docker image " + image);
-        container.stop();
-      }
-    }
+    if (globalSession != null) globalSession.getCluster().close();
   }
 
   static final class CassandraContainer extends GenericContainer<CassandraContainer> {
@@ -128,35 +101,19 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
       super(image);
     }
 
-    @Override
-    protected void waitUntilContainerStarted() {
-      Unreliables.retryUntilSuccess(
-        120,
-        TimeUnit.SECONDS,
-        () -> {
-          if (!isRunning()) {
-            throw new ContainerLaunchException("Container failed to start");
-          }
+    @Override protected void waitUntilContainerStarted() {
+      Unreliables.retryUntilSuccess(120, TimeUnit.SECONDS, () -> {
+        if (!isRunning()) {
+          throw new ContainerLaunchException("Container failed to start");
+        }
 
-          InetSocketAddress address =
-            new InetSocketAddress(getContainerIpAddress(), getMappedPort(9042));
-
-          try (Cluster cluster = getCluster(address);
-               Session session = cluster.newSession()) {
-            session.execute("SELECT now() FROM system.local");
-            logger().info("Obtained a connection to container ({})", cluster.getClusterName());
-            return null; // unused value
-          }
-        });
+        String contactPoint = getContainerIpAddress() + ":" + getMappedPort(9042);
+        try (Session session = Access.tryToInitializeSession(contactPoint)) {
+          session.execute("SELECT now() FROM system.local");
+          logger().info("Obtained a connection to container ({})", contactPoint);
+          return null; // unused value
+        }
+      });
     }
-  }
-
-  static Cluster getCluster(InetSocketAddress contactPoint) {
-    return Cluster.builder()
-      .withoutJMXReporting()
-      .addContactPointsWithPorts(contactPoint)
-      .withRetryPolicy(ZipkinRetryPolicy.INSTANCE)
-      .withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(HostDistance.LOCAL, 1))
-      .build();
   }
 }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -50,7 +50,7 @@ class ITCassandraStorage {
     }
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-      return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
+      return backend.newStorageBuilder(testInfo);
     }
 
     @Override @Test @Disabled("No consumer-side span deduplication")
@@ -73,7 +73,7 @@ class ITCassandraStorage {
     }
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-      return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
+      return backend.newStorageBuilder(testInfo);
     }
 
     @Override @Test @Disabled("All services query unsupported when combined with other qualifiers")
@@ -178,7 +178,7 @@ class ITCassandraStorage {
     }
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-      return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
+      return backend.newStorageBuilder(testInfo);
     }
 
     @Override protected void blockWhileInFlight() {
@@ -197,7 +197,7 @@ class ITCassandraStorage {
     }
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-      return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
+      return backend.newStorageBuilder(testInfo);
     }
 
     @Override protected void blockWhileInFlight() {
@@ -216,7 +216,7 @@ class ITCassandraStorage {
     }
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-      return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
+      return backend.newStorageBuilder(testInfo);
     }
 
     @Override protected void blockWhileInFlight() {
@@ -235,7 +235,7 @@ class ITCassandraStorage {
     }
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-      return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
+      return backend.newStorageBuilder(testInfo);
     }
 
     @Override protected void blockWhileInFlight() {
@@ -254,7 +254,7 @@ class ITCassandraStorage {
     }
 
     @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-      return backend.computeStorageBuilder().keyspace(InternalForTests.keyspace(testInfo));
+      return backend.newStorageBuilder(testInfo);
     }
 
     @Override protected void blockWhileInFlight() {
@@ -269,7 +269,7 @@ class ITCassandraStorage {
      * The current implementation does not include dependency aggregation. It includes retrieval of
      * pre-aggregated links, usually made via zipkin-dependencies
      */
-    @Override protected void processDependencies(List<Span> spans) throws Exception {
+    @Override protected void processDependencies(List<Span> spans) {
       aggregateLinks(spans).forEach(
         (midnight, links) -> writeDependencyLinks(storage, links, midnight));
     }
@@ -288,18 +288,18 @@ class ITCassandraStorage {
     }
 
     @Override protected Session session() {
-      return backend.session;
+      return backend.globalSession;
     }
 
-    @Override protected InetSocketAddress contactPoint() {
+    @Override protected String contactPoint() {
       return backend.contactPoint();
     }
   }
 
   @Nested
   class ITSpanConsumer extends zipkin2.storage.cassandra.v1.ITSpanConsumer {
-    @Override CassandraStorage.Builder storageBuilder() {
-      return backend.computeStorageBuilder();
+    @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
+      return backend.newStorageBuilder(testInfo);
     }
   }
 

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITEnsureSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package zipkin2.storage.cassandra.v1;
 
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
-import java.net.InetSocketAddress;
 import org.junit.jupiter.api.Test;
 import zipkin2.TestObjects;
 import zipkin2.storage.QueryRequest;
@@ -33,7 +32,7 @@ abstract class ITEnsureSchema {
 
   abstract Session session();
 
-  abstract InetSocketAddress contactPoint();
+  abstract String contactPoint();
 
   @Test public void installsKeyspaceWhenMissing() {
     Schema.ensureExists(keyspace(), session());
@@ -70,9 +69,7 @@ abstract class ITEnsureSchema {
   @Test public void worksWithOldSchema() throws Exception {
     Schema.applyCqlFile(keyspace(), session(), "/cassandra-schema-cql3-original.txt");
 
-    InetSocketAddress contactPoint = contactPoint();
-    try (CassandraStorage storage = CassandraStorage.newBuilder()
-      .contactPoints(contactPoint.getHostString() + ":" + contactPoint.getPort())
+    try (CassandraStorage storage = CassandraStorageExtension.newStorageBuilder(contactPoint())
       .ensureSchema(false)
       .autocompleteKeys(asList("environment"))
       .keyspace(keyspace()).build()) {

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITSpanConsumer.java
@@ -15,7 +15,6 @@ package zipkin2.storage.cassandra.v1;
 
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import zipkin2.Span;
 import zipkin2.TestObjects;
 import zipkin2.storage.ITStorage;
@@ -32,10 +31,6 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
     return true;
   }
 
-  @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-    return storageBuilder().keyspace(InternalForTests.keyspace(testInfo));
-  }
-
   @Override protected void configureStorageForTest(StorageComponent.Builder storage) {
     storage.autocompleteKeys(asList("environment"));
   }
@@ -43,8 +38,6 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
   @Override public void clear() {
     // Just let the data pile up to prevent warnings and slowness.
   }
-
-  abstract CassandraStorage.Builder storageBuilder();
 
   /**
    * Core/Boundary annotations like "sr" aren't queryable, and don't add value to users. Address

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package zipkin2.storage.cassandra;
 
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
-import java.net.InetSocketAddress;
 import org.junit.jupiter.api.Test;
 import zipkin2.TestObjects;
 import zipkin2.storage.QueryRequest;
@@ -33,7 +32,7 @@ abstract class ITEnsureSchema {
 
   abstract protected Session session();
 
-  abstract InetSocketAddress contactPoint();
+  abstract String contactPoint();
 
   @Test void installsKeyspaceWhenMissing() {
     Schema.ensureExists(keyspace(), false, session());
@@ -91,9 +90,7 @@ abstract class ITEnsureSchema {
     Schema.applyCqlFile(keyspace(), session(), "/zipkin2-schema.cql");
     Schema.applyCqlFile(keyspace(), session(), "/zipkin2-schema-indexes-original.cql");
 
-    InetSocketAddress contactPoint = contactPoint();
-    try (CassandraStorage storage = CassandraStorage.newBuilder()
-      .contactPoints(contactPoint.getHostString() + ":" + contactPoint.getPort())
+    try (CassandraStorage storage = CassandraStorageExtension.newStorageBuilder(contactPoint())
       .ensureSchema(false)
       .autocompleteKeys(asList("environment"))
       .keyspace(keyspace()).build()) {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package zipkin2.storage.cassandra;
 import java.io.IOException;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import zipkin2.Span;
 import zipkin2.TestObjects;
 import zipkin2.storage.ITStorage;
@@ -33,10 +32,6 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
     return true;
   }
 
-  @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-    return storageBuilder().keyspace(InternalForTests.keyspace(testInfo));
-  }
-
   @Override protected void configureStorageForTest(StorageComponent.Builder storage) {
     storage.autocompleteKeys(asList("environment"));
   }
@@ -45,11 +40,9 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
     // Just let the data pile up to prevent warnings and slowness.
   }
 
-  abstract CassandraStorage.Builder storageBuilder();
-
   /**
-   * {@link Span#duration} == 0 is likely to be a mistake, and coerces to null. It is not helpful to
-   * index rows who have no duration.
+   * {@link Span#duration()} == 0 is likely to be a mistake, and coerces to null. It is not helpful
+   * to index rows who have no duration.
    */
   @Test public void doesntIndexSpansMissingDuration() throws IOException {
     Span span = Span.newBuilder().traceId("1").id("1").name("get").duration(0L).build();


### PR DESCRIPTION
The more notable change in Datastax Driver v4 is consolidation of
Cluster and Session types. This centralizes logic to create a session
regardless of test or mainline. It also ensures the cluster object is
closed during main and test code when storage is.