### PR TITLE
Stops using prepared or query builder statements for simple queries

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -239,10 +239,12 @@ The following are tuning parameters which may not concern all users:
     * `CASSANDRA_INDEX_CACHE_TTL`: How many seconds to cache index metadata about a trace. Defaults to 60.
     * `CASSANDRA_INDEX_FETCH_MULTIPLIER`: How many more index rows to fetch than the user-supplied query limit. Defaults to 3.
 
-Example usage with logging:
+Example usage with Cassandra connection and query logging:
 
 ```bash
-$ STORAGE_TYPE=cassandra3 java -jar zipkin.jar --logging.level.zipkin=trace --logging.level.zipkin2=trace --logging.level.com.datastax.driver.core.Connection=debug
+$ STORAGE_TYPE=cassandra3 java -jar zipkin.jar \
+ --logging.level.com.datastax.driver.core.Connection=debug \
+ --logging.level.com.datastax.driver.core.QueryLogger.NORMAL=trace
 ```
 
 ### Elasticsearch Storage

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -242,7 +242,7 @@ The following are tuning parameters which may not concern all users:
 Example usage with logging:
 
 ```bash
-$ STORAGE_TYPE=cassandra3 java -jar zipkin.jar --logging.level.zipkin=trace --logging.level.zipkin2=trace --logging.level.com.datastax.driver.core=debug
+$ STORAGE_TYPE=cassandra3 java -jar zipkin.jar --logging.level.zipkin=trace --logging.level.zipkin2=trace --logging.level.com.datastax.driver.core.Connection=debug
 ```
 
 ### Elasticsearch Storage

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -261,7 +261,9 @@ logging:
 #     # investigate /api/v2/dependencies
 #     zipkin2.internal.DependencyLinker: 'DEBUG'
 #     # log cassandra queries (DEBUG is without values)
-#     com.datastax.driver.core.QueryLogger: 'TRACE'
+#     com.datastax.driver.core.QueryLogger.NORMAL: 'TRACE'
+#     # log cassandra connections
+#     com.datastax.driver.core.Connection: 'DEBUG'
 #     # log cassandra trace propagation
 #     com.datastax.driver.core.Message: 'TRACE'
 #     # log reason behind http collector dropped messages

--- a/zipkin-storage/cassandra-v1/README.md
+++ b/zipkin-storage/cassandra-v1/README.md
@@ -11,8 +11,8 @@ The implementation uses the [Datastax Java Driver 3.x](https://github.com/datast
 operate against a local Cassandra installation.
 
 ## Logging
-Queries are logged to the category "com.datastax.driver.core.QueryLogger" when debug or trace is
-enabled via SLF4J. Trace level includes bound values.
+Queries are logged to the category "com.datastax.driver.core.QueryLogger.NORMAL" when debug or trace
+is enabled via SLF4J. Trace level includes bound values.
 
 See [Logging Query Latencies](http://docs.datastax.com/en/developer/java-driver/3.0/supplemental/manual/logging/#logging-query-latencies) for more details.
 

--- a/zipkin-storage/cassandra-v1/src/test/resources/simplelogger.properties
+++ b/zipkin-storage/cassandra-v1/src/test/resources/simplelogger.properties
@@ -7,7 +7,8 @@ org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS
 
 # Note: this will dump a large amount of data in the logs
 #org.slf4j.simpleLogger.log.zipkin2.storage.cassandra.v1=info
-#org.slf4j.simpleLogger.log.com.datastax.driver.core.QueryLogger=trace
+#org.slf4j.simpleLogger.log.com.datastax.driver.core.QueryLogger.NORMAL=trace
+#org.slf4j.simpleLogger.log.com.datastax.driver.core.Connection=debug
 # don't spam about round-robin or connection delay
 org.slf4j.simpleLogger.log.com.datastax.driver.core.policies=off
 org.slf4j.simpleLogger.log.com.datastax.driver.core.ControlConnection=error

--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -20,7 +20,7 @@ Depending on details desired, the underlying driver's category
 "com.datastax.driver.core" at debug level may help.
 
 If you just want to see queries and latency, set the category
-"com.datastax.driver.core.QueryLogger" to debug or trace. Trace level
+"com.datastax.driver.core.QueryLogger.NORMAL" to debug or trace. Trace level
 includes bound values.
 
 See [Logging Query Latencies](http://docs.datastax.com/en/developer/java-driver/3.0/supplemental/manual/logging/#logging-query-latencies) for more details.

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectServiceNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectServiceNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,11 +13,9 @@
  */
 package zipkin2.storage.cassandra;
 
-import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
 import java.util.List;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
@@ -28,28 +26,24 @@ import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_SPANS;
 final class SelectServiceNames extends ResultSetFutureCall<ResultSet> {
   static class Factory {
     final Session session;
-    final PreparedStatement preparedStatement;
-    final DistinctSortedStrings services = new DistinctSortedStrings("service");
 
     Factory(Session session) {
       this.session = session;
-      this.preparedStatement =
-          session.prepare(QueryBuilder.select("service").distinct().from(TABLE_SERVICE_SPANS));
     }
 
     Call<List<String>> create() {
-      return new SelectServiceNames(this).flatMap(services);
+      return new SelectServiceNames(session).flatMap(new DistinctSortedStrings("service"));
     }
   }
 
-  final Factory factory;
+  final Session session;
 
-  SelectServiceNames(Factory factory) {
-    this.factory = factory;
+  SelectServiceNames(Session session) {
+    this.session = session;
   }
 
   @Override protected ResultSetFuture newFuture() {
-    return factory.session.executeAsync(factory.preparedStatement.bind());
+    return session.executeAsync("SELECT DISTINCT service FROM " + TABLE_SERVICE_SPANS);
   }
 
   @Override public ResultSet map(ResultSet input) {
@@ -61,6 +55,6 @@ final class SelectServiceNames extends ResultSetFutureCall<ResultSet> {
   }
 
   @Override public SelectServiceNames clone() {
-    return new SelectServiceNames(factory);
+    return new SelectServiceNames(session);
   }
 }

--- a/zipkin-storage/cassandra/src/test/resources/simplelogger.properties
+++ b/zipkin-storage/cassandra/src/test/resources/simplelogger.properties
@@ -7,7 +7,8 @@ org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS
 
 # Note: this will dump a large amount of data in the logs
 #org.slf4j.simpleLogger.log.zipkin2.storage.cassandra=info
-#org.slf4j.simpleLogger.log.com.datastax.driver.core.QueryLogger=trace
+#org.slf4j.simpleLogger.log.com.datastax.driver.core.QueryLogger.NORMAL=trace
+#org.slf4j.simpleLogger.log.com.datastax.driver.core.Connection=debug
 # don't spam about round-robin or connection delay
 org.slf4j.simpleLogger.log.com.datastax.driver.core.policies=off
 org.slf4j.simpleLogger.log.com.datastax.driver.core.ControlConnection=error


### PR DESCRIPTION
Before, we needlessly prepared service name query, which would have no
parameters. While, this is being followed up below, it is unlikely that
preparing is better than directly executing the statement:
https://groups.google.com/a/lists.datastax.com/forum/#!topic/java-driver-user/d6wLkH3xDLI

More importantly, there is a bug in the cassandra driver >v3.6 which
crashes on `QueryBuilder` statements that have no parameters. This
uses a simple statement for that instead (healthcheck). Moreover, the
log category that shows connection failures is now suggested in our
docs.

See https://github.com/datastax/java-driver/pull/1138 for the NPE