### PR TITLE
Reduces clutter in Zipkin startup logging

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
@@ -49,6 +49,8 @@ public class ZipkinServer {
     new SpringApplicationBuilder(ZipkinServer.class)
       .banner(new ZipkinBanner())
       .initializers(new ZipkinModuleImporter(), new ZipkinActuatorImporter())
+      // Avoids potentially expensive ns lookup and inaccurate startup timing
+      .logStartupInfo(false)
       .properties(
         EnableAutoConfiguration.ENABLED_OVERRIDE_PROPERTY + "=false",
         "spring.config.name=zipkin-server").run(args);

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServer.java
@@ -49,7 +49,7 @@ public class ZipkinServer {
     new SpringApplicationBuilder(ZipkinServer.class)
       .banner(new ZipkinBanner())
       .initializers(new ZipkinModuleImporter(), new ZipkinActuatorImporter())
-      // Avoids potentially expensive ns lookup and inaccurate startup timing
+      // Avoids potentially expensive DNS lookup and inaccurate startup timing
       .logStartupInfo(false)
       .properties(
         EnableAutoConfiguration.ENABLED_OVERRIDE_PROPERTY + "=false",

--- a/zipkin-server/src/main/resources/simplelogger.properties
+++ b/zipkin-server/src/main/resources/simplelogger.properties
@@ -7,6 +7,9 @@ org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS
 org.slf4j.simpleLogger.showShortLogName=true
 
 # this mirrors the logging configuration applied in zipkin-server-shared.yml , logging.level
+# This only includes Armeria as for example Kafka and Cassandra are not in the slim dist
 org.slf4j.simpleLogger.log.com.linecorp.armeria.client.HttpResponseDecoder=OFF
 org.slf4j.simpleLogger.log.com.linecorp.armeria.common.Flags=OFF
 org.slf4j.simpleLogger.log.com.linecorp.armeria.server.docs.DocStringExtractor=OFF
+org.slf4j.simpleLogger.log.com.linecorp.armeria.spring.ArmeriaAutoConfiguration=WARN
+org.slf4j.simpleLogger.log.com.linecorp.armeria.common.util.SystemInfo=WARN

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -253,11 +253,24 @@ logging:
   pattern:
     level: "%clr(%5p) %clr([%X{traceId}/%X{spanId}]){yellow}"
   level:
+    # 'modern compatibility layer' of Guava, and this will be gone in v4
+    com.datastax.driver.core.GuavaCompatibility: 'WARN'
+    # use of native clocks in Cassandra is not insightful
+    com.datastax.driver.core.ClockFactory: 'WARN'
+    # shading will not change now and be gone in v4
+    com.datastax.driver.core.NettyUtil: 'WARN'
+    # "request at Consistency Level LOCAL_ONE but the non-DC aware RoundRobinPolicy is in use"
+    # This will go away in v4 and there's no intention to change prior to that
+    com.datastax.driver.core.policies.RoundRobinPolicy: 'OFF'
     # Silence ResponseTimeoutException in the Armeria framework since we log it anyways in HTTP
     # logging when enabled. https://github.com/line/armeria/issues/2000
     com.linecorp.armeria.client.HttpResponseDecoder: 'OFF'
     com.linecorp.armeria.common.Flags: 'OFF'
     com.linecorp.armeria.server.docs.DocStringExtractor: 'OFF'
+    # Redundant to logging already done in c.l.a.s.Server
+    com.linecorp.armeria.spring.ArmeriaAutoConfiguration: 'WARN'
+    # Hostname logging is not Zipkin's duty
+    com.linecorp.armeria.common.util.SystemInfo: 'WARN'
 #     # investigate /api/v2/dependencies
 #     zipkin2.internal.DependencyLinker: 'DEBUG'
 #     # log cassandra queries (DEBUG is without values)


### PR DESCRIPTION
This reduces redundant or inactionable messages from startup. It also
removes Spring's default which caused a 5s delay for me at startup due
to name lookups.

Here's the result, short and sweet:
```

                  oo
                 oooo
                oooooo
               oooooooo
              oooooooooo
             oooooooooooo
           ooooooo  ooooooo
          oooooo     ooooooo
         oooooo       ooooooo
        oooooo   o  o   oooooo
       oooooo   oo  oo   oooooo
     ooooooo  oooo  oooo  ooooooo
    oooooo   ooooo  ooooo  ooooooo
   oooooo   oooooo  oooooo  ooooooo
  oooooooo      oo  oo      oooooooo
  ooooooooooooo oo  oo ooooooooooooo
      oooooooooooo  oooooooooooo
          oooooooo  oooooooo
              oooo  oooo

     ________ ____  _  _____ _   _
    |__  /_ _|  _ \| |/ /_ _| \ | |
      / / | || |_) | ' / | ||  \| |
     / /_ | ||  __/| . \ | || |\  |
    |____|___|_|   |_|\_\___|_| \_|

:: version 2.21.6-SNAPSHOT :: commit 50c748c ::

2020-08-02 15:48:33.034  INFO 66057 --- [oss-http-*:9411] c.l.a.s.Server                           : Serving HTTP at /0:0:0:0:0:0:0:0:9411 - http://127.0.0.1:9411/
```

Note: this does take away the spring timing which were inaccurate anyway
as they count after the JVM thinks it started. There is no more reminder
of how long things in the console now.