### PR TITLE
Updates Cassandra docker to a newer JRE 1.8

### DIFF
--- a/docker/storage/cassandra/Dockerfile
+++ b/docker/storage/cassandra/Dockerfile
@@ -23,8 +23,8 @@ COPY zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema.cql /zipkin
 COPY docker/storage/cassandra/install.sh /usr/local/bin/install
 
 # Share the same base image to reduce layers used in testing
-FROM openzipkin/jre-full:1.8.0_212
-MAINTAINER OpenZipkin "http://zipkin.io/"
+FROM openzipkin/jre-full:1.8.0_252
+MAINTAINER OpenZipkin "https://zipkin.io/"
 
 ENV CASSANDRA_VERSION=3.11.7 \
     JAVA=/usr/local/java/jre/bin/java \

--- a/docker/storage/cassandra/install.sh
+++ b/docker/storage/cassandra/install.sh
@@ -16,8 +16,8 @@
 
 set -eu
 
-echo "*** Installing Python"
-apk add --update --no-cache python2
+echo "*** Temporarily installing Python and curl"
+apk add --update --no-cache python2 curl
 
 echo "*** Installing Cassandra"
 # DataStax only hosts 3.0 series at the moment

--- a/docker/storage/cassandra/install.sh
+++ b/docker/storage/cassandra/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright 2015-2019 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -16,8 +16,8 @@
 
 set -eu
 
-echo "*** Installing Python and curl"
-apk add --update --no-cache python2 curl
+echo "*** Installing Python"
+apk add --update --no-cache python2
 
 echo "*** Installing Cassandra"
 # DataStax only hosts 3.0 series at the moment

--- a/docker/storage/cassandra/run.sh
+++ b/docker/storage/cassandra/run.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 #
-# Copyright 2015-2019 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Depends on https://github.com/openzipkin/docker-jre-full/pull/19