### PR TITLE
Add the spanId towards the end of the span bar in trace timeline view

### DIFF
--- a/zipkin-lens/src/components/TracePage/TraceSummary.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummary.jsx
@@ -34,7 +34,13 @@ const TraceSummary = React.memo(({ traceSummary }) => {
   const isRootedTrace = hasRootSpan(traceSummary.spans);
   const [rootSpanIndex, setRootSpanIndex] = useState(0);
   const isRerooted = rootSpanIndex !== 0;
-  const [currentSpanIndex, setCurrentSpanIndex] = useState(0);
+
+  
+  // If spanId is present as hash (subresource) make that the spanIndex to load
+  const getSpanIndexOnLoad = window.location.hash !== "" ?
+   findSpanIndex(traceSummary.spans, window.location.hash.substring(1)) : 0;
+
+  const [currentSpanIndex, setCurrentSpanIndex] = useState(getSpanIndexOnLoad);
   const [childrenHiddenSpanIndices, setChildrenHiddenSpanIndices] = useState(
     {},
   );


### PR DESCRIPTION
Taking a stab at adding the span Id on the trace bars. this helps search for a spanId visually on the page without too much work as well.

Couple of call outs
1. Am super new to react so would love to know if the hard coding i have done of 0 and 80% are better replaced by something else
2. I wasnt able to quite understand what isTextLeft was about, flipping the condition to !isTextLeft made even existing span Name data look busted.

![image](https://user-images.githubusercontent.com/66497287/89331883-55e03300-d647-11ea-9496-137a911e471a.png)
