### PR TITLE
Adjusts Docker HEALTHCHECK for Kafka from 2s to 5s timeout

### DIFF
--- a/docker/RATIONALE.md
+++ b/docker/RATIONALE.md
@@ -27,5 +27,5 @@ on network connections themselves for the same reason.
 
 `kafka-topics.sh` uses Java and a relatively large classpath. It can be slow when many other
 processes are starting at the same time. For example, when launching many containers in Docker
-Compose, `kafka-topics.sh` was failed on 2s timeout after succeeding, causing a condition to break
+Compose, `kafka-topics.sh` timed out after 2s even though the prior run succeeded. This broke a condition
 which broke the rest of the automation. A 5s timeout is excessive usually, but avoided this problem.

--- a/docker/RATIONALE.md
+++ b/docker/RATIONALE.md
@@ -15,3 +15,17 @@ Ex. The following command can be used ad-hoc or in scripts without the user know
 $ docker inspect --format='{{json .State.Health.Status}}' kafka-zookeeper
 "unhealthy"
 ```
+
+### Why default timeout to 5s for Kafka HEALTHCHECK?
+
+Docker `HEALTHCHECK` marks a container unhealthy on the first failure that occurs past its start
+period. It is important to avoid false negatives that are host contention in nature, as they can
+break orchestration such as docker-compose.
+
+Commands like `nc` will almost never timeout launching due to contention, even if they might timeout
+on network connections themselves for the same reason.
+
+`kafka-topics.sh` uses Java and a relatively large classpath. It can be slow when many other
+processes are starting at the same time. For example, when launching many containers in Docker
+Compose, `kafka-topics.sh` was failed on 2s timeout after succeeding, causing a condition to break
+which broke the rest of the automation. A 5s timeout is excessive usually, but avoided this problem.

--- a/docker/collector/kafka/Dockerfile
+++ b/docker/collector/kafka/Dockerfile
@@ -40,7 +40,11 @@ USER kafka
 EXPOSE 2181 9092 19092
 
 # We use start period of 10s to avoid marking Kafka unhealthy on slow or contended CI hosts
-HEALTHCHECK --interval=1s --start-period=10s --timeout=2s \
+#
+# We use a timeout of 5s as kafka-topics.sh invokes a Java command which can be slow when
+# multiple processes are starting up (ex docker-compose with >10 containers). A smaller timeout
+# flips the service unhealthy and can interfere with docker-compose v2 condition: service_healthy
+HEALTHCHECK --interval=2s --start-period=10s --timeout=5s \
   # We use bootstrap-server, not zookeeper, as KIP-500 will eventually remove the dependency
   CMD /kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list > /dev/null || exit 1
 


### PR DESCRIPTION
This helps avoid annoying flakes, or having people need to override our
defaults.