### PR TITLE
Update Kafka to 2.6 which formally supports JRE 14

### DIFF
--- a/docker/collector/kafka/Dockerfile
+++ b/docker/collector/kafka/Dockerfile
@@ -14,12 +14,12 @@
 
 FROM alpine:3.12
 
-ENV SCALA_VERSION 2.12
-ENV KAFKA_VERSION 2.5.0
+ENV SCALA_VERSION 2.13
+ENV KAFKA_VERSION 2.6.0
 
 WORKDIR /kafka
 ADD docker/collector/kafka/install.sh /kafka/install
-RUN /kafka/install
+RUN /kafka/install && rm /kafka/install
 
 ADD docker/collector/kafka/wait-for-zookeeper.sh /kafka/bin
 ADD docker/collector/kafka/start.sh /kafka/bin

--- a/docker/collector/kafka/install.sh
+++ b/docker/collector/kafka/install.sh
@@ -41,4 +41,10 @@ EOF
 
 mkdir /kafka/logs
 
+echo "*** Cleaning Up"
+apk del jq curl --purge
+# TODO: eventually cleanup irrelevant binaries from RocksDB
+# https://issues.apache.org/jira/browse/KAFKA-10380
+rm -rf kafka_$SCALA_VERSION-$KAFKA_VERSION site-docs bin/windows
+
 echo "*** Image build complete"

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -29,11 +29,10 @@
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- when changing this, a change to the version of kafka-junit is likely needed, too -->
-    <!-- TODO: update to 2.6.0 once https://github.com/charithe/kafka-junit/issues/54 is complete -->
-    <kafka.version>2.5.0</kafka.version>
+    <kafka.version>2.6.0</kafka.version>
     <!-- This version is tightly coupled to the version of kafka-clients being used.
      https://github.com/charithe/kafka-junit -->
-    <kafka-junit.version>4.1.9</kafka-junit.version>
+    <kafka-junit.version>4.1.10</kafka-junit.version>
   </properties>
 
   <dependencies>

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- when changing this, a change to the version of kafka-junit is likely needed, too -->
+    <!-- TODO: update to 2.6.0 once https://github.com/charithe/kafka-junit/issues/54 is complete -->
     <kafka.version>2.5.0</kafka.version>
     <!-- This version is tightly coupled to the version of kafka-clients being used.
      https://github.com/charithe/kafka-junit -->


### PR DESCRIPTION
While we haven't had any problems, it is nice to use the version that
formally supports JRE 14 as that's our base image.

I cleaned up a bit to keep the overall image the same as before.

See https://downloads.apache.org/kafka/2.6.0/RELEASE_NOTES.html