### PR TITLE
Uses prepared statements for all Cassandra Queries

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -31,7 +31,7 @@
     <main.basedir>${project.basedir}/..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
-    <jmh.version>1.23</jmh.version>
+    <jmh.version>1.25</jmh.version>
     <unpack-proto.directory>${project.build.directory}/main/proto</unpack-proto.directory>
   </properties>
 
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.12.4</version>
+      <version>3.13.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <wire.version>3.0.2</wire.version>
     <unpack-proto.directory>${project.build.directory}/test/proto</unpack-proto.directory>
 
-    <cassandra-driver-core.version>3.10.0</cassandra-driver-core.version>
+    <cassandra-driver-core.version>3.10.1</cassandra-driver-core.version>
     <jooq.version>3.13.4</jooq.version>
     <micrometer.version>1.5.4</micrometer.version>
     <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
@@ -70,7 +70,6 @@
          MariaDB has a friendlier license, LGPL, which is less scary in audits.
     -->
     <mariadb-java-client.version>2.6.2</mariadb-java-client.version>
-    <!-- Java 8 dep, which is ok as zipkin-mysql is Java 8 anyway -->
     <HikariCP.version>3.4.5</HikariCP.version>
     <slf4j.version>1.7.30</slf4j.version>
 
@@ -82,7 +81,7 @@
     <awaitility.version>4.0.3</awaitility.version>
     <hamcrest.version>1.3</hamcrest.version>
     <testcontainers.version>1.14.3</testcontainers.version>
-    <okhttp.version>4.8.0</okhttp.version>
+    <okhttp.version>4.8.1</okhttp.version>
 
     <auto-value.version>1.7.4</auto-value.version>
     <animal-sniffer-maven-plugin.version>1.19</animal-sniffer-maven-plugin.version>
@@ -100,7 +99,7 @@
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.0.rc1</license-maven-plugin.version>
-    <git-commit-id.version>4.0.1</git-commit-id.version>
+    <git-commit-id.version>4.0.2</git-commit-id.version>
   </properties>
 
   <name>Zipkin (Parent)</name>
@@ -259,7 +258,7 @@
       <dependency>
         <groupId>com.esotericsoftware</groupId>
         <artifactId>kryo</artifactId>
-        <version>5.0.0-RC7</version>
+        <version>5.0.0-RC9</version>
       </dependency>
 
       <!-- Internal classes used in SpanBytesDecoder.JSON_V[12] -->

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
@@ -383,11 +383,7 @@ public class CassandraStorage extends StorageComponent { // not final for mockin
   public CheckResult check() {
     if (closeCalled) throw new IllegalStateException("closed");
     try {
-      // Use direct CQL instead of query builder for simple statements.
-      // BuiltStatement has a NPE bug when there are no input parameters.
-      //
-      // https://github.com/datastax/java-driver/pull/1138
-      session().execute("select trace_id from traces limit 1");
+      session.healthCheck();
     } catch (Throwable e) {
       Call.propagateIfFatal(e);
       return CheckResult.failed(e);

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTrace.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/InsertTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,6 +27,8 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 import zipkin2.v1.V1Span;
 
+import static zipkin2.storage.cassandra.v1.Tables.TRACES;
+
 final class InsertTrace extends ResultSetFutureCall<Void> {
   private static final Logger LOG = LoggerFactory.getLogger(InsertTrace.class);
 
@@ -51,7 +53,7 @@ final class InsertTrace extends ResultSetFutureCall<Void> {
       this.session = session;
       this.timestampCodec = new TimestampCodec(session);
       Insert insertQuery =
-          QueryBuilder.insertInto("traces")
+          QueryBuilder.insertInto(TRACES)
               .value("trace_id", QueryBuilder.bindMarker("trace_id"))
               .value("ts", QueryBuilder.bindMarker("ts"))
               .value("span_name", QueryBuilder.bindMarker("span_name"))
@@ -77,10 +79,10 @@ final class InsertTrace extends ResultSetFutureCall<Void> {
         LOG.warn(
             "Span {} in trace {} had no timestamp. "
                 + "If this happens a lot consider switching back to SizeTieredCompactionStrategy for "
-                + "{}.traces",
+                + "{}.{}",
             span_name,
             v1.traceId(),
-            session.getLoggedKeyspace());
+            session.getLoggedKeyspace(), TRACES);
       }
 
       return new AutoValue_InsertTrace_Input(v1.traceId(), ts_micro, span_name, v1Bytes);

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Schema.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import static zipkin2.storage.cassandra.internal.Resources.resourceToString;
 import static zipkin2.storage.cassandra.v1.Tables.AUTOCOMPLETE_TAGS;
 import static zipkin2.storage.cassandra.v1.Tables.REMOTE_SERVICE_NAMES;
+import static zipkin2.storage.cassandra.v1.Tables.TRACES;
 
 final class Schema {
   private static final Logger LOG = LoggerFactory.getLogger(Schema.class);
@@ -45,7 +46,7 @@ final class Schema {
       LOG.warn("running with RF=1, this is not suitable for production. Optimal is 3+");
     }
     String compactionClass =
-      keyspaceMetadata.getTable("traces").getOptions().getCompaction().get("class");
+      keyspaceMetadata.getTable(TRACES).getOptions().getCompaction().get("class");
     boolean hasDefaultTtl = hasUpgrade1_defaultTtl(keyspaceMetadata);
     if (!hasDefaultTtl) {
       LOG.warn(
@@ -104,7 +105,7 @@ final class Schema {
 
   static void ensureExists(String keyspace, Session session) {
     KeyspaceMetadata keyspaceMetadata = session.getCluster().getMetadata().getKeyspace(keyspace);
-    if (keyspaceMetadata == null || keyspaceMetadata.getTable("traces") == null) {
+    if (keyspaceMetadata == null || keyspaceMetadata.getTable(TRACES) == null) {
       LOG.info("Installing schema {}", SCHEMA);
       applyCqlFile(keyspace, session, SCHEMA);
       // refresh metadata since we've installed the schema
@@ -128,7 +129,7 @@ final class Schema {
     // TODO: we need some approach to forward-check compatibility as well.
     //  backward: this code knows the current schema is too old.
     //  forward:  this code knows the current schema is too new.
-    return keyspaceMetadata.getTable("traces").getOptions().getDefaultTimeToLive() > 0;
+    return keyspaceMetadata.getTable(TRACES).getOptions().getDefaultTimeToLive() > 0;
   }
 
   static boolean hasUpgrade2_autocompleteTags(KeyspaceMetadata keyspaceMetadata) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectFromTraces.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectFromTraces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -42,6 +42,8 @@ import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 import zipkin2.v1.V1Span;
 import zipkin2.v1.V1SpanConverter;
 
+import static zipkin2.storage.cassandra.v1.Tables.TRACES;
+
 final class SelectFromTraces extends ResultSetFutureCall<ResultSet> {
 
   static class Factory {
@@ -59,7 +61,7 @@ final class SelectFromTraces extends ResultSetFutureCall<ResultSet> {
       this.preparedStatement =
         session.prepare(
           QueryBuilder.select("trace_id", "span")
-            .from("traces")
+            .from(TRACES)
             .where(QueryBuilder.in("trace_id", QueryBuilder.bindMarker("trace_id")))
             .limit(QueryBuilder.bindMarker("limit_")));
       this.maxTraceCols = maxTraceCols;

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Tables.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/Tables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,11 +14,17 @@
 package zipkin2.storage.cassandra.v1;
 
 import zipkin2.Span;
+import zipkin2.internal.V1ThriftSpanWriter;
 import zipkin2.storage.AutocompleteTags;
 import zipkin2.storage.QueryRequest;
 import zipkin2.storage.ServiceAndSpanNames;
 
 final class Tables {
+  /**
+   * This table includes {@linkplain V1ThriftSpanWriter thrift-encoded} spans, supporting
+   * {@link SelectFromTraces}.
+   */
+  static final String TRACES = "traces";
 
   /**
    * This index supports {@link ServiceAndSpanNames#getServiceNames()}}.

--- a/zipkin-storage/cassandra/RATIONALE.md
+++ b/zipkin-storage/cassandra/RATIONALE.md
@@ -1,0 +1,15 @@
+# zipkin-storage-cassandra rationale
+
+## Why do we use prepared statements?
+
+We use prepared statements (instead of simple statements) for anything executed more than once.
+This reduces load on the server, as the CQL query does not have to parsed server-side again and
+again.
+
+This applies even for health checks and querying for service names, which have only constant
+parameters and do not select partition keys.
+
+When partition keys are in use, ex `SELECT * FROM span WHERE trace_id = ?`, prepared statements
+offer a second advantage in that you get automatic token-aware routing.
+
+The above was distilled from https://groups.google.com/a/lists.datastax.com/d/msg/java-driver-user/d6wLkH3xDLI/jUWOokKVAgAJ

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertAutocompleteValue.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertAutocompleteValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import java.util.Map;
+import java.util.Map.Entry;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DeduplicatingVoidCallFactory;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
@@ -27,8 +27,7 @@ import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 import static zipkin2.storage.cassandra.Schema.TABLE_AUTOCOMPLETE_TAGS;
 
 final class InsertAutocompleteValue extends ResultSetFutureCall<Void> {
-
-  static class Factory extends DeduplicatingVoidCallFactory<Map.Entry<String, String>> {
+  static class Factory extends DeduplicatingVoidCallFactory<Entry<String, String>> {
     final Session session;
     final PreparedStatement preparedStatement;
 
@@ -41,15 +40,15 @@ final class InsertAutocompleteValue extends ResultSetFutureCall<Void> {
       preparedStatement = session.prepare(insertQuery);
     }
 
-    @Override protected Call<Void> newCall(Map.Entry<String, String> input) {
+    @Override protected Call<Void> newCall(Entry<String, String> input) {
       return new InsertAutocompleteValue(this, input);
     }
   }
 
   final Factory factory;
-  final Map.Entry<String, String> input;
+  final Entry<String, String> input;
 
-  InsertAutocompleteValue(Factory factory, Map.Entry<String, String> input) {
+  InsertAutocompleteValue(Factory factory, Entry<String, String> input) {
     this.factory = factory;
     this.input = input;
   }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertServiceSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,29 +19,14 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.google.auto.value.AutoValue;
+import java.util.Map.Entry;
 import zipkin2.storage.cassandra.internal.call.DeduplicatingVoidCallFactory;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
 import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_SPANS;
 
 final class InsertServiceSpan extends ResultSetFutureCall<Void> {
-
-  @AutoValue
-  abstract static class Input {
-    static Input create(String service, String span) {
-      return new AutoValue_InsertServiceSpan_Input(service, span);
-    }
-
-    abstract String service();
-
-    abstract String span();
-
-    Input() {
-    }
-  }
-
-  static class Factory extends DeduplicatingVoidCallFactory<Input> {
+  static class Factory extends DeduplicatingVoidCallFactory<Entry<String, String>> {
     final Session session;
     final PreparedStatement preparedStatement;
 
@@ -54,27 +39,23 @@ final class InsertServiceSpan extends ResultSetFutureCall<Void> {
       preparedStatement = session.prepare(insertQuery);
     }
 
-    Input newInput(String service, String span) {
-      return Input.create(service, span);
-    }
-
-    @Override protected InsertServiceSpan newCall(Input input) {
+    @Override protected InsertServiceSpan newCall(Entry<String, String> input) {
       return new InsertServiceSpan(this, input);
     }
   }
 
   final Factory factory;
-  final Input input;
+  final Entry<String, String> input;
 
-  InsertServiceSpan(Factory factory, Input input) {
+  InsertServiceSpan(Factory factory, Entry<String, String> input) {
     this.factory = factory;
     this.input = input;
   }
 
   @Override protected ResultSetFuture newFuture() {
     return factory.session.executeAsync(factory.preparedStatement.bind()
-      .setString("service", input.service())
-      .setString("span", input.span()));
+      .setString("service", input.getKey())
+      .setString("span", input.getValue()));
   }
 
   @Override public Void map(ResultSet input) {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
@@ -104,8 +104,8 @@ public class CassandraSpanConsumerTest {
 
     assertEnclosedCalls(call)
       .filteredOn(c -> c instanceof DeduplicatingVoidCallFactory.InvalidatingVoidCall)
-      .extracting("input.service", "input.span")
-      .containsExactly(tuple(FRONTEND.serviceName(), span.name()));
+      .extracting("input")
+      .containsExactly(entry(FRONTEND.serviceName(), span.name()));
   }
 
   @Test

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,6 +26,7 @@ import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.util.introspection.PropertyOrFieldSupport.EXTRACTION;
 import static org.mockito.Mockito.mock;
@@ -117,8 +118,8 @@ public class CassandraSpanConsumerTest {
       .filteredOn(c -> c instanceof DeduplicatingVoidCallFactory.InvalidatingVoidCall)
       .extracting("input")
       .containsExactly(
-        InsertServiceSpan.Input.create(FRONTEND.serviceName(), span.name()),
-        InsertServiceRemoteService.Input.create(FRONTEND.serviceName(), BACKEND.serviceName())
+        entry(FRONTEND.serviceName(), span.name()),
+        entry(FRONTEND.serviceName(), BACKEND.serviceName())
       );
   }
 


### PR DESCRIPTION
In #3156, we stopped using prepared statements for simple queries for
reasons including a bug in logging, which is now fixed. This restores
use of prepared statements for all Cassandra queries and backfills
rationale of why this helps.