### PR TITLE
Moves tests that read back prometheus metrics to ITZipkinMetricsDirty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
 
     <cassandra-driver-core.version>3.10.0</cassandra-driver-core.version>
     <jooq.version>3.13.4</jooq.version>
-    <micrometer.version>1.5.3</micrometer.version>
-    <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
+    <micrometer.version>1.5.4</micrometer.version>
+    <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
 


### PR DESCRIPTION
Before, we moved most tests that read back metrics to `ITZipkinMetricsDirty`,
but "we missed a spot" and in doing so it causes flakes in Travis at the
moment on random change. This moves the last over and strengthens the
comments.