### PR TITLE
Replace kafka-junit with testcontainer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
-    <license-maven-plugin.version>4.0.rc1</license-maven-plugin.version>
+    <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
     <git-commit-id.version>4.0.2</git-commit-id.version>
   </properties>
 

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -50,10 +50,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -28,11 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <!-- when changing this, a change to the version of kafka-junit is likely needed, too -->
-    <kafka.version>2.6.0</kafka.version>
-    <!-- This version is tightly coupled to the version of kafka-clients being used.
-     https://github.com/charithe/kafka-junit -->
-    <kafka-junit.version>4.1.10</kafka-junit.version>
+    <kafka.version>2.5.0</kafka.version>
   </properties>
 
   <dependencies>
@@ -49,16 +45,13 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.charithe</groupId>
-      <artifactId>kafka-junit</artifactId>
-      <version>${kafka-junit.version}</version>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>log4j-over-slf4j</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <kafka.version>2.5.0</kafka.version>
+    <kafka.version>2.6.0</kafka.version>
   </properties>
 
   <dependencies>

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaCollectorRule.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaCollectorRule.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ExecutionException;
 /** This should be used as a {@link ClassRule} as it takes a very long time to start-up. */
 class KafkaCollectorRule extends ExternalResource {
   static final Logger LOGGER = LoggerFactory.getLogger(KafkaCollectorRule.class);
-  static final String IMAGE = "openzipkin/zipkin-kafka:latest";
+  static final String IMAGE = "openzipkin/zipkin-kafka:2.21.5";
   static final int KAFKA_PORT = 19092;
   static final String KAFKA_BOOTSTRAP_SERVERS = "localhost:" + KAFKA_PORT;
   static final String KAFKA_TOPIC = "zipkin";

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaCollectorRule.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaCollectorRule.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.collector.kafka;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.AssumptionViolatedException;
+import org.junit.ClassRule;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+/** This should be used as a {@link ClassRule} as it takes a very long time to start-up. */
+class KafkaCollectorRule extends ExternalResource {
+  static final Logger LOGGER = LoggerFactory.getLogger(KafkaCollectorRule.class);
+  static final String IMAGE = "openzipkin/zipkin-kafka";
+  static final int KAFKA_PORT = 19092;
+  static final String KAFKA_BOOTSTRAP_SERVERS = "localhost:" + KAFKA_PORT;
+  static final String KAFKA_TOPIC = "zipkin";
+
+  static final class KafkaContainer extends FixedHostPortGenericContainer<KafkaContainer> {
+    KafkaContainer(String image) {
+      super(image);
+      withFixedExposedPort(KAFKA_PORT, KAFKA_PORT);
+      this.waitStrategy =
+        new LogMessageWaitStrategy().withRegEx(".*INFO \\[KafkaServer id=0\\] started.*");
+    }
+  }
+
+  KafkaContainer container;
+
+  @Override protected void before() {
+    if ("true".equals(System.getProperty("docker.skip"))) {
+      throw new AssumptionViolatedException("Skipping startup of docker " + IMAGE);
+    }
+
+    try {
+      LOGGER.info("Starting docker image " + IMAGE);
+      container = new KafkaContainer(IMAGE);
+      container.start();
+    } catch (Throwable e) {
+      throw new AssumptionViolatedException(
+          "Couldn't start docker image " + IMAGE + ": " + e.getMessage(), e);
+    }
+
+    prepareTopic(KAFKA_TOPIC, 1);
+  }
+
+  void prepareTopic(final String topic, final int partitions) {
+    final Properties config = new Properties();
+    config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_BOOTSTRAP_SERVERS);
+    AdminClient adminClient = AdminClient.create(config);
+    try {
+      adminClient.createTopics(
+        Collections.singletonList(new NewTopic(topic, partitions, (short) 1))
+      ).all().get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new AssumptionViolatedException(
+        "Topic cannot be created " + topic + ": " + e.getMessage(), e);
+    }
+  }
+
+
+  KafkaCollector.Builder newCollectorBuilder() {
+    return KafkaCollector.builder().bootstrapServers(KAFKA_BOOTSTRAP_SERVERS);
+  }
+
+  @Override protected void after() {
+    if (container != null) {
+      LOGGER.info("Stopping docker container " + container);
+      container.stop();
+    }
+  }
+}

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaCollectorRule.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaCollectorRule.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ExecutionException;
 /** This should be used as a {@link ClassRule} as it takes a very long time to start-up. */
 class KafkaCollectorRule extends ExternalResource {
   static final Logger LOGGER = LoggerFactory.getLogger(KafkaCollectorRule.class);
-  static final String IMAGE = "openzipkin/zipkin-kafka";
+  static final String IMAGE = "openzipkin/zipkin-kafka:latest";
   static final int KAFKA_PORT = 19092;
   static final String KAFKA_BOOTSTRAP_SERVERS = "localhost:" + KAFKA_PORT;
   static final String KAFKA_TOPIC = "zipkin";


### PR DESCRIPTION
Similar to rabbitmq integration test, this replaces usage of kafka-junit.