### PR TITLE
Preventing Criterion from flickering

### DIFF
--- a/zipkin-lens/src/components/DiscoverPage/SearchBar/CriterionBox.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/SearchBar/CriterionBox.tsx
@@ -20,6 +20,7 @@ import { Box, ClickAwayListener } from '@material-ui/core';
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -148,7 +149,7 @@ const CriterionBox: React.FC<CriterionBoxProps> = ({
   });
 
   const prevIsFocused = useRef(isFocused);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (prevIsFocused.current && !isFocused) {
       if (!fixedText) {
         onDelete(criterionIndex);


### PR DESCRIPTION
If you look carefully, sometimes criterion flicker.
This PR fix it.
Simply put, I adjusted the timing of the rendering so that no extra drawing occurs.