### PR TITLE
Set default spanIndex based on spanId specified in URL hash

### DIFF
--- a/zipkin-lens/src/components/TracePage/TraceSummary.jsx
+++ b/zipkin-lens/src/components/TracePage/TraceSummary.jsx
@@ -34,7 +34,14 @@ const TraceSummary = React.memo(({ traceSummary }) => {
   const isRootedTrace = hasRootSpan(traceSummary.spans);
   const [rootSpanIndex, setRootSpanIndex] = useState(0);
   const isRerooted = rootSpanIndex !== 0;
-  const [currentSpanIndex, setCurrentSpanIndex] = useState(0);
+
+  // If spanId is present as hash (subresource) make that the currentSpanIndex to load
+  const getSpanIndexOnLoad =
+    window.location.hash !== ''
+      ? findSpanIndex(traceSummary.spans, window.location.hash.substring(1))
+      : 0;
+
+  const [currentSpanIndex, setCurrentSpanIndex] = useState(getSpanIndexOnLoad);
   const [childrenHiddenSpanIndices, setChildrenHiddenSpanIndices] = useState(
     {},
   );


### PR DESCRIPTION
Set default spanIndex based on spanId specified in URL hash, this should scroll to the span, open up the span and highlight it

Need some guidance on how to make it scroll. the change currently works to highlight and open the details of the appropriate span @jorgheymans 