### PR TITLE
Composable index templates for ES 7.8

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -291,6 +291,8 @@ The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
                          Options are BASIC, HEADERS, BODY
     * `ES_SSL_NO_VERIFY`: When true, disables the verification of server's key certificate chain.
                           This is not appropriate for production. Defaults to false.
+    * `ES_TEMPLATE_PRIORITY`: The priority value of the composable index templates. This is only applicable
+                              for ES version 7.8 or above. Must be set, even to 0, to use composable template
 
 Example usage:
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -50,6 +50,7 @@ import zipkin2.elasticsearch.ElasticsearchStorage.LazyHttpClient;
  *     enabled: true
  *     http-logging: HEADERS
  *     interval: 3s
+ *   template-priority: 0
  * }</pre>
  */
 @ConfigurationProperties("zipkin.storage.elasticsearch")
@@ -212,6 +213,8 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
 
   private HealthCheck healthCheck = new HealthCheck();
 
+  private Integer templatePriority;
+
   public String getPipeline() {
     return pipeline;
   }
@@ -346,6 +349,10 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
     this.ssl = ssl;
   }
 
+  public Integer getTemplatePriority() { return templatePriority; }
+
+  public void setTemplatePriority(Integer templatePriority) { this.templatePriority = templatePriority; }
+
   public ElasticsearchStorage.Builder toBuilder(LazyHttpClient httpClient) {
     ElasticsearchStorage.Builder builder = ElasticsearchStorage.newBuilder(httpClient);
     if (index != null) builder.index(index);
@@ -360,6 +367,7 @@ class ZipkinElasticsearchStorageProperties implements Serializable { // for Spar
     if (maxRequests != null) {
       log.warning("ES_MAX_REQUESTS is no longer honored. Use STORAGE_THROTTLE_ENABLED instead");
     }
+    if (templatePriority != null) builder.templatePriority(templatePriority);
     return builder;
   }
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -164,6 +164,7 @@ zipkin:
       health-check:
         enabled: ${ES_HEALTH_CHECK_ENABLED:true}
         interval: ${ES_HEALTH_CHECK_INTERVAL:3s}
+      template-priority: ${ES_TEMPLATE_PRIORITY:}
     mysql:
       jdbc-url: ${MYSQL_JDBC_URL:}
       host: ${MYSQL_HOST:localhost}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -405,6 +406,42 @@ public class ZipkinElasticsearchStorageConfigurationTest {
 
     assertThat(es()).extracting("autocompleteCardinality")
       .isEqualTo(5000);
+  }
+
+  @Test public void templatePriority_valid() {
+    TestPropertyValues.of(
+      "zipkin.storage.type:elasticsearch",
+      "zipkin.storage.elasticsearch.template-priority:0")
+      .applyTo(context);
+    Access.registerElasticsearch(context);
+    context.refresh();
+
+    assertThat(es()).extracting("templatePriority")
+      .isEqualTo(0);
+  }
+
+  @Test public void templatePriority_null() {
+    TestPropertyValues.of(
+      "zipkin.storage.type:elasticsearch",
+      "zipkin.storage.elasticsearch.template-priority:")
+      .applyTo(context);
+    Access.registerElasticsearch(context);
+    context.refresh();
+
+    assertThat(es()).extracting("templatePriority")
+      .isNull();
+  }
+
+  @Test(expected = UnsatisfiedDependencyException.class)
+  public void templatePriority_Invalid() {
+    TestPropertyValues.of(
+      "zipkin.storage.type:elasticsearch",
+      "zipkin.storage.elasticsearch.template-priority:string")
+      .applyTo(context);
+    Access.registerElasticsearch(context);
+    context.refresh();
+
+    es();
   }
 
   ElasticsearchStorage es() {

--- a/zipkin-storage/elasticsearch/README.md
+++ b/zipkin-storage/elasticsearch/README.md
@@ -120,6 +120,17 @@ be written, nor analyzed.
 
 [Disabling search](../../README.md#disabling-search) disables indexing.
 
+### Composable Index Template
+Elasticsearch 7.8 introduces [composable templates](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html) and
+deprecates [legacy/v1 templates](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html) used in version prior.
+Merging of multiple templates with matching index patterns is no longer allowed, and Elasticsearch will return error on PUT of the second template
+with matching index pattern and priority. Templates with matching index patterns are required to have different priorities, and Elasticsearch will
+only use the template with the highest priority. This also means that [secondary template](https://gist.github.com/adriancole/1af1259102e7a2da1b3c9103565165d7)
+is no longer achievable.
+
+By default, Zipkin will use legacy template during initialization, but you can opt to use composable template by
+providing `ES_TEMPLATE_PRIORITY` environment variable.
+
 ## Customizing the ingest pipeline
 
 You can setup an [ingest pipeline](https://www.elastic.co/guide/en/elasticsearch/reference/master/pipeline.html) to perform custom processing.

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchStorageTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchStorageTest.java
@@ -199,6 +199,108 @@ class ElasticsearchStorageTest {
       String.format("ElasticsearchStorage{initialEndpoints=%s, index=zipkin}", server.httpUri()));
   }
 
+  /**
+   * Ensure that Zipkin uses the legacy resource path when priority is not set
+   */
+  @Test void check_create_legacy_indexTemplate_resourcePath_version78() throws Exception {
+    server.enqueue(AggregatedHttpResponse.of(
+      HttpStatus.OK, MediaType.JSON_UTF_8, "{\"version\":{\"number\":\"7.8.0\"}}"));
+    server.enqueue(SUCCESS_RESPONSE); // get span template
+    server.enqueue(SUCCESS_RESPONSE); // get dependency template
+    server.enqueue(SUCCESS_RESPONSE); // get autocomplete template
+    server.enqueue(SUCCESS_RESPONSE); // cluster health
+
+    storage.check();
+
+    server.takeRequest(); // get version
+
+    assertThat(server.takeRequest().request().path()) // get span template
+      .startsWith("/_template/zipkin-span_template");
+    assertThat(server.takeRequest().request().path()) // // get dependency template
+      .startsWith("/_template/zipkin-dependency_template");
+    assertThat(server.takeRequest().request().path()) // get autocomplete template
+      .startsWith("/_template/zipkin-autocomplete_template");
+  }
+
+  /**
+   * Ensure that Zipkin uses the correct resource path of /_index_template when creating index
+   * template for ES 7.8 when priority is set, as opposed to ES < 7.8 that uses /_template/
+   */
+  @Test void check_create_composable_indexTemplate_resourcePath_version78() throws Exception {
+    // Set up a new storage with priority
+    storage.close();
+    storage = newBuilder().templatePriority(0).build();
+
+    server.enqueue(AggregatedHttpResponse.of(
+      HttpStatus.OK, MediaType.JSON_UTF_8, "{\"version\":{\"number\":\"7.8.0\"}}"));
+    server.enqueue(SUCCESS_RESPONSE); // get span template
+    server.enqueue(SUCCESS_RESPONSE); // get dependency template
+    server.enqueue(SUCCESS_RESPONSE); // get autocomplete template
+    server.enqueue(SUCCESS_RESPONSE); // cluster health
+
+    storage.check();
+
+    server.takeRequest(); // get version
+
+    assertThat(server.takeRequest().request().path()) // get span template
+      .startsWith("/_index_template/zipkin-span_template");
+    assertThat(server.takeRequest().request().path()) // // get dependency template
+      .startsWith("/_index_template/zipkin-dependency_template");
+    assertThat(server.takeRequest().request().path()) // get autocomplete template
+      .startsWith("/_index_template/zipkin-autocomplete_template");
+  }
+
+  /**
+   * Ensure that Zipkin uses the legacy resource path when priority is not set
+   */
+  @Test void check_create_legacy_indexTemplate_resourcePath_version79() throws Exception {
+    server.enqueue(AggregatedHttpResponse.of(
+      HttpStatus.OK, MediaType.JSON_UTF_8, "{\"version\":{\"number\":\"7.9.0\"}}"));
+    server.enqueue(SUCCESS_RESPONSE); // get span template
+    server.enqueue(SUCCESS_RESPONSE); // get dependency template
+    server.enqueue(SUCCESS_RESPONSE); // get autocomplete template
+    server.enqueue(SUCCESS_RESPONSE); // cluster health
+
+    storage.check();
+
+    server.takeRequest(); // get version
+
+    assertThat(server.takeRequest().request().path()) // get span template
+      .startsWith("/_template/zipkin-span_template");
+    assertThat(server.takeRequest().request().path()) // // get dependency template
+      .startsWith("/_template/zipkin-dependency_template");
+    assertThat(server.takeRequest().request().path()) // get autocomplete template
+      .startsWith("/_template/zipkin-autocomplete_template");
+  }
+
+  /**
+   * Ensure that Zipkin uses the correct resource path of /_index_template when creating index
+   * template for ES 7.9 when priority is set, as opposed to ES < 7.8 that uses /_template/
+   */
+  @Test void check_create_composable_indexTemplate_resourcePath_version79() throws Exception {
+    // Set up a new storage with priority
+    storage.close();
+    storage = newBuilder().templatePriority(0).build();
+
+    server.enqueue(AggregatedHttpResponse.of(
+      HttpStatus.OK, MediaType.JSON_UTF_8, "{\"version\":{\"number\":\"7.9.0\"}}"));
+    server.enqueue(SUCCESS_RESPONSE); // get span template
+    server.enqueue(SUCCESS_RESPONSE); // get dependency template
+    server.enqueue(SUCCESS_RESPONSE); // get autocomplete template
+    server.enqueue(SUCCESS_RESPONSE); // cluster health
+
+    storage.check();
+
+    server.takeRequest(); // get version
+
+    assertThat(server.takeRequest().request().path()) // get span template
+      .startsWith("/_index_template/zipkin-span_template");
+    assertThat(server.takeRequest().request().path()) // // get dependency template
+      .startsWith("/_index_template/zipkin-dependency_template");
+    assertThat(server.takeRequest().request().path()) // get autocomplete template
+      .startsWith("/_index_template/zipkin-autocomplete_template");
+  }
+
   ElasticsearchStorage.Builder newBuilder() {
     return ElasticsearchStorage.newBuilder(new LazyHttpClient() {
       @Override public WebClient get() {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
@@ -107,6 +107,84 @@ class VersionSpecificTemplatesTest {
       + "  }");
   }
 
+  @Test void version78_legacy() {
+    IndexTemplates template = storage.versionSpecificTemplates(7.8f);
+
+    assertThat(template.version()).isEqualTo(7.8f);
+    assertThat(template.autocomplete())
+      .withFailMessage("Starting at v7.x, we delimit index and type with hyphen")
+      .contains("\"index_patterns\": \"zipkin-autocomplete-*\"");
+    assertThat(template.span())
+      .doesNotContain("\"template\": {\n")
+      .doesNotContain("\"priority\": 0\n");
+    assertThat(template.autocomplete())
+      .doesNotContain("\"template\": {\n")
+      .doesNotContain("\"priority\": 0\n");
+    assertThat(template.dependency())
+      .doesNotContain("\"template\": {\n")
+      .doesNotContain("\"priority\": 0\n");
+  }
+
+  @Test void version78_composable() {
+    // Set up a new storage with priority
+    storage.close();
+    storage = ElasticsearchStorage.newBuilder(() -> mock(WebClient.class)).templatePriority(0).build();
+    IndexTemplates template = storage.versionSpecificTemplates(7.8f);
+
+    assertThat(template.version()).isEqualTo(7.8f);
+    assertThat(template.autocomplete())
+      .withFailMessage("Starting at v7.x, we delimit index and type with hyphen")
+      .contains("\"index_patterns\": \"zipkin-autocomplete-*\"");
+    assertThat(template.span())
+      .contains("\"template\": {\n")
+      .contains("\"priority\": 0\n");
+    assertThat(template.autocomplete())
+      .contains("\"template\": {\n")
+      .contains("\"priority\": 0\n");
+    assertThat(template.dependency())
+      .contains("\"template\": {\n")
+      .contains("\"priority\": 0\n");
+  }
+
+  @Test void version79_legacy() {
+    IndexTemplates template = storage.versionSpecificTemplates(7.9f);
+
+    assertThat(template.version()).isEqualTo(7.9f);
+    assertThat(template.autocomplete())
+      .withFailMessage("Starting at v7.x, we delimit index and type with hyphen")
+      .contains("\"index_patterns\": \"zipkin-autocomplete-*\"");
+    assertThat(template.span())
+      .doesNotContain("\"template\": {\n")
+      .doesNotContain("\"priority\": 0\n");
+    assertThat(template.autocomplete())
+      .doesNotContain("\"template\": {\n")
+      .doesNotContain("\"priority\": 0\n");
+    assertThat(template.dependency())
+      .doesNotContain("\"template\": {\n")
+      .doesNotContain("\"priority\": 0\n");
+  }
+
+  @Test void version79_composable() {
+    // Set up a new storage with priority
+    storage.close();
+    storage = ElasticsearchStorage.newBuilder(() -> mock(WebClient.class)).templatePriority(0).build();
+    IndexTemplates template = storage.versionSpecificTemplates(7.9f);
+
+    assertThat(template.version()).isEqualTo(7.9f);
+    assertThat(template.autocomplete())
+      .withFailMessage("Starting at v7.x, we delimit index and type with hyphen")
+      .contains("\"index_patterns\": \"zipkin-autocomplete-*\"");
+    assertThat(template.span())
+      .contains("\"template\": {\n")
+      .contains("\"priority\": 0\n");
+    assertThat(template.autocomplete())
+      .contains("\"template\": {\n")
+      .contains("\"priority\": 0\n");
+    assertThat(template.dependency())
+      .contains("\"template\": {\n")
+      .contains("\"priority\": 0\n");
+  }
+
   @Test void searchEnabled_minimalSpanIndexing_6x() {
     storage.close();
     storage = ElasticsearchStorage.newBuilder(() -> mock(WebClient.class))

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchStorageExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchStorageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -38,10 +38,14 @@ class ElasticsearchStorageExtension implements BeforeAllCallback, AfterAllCallba
   static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchStorageExtension.class);
   static final int ELASTICSEARCH_PORT = 9200;
   final String image;
+  final Integer priority;
   GenericContainer container;
 
-  ElasticsearchStorageExtension(String image) {
+  ElasticsearchStorageExtension(String image, Integer priority) {
     this.image = image;
+
+    // This is so that both legacy and composable templates can be tested with this class
+    this.priority = priority;
   }
 
   @Override public void beforeAll(ExtensionContext context) throws IOException {
@@ -116,7 +120,8 @@ class ElasticsearchStorageExtension implements BeforeAllCallback, AfterAllCallba
     WebClient client = builder.build();
     return ElasticsearchStorage.newBuilder(() -> client)
       .index("zipkin-test")
-      .flushOnWrites(true);
+      .flushOnWrites(true)
+      .templatePriority(priority);
   }
 
   String baseUrl() {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class ITElasticsearchStorageV6 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch6:2.21.5");
+    "openzipkin/zipkin-elasticsearch6:2.21.5", null);
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7Composable.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7Composable.java
@@ -13,17 +13,34 @@
  */
 package zipkin2.elasticsearch.integration;
 
+import java.io.IOException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import zipkin2.elasticsearch.ElasticsearchStorage;
 
-/** For testing legacy template */
+import static zipkin2.elasticsearch.integration.ElasticsearchStorageExtension.index;
+
+/** For testing composable template */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ITElasticsearchStorageV7 extends ITElasticsearchStorage {
+public class ITElasticsearchStorageV7Composable extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch7:2.21.5", null);
+    "openzipkin/zipkin-elasticsearch7:2.21.5", 0);
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;
+  }
+
+  @Nested
+  class ITEnsureIndexTemplate extends zipkin2.elasticsearch.integration.ITEnsureIndexTemplate {
+    @Override protected ElasticsearchStorage.Builder newStorageBuilder(TestInfo testInfo) {
+      return backend().computeStorageBuilder().index(index(testInfo));
+    }
+
+    @Override public void clear() throws IOException {
+      storage.clear();
+    }
   }
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITEnsureIndexTemplate.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITEnsureIndexTemplate.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.elasticsearch.integration;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import zipkin2.CheckResult;
+import zipkin2.Span;
+import zipkin2.elasticsearch.ElasticsearchStorage;
+import zipkin2.elasticsearch.internal.Internal;
+import zipkin2.storage.QueryRequest;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+import static zipkin2.TestObjects.DAY;
+import static zipkin2.TestObjects.TODAY;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class ITEnsureIndexTemplate {
+
+  ElasticsearchStorage storage;
+
+  /**
+   * Returns a new {@link ElasticsearchStorage.Builder} for connecting to the backend for the test.
+   */
+  abstract ElasticsearchStorage.Builder newStorageBuilder(TestInfo testInfo);
+
+  abstract void clear() throws Exception;
+
+  @AfterAll void closeStorage() {
+    storage.close();
+  }
+
+  @AfterEach void clearStorage() throws Exception {
+    clear();
+  }
+
+  @Test void createZipkinIndexTemplate_getTraces_returnsSuccess(TestInfo testInfo) throws IOException {
+    ElasticsearchStorage.Builder builder = newStorageBuilder(testInfo);
+    storage = builder
+      .templatePriority(10)
+      .build();
+
+    try {
+      /**
+       * Delete all index templates in order to create the "catch-all" index template, because
+       * ES does not allow multiple index templates of the same index_patterns and priority
+       */
+      deleteIndexTemplate("*");
+      setUpCatchAllTemplate();
+
+      /** Create index template with {@link ElasticsearchStorage#ensureIndexTemplates()} */
+      CheckResult check = storage.check();
+
+      assertThat(check.ok()).isTrue();
+
+      Span span = Span.newBuilder().traceId(CLIENT_SPAN.traceId())
+        .id("1")
+        .timestamp(TODAY * 1000L)
+        .putTag("queryTest", "ok")
+        .build();
+
+      storage.spanConsumer().accept(asList(span)).execute();
+
+      // Assert that Zipkin's templates work and source is returned
+      assertThat(storage.spanStore().getTraces(QueryRequest.newBuilder()
+        .endTs(TODAY + DAY)
+        .lookback(DAY * 2)
+        .limit(10)
+        .parseAnnotationQuery("queryTest=" + span.tags().get("queryTest"))
+        .build()).execute())
+      .flatExtracting(t -> t).containsExactly(span);
+    }
+    finally {
+      /**
+       * Delete "catch-all" index template so it does not interfere with any other test
+       */
+      deleteIndexTemplate("catch-all");
+    }
+  }
+
+  /**
+   * Create a "catch-all" index template with the lowest priority prior to running tests to
+   * ensure that the index templates created during tests with higher priority function as
+   * designed. Only applicable for ES >= 7.8
+   */
+  void setUpCatchAllTemplate() throws IOException {
+    AggregatedHttpRequest updateTemplate = AggregatedHttpRequest.of(
+      RequestHeaders.of(
+        HttpMethod.PUT, catchAllIndexPath(), HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8),
+      HttpData.ofUtf8(catchAllTemplate()));
+    Internal.instance.http(storage).newCall(updateTemplate, (parser, contentString) -> null,
+      "update-template").execute();
+  }
+
+  String catchAllIndexPath() {
+    return "/_index_template/catch-all";
+  }
+
+  /**
+   * Catch-all template doesn't store source
+   */
+  String catchAllTemplate() {
+    return "{\n"
+      + "  \"index_patterns\" : [\"*\"],\n"
+      + "  \"priority\" : 0,\n"
+      + "  \"template\": {\n"
+      + "    \"settings\" : {\n"
+      + "      \"number_of_shards\" : 1\n"
+      + "    },\n"
+      + "    \"mappings\" : {\n"
+      + "      \"_source\": {\"enabled\": false }\n"
+      + "    }\n"
+      + "  }\n"
+      + "}";
+  }
+
+  void deleteIndexTemplate(String pattern) throws IOException {
+    String url = "/_index_template/" + pattern;
+    AggregatedHttpRequest delete = AggregatedHttpRequest.of(HttpMethod.DELETE, url);
+    Internal.instance.http(storage)
+      .newCall(delete, (parser, contentString) -> null, "delete-index").execute();
+  }
+}


### PR DESCRIPTION
# Description

For #3138, this PR lets Zipkin uses composable index templates for ES >= 7.8. Also, a new env variable is added for index template priority.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Unit tests are added for the features. The unit tests passed when ran locally. Also, I have done E2E tests using both ES >=7.8 and ES < 7.8 using the brave sample project.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works