### PR TITLE
Uses OS package to install JDK 14 as it doesn't rely on jdk.java.net

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - export JAVA_VERSION=14
   - sudo apt-get -y install openjdk-$JAVA_VERSION-jdk
   - export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION-openjdk-amd64/
+  - ./mvnw -version
 
   # Required for Elasticsearch 5 (See https://github.com/docker-library/docs/tree/master/elasticsearch#host-setup)
   - sudo sysctl -w vm.max_map_count=262144

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@
 
 dist: focal
 language: java
-jdk: openjdk14
+# Intentionally don't use "jdk" key as it is coupled to jdk.java.net availability.
+addons:
+  apt:
+    update: true
 
 # Don't do a shallow clone to allow license plugin to correctly read git history.
 git:
@@ -18,6 +21,10 @@ services:
   - docker
 
 before_install:
+  # Use OS package to update JDK
+  - export JAVA_VERSION=14
+  - sudo apt-get -y install openjdk-$JAVA_VERSION-jdk
+  - export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION-openjdk-amd64/
 
   # Required for Elasticsearch 5 (See https://github.com/docker-library/docs/tree/master/elasticsearch#host-setup)
   - sudo sysctl -w vm.max_map_count=262144


### PR DESCRIPTION
When jdk.java.net is down, the normal travis installer will error out