### PR TITLE
[Feedback Needed] Add service scatter chart

### DIFF
--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPageContent.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPageContent.tsx
@@ -703,7 +703,7 @@ const DiscoverPageContent: React.FC<DiscoverPageContentProps> = ({
                 </Box>
               </Box>
               <Collapse in={openServiceScatterChart}>
-                <Box width="100%" height={250} pt={1} pb={1} pl={4} pr={4}>
+                <Box width="100%" height={180} pt={1} pb={1} pl={4} pr={4}>
                   <ServiceScatterChart
                     traceSummaries={filteredTraceSummaries}
                   />

--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPageContent.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPageContent.tsx
@@ -29,13 +29,20 @@ import {
   Collapse,
   Typography,
   ButtonGroup,
+  Switch,
 } from '@material-ui/core';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { Autocomplete } from '@material-ui/lab';
 import moment from 'moment';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
@@ -43,6 +50,7 @@ import styled from 'styled-components';
 import Criterion, { newCriterion } from './Criterion';
 import LookbackMenu from './LookbackMenu';
 import SearchBar from './SearchBar';
+import ServiceScatterChart from './ServiceScatterChart';
 import TraceSummaryTable from './TraceSummaryTable';
 import { Lookback, fixedLookbackMap, millisecondsToValue } from './lookback';
 import { useUiConfig } from '../UiConfig';
@@ -503,6 +511,11 @@ const DiscoverPageContent: React.FC<DiscoverPageContentProps> = ({
     setIsOpeningSettings((prev) => !prev);
   }, []);
 
+  const [openServiceScatterChart, toggleOpenServiceScatterChart] = useReducer(
+    (state: boolean) => !state,
+    false,
+  );
+
   const {
     filters,
     handleFiltersChange,
@@ -660,13 +673,12 @@ const DiscoverPageContent: React.FC<DiscoverPageContentProps> = ({
                     <Trans>{filteredTraceSummaries.length} Results</Trans>
                   )}
                 </Typography>
-
                 <Box display="flex">
                   <ButtonGroup>
                     <Button onClick={expandAll}>Expand All</Button>
                     <Button onClick={collapseAll}>Collapse All</Button>
                   </ButtonGroup>
-                  <Box width={300} ml={2}>
+                  <Box width={300} ml={2} mr={2}>
                     <Autocomplete
                       multiple
                       value={filters}
@@ -684,8 +696,19 @@ const DiscoverPageContent: React.FC<DiscoverPageContentProps> = ({
                       onChange={handleFiltersChange}
                     />
                   </Box>
+                  <Switch
+                    checked={openServiceScatterChart}
+                    onChange={toggleOpenServiceScatterChart}
+                  />
                 </Box>
               </Box>
+              <Collapse in={openServiceScatterChart}>
+                <Box width="100%" height={250} pt={1} pb={1} pl={4} pr={4}>
+                  <ServiceScatterChart
+                    traceSummaries={filteredTraceSummaries}
+                  />
+                </Box>
+              </Collapse>
             </Container>
           </>
         )}

--- a/zipkin-lens/src/components/DiscoverPage/ServiceScatterChart.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/ServiceScatterChart.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import moment from 'moment';
+import React, { useMemo, useCallback } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+  CartesianGrid,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from 'recharts';
+
+import { selectColorByInfoClass } from '../../constants/color';
+import TraceSummary from '../../models/TraceSummary';
+import { formatDuration } from '../../util/timestamp';
+
+interface ServiceScatterChartProps {
+  traceSummaries: TraceSummary[];
+}
+
+const ServiceScatterChart: React.FC<ServiceScatterChartProps> = ({
+  traceSummaries,
+}) => {
+  const traceSummariesMap = useMemo(
+    () =>
+      traceSummaries.reduce((acc, cur) => {
+        const infoClass = !cur.infoClass ? 'normal' : cur.infoClass;
+        if (!acc[infoClass]) {
+          acc[infoClass] = [] as TraceSummary[];
+        }
+        acc[infoClass].push(cur);
+        return acc;
+      }, {} as { [key: string]: TraceSummary[] }),
+    [traceSummaries],
+  );
+
+  const history = useHistory();
+
+  const handleScatterClick = useCallback(
+    (traceSummary: TraceSummary) => {
+      history.push(`traces/${traceSummary.traceId}`);
+    },
+    [history],
+  );
+
+  return (
+    <ResponsiveContainer>
+      <ScatterChart margin={{ top: 20, right: 30, bottom: 10, left: 30 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="timestamp"
+          name="Start Time"
+          domain={['auto', 'auto']}
+          type="number"
+          tickFormatter={(ts) => moment(ts).format('HH:mm:ss:SSS')}
+        />
+        <YAxis
+          dataKey="duration"
+          name="Duration"
+          domain={['auto', 'auto']}
+          type="number"
+          tickFormatter={(duration) => formatDuration(duration)}
+        />
+        <ZAxis dataKey="spanCount" name="Span Count" range={[200, 700]} />
+        <Tooltip
+          cursor={{ strokeDasharray: '3 3' }}
+          formatter={(value, name) => {
+            switch (name) {
+              case 'Start Time':
+                return moment(value).format('M/DD HH:mm:ss:SSS');
+              case 'Duration':
+                return formatDuration(value);
+              case 'Span Count':
+                return value;
+              default:
+                return value;
+            }
+          }}
+        />
+        {Object.keys(traceSummariesMap).map((infoClass) => (
+          <Scatter
+            data={traceSummariesMap[infoClass]}
+            fill={selectColorByInfoClass(infoClass)}
+            opacity={0.7}
+            onClick={handleScatterClick}
+          />
+        ))}
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default ServiceScatterChart;


### PR DESCRIPTION
This is a chart showing the distribution of the duration, span count and start time of the trace search results.
It also indicates by color whether the trace contains error spans or not.

![スクリーンショット 2020-09-06 11 43 59](https://user-images.githubusercontent.com/19551419/92316975-4bde9500-f036-11ea-9ae2-e5e0edbb2d07.png)

![service-scatter-chart](https://user-images.githubusercontent.com/19551419/92316132-1d0ef180-f02b-11ea-9c13-a7d8dbe8aa1b.gif)

I like this chart because it allows me to understand the search results at a glance.
But I know that some people feel this complicated.

I have created a PR for more discussion.
I'd appreciate it if you could try it out and give me feedback.

Related: #2636 