### PR TITLE
Ports MySQL test image to our conventions

### DIFF
--- a/docker/storage/mysql/Dockerfile
+++ b/docker/storage/mysql/Dockerfile
@@ -17,17 +17,44 @@
 # COPY --from= works around the issue.
 FROM scratch as scratch
 
-COPY docker/storage/mysql/*.sh /mysql/
-COPY zipkin-storage/mysql-v1/src/main/resources/mysql.sql /mysql/zipkin.sql
+COPY zipkin-storage/mysql-v1/src/main/resources/mysql.sql /zipkin-schemas/mysql.sql
 
+FROM alpine:3.12 as install
+
+WORKDIR /install
+
+COPY --from=scratch /zipkin-schemas/* ./zipkin-schemas/
+COPY docker/storage/mysql/install.sh /tmp/
+RUN /tmp/install.sh && rm /tmp/install.sh
+
+# Use a small base image at runtime
 FROM alpine:3.12
-LABEL MAINTAINER Zipkin "https://zipkin.io/"
+LABEL MAINTAINER OpenZipkin "https://zipkin.io/"
 
-WORKDIR /mysql
-COPY --from=scratch /mysql/* /mysql/
+# Add the mysql binary and handle installation edge cases
+RUN apk add --no-cache mysql && \
+    # Prevent "Bind on unix socket: No such file or directory"
+    mkdir -p /run/mysqld/ && chown -R mysql /run/mysqld/ && \
+    # Enable networking
+    echo skip-networking=0 >> /etc/my.cnf && \
+    echo bind-address=0.0.0.0 >> /etc/my.cnf && \
+    # Remove large binaries
+    (cd /usr/bin; rm mysql_* aria_* mysqlbinlog myis* test-connect-t mysqlslap innochecksum resolve* my_print_defaults sst_dump)
 
-RUN /mysql/install.sh
+# Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
+COPY docker/storage/mysql/docker-bin/* /usr/local/bin/
+# We use start period of 30s to avoid marking the container unhealthy on slow or contended CI hosts
+HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthcheck"]
+ENTRYPOINT ["start-mysql"]
 
-CMD /mysql/run.sh
+# All content including binaries and logs write under WORKDIR
+ARG USER=mysql
+WORKDIR /${USER}
+
+# mysql package adds the mysql user
+USER ${USER}
+
+# Copy binaries and config we installed earlier
+COPY --from=install --chown=${USER} /install .
 
 EXPOSE 3306

--- a/docker/storage/mysql/docker-bin/docker-healthcheck
+++ b/docker/storage/mysql/docker-bin/docker-healthcheck
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015-2019 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -13,4 +13,20 @@
 # the License.
 #
 
-/usr/bin/mysqld_safe --user=mysql --basedir=/usr/ --datadir=/mysql/data
+# HEALTHCHECK for use in `docker ps` or `docker-compose ps`.
+# It can also be used as a readiness probe in k8s
+
+# Fail on unset variables, but don't quit on rc!=0, so we can log what happened
+set -u +e
+
+IP="$(hostname -i || echo '127.0.0.1')"
+
+# mysqladmin requires another package, which we don't want to install
+NC_OUTPUT=$(nc -z ${IP} 3306 > /dev/null 2>&1)
+NC_RC=$?
+if [ "$NC_RC" == "0" ]; then
+  exit 0
+fi
+
+echo MySQL port check failed: $NC_OUTPUT
+exit 1

--- a/docker/storage/mysql/docker-bin/start-mysql
+++ b/docker/storage/mysql/docker-bin/start-mysql
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Copyright 2015-2020 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# ENTRYPOINT script that starts MySQL
+#
+# This intentionally locates config using the current working directory, in order to consolidate
+# Dockerfile instructions to WORKDIR
+set -eu
+
+echo Starting MySQL
+MYSQL_OPTS="--user=mysql --basedir=${PWD} --datadir=${PWD}/data --tmpdir=/tmp"
+exec mysqld_safe ${MYSQL_OPTS}

--- a/docker/storage/mysql/install.sh
+++ b/docker/storage/mysql/install.sh
@@ -35,7 +35,7 @@ mysqld ${MYSQL_OPTS} &
 
 # Excessively long timeout to avoid having to create an ENV variable, decide its name, etc.
 timeout=180
-echo "Will wait up to ${timeout} seconds for Cassandra to come up before installing Schema"
+echo "Will wait up to ${timeout} seconds for MySQL to come up before installing Schema"
 while [ "$timeout" -gt 0 ] && ! mysql --protocol=socket -uroot -e 'SELECT 1' > /dev/null 2>&1; do
     sleep 1
     timeout=$(($timeout - 1))

--- a/docker/storage/mysql/install.sh
+++ b/docker/storage/mysql/install.sh
@@ -19,22 +19,30 @@ echo "*** Installing MySQL"
 apk add --update --no-cache mysql mysql-client
 # Fake auth tools install as 10.4.0 install dies otherwise
 mkdir -p /auth_pam_tool_dir/auth_pam_tool
-mysql_install_db --user=mysql --basedir=/usr/ --datadir=/mysql/data --force
-mkdir -p /run/mysqld/
-chown -R mysql /mysql /run/mysqld/
+
+MYSQL_OPTS="--user=mysql --basedir=${PWD} --datadir=${PWD}/data --tmpdir=/tmp"
+
+# Create the database (stored in the data directory)
+ln -s /usr/bin bin
+ln -s /usr/share share
+mysql_install_db ${MYSQL_OPTS} --force
+
+# Prevent "Bind on unix socket: No such file or directory"
+mkdir -p /run/mysqld/ && chown mysql /run/mysqld/
 
 echo "*** Starting MySQL"
-mysqld --user=mysql --basedir=/usr/ --datadir=/mysql/data &
+mysqld ${MYSQL_OPTS} &
 
-timeout=300
-while [[ "$timeout" -gt 0 ]] && ! mysql --user=mysql --protocol=socket -uroot -e 'SELECT 1' >/dev/null 2>/dev/null; do
-    echo "Waiting ${timeout} seconds for mysql to come up"
-    sleep 2
-    timeout=$(($timeout - 2))
+# Excessively long timeout to avoid having to create an ENV variable, decide its name, etc.
+timeout=180
+echo "Will wait up to ${timeout} seconds for Cassandra to come up before installing Schema"
+while [ "$timeout" -gt 0 ] && ! mysql --protocol=socket -uroot -e 'SELECT 1' > /dev/null 2>&1; do
+    sleep 1
+    timeout=$(($timeout - 1))
 done
 
 echo "*** Installing Schema"
-mysql --verbose --user=mysql --protocol=socket -uroot <<-EOSQL
+mysql --verbose --user=mysql --protocol=socket -uroot <<-'EOF'
 USE mysql ;
 
 DELETE FROM mysql.user ;
@@ -43,22 +51,14 @@ DROP DATABASE IF EXISTS test ;
 CREATE DATABASE zipkin ;
 
 USE zipkin;
-SOURCE /mysql/zipkin.sql ;
+SOURCE zipkin-schemas/mysql.sql ;
 
 GRANT ALL PRIVILEGES ON zipkin.* TO zipkin@'%' IDENTIFIED BY 'zipkin' WITH GRANT OPTION ;
 FLUSH PRIVILEGES ;
-EOSQL
+EOF
 
 echo "*** Stopping MySQL"
 pkill -f mysqld
 
-
-echo "*** Enabling Networking"
-cat >> /etc/my.cnf <<-"EOF"
-[mysqld]
-skip-networking=0
-skip-bind-address
-EOF
-
 echo "*** Cleaning Up"
-apk del mysql-client --purge
+rm bin share

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageExtension.java
@@ -46,12 +46,12 @@ class MySQLStorageExtension implements BeforeAllCallback, AfterAllCallback {
       try {
         container = new ZipkinMySQLContainer(image);
         container.start();
-        LOGGER.info("Starting docker image " + container.getDockerImageName());
-      } catch (Exception e) {
-        LOGGER.warn("Couldn't start docker image " + container.getDockerImageName(), e);
+        LOGGER.info("Starting docker image " + image);
+      } catch (RuntimeException e) {
+        LOGGER.warn("Couldn't start docker image " + image + ": " + e.getMessage(), e);
       }
     } else {
-      LOGGER.info("Skipping startup of docker");
+      LOGGER.info("Skipping startup of docker " + image);
     }
 
     try (MySQLStorage result = computeStorageBuilder().build()) {


### PR DESCRIPTION
Particularly, this image adds HEALTHCHECK and deletes 100MB of binaries not used at runtime, making it 170MB (compared to the official mariadb image which is 400MB)

Once released, this completes our storage images: we can add a health condition on any storage image or kafka:

Ex.
```
    depends_on:
      storage:
        condition: service_healthy
      kafka-zookeeper:
        condition: service_healthy
```