### PR TITLE
[Feedback Needed] Show Pie charts and tables instead of badges for span counts

### DIFF
--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -7071,6 +7071,30 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "echarts": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-4.9.0.tgz",
+      "integrity": "sha512-+ugizgtJ+KmsJyyDPxaw2Br5FqzuBnyOWwcxPKO6y0gc5caYcfnEUIlNStx02necw8jmKmTafmpHhGo4XDtEIA==",
+      "requires": {
+        "zrender": "4.3.2"
+      }
+    },
+    "echarts-for-react": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-2.0.16.tgz",
+      "integrity": "sha512-VmHCktay2qKt/+wpL/C7thbvIa7dYBEey0/U4Zaqo+qeA4wx+uiCd5NeCsPIhD/0Pv+2qqNswqiNiUCtcgccOw==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "size-sensor": "^1.0.0"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -19565,6 +19589,11 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
+    "size-sensor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.1.tgz",
+      "integrity": "sha512-QTy7MnuugCFXIedXRpUSk9gUnyNiaxIdxGfUjr8xxXOqIB3QvBUYP9+b51oCg2C4dnhaeNk/h57TxjbvoJrJUA=="
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -22621,6 +22650,11 @@
           }
         }
       }
+    },
+    "zrender": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-4.3.2.tgz",
+      "integrity": "sha512-bIusJLS8c4DkIcdiK+s13HiQ/zjQQVgpNohtd8d94Y2DnJqgM1yjh/jpDb8DoL6hd7r8Awagw8e3qK/oLaWr3g=="
     }
   }
 }

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -47,6 +47,8 @@
     "@typescript-eslint/eslint-plugin": "^2.23.0",
     "@typescript-eslint/parser": "^2.23.0",
     "classnames": "^2.2.6",
+    "echarts": "^4.9.0",
+    "echarts-for-react": "^2.0.16",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
     "eslint-config-airbnb-typescript": "^7.0.0",

--- a/zipkin-lens/src/components/DiscoverPage/SpanCountChart.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/SpanCountChart.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {
+  Box,
+  Button,
+  Grid,
+  Table as MuiTable,
+  TableBody,
+  TableCell as MuiTableCell,
+  TableContainer,
+  TableRow,
+} from '@material-ui/core';
+import ReactEcharts from 'echarts-for-react';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+
+import { selectServiceTheme } from '../../constants/color';
+import { ServiceNameAndSpanCount } from '../../models/TraceSummary';
+
+interface SimpleLineProps {
+  color: string;
+}
+
+const SimpleLine: React.FC<SimpleLineProps> = ({ color }) => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      xmlns="http://www.w3.org/2000/svg"
+      version="1.1"
+    >
+      <line x1="0" x2="16" y1="8" y2="8" strokeWidth="4" stroke={color} />
+    </svg>
+  );
+};
+
+interface SpanCountChartProps {
+  serviceSummaries: ServiceNameAndSpanCount[];
+  toggleFilter: (serviceName: string) => void;
+}
+
+const SpanCountChart: React.FC<SpanCountChartProps> = ({
+  serviceSummaries,
+  toggleFilter,
+}) => {
+  const sortedServiceSummaries = [...serviceSummaries].sort(
+    (a, b) => b.spanCount - a.spanCount,
+  );
+
+  const data = useMemo(
+    () =>
+      sortedServiceSummaries.map((serviceSummary) => ({
+        name: serviceSummary.serviceName,
+        value: serviceSummary.spanCount,
+      })),
+    [sortedServiceSummaries],
+  );
+
+  const colorPalette = useMemo(
+    () =>
+      sortedServiceSummaries.map(
+        (serviceSummary) =>
+          selectServiceTheme(serviceSummary.serviceName).palette.primary.main,
+      ),
+    [sortedServiceSummaries],
+  );
+
+  const option = useMemo(
+    () => ({
+      series: [
+        {
+          radius: ['50%', '70%'],
+          type: 'pie',
+          data,
+          color: colorPalette,
+          height: 300,
+          label: {
+            normal: {
+              show: true,
+            },
+          },
+        },
+      ],
+    }),
+    [colorPalette, data],
+  );
+
+  return (
+    <Grid container>
+      <Grid item xs={6}>
+        <ReactEcharts option={option} notMerge lazyUpdate />
+      </Grid>
+      <TableGrid item xs={6}>
+        <TableContainer>
+          <Table size="small">
+            <TableBody>
+              {sortedServiceSummaries.map((serviceSummary) => (
+                <TableRow key={serviceSummary.serviceName}>
+                  <TableCell component="th" scope="row">
+                    <Box display="flex" alignItems="center">
+                      <Box flexShrink={0}>
+                        <SimpleLine
+                          color={
+                            selectServiceTheme(serviceSummary.serviceName)
+                              .palette.primary.main
+                          }
+                        />
+                      </Box>
+                      <ServiceName ml={1}>
+                        {serviceSummary.serviceName}
+                      </ServiceName>
+                    </Box>
+                  </TableCell>
+                  <TableCell align="right">
+                    {serviceSummary.spanCount}
+                    <FilterButton
+                      size="small"
+                      variant="outlined"
+                      onClick={() => toggleFilter(serviceSummary.serviceName)}
+                    >
+                      Filter
+                    </FilterButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </TableGrid>
+    </Grid>
+  );
+};
+
+export default SpanCountChart;
+
+const TableGrid = styled(Grid)`
+  max-height: 300px;
+  overflow: auto;
+`;
+
+const Table = styled(MuiTable)`
+  table-layout: fixed;
+`;
+
+const TableCell = styled(MuiTableCell)`
+  font-size: 0.75rem;
+`;
+
+const FilterButton = styled(Button)`
+  font-size: 0.6rem;
+  margin-left: ${({ theme }) => theme.spacing(2)}px;
+  padding: 2px 9px;
+`;
+
+const ServiceName = styled(Box)`
+  flex-grow: 1;
+  width: 100%;
+  overflow-wrap: break-word;
+`;

--- a/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.tsx
@@ -24,14 +24,14 @@ import {
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import moment from 'moment';
-import React, { useMemo, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
+import SpanCountChart from './SpanCountChart';
 import { selectColorByInfoClass } from '../../constants/color';
 import TraceSummary from '../../models/TraceSummary';
 import { formatDuration } from '../../util/timestamp';
-import ServiceBadge from '../common/ServiceBadge';
 
 interface TraceSummaryRowProps {
   traceSummary: TraceSummary;
@@ -47,14 +47,6 @@ const TraceSummaryRow: React.FC<TraceSummaryRowProps> = ({
   toggleOpen,
 }) => {
   const startTime = moment(traceSummary.timestamp / 1000);
-
-  const sortedServiceSummaries = useMemo(
-    () =>
-      [...traceSummary.serviceSummaries].sort(
-        (a, b) => b.spanCount - a.spanCount,
-      ),
-    [traceSummary.serviceSummaries],
-  );
 
   const handleToggleOpen = useCallback(() => {
     toggleOpen(traceSummary.traceId);
@@ -110,22 +102,17 @@ const TraceSummaryRow: React.FC<TraceSummaryRowProps> = ({
       <TableRow>
         <CollapsibleTableCell>
           <Collapse in={open} timeout="auto" unmountOnExit>
-            <Box margin={1}>
+            <Box mt={1} mr={1} ml={1} mb={2}>
               <Box display="flex" alignItems="center">
                 <Typography variant="body1" color="textSecondary">
                   Trace ID:
                 </Typography>
                 <TraceIdTypography>{traceSummary.traceId}</TraceIdTypography>
               </Box>
-              <BadgesWrapper>
-                {sortedServiceSummaries.map((serviceSummary) => (
-                  <ServiceBadge
-                    serviceName={serviceSummary.serviceName}
-                    count={serviceSummary.spanCount}
-                    onClick={toggleFilter}
-                  />
-                ))}
-              </BadgesWrapper>
+              <SpanCountChart
+                serviceSummaries={traceSummary.serviceSummaries}
+                toggleFilter={toggleFilter}
+              />
             </Box>
           </Collapse>
         </CollapsibleTableCell>
@@ -181,12 +168,4 @@ const TraceIdTypography = styled(Typography).attrs({
   variant: 'body1',
 })`
   margin-left: ${({ theme }) => theme.spacing(0.5)}px;
-`;
-
-const BadgesWrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  & > * {
-    margin: ${({ theme }) => theme.spacing(0.5)}px;
-  }
 `;


### PR DESCRIPTION
in #3180, we had a discussion about how to display span counts.
At that time I created a chart with the following design, but we found some problems for usability.

**rejected design**:
<img width="600" alt="OLD CHART" src="https://user-images.githubusercontent.com/19551419/93707085-d2cb5b80-fb66-11ea-99b7-0831b1a8a118.png">

So I created a new design with pie chart and table like the following:

**new design**:
<img width="1440" alt="スクリーンショット 2020-09-20 17 25 14" src="https://user-images.githubusercontent.com/19551419/93707012-62bcd580-fb66-11ea-9492-62196bb9d9ff.png">

What do you think about this? Please give me your feedback.

cc @adriancole @shakuzen 