### PR TITLE
Moves Docker images to JRE 15 and off curl where we can

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,8 +35,14 @@ RUN ./mvnw -q --batch-mode -DskipTests --also-make -pl zipkin-server install
 RUN mkdir -p /zipkin && cp zipkin-server/target/zipkin-server-*-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar
 RUN mkdir -p /zipkin-slim && cp zipkin-server/target/zipkin-server-*-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
 
+# docker/hooks/post_push will republish what is otherwise built in docker/build/Dockerfile
 FROM maven:3-openjdk-14-slim as zipkin-builder
+LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
+# Unset MAVEN_CONFIG until we don't depend on the maven image which conflicts with the Takari env
+ENV MAVEN_CONFIG=
+
+# This cache is used by DockerHub which doesn't support another way to retain cache between builds
 COPY --from=built /root/.m2 /root/.m2
 COPY --from=built /root/.npm /root/.npm
 
@@ -66,7 +72,7 @@ CMD ["/usr/local/bin/nginx.sh"]
 # zipkin-slim - An image containing the slim distribution of Zipkin server.
 #####
 
-FROM openzipkin/jre-full:14.0.2-14.29.23 as zipkin-slim
+FROM openzipkin/jre-full:15.0.0-15.27.17 as zipkin-slim
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.
@@ -117,7 +123,7 @@ ENTRYPOINT /zipkin/run.sh
 # zipkin-server - An image containing the full distribution of Zipkin server.
 #####
 
-FROM openzipkin/jre-full:14.0.2-14.29.23 as zipkin-server
+FROM openzipkin/jre-full:15.0.0-15.27.17 as zipkin-server
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -66,7 +66,7 @@ CMD ["/usr/local/bin/nginx.sh"]
 # zipkin-slim - An image containing the slim distribution of Zipkin server.
 #####
 
-FROM openzipkin/jre-full:14.0.2-14.29.23 as zipkin-slim
+FROM openzipkin/jre-full:15.0.0-15.27.17 as zipkin-slim
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.
@@ -89,7 +89,7 @@ ENTRYPOINT /zipkin/run.sh
 # zipkin-server - An image containing the full distribution of Zipkin server.
 #####
 
-FROM openzipkin/jre-full:14.0.2-14.29.23 as zipkin-server
+FROM openzipkin/jre-full:15.0.0-15.27.17 as zipkin-server
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Use to set heap, trust store or other system properties.

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -16,13 +16,18 @@
 # an empty image.
 
 FROM maven:3-openjdk-14-slim
+LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 COPY . /code/
 
 # Unset MAVEN_CONFIG until we don't depend on the maven image which conflicts with the Takari env
 ENV MAVEN_CONFIG=
 
-# Use the same command as we suggest in zipkin-server/README.md to hydrate the maven cache
+# The image retains /root/.m2 and /root/.npm to optimize for DockerHub which doesn't support
+# another way to retain cache between build runs.
+#
+# The below commands are equivalent to executing Maven go-offline and NPM commands, but take longer
+# due to compilation. We use this as it is the same command mentioned in zipkin-server/README.md
 RUN cd /code && \
     ./mvnw -q --batch-mode -DskipTests --also-make -pl zipkin-server package && \
     cd / && rm -rf /code

--- a/docker/collector/kafka/Dockerfile
+++ b/docker/collector/kafka/Dockerfile
@@ -22,7 +22,7 @@ COPY docker/collector/kafka/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 
 # Share the same base image to reduce layers used in testing
-FROM openzipkin/jre-full:14.0.2-14.29.23
+FROM openzipkin/jre-full:15.0.0-15.27.17
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path

--- a/docker/storage/cassandra/install.sh
+++ b/docker/storage/cassandra/install.sh
@@ -20,9 +20,9 @@ set -eux
 
 echo "*** Installing Cassandra and dependencies"
 # BusyBux built-in tar doesn't support --strip=1
-apk add --update --no-cache python2 curl tar
-APACHE_MIRROR=$(curl -sSL https://www.apache.org/dyn/closer.cgi\?as_json\=1 | sed -n '/preferred/s/.*"\(.*\)"/\1/gp')
-curl -sSL $APACHE_MIRROR/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz | tar xz \
+apk add --update --no-cache python2 tar
+APACHE_MIRROR=$(wget -qO- https://www.apache.org/dyn/closer.cgi\?as_json\=1 | sed -n '/preferred/s/.*"\(.*\)"/\1/gp')
+wget -qO- $APACHE_MIRROR/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz | tar xz \
   --strip=1
 
 # Merge in our custom configuration

--- a/docker/storage/elasticsearch6/Dockerfile
+++ b/docker/storage/elasticsearch6/Dockerfile
@@ -12,19 +12,19 @@
 # the License.
 #
 
-FROM openzipkin/zipkin-builder as install
+FROM openzipkin/jre-full:15.0.0-15.27.17 as install
 
 ENV ELASTICSEARCH_VERSION 6.8.12
 
 WORKDIR /install
 
 # We don't download bin scripts as we customize for reasons including BusyBox problems
-RUN curl -sSL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION.tar.gz| tar xz \
+RUN wget -qO- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION.tar.gz| tar xz \
     --wildcards --strip=1 --exclude=*/bin
 
 COPY docker/storage/elasticsearch6/config /install/config
 
-FROM openzipkin/jre-full:14.0.2-14.29.23
+FROM openzipkin/jre-full:15.0.0-15.27.17
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path

--- a/docker/storage/elasticsearch7/Dockerfile
+++ b/docker/storage/elasticsearch7/Dockerfile
@@ -12,20 +12,20 @@
 # the License.
 #
 
-FROM openzipkin/zipkin-builder as install
+FROM openzipkin/jre-full:15.0.0-15.27.17 as install
 
-ENV ELASTICSEARCH_VERSION 7.9.1
+ENV ELASTICSEARCH_VERSION 7.9.2
 
 WORKDIR /install
 
 # Download only the OSS distribution (lacks X-Pack)
 # We don't download bin scripts as we customize for reasons including BusyBox problems
-RUN curl -sSL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION-no-jdk-linux-x86_64.tar.gz| tar xz \
+RUN wget -qO- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION-no-jdk-linux-x86_64.tar.gz| tar xz \
     --wildcards --strip=1 --exclude=*/bin
 
 COPY docker/storage/elasticsearch7/config /install/config
 
-FROM openzipkin/jre-full:14.0.2-14.29.23
+FROM openzipkin/jre-full:15.0.0-15.27.17
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path


### PR DESCRIPTION
This uses our new smaller JRE 15 in our Docker images except the
"Zipkin builder". This one will stick to 14 until there's a 15 for that
or we sort out #3219

This also moves off curl where we can as that's not a part of Alpine.