### PR TITLE
Reduces the size of intermediate layers when building images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 **/.*
 !.dockerignore
-!.git
 !.mvn
 !docker/zipkin/**
 !**/.eslintrc*
@@ -13,6 +12,7 @@
 **/node_modules
 **/*.iml
 
+**/.idea
 **/*.md
 
 **/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,11 +29,14 @@ COPY --from=scratch /code /code
 
 WORKDIR /code
 
-# Same command as we suggest in zipkin-server/README.md
-RUN ./mvnw -q --batch-mode -DskipTests --also-make -pl zipkin-server install
-
-RUN mkdir -p /zipkin && cp zipkin-server/target/zipkin-server-*-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar
-RUN mkdir -p /zipkin-slim && cp zipkin-server/target/zipkin-server-*-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar
+# Use the same command as we suggest in zipkin-server/README.md
+RUN ./mvnw -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package && \
+    (mkdir -p /zipkin && cp zipkin-server/target/zipkin-server-*-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar) && \
+    (mkdir -p /zipkin-slim && cp zipkin-server/target/zipkin-server-*-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar) && \
+    # :zipkin-lens "npm run build" generates the build directory
+    (mkdir -p /zipkin-lens && cp -r zipkin-lens/build/* /zipkin-lens/) && \
+    # Delete /code to contain the image layer to static content, server binaries, ~/.m2 and ~/.npm
+    cd / && rm -rf /code
 
 # docker/hooks/post_push will republish what is otherwise built in docker/build/Dockerfile
 # This is a copy/paste from builder/Dockerfile:
@@ -43,9 +46,11 @@ RUN mkdir -p /zipkin-slim && cp zipkin-server/target/zipkin-server-*-slim.jar /z
 FROM azul/zulu-openjdk-alpine:15.0.0-15.27.17 as zipkin-builder
 MAINTAINER OpenZipkin "https://zipkin.io/"
 
+# Install Maven, tar and libc hooks
 COPY docker/builder/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 
+# Don't re-issue download-node.sh as it should already be in the Maven cache
 COPY --from=built /root/.m2 /root/.m2
 COPY --from=built /root/.npm /root/.npm
 
@@ -58,9 +63,7 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 ENV ZIPKIN_BASE_URL=http://zipkin:9411
 
-
-# :zipkin-lens "npm run build" generates the build directory
-COPY --from=built /code/zipkin-lens/build /var/www/html/zipkin
+COPY --from=built /zipkin-lens/ /var/www/html/zipkin/
 RUN mkdir -p /var/tmp/nginx && chown -R nginx:nginx /var/tmp/nginx
 
 # Setup services

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,3 +88,9 @@ If you want the slim distribution instead, run:
 ```bash
 $ docker build -t openzipkin/zipkin-slim:test -f docker/Dockerfile . --target zipkin-slim
 ```
+
+If you want the NGINX UI proxy instead, run:
+
+```bash
+$ docker build -t openzipkin/zipkin-ui:test -f docker/Dockerfile . --target zipkin-ui
+```

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -18,28 +18,23 @@
 FROM azul/zulu-openjdk-alpine:15.0.0-15.27.17 as built
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
+# Install Maven, tar and libc hooks
 COPY docker/builder/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
+
+WORKDIR /code
 
 # Copy Maven source tree into the Docker context
 COPY . .
 
+# Make sure zipkin-lens can build on Alpine by eagerly caching an unofficial build.
 # Temporarily workaround https://github.com/eirslett/frontend-maven-plugin/pull/853
 COPY docker/builder/download-node.sh .
 RUN ./download-node.sh
 
 # Use the same command as we suggest in zipkin-server/README.md to hydrate the Maven and NPM cache
-RUN ./mvnw -q --batch-mode -DskipTests --also-make -pl zipkin-server package
+# We delete /code in order to keep the image layer contained to retain ~/.m2 and ~/.npm
+RUN ./mvnw -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package && \
+    cd / && rm -rf /code
 
-# We make another layer here because we don't want the image to include the docker context
-#
-# zipkin-builder is JDK + artifact caches because DockerHub doesn't support another way to update
-# cache between builds.
-FROM azul/zulu-openjdk-alpine:15.0.0-15.27.17 as zipkin-builder
-MAINTAINER OpenZipkin "https://zipkin.io/"
-
-COPY docker/builder/install.sh /tmp/
-RUN /tmp/install.sh && rm /tmp/install.sh
-
-COPY --from=built /root/.m2 /root/.m2
-COPY --from=built /root/.npm /root/.npm
+WORKDIR /

--- a/docker/builder/README.md
+++ b/docker/builder/README.md
@@ -10,7 +10,7 @@ accumulated too much cruft, it can be refreshed with
 ```bash
 $ docker login
 $ docker build -t openzipkin/zipkin-builder -f docker/builder/Dockerfile .
-$ docker push openzipkin/zipkin-builder 
+$ docker push openzipkin/zipkin-builder
 ```
 
 We'll add a weekly cron at some point to do this automatically.

--- a/docker/builder/download-node.sh
+++ b/docker/builder/download-node.sh
@@ -38,4 +38,6 @@ if [ ! -f "${NODE_MAVEN_PATH}" ]; then
   # Create a new archive where Maven would expect it
   mkdir -p $(dirname "${NODE_MAVEN_PATH}")
   tar -czf ${NODE_MAVEN_PATH} *
+  cd -
+  rm -rf /tmp/$$
 fi

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -605,7 +605,7 @@ See [docker-zipkin](https://github.com/openzipkin/docker-zipkin) for details.
 To build and run the server from the currently checked out source, enter the following.
 ```bash
 # Build the server and also make its dependencies
-$ ./mvnw -q --batch-mode -DskipTests --also-make -pl zipkin-server clean install
+$ ./mvnw -q --batch-mode -DskipTests --also-make -pl zipkin-server clean package
 # Run the server
 $ java -jar ./zipkin-server/target/zipkin-server-*exec.jar
 # or Run the slim server

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -605,7 +605,7 @@ See [docker-zipkin](https://github.com/openzipkin/docker-zipkin) for details.
 To build and run the server from the currently checked out source, enter the following.
 ```bash
 # Build the server and also make its dependencies
-$ ./mvnw -q --batch-mode -DskipTests --also-make -pl zipkin-server clean package
+$ ./mvnw -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server clean package
 # Run the server
 $ java -jar ./zipkin-server/target/zipkin-server-*exec.jar
 # or Run the slim server


### PR DESCRIPTION
According to `docker system df`, this change results in 1.2GB of image
size, prunable to 800MB after building all our base images (not Kafka or
storage).