### PR TITLE
Uses installed Maven to reduce image layer size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,8 +29,9 @@ COPY --from=scratch /code /code
 
 WORKDIR /code
 
-# Use the same command as we suggest in zipkin-server/README.md
-RUN ./mvnw -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package && \
+# Use the same command as we suggest in zipkin-server/README.md to hydrate the Maven and NPM cache
+#  * Uses mvn not ./mvnw to reduce layer size: we control the Maven version independently in Docker
+RUN mvn -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package && \
     (mkdir -p /zipkin && cp zipkin-server/target/zipkin-server-*-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar) && \
     (mkdir -p /zipkin-slim && cp zipkin-server/target/zipkin-server-*-slim.jar /zipkin-slim && cd /zipkin-slim && jar xf *.jar && rm *.jar) && \
     # :zipkin-lens "npm run build" generates the build directory

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=scratch /code /code
 
 WORKDIR /code
 
-# Use the same command as we suggest in zipkin-server/README.md to hydrate the Maven and NPM cache
+# Use the same command as we suggest in zipkin-server/README.md
 #  * Uses mvn not ./mvnw to reduce layer size: we control the Maven version independently in Docker
 RUN mvn -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package && \
     (mkdir -p /zipkin && cp zipkin-server/target/zipkin-server-*-exec.jar /zipkin && cd /zipkin && jar xf *.jar && rm *.jar) && \

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -33,8 +33,9 @@ COPY docker/builder/download-node.sh .
 RUN ./download-node.sh
 
 # Use the same command as we suggest in zipkin-server/README.md to hydrate the Maven and NPM cache
-# We delete /code in order to keep the image layer contained to retain ~/.m2 and ~/.npm
-RUN ./mvnw -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package && \
+#  * Uses mvn not ./mvnw to reduce layer size: we control the Maven version independently in Docker
+RUN mvn -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package && \
+    # Delete /code to retain only ~/.m2 and ~/.npm
     cd / && rm -rf /code
 
 WORKDIR /


### PR DESCRIPTION
We can save 21MB of downloading and copying by not using the Maven
wrapper when in Docker, as we control the OS and Maven version
explicity here.