### PR TITLE
Clarifies clone instructions to avoid large Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
 **/.*
 !.dockerignore
 !.mvn
-# Adds 70+MB on a normal clone, but needed for the git-commit-id in the server console
-# See https://github.com/openzipkin/zipkin/issues/3224
+# Builds don't run license check, but need git-commit-id in the server console
+#  * When releasing docker/builder, use a shallow clone to avoid >70MB!
 !.git
 !docker/zipkin/**
 !**/.eslintrc*

--- a/docker/builder/README.md
+++ b/docker/builder/README.md
@@ -8,6 +8,11 @@ means it accumulates old dependencies over time. If the image disappears for any
 accumulated too much cruft, it can be refreshed with
 
 ```bash
+# Make sure you don't inflate the image with a large .git directory
+$ git clone --depth 1 https://github.com/openzipkin/zipkin.git
+$ cd zipkin
+
+# Build the builder and publish it
 $ docker login
 $ docker build -t openzipkin/zipkin-builder -f docker/builder/Dockerfile .
 $ docker push openzipkin/zipkin-builder


### PR DESCRIPTION
If shallow clones are used (as are in docker hub builds), the impact of the .git folder is minimal

```
18375bdfd636        31 minutes ago      /bin/sh -c #(nop) COPY dir:705e52b9c2dd17ff7…   6.43MB
```

Fixes #3224