### PR TITLE
Makes docker-builder .git size agnostic

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,8 @@
 # the License.
 #
 
+ARG java_version=15.0.0-15.27.17
+
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
 # COPY --from= works around the issue.
@@ -45,9 +47,8 @@ RUN mvn -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-s
 #
 # zipkin-builder is JDK + artifact caches because DockerHub doesn't support another way to update
 # cache between builds.
-FROM openzipkin/java:15.0.0-15.27.17 as zipkin-builder
+FROM openzipkin/java:${java_version} as zipkin-builder
 
-# Don't re-issue download-node.sh as it should already be in the Maven cache
 COPY --from=built /root/.m2 /root/.m2
 COPY --from=built /root/.npm /root/.npm
 
@@ -72,7 +73,7 @@ EXPOSE 80
 CMD ["/usr/local/bin/nginx.sh"]
 
 # Almost everything is common between the slim and normal build
-FROM openzipkin/java:15.0.0-15.27.17-jre as base-server
+FROM openzipkin/java:${java_version}-jre as base-server
 
 # Use to set heap, trust store or other system properties.
 ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -12,10 +12,9 @@
 # the License.
 #
 
-# Refreshing the builder image to remove stale dependencies just involves building zipkin-server on
-# an empty image.
+ARG java_version=15.0.0-15.27.17
 
-FROM openzipkin/java:15.0.0-15.27.17 as zipkin-builder
+FROM openzipkin/java:${java_version} as built
 
 WORKDIR /code
 
@@ -24,8 +23,11 @@ COPY . .
 
 # Use the same command as we suggest in zipkin-server/README.md to hydrate the Maven and NPM cache
 #  * Uses mvn not ./mvnw to reduce layer size: we control the Maven version independently in Docker
-RUN mvn -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package && \
-    # Delete /code to retain only ~/.m2 and ~/.npm
-    cd / && rm -rf /code
+RUN mvn -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package
 
-WORKDIR /
+# zipkin-builder is JDK + artifact caches because DockerHub doesn't support another way to update
+# cache between builds.
+FROM openzipkin/java:${java_version} as zipkin-builder
+
+COPY --from=built /root/.m2 /root/.m2
+COPY --from=built /root/.npm /root/.npm

--- a/docker/builder/README.md
+++ b/docker/builder/README.md
@@ -5,13 +5,9 @@ cache of maven and npm dependencies so downstream builds do not have to do so ev
 
 Normally, zipkin-builder is updated as part of the normal master build of zipkin-server. This
 means it accumulates old dependencies over time. If the image disappears for any reason, or it has
-accumulated too much cruft, it can be refreshed with
+accumulated too much cruft, it can be refreshed with the following:
 
 ```bash
-# Make sure you don't inflate the image with a large .git directory
-$ git clone --depth 1 https://github.com/openzipkin/zipkin.git
-$ cd zipkin
-
 # Build the builder and publish it
 $ docker login
 $ docker build -t openzipkin/zipkin-builder -f docker/builder/Dockerfile .


### PR DESCRIPTION
Thanks to @anuraaga for the nudge. By using another layer in the
builder dockerfile, we can avoid explaining how shallow clones
result in a smaller .git directory.