### PR TITLE
Fix a bug in the unit of duration

### DIFF
--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -15597,9 +15597,9 @@
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -19307,11 +19307,11 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.test.js
+++ b/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.test.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React from 'react';
+
+import TraceSummaryRow from './TraceSummaryRow';
+import render from '../../test/util/render-with-default-settings';
+
+describe('<TraceSummaryRow />', () => {
+  it('should render timestamp and duration in correct unit', () => {
+    const { queryByTestId } = render(
+      <TraceSummaryRow
+        traceSummary={{
+          traceId: 'a03ee8fff1dcd9b9',
+          timestamp: 1571896375237354,
+          duration: 131848,
+          serviceSummaries: [],
+          spanCount: 10,
+          width: 10,
+          root: {
+            serviceName: 'routing',
+            spanName: 'post /location/update/v4',
+          },
+        }}
+      />,
+    );
+
+    const startTimeFormat = queryByTestId('TraceSummaryRow-startTimeFormat');
+    expect(startTimeFormat).toBeInTheDocument();
+    expect(startTimeFormat).toHaveTextContent('10/24 13:52:55:237');
+    // intentionally not asserting the relative time from now as it would drift tests
+
+    const duration = queryByTestId('TraceSummaryRow-duration');
+    expect(duration).toBeInTheDocument();
+    expect(duration).toHaveTextContent('131.848ms');
+  });
+});

--- a/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.test.js
+++ b/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.test.js
@@ -42,7 +42,7 @@ describe('<TraceSummaryRow />', () => {
     const startTimeFormat = queryByTestId('TraceSummaryRow-startTimeFormat');
     expect(startTimeFormat).toBeInTheDocument();
     // Don't assert on hour as the timezone will be different in CI
-    expect(startTimeFormat).toHaveTextContent(/10\/24 [0-9][0-9]:52:55:237/);
+    expect(startTimeFormat).toHaveTextContent(/10\/2[34] [0-9][0-9]:52:55:237/);
     // Intentionally not asserting the relative time from now as it would drift tests
 
     const duration = queryByTestId('TraceSummaryRow-duration');

--- a/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.test.js
+++ b/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.test.js
@@ -19,26 +19,31 @@ import render from '../../test/util/render-with-default-settings';
 describe('<TraceSummaryRow />', () => {
   it('should render timestamp and duration in correct unit', () => {
     const { queryByTestId } = render(
-      <TraceSummaryRow
-        traceSummary={{
-          traceId: 'a03ee8fff1dcd9b9',
-          timestamp: 1571896375237354,
-          duration: 131848,
-          serviceSummaries: [],
-          spanCount: 10,
-          width: 10,
-          root: {
-            serviceName: 'routing',
-            spanName: 'post /location/update/v4',
-          },
-        }}
-      />,
+      <table>
+        <tbody>
+          <TraceSummaryRow
+            traceSummary={{
+              traceId: 'a03ee8fff1dcd9b9',
+              timestamp: 1571896375237354,
+              duration: 131848,
+              serviceSummaries: [],
+              spanCount: 10,
+              width: 10,
+              root: {
+                serviceName: 'routing',
+                spanName: 'post /location/update/v4',
+              },
+            }}
+          />
+        </tbody>
+      </table>,
     );
 
     const startTimeFormat = queryByTestId('TraceSummaryRow-startTimeFormat');
     expect(startTimeFormat).toBeInTheDocument();
-    expect(startTimeFormat).toHaveTextContent('10/24 13:52:55:237');
-    // intentionally not asserting the relative time from now as it would drift tests
+    // Don't assert on hour as the timezone will be different in CI
+    expect(startTimeFormat).toHaveTextContent(/10\/24 [0-9][0-9]:52:55:237/);
+    // Intentionally not asserting the relative time from now as it would drift tests
 
     const duration = queryByTestId('TraceSummaryRow-duration');
     expect(duration).toBeInTheDocument();

--- a/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.tsx
@@ -89,7 +89,7 @@ const TraceSummaryRow: React.FC<TraceSummaryRowProps> = ({
         <TableCell align="right">{traceSummary.spanCount}</TableCell>
         <TableCell align="right">
           <Box position="relative" width="100%">
-            {formatDuration(traceSummary.duration)}
+            {formatDuration(traceSummary.duration * 1000)}
             <DurationBar
               width={traceSummary.width}
               infoClass={traceSummary.infoClass}

--- a/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.tsx
@@ -81,15 +81,23 @@ const TraceSummaryRow: React.FC<TraceSummaryRowProps> = ({
         <TableCell>
           <Box display="flex" justifyContent="flex-end" alignItems="center">
             <FromNowTypography>{startTime.fromNow()}</FromNowTypography>
-            <Typography variant="body2" color="textSecondary">
+            <Typography
+              variant="body2"
+              color="textSecondary"
+              data-testid="TraceSummaryRow-startTimeFormat"
+            >
               ({startTime.format('MM/DD HH:mm:ss:SSS')})
             </Typography>
           </Box>
         </TableCell>
         <TableCell align="right">{traceSummary.spanCount}</TableCell>
         <TableCell align="right">
-          <Box position="relative" width="100%">
-            {formatDuration(traceSummary.duration * 1000)}
+          <Box
+            position="relative"
+            width="100%"
+            data-testid="TraceSummaryRow-duration"
+          >
+            {formatDuration(traceSummary.duration)}
             <DurationBar
               width={traceSummary.width}
               infoClass={traceSummary.infoClass}

--- a/zipkin-lens/src/models/TraceSummary.ts
+++ b/zipkin-lens/src/models/TraceSummary.ts
@@ -20,7 +20,6 @@ export type ServiceNameAndSpanCount = {
 type TraceSummary = {
   traceId: string;
   timestamp: number;
-  // Unlike most places, this is milliseconds, not microseconds
   duration: number;
   serviceSummaries: ServiceNameAndSpanCount[];
   infoClass?: string;

--- a/zipkin-lens/src/models/TraceSummary.ts
+++ b/zipkin-lens/src/models/TraceSummary.ts
@@ -20,6 +20,7 @@ export type ServiceNameAndSpanCount = {
 type TraceSummary = {
   traceId: string;
   timestamp: number;
+  // Unlike most places, this is milliseconds, not microseconds
   duration: number;
   serviceSummaries: ServiceNameAndSpanCount[];
   infoClass?: string;

--- a/zipkin-lens/src/zipkin/trace.js
+++ b/zipkin-lens/src/zipkin/trace.js
@@ -171,7 +171,7 @@ export function traceSummaries(serviceName, summaries, utc = false) {
           (parseFloat(duration) / parseFloat(maxDuration)) * 100,
           10,
         );
-        res.duration = duration / 1000; // used only for client-side sort
+        res.duration = duration; // Used in summary view and client-side sort
         res.durationStr = mkDurationStr(duration);
       }
 

--- a/zipkin-lens/src/zipkin/trace.test.js
+++ b/zipkin-lens/src/zipkin/trace.test.js
@@ -231,9 +231,10 @@ describe('traceSummariesToMustache', () => {
     expect(traceSummaries(null, [])).toEqual([]);
   });
 
-  it('should convert duration from micros to millis', () => {
+  it('should not change unit of timestamp or duration', () => {
     const model = traceSummaries(null, [summary]);
-    expect(model[0].duration).toBe(168.731);
+    expect(model[0].timestamp).toBe(summary.timestamp);
+    expect(model[0].duration).toBe(summary.duration);
   });
 
   it('should render empty serviceSummaries when spans lack localEndpoint', () => {


### PR DESCRIPTION
resolve: https://github.com/openzipkin/zipkin/issues/3233

`formatDuration` requires a microsecond-value as its argument, but `trace.duration` is millisecond-value.
So we need to multiply `trace.duration` by 1000.