### PR TITLE
Removes last clutter from zipkin startup

### DIFF
--- a/zipkin-server/src/main/resources/simplelogger.properties
+++ b/zipkin-server/src/main/resources/simplelogger.properties
@@ -10,9 +10,8 @@ org.slf4j.simpleLogger.showShortLogName=true
 # This only includes Armeria as for example Kafka and Cassandra are not in the slim dist
 org.slf4j.simpleLogger.log.com.linecorp.armeria.client.HttpResponseDecoder=OFF
 org.slf4j.simpleLogger.log.com.linecorp.armeria.common.Flags=OFF
+org.slf4j.simpleLogger.log.com.linecorp.armeria.common.util.SystemInfo=WARN
+org.slf4j.simpleLogger.log.com.linecorp.armeria.internal.common.JavaVersionSpecific=OFF
+org.slf4j.simpleLogger.log.com.linecorp.armeria.server.docs.DocService=OFF
 org.slf4j.simpleLogger.log.com.linecorp.armeria.server.docs.DocStringExtractor=OFF
 org.slf4j.simpleLogger.log.com.linecorp.armeria.spring.ArmeriaAutoConfiguration=WARN
-org.slf4j.simpleLogger.log.com.linecorp.armeria.common.util.SystemInfo=WARN
-org.slf4j.simpleLogger.log.com.linecorp.armeria.server.docs.DocService=OFF
-org.slf4j.simpleLogger.log.com.linecorp.armeria.internal.common.thrift.ThriftSerializationFormatProvider=OFF
-

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -267,13 +267,14 @@ logging:
     # logging when enabled. https://github.com/line/armeria/issues/2000
     com.linecorp.armeria.client.HttpResponseDecoder: 'OFF'
     com.linecorp.armeria.common.Flags: 'OFF'
-    com.linecorp.armeria.server.docs.DocStringExtractor: 'OFF'
-    com.linecorp.armeria.server.docs.DocService: 'OFF'
-    com.linecorp.armeria.internal.common.thrift.ThriftSerializationFormatProvider: 'OFF'
-    # Redundant to logging already done in c.l.a.s.Server
-    com.linecorp.armeria.spring.ArmeriaAutoConfiguration: 'WARN'
+    com.linecorp.armeria.common.SerializationFormat: 'OFF'
     # Hostname logging is not Zipkin's duty
     com.linecorp.armeria.common.util.SystemInfo: 'WARN'
+    com.linecorp.armeria.internal.common.JavaVersionSpecific: 'OFF'
+    com.linecorp.armeria.server.docs.DocStringExtractor: 'OFF'
+    com.linecorp.armeria.server.docs.DocService: 'OFF'
+    # Redundant to logging already done in c.l.a.s.Server
+    com.linecorp.armeria.spring.ArmeriaAutoConfiguration: 'WARN'
     # kafka is quite chatty so we switch everything off by default
     org.apache.kafka: 'OFF'
 #     # investigate /api/v2/dependencies


### PR DESCRIPTION
There was some difference between lens and the full dist. Regardless, we
don't need to log every time that we are using Java 9+.