### PR TITLE
Tracing kafka collector

### DIFF
--- a/docker/examples/docker-compose.yml
+++ b/docker/examples/docker-compose.yml
@@ -34,9 +34,9 @@ services:
       # Point the zipkin at the storage backend
       - MYSQL_HOST=mysql
       # Uncomment to enable self-tracing
-      # - SELF_TRACING_ENABLED=true
-      # Uncomment to increase heap size
-      # - JAVA_OPTS=-Xms128m -Xmx128m -XX:+ExitOnOutOfMemoryError
+      - SELF_TRACING_ENABLED=true
+      # Uncomment to enable debug logging
+      # - JAVA_OPTS=-Dlogging.level.zipkin2=DEBUG
     ports:
       # Port used for the Zipkin UI and HTTP Api
       - 9411:9411

--- a/docker/examples/docker-compose.yml
+++ b/docker/examples/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       # Point the zipkin at the storage backend
       - MYSQL_HOST=mysql
       # Uncomment to enable self-tracing
-      - SELF_TRACING_ENABLED=true
+      # - SELF_TRACING_ENABLED=true
       # Uncomment to enable debug logging
       # - JAVA_OPTS=-Dlogging.level.zipkin2=DEBUG
     ports:

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
@@ -15,13 +15,19 @@ package zipkin2.collector.kafka;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
@@ -65,6 +71,7 @@ public final class KafkaCollector extends CollectorComponent {
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
     String topic = "zipkin";
     int streams = 1;
+    Function<Properties, Consumer<byte[], byte[]>> consumerSupplier = KafkaConsumer::new;
 
     @Override
     public Builder storage(StorageComponent storage) {
@@ -113,6 +120,11 @@ public final class KafkaCollector extends CollectorComponent {
     /** Count of threads consuming the topic. Defaults to 1 */
     public Builder streams(int streams) {
       this.streams = streams;
+      return this;
+    }
+
+    public Builder consumerSupplier(Function<Properties, Consumer<byte[], byte[]>> consumerSupplier) {
+      this.consumerSupplier = consumerSupplier;
       return this;
     }
 

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollector.java
@@ -15,7 +15,6 @@ package zipkin2.collector.kafka;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
@@ -23,7 +22,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.Consumer;

--- a/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
+++ b/zipkin-collector/kafka/src/main/java/zipkin2/collector/kafka/KafkaCollectorWorker.java
@@ -25,7 +25,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -272,6 +272,17 @@
 <!--      <version>0.10.3</version>-->
 <!--      <optional>true</optional>-->
 <!--    </dependency>-->
+    <dependency>
+      <groupId>io.zipkin.brave.cassandra</groupId>
+      <artifactId>brave-instrumentation-cassandra-driver</artifactId>
+      <version>0.10.3</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-kafka-clients</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Test dependencies -->
     <!-- to test the experimental grpc endpoint with the square/wire library -->

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ConditionalOnSelfTracing.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ConditionalOnSelfTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ConditionalOnSelfTracing.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ConditionalOnSelfTracing.java
@@ -60,7 +60,7 @@ public @interface ConditionalOnSelfTracing {
       String selfTracingEnabled = context.getEnvironment()
           .getProperty("zipkin.self-tracing.enabled");
 
-      if (!Boolean.valueOf(selfTracingEnabled)) {
+      if (!Boolean.parseBoolean(selfTracingEnabled)) {
         return ConditionOutcome.noMatch("zipkin.self-tracing.enabled isn't true");
       }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
@@ -108,7 +108,7 @@ public class ZipkinSelfTracingConfiguration {
       // Reduce the impact on untraced downstream http services such as Elasticsearch
       .propagationFactory(B3Propagation.newFactoryBuilder()
         .injectFormat(brave.Span.Kind.CLIENT, B3Propagation.Format.SINGLE)
-        .injectFormat(brave.Span.Kind.CONSUMER, B3Propagation.Format.SINGLE)
+        .injectFormat(brave.Span.Kind.CONSUMER, B3Propagation.Format.SINGLE_NO_PARENT)
         .build())
       .addSpanHandler(zipkinSpanHandler)
       .build();

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
@@ -16,6 +16,8 @@ package zipkin2.server.internal.brave;
 import brave.Tracing;
 import brave.context.slf4j.MDCScopeDecorator;
 import brave.http.HttpTracing;
+import brave.kafka.clients.KafkaTracing;
+import brave.messaging.MessagingTracing;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.ThreadLocalSpan;
@@ -125,6 +127,14 @@ public class ZipkinSelfTracingConfiguration {
           return false;
         }
       )
+      .build();
+  }
+
+  @Bean KafkaTracing kafkaTracing(Tracing tracing) {
+    final MessagingTracing messagingTracing = MessagingTracing.newBuilder(tracing)
+      .build();
+    return KafkaTracing.newBuilder(messagingTracing)
+      .remoteServiceName("zipkin-kafka")
       .build();
   }
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/brave/ZipkinSelfTracingConfiguration.java
@@ -108,6 +108,7 @@ public class ZipkinSelfTracingConfiguration {
       // Reduce the impact on untraced downstream http services such as Elasticsearch
       .propagationFactory(B3Propagation.newFactoryBuilder()
         .injectFormat(brave.Span.Kind.CLIENT, B3Propagation.Format.SINGLE)
+        .injectFormat(brave.Span.Kind.CONSUMER, B3Propagation.Format.SINGLE)
         .build())
       .addSpanHandler(zipkinSpanHandler)
       .build();

--- a/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfiguration.java
@@ -47,9 +47,14 @@ public class ZipkinKafkaCollectorConfiguration { // makes simple type name uniqu
       CollectorMetrics metrics,
       StorageComponent storage,
       Optional<Tracing> maybeTracing) {
-    KafkaCollector.Builder builder = properties.toBuilder().sampler(sampler).metrics(metrics).storage(storage);
+    final KafkaCollector.Builder builder = properties.toBuilder()
+      .sampler(sampler)
+      .metrics(metrics)
+      .storage(storage);
     if (maybeTracing.isPresent()) {
-      KafkaTracing kafkaTracing = KafkaTracing.newBuilder(maybeTracing.get()).build();
+      final KafkaTracing kafkaTracing = KafkaTracing.newBuilder(maybeTracing.get())
+        .remoteServiceName("zipkin-kafka")
+        .build();
       builder.consumerSupplier(props -> kafkaTracing.consumer(new KafkaConsumer<>(props)));
     }
     return builder.build();

--- a/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfigurationTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.server.internal.kafka;
 
+import java.util.function.Function;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,7 +66,8 @@ public class ZipkinKafkaCollectorConfigurationTest {
     context.register(
       PropertyPlaceholderAutoConfiguration.class,
       ZipkinKafkaCollectorConfiguration.class,
-      InMemoryConfiguration.class);
+      InMemoryConfiguration.class,
+      Function.class);
     context.refresh();
 
     assertThat(context.getBean(KafkaCollector.class)).isNotNull();


### PR DESCRIPTION
Fix  #2872

Changes to enable self-tracing on kafka-collector. As mentioned on the issue, `RequestContextCurrentTraceContext` causes an issue to propagate traces.

From [Armeria Slack](https://line-armeria.slack.com/archives/C1NGPBUH2/p1598884943010400):

> We usually recommend to create a fake ServiceRequestContext  in that case.
> <https://armeria.dev/docs/advanced-unit-testing#using-a-fake-context-to-emulate-an-incoming-request>
> So we can emulate the event from the  kafka consumer as a request from a client. 

