### PR TITLE
Removes Cassandra querybuilder dependency

### DIFF
--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/IndexTraceIdByRemoteServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/IndexTraceIdByRemoteServiceName.java
@@ -14,22 +14,18 @@
 package zipkin2.storage.cassandra.v1;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
-import com.datastax.oss.driver.api.querybuilder.insert.RegularInsert;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static zipkin2.storage.cassandra.v1.Tables.SERVICE_REMOTE_SERVICE_NAME_INDEX;
 
 // QueryRequest.remoteServiceName
 final class IndexTraceIdByRemoteServiceName extends IndexTraceId.Factory {
   IndexTraceIdByRemoteServiceName(CassandraStorage storage, int indexTtl) {
-    super(storage, SERVICE_REMOTE_SERVICE_NAME_INDEX, indexTtl);
+    super("INSERT INTO " + SERVICE_REMOTE_SERVICE_NAME_INDEX
+        + " (ts, trace_id, service_remote_service_name) VALUES (?,?,?)",
+      storage, indexTtl);
   }
 
-  @Override RegularInsert declarePartitionKey(RegularInsert insert) {
-    return insert.value("service_remote_service_name", bindMarker());
-  }
-
-  @Override void bindPartitionKey(BoundStatementBuilder bound, String partitionKey) {
-    bound.setString(2, partitionKey);
+  @Override void bindPartitionKey(BoundStatementBuilder bound, String service_remote_service_name) {
+    bound.setString(2, service_remote_service_name);
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/IndexTraceIdByServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/IndexTraceIdByServiceName.java
@@ -14,28 +14,22 @@
 package zipkin2.storage.cassandra.v1;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
-import com.datastax.oss.driver.api.querybuilder.insert.RegularInsert;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static zipkin2.storage.cassandra.v1.IndexTraceId.BUCKET_COUNT;
 import static zipkin2.storage.cassandra.v1.Tables.SERVICE_NAME_INDEX;
 
 // QueryRequest.serviceName
 final class IndexTraceIdByServiceName extends IndexTraceId.Factory {
   IndexTraceIdByServiceName(CassandraStorage storage, int indexTtl) {
-    super(storage, SERVICE_NAME_INDEX, indexTtl);
+    super("INSERT INTO " + SERVICE_NAME_INDEX
+        + " (ts, trace_id, service_name, bucket) VALUES (?,?,?,?)",
+      storage, indexTtl);
   }
 
-  @Override RegularInsert declarePartitionKey(RegularInsert insert) {
-    return insert
-      .value("service_name", bindMarker())
-      .value("bucket", bindMarker());
-  }
-
-  @Override void bindPartitionKey(BoundStatementBuilder bound, String partitionKey) {
+  @Override void bindPartitionKey(BoundStatementBuilder bound, String service_name) {
     bound
-      .setString(2, partitionKey)
+      .setString(2, service_name)
       .setInt(3, ThreadLocalRandom.current().nextInt(BUCKET_COUNT));
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/IndexTraceIdBySpanName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/IndexTraceIdBySpanName.java
@@ -14,22 +14,18 @@
 package zipkin2.storage.cassandra.v1;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
-import com.datastax.oss.driver.api.querybuilder.insert.RegularInsert;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static zipkin2.storage.cassandra.v1.Tables.SERVICE_SPAN_NAME_INDEX;
 
 // QueryRequest.spanName
 final class IndexTraceIdBySpanName extends IndexTraceId.Factory {
   IndexTraceIdBySpanName(CassandraStorage storage, int indexTtl) {
-    super(storage, SERVICE_SPAN_NAME_INDEX, indexTtl);
+    super("INSERT INTO " + SERVICE_SPAN_NAME_INDEX
+        + " (ts, trace_id, service_span_name) VALUES (?,?,?)",
+      storage, indexTtl);
   }
 
-  @Override RegularInsert declarePartitionKey(RegularInsert insert) {
-    return insert.value("service_span_name", bindMarker());
-  }
-
-  @Override void bindPartitionKey(BoundStatementBuilder bound, String partitionKey) {
-    bound.setString(2, partitionKey);
+  @Override void bindPartitionKey(BoundStatementBuilder bound, String service_span_name) {
+    bound.setString(2, service_span_name);
   }
 }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectAutocompleteValues.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectAutocompleteValues.java
@@ -22,8 +22,6 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
 import static zipkin2.storage.cassandra.v1.Tables.AUTOCOMPLETE_TAGS;
 
 final class SelectAutocompleteValues extends ResultSetFutureCall<AsyncResultSet> {
@@ -33,9 +31,10 @@ final class SelectAutocompleteValues extends ResultSetFutureCall<AsyncResultSet>
 
     Factory(CqlSession session) {
       this.session = session;
-      this.preparedStatement = session.prepare(selectFrom(AUTOCOMPLETE_TAGS).column("value")
-        .whereColumn("key").isEqualTo(bindMarker())
-        .limit(10000).build());
+      this.preparedStatement = session.prepare("SELECT value"
+        + " FROM " + AUTOCOMPLETE_TAGS
+        + " WHERE key=?"
+        + " LIMIT " + 10000);
     }
 
     Call<List<String>> create(String key) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectDependencies.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectDependencies.java
@@ -28,8 +28,6 @@ import zipkin2.internal.Dependencies;
 import zipkin2.internal.DependencyLinker;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
 import static zipkin2.storage.cassandra.v1.Tables.DEPENDENCIES;
 
 final class SelectDependencies extends ResultSetFutureCall<List<DependencyLink>> {
@@ -39,8 +37,9 @@ final class SelectDependencies extends ResultSetFutureCall<List<DependencyLink>>
 
     Factory(CqlSession session) {
       this.session = session;
-      this.preparedStatement = session.prepare(selectFrom(DEPENDENCIES).column("dependencies")
-        .whereColumn("day").in(bindMarker()).build());
+      this.preparedStatement = session.prepare("SELECT dependencies"
+        + " FROM " + DEPENDENCIES
+        + " WHERE day IN ?");
     }
 
     Call<List<DependencyLink>> create(long endTs, long lookback) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectRemoteServiceNames.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectRemoteServiceNames.java
@@ -23,22 +23,19 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
 import static zipkin2.storage.cassandra.v1.Tables.REMOTE_SERVICE_NAMES;
 
 final class SelectRemoteServiceNames extends ResultSetFutureCall<AsyncResultSet> {
-
   static final class Factory {
     final CqlSession session;
     final PreparedStatement preparedStatement;
 
     Factory(CqlSession session) {
       this.session = session;
-      this.preparedStatement =
-        session.prepare(selectFrom(REMOTE_SERVICE_NAMES).column("remote_service_name")
-          .whereColumn("service_name").isEqualTo(bindMarker())
-          .limit(1000).build());
+      this.preparedStatement = session.prepare("SELECT remote_service_name"
+        + " FROM " + REMOTE_SERVICE_NAMES
+        + " WHERE service_name=?"
+        + " LIMIT " + 1000);
     }
 
     Call<List<String>> create(String serviceName) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectSpanNames.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectSpanNames.java
@@ -23,22 +23,20 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
+import static zipkin2.storage.cassandra.v1.Tables.SPAN_NAMES;
 
 final class SelectSpanNames extends ResultSetFutureCall<AsyncResultSet> {
-
   static final class Factory {
     final CqlSession session;
     final PreparedStatement preparedStatement;
 
     Factory(CqlSession session) {
       this.session = session;
-      this.preparedStatement = session.prepare(selectFrom(Tables.SPAN_NAMES).column("span_name")
-        .whereColumn("service_name").isEqualTo(bindMarker())
-        .whereColumn("bucket").isEqualTo(literal(0))
-        .limit(10000).build());
+      this.preparedStatement = session.prepare("SELECT span_name"
+        + " FROM " + SPAN_NAMES
+        + " WHERE service_name=?"
+        + " AND bucket=0"
+        + " LIMIT " + 10000);
     }
 
     Call<List<String>> create(String serviceName) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromAnnotations.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromAnnotations.java
@@ -15,9 +15,7 @@ package zipkin2.storage.cassandra.v1;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
-import com.datastax.oss.driver.api.querybuilder.select.Select;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static zipkin2.storage.cassandra.v1.IndexTraceId.BUCKETS;
 import static zipkin2.storage.cassandra.v1.Tables.ANNOTATIONS_INDEX;
 
@@ -27,10 +25,9 @@ final class SelectTraceIdTimestampFromAnnotations extends SelectTraceIdIndex.Fac
     super(session, ANNOTATIONS_INDEX, "annotation", 2);
   }
 
-  @Override Select declarePartitionKey(Select select) {
-    return super
-      .declarePartitionKey(select)
-      .whereColumn("bucket").in(bindMarker());
+  @Override String selectStatement(String table, String partitionKeyColumn) {
+    return super.selectStatement(table, partitionKeyColumn)
+      + " AND bucket IN ?";
   }
 
   @Override void bindPartitionKey(BoundStatementBuilder bound, String partitionKey) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceName.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceName.java
@@ -15,9 +15,7 @@ package zipkin2.storage.cassandra.v1;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
-import com.datastax.oss.driver.api.querybuilder.select.Select;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static zipkin2.storage.cassandra.v1.IndexTraceId.BUCKETS;
 import static zipkin2.storage.cassandra.v1.Tables.SERVICE_NAME_INDEX;
 
@@ -27,10 +25,9 @@ final class SelectTraceIdTimestampFromServiceName extends SelectTraceIdIndex.Fac
     super(session, SERVICE_NAME_INDEX, "service_name", 2);
   }
 
-  @Override Select declarePartitionKey(Select select) {
-    return super
-      .declarePartitionKey(select)
-      .whereColumn("bucket").in(bindMarker());
+  @Override String selectStatement(String table, String partitionKeyColumn) {
+    return super.selectStatement(table, partitionKeyColumn)
+      + " AND bucket IN ?";
   }
 
   @Override void bindPartitionKey(BoundStatementBuilder bound, String serviceName) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceNames.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceNames.java
@@ -37,7 +37,9 @@ final class SelectTraceIdTimestampFromServiceNames
   }
 
   @Override String selectStatement(String table, String partitionKeyColumn) {
-    return super.selectStatement(table, partitionKeyColumn)
+    return "SELECT trace_id,ts"
+      + " FROM " + table
+      + " WHERE " + partitionKeyColumn + " IN ?"
       + " AND bucket IN ?";
   }
 

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceNames.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/SelectTraceIdTimestampFromServiceNames.java
@@ -15,14 +15,12 @@ package zipkin2.storage.cassandra.v1;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
-import com.datastax.oss.driver.api.querybuilder.select.Select;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.v1.SelectTraceIdIndex.Input;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static zipkin2.storage.cassandra.v1.IndexTraceId.BUCKETS;
 import static zipkin2.storage.cassandra.v1.Tables.SERVICE_NAME_INDEX;
 
@@ -38,10 +36,9 @@ final class SelectTraceIdTimestampFromServiceNames
     super(session, SERVICE_NAME_INDEX, "service_name", 2);
   }
 
-  @Override Select declarePartitionKey(Select select) {
-    return select
-      .whereColumn(partitionKeyColumn).in(bindMarker())
-      .whereColumn("bucket").in(bindMarker());
+  @Override String selectStatement(String table, String partitionKeyColumn) {
+    return super.selectStatement(table, partitionKeyColumn)
+      + " AND bucket IN ?";
   }
 
   @Override void bindPartitionKey(BoundStatementBuilder bound, List<String> serviceNames) {

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/TraceIdIndexer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/TraceIdIndexer.java
@@ -65,10 +65,10 @@ interface TraceIdIndexer extends Iterable<Input> {
     final DelayQueue<Expiration<Map.Entry<String, Long>, Pair>> expirations = new DelayQueue<>();
     final long ttlNanos;
     final int cardinality;
-    final String table;
+    final String statement;
 
-    Factory(String table, long ttlNanos, int cardinality) {
-      this.table = table;
+    Factory(String statement, long ttlNanos, int cardinality) {
+      this.statement = statement;
       this.ttlNanos = ttlNanos;
       this.cardinality = cardinality;
     }
@@ -165,7 +165,7 @@ interface TraceIdIndexer extends Iterable<Input> {
       Set<Input> result = entriesThatIncreaseGap();
       if (LOG.isDebugEnabled() && inputs.size() > result.size()) {
         int delta = inputs.size() - result.size();
-        LOG.debug("optimized out {}/{} inputs to {}", delta, inputs.size(), factory.table);
+        LOG.debug("optimized out {}/{} inputs to {}", delta, inputs.size(), factory.statement);
       }
       return result.iterator();
     }

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/TraceIdIndexer.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/TraceIdIndexer.java
@@ -165,7 +165,7 @@ interface TraceIdIndexer extends Iterable<Input> {
       Set<Input> result = entriesThatIncreaseGap();
       if (LOG.isDebugEnabled() && inputs.size() > result.size()) {
         int delta = inputs.size() - result.size();
-        LOG.debug("optimized out {}/{} inserts into {}", delta, inputs.size(), factory.table);
+        LOG.debug("optimized out {}/{} inputs to {}", delta, inputs.size(), factory.table);
       }
       return result.iterator();
     }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraSpanConsumerTest.java
@@ -138,12 +138,20 @@ public class CassandraSpanConsumerTest {
     AggregateCall<?, Void> call = (AggregateCall<?, Void>) consumer.accept(asList(span1, span2));
     assertThat(call.delegate())
       .filteredOn(c -> c instanceof IndexTraceId)
-      .extracting("factory.indexerFactory.table", "input.partitionKey")
+      .extracting("factory.indexerFactory.statement", "input.partitionKey")
       .containsExactly(
-        tuple(Tables.SERVICE_NAME_INDEX, "app"),
-        tuple(Tables.SERVICE_NAME_INDEX, "app.foo"),
-        tuple(Tables.SERVICE_REMOTE_SERVICE_NAME_INDEX, "app.foo"),
-        tuple(Tables.SERVICE_SPAN_NAME_INDEX, "app.foo")
+        tuple(
+          "INSERT INTO service_name_index (ts, trace_id, service_name, bucket) VALUES (?,?,?,?)",
+          "app"),
+        tuple(
+          "INSERT INTO service_name_index (ts, trace_id, service_name, bucket) VALUES (?,?,?,?)",
+          "app.foo"),
+        tuple(
+          "INSERT INTO service_remote_service_name_index (ts, trace_id, service_remote_service_name) VALUES (?,?,?)",
+          "app.foo"),
+        tuple(
+          "INSERT INTO service_span_name_index (ts, trace_id, service_span_name) VALUES (?,?,?)",
+          "app.foo")
       );
 
     // intentionally redundantly accept span2 which double-checks deduplication of index calls

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/InternalForTests.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/InternalForTests.java
@@ -29,8 +29,6 @@ import java.util.Optional;
 import zipkin2.DependencyLink;
 import zipkin2.internal.Dependencies;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
 import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -70,9 +68,9 @@ class InternalForTests {
     CassandraStorage storage, List<DependencyLink> links, long midnightUTC) {
     Dependencies deps = Dependencies.create(midnightUTC, midnightUTC /* ignored */, links);
     ByteBuffer thrift = deps.toThrift();
-    PreparedStatement prepared = storage.session().prepare(insertInto(DEPENDENCIES)
-      .value("day", bindMarker())
-      .value("dependencies", bindMarker()).build());
+
+    PreparedStatement prepared =
+      storage.session().prepare("INSERT INTO " + DEPENDENCIES + " (day,dependencies) VALUES (?,?)");
 
     storage.session().execute(prepared.bind(Instant.ofEpochMilli(midnightUTC), thrift));
   }

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -50,7 +50,7 @@
 
     <dependency>
       <groupId>com.datastax.oss</groupId>
-      <artifactId>java-driver-query-builder</artifactId>
+      <artifactId>java-driver-core</artifactId>
       <version>${java-driver.version}</version>
       <!-- Exclude unused graph and geo dependencies -->
       <exclusions>

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
@@ -87,7 +87,7 @@ class CassandraSpanConsumer implements SpanConsumer { // not final for testing
       insertTraceByServiceRemoteService =
         new InsertTraceByServiceRemoteService.Factory(session, strictTraceId);
       insertServiceRemoteService = new InsertEntry.Factory(
-        TABLE_SERVICE_REMOTE_SERVICES, "service", "remote_service",
+        "INSERT INTO " + TABLE_SERVICE_REMOTE_SERVICES + " (service, remote_service) VALUES (?,?)",
         session, autocompleteTtl, autocompleteCardinality
       );
     } else {
@@ -95,12 +95,12 @@ class CassandraSpanConsumer implements SpanConsumer { // not final for testing
       insertServiceRemoteService = null;
     }
     insertServiceSpan = new InsertEntry.Factory(
-      TABLE_SERVICE_SPANS, "service", "span",
+      "INSERT INTO " + TABLE_SERVICE_SPANS + " (service, span) VALUES (?,?)",
       session, autocompleteTtl, autocompleteCardinality
     );
     if (metadata.hasAutocompleteTags && !autocompleteKeys.isEmpty()) {
       insertAutocompleteValue = new InsertEntry.Factory(
-        TABLE_AUTOCOMPLETE_TAGS, "key", "value",
+        "INSERT INTO " + TABLE_AUTOCOMPLETE_TAGS + " (key, value) VALUES (?,?)",
         session, autocompleteTtl, autocompleteCardinality
       );
     } else {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertTraceByServiceRemoteService.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertTraceByServiceRemoteService.java
@@ -22,12 +22,9 @@ import java.util.concurrent.CompletionStage;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
 import static zipkin2.storage.cassandra.Schema.TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE;
 
 final class InsertTraceByServiceRemoteService extends ResultSetFutureCall<Void> {
-
   @AutoValue abstract static class Input {
     abstract String service();
 
@@ -47,12 +44,10 @@ final class InsertTraceByServiceRemoteService extends ResultSetFutureCall<Void> 
 
     Factory(CqlSession session, boolean strictTraceId) {
       this.session = session;
-      this.preparedStatement = session.prepare(insertInto(TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE)
-        .value("service", bindMarker())
-        .value("remote_service", bindMarker())
-        .value("bucket", bindMarker())
-        .value("ts", bindMarker())
-        .value("trace_id", bindMarker()).build());
+      this.preparedStatement =
+        session.prepare("INSERT INTO " + TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE
+          + " (service,remote_service,bucket,ts,trace_id)"
+          + " VALUES (?,?,?,?,?)");
       this.strictTraceId = strictTraceId;
     }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertTraceByServiceSpan.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/InsertTraceByServiceSpan.java
@@ -23,14 +23,10 @@ import java.util.concurrent.CompletionStage;
 import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
 import static zipkin2.storage.cassandra.Schema.TABLE_TRACE_BY_SERVICE_SPAN;
 
 final class InsertTraceByServiceSpan extends ResultSetFutureCall<Void> {
-
-  @AutoValue
-  abstract static class Input {
+  @AutoValue abstract static class Input {
     abstract String service();
 
     abstract String span();
@@ -51,13 +47,9 @@ final class InsertTraceByServiceSpan extends ResultSetFutureCall<Void> {
 
     Factory(CqlSession session, boolean strictTraceId) {
       this.session = session;
-      this.preparedStatement = session.prepare(insertInto(TABLE_TRACE_BY_SERVICE_SPAN)
-        .value("service", bindMarker())
-        .value("span", bindMarker())
-        .value("bucket", bindMarker())
-        .value("ts", bindMarker())
-        .value("trace_id", bindMarker())
-        .value("duration", bindMarker()).build());
+      this.preparedStatement = session.prepare("INSERT INTO " + TABLE_TRACE_BY_SERVICE_SPAN
+        + " (service,span,bucket,ts,trace_id,duration)"
+        + " VALUES (?,?,?,?,?,?)");
       this.strictTraceId = strictTraceId;
     }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectAutocompleteValues.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectAutocompleteValues.java
@@ -22,21 +22,19 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
 import static zipkin2.storage.cassandra.Schema.TABLE_AUTOCOMPLETE_TAGS;
 
 final class SelectAutocompleteValues extends ResultSetFutureCall<AsyncResultSet> {
-
   static final class Factory {
     final CqlSession session;
     final PreparedStatement preparedStatement;
 
     Factory(CqlSession session) {
       this.session = session;
-      this.preparedStatement = session.prepare(selectFrom(TABLE_AUTOCOMPLETE_TAGS).column("value")
-        .whereColumn("key").isEqualTo(bindMarker())
-        .limit(10000).build());
+      this.preparedStatement = session.prepare("SELECT value"
+        + " FROM " + TABLE_AUTOCOMPLETE_TAGS
+        + " WHERE key=?"
+        + " LIMIT " + 10000);
     }
 
     Call<List<String>> create(String key) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectDependencies.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectDependencies.java
@@ -26,22 +26,18 @@ import zipkin2.DependencyLink;
 import zipkin2.internal.DependencyLinker;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
 import static zipkin2.storage.cassandra.Schema.TABLE_DEPENDENCY;
 
 final class SelectDependencies extends ResultSetFutureCall<List<DependencyLink>> {
-
   static final class Factory {
     final CqlSession session;
     final PreparedStatement preparedStatement;
 
     Factory(CqlSession session) {
       this.session = session;
-      this.preparedStatement =
-        session.prepare(selectFrom(TABLE_DEPENDENCY)
-          .columns("parent", "child", "errors", "calls")
-          .whereColumn("day").in(bindMarker()).build());
+      this.preparedStatement = session.prepare("SELECT parent,child,errors,calls"
+        + " FROM " + TABLE_DEPENDENCY
+        + " WHERE day IN ?");
     }
 
     Call<List<DependencyLink>> create(long endTs, long lookback) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectRemoteServiceNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectRemoteServiceNames.java
@@ -23,22 +23,19 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
 import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_REMOTE_SERVICES;
 
 final class SelectRemoteServiceNames extends ResultSetFutureCall<AsyncResultSet> {
-
   static final class Factory {
     final CqlSession session;
     final PreparedStatement preparedStatement;
 
     Factory(CqlSession session) {
       this.session = session;
-      this.preparedStatement =
-        session.prepare(selectFrom(TABLE_SERVICE_REMOTE_SERVICES).column("remote_service")
-          .whereColumn("service").isEqualTo(bindMarker())
-          .limit(1000).build());
+      this.preparedStatement = session.prepare("SELECT remote_service"
+        + " FROM " + TABLE_SERVICE_REMOTE_SERVICES
+        + " WHERE service=?"
+        + " LIMIT " + 1000);
     }
 
     Call<List<String>> create(String serviceName) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectServiceNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectServiceNames.java
@@ -31,8 +31,8 @@ final class SelectServiceNames extends ResultSetFutureCall<AsyncResultSet> {
 
     Factory(CqlSession session) {
       this.session = session;
-      this.preparedStatement =
-        session.prepare("SELECT DISTINCT service FROM " + TABLE_SERVICE_SPANS);
+      this.preparedStatement = session.prepare("SELECT DISTINCT service"
+          + " FROM " + TABLE_SERVICE_SPANS);
     }
 
     Call<List<String>> create() {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/SelectSpanNames.java
@@ -16,7 +16,6 @@ package zipkin2.storage.cassandra;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
-import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletionStage;
@@ -24,21 +23,19 @@ import zipkin2.Call;
 import zipkin2.storage.cassandra.internal.call.DistinctSortedStrings;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
 import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_SPANS;
 
 final class SelectSpanNames extends ResultSetFutureCall<AsyncResultSet> {
-
   static final class Factory {
     final CqlSession session;
     final PreparedStatement preparedStatement;
 
     Factory(CqlSession session) {
       this.session = session;
-      this.preparedStatement =
-        session.prepare(QueryBuilder.selectFrom(TABLE_SERVICE_SPANS).columns("span")
-          .whereColumn("service").isEqualTo(bindMarker())
-          .limit(10000).build());
+      this.preparedStatement = session.prepare("SELECT span"
+        + " FROM " + TABLE_SERVICE_SPANS
+        + " WHERE service=?"
+        + " LIMIT " + 10000);
     }
 
     Call<List<String>> create(String serviceName) {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
@@ -130,10 +130,10 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
       .collect(Collectors.toList());
 
     assertThat(insertEntryCalls.get(0))
-      .hasToString("InsertEntry{table=span_by_service, service=frontend, span=get}");
+      .hasToString("INSERT INTO span_by_service (service, span) VALUES (frontend,get)");
     assertThat(insertEntryCalls.get(1))
       .hasToString(
-        "InsertEntry{table=remote_service_by_service, service=frontend, remote_service=backend}");
+        "INSERT INTO remote_service_by_service (service, remote_service) VALUES (frontend,backend)");
   }
 
   static long rowCountForTraceByServiceSpan(CassandraStorage storage) {


### PR DESCRIPTION
This removes the querybuilder dependency in efforts to reduce size.

While this saves a couple hundred K, it doesn't change things further as
datastax core lib depends still on a 2.8M shaded guava jar.

I've raised a help request on that for now, but reducing the API surface
area to only core libs should help anyway.

https://groups.google.com/u/1/a/lists.datastax.com/g/java-driver-user/c/aN7NkxX_yQk