### PR TITLE
Removes JMX dependency from our docker configuration

### DIFF
--- a/docker/bin/start-zipkin
+++ b/docker/bin/start-zipkin
@@ -33,5 +33,9 @@ if [ -z "${MODULE_OPTS+x}" ]; then
   exec java ${JAVA_OPTS} -cp '.:BOOT-INF/lib/*:BOOT-INF/classes' zipkin.server.ZipkinServer "$@"
 else
   JAVA_OPTS=${JAVA_OPTS:-"-Xms64m -Xmx64m -XX:+ExitOnOutOfMemoryError"}
-  exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher "$@"
+
+  # Disable Log4j2 JMX extensions when running the full build
+  exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp . \
+  -Dlog4j2.disable.jmx=true \
+  org.springframework.boot.loader.PropertiesLauncher "$@"
 fi

--- a/docker/collector/kafka/Dockerfile
+++ b/docker/collector/kafka/Dockerfile
@@ -52,7 +52,9 @@ USER ${USER}
 COPY --from=install --chown=${USER} /install .
 
 # ${KAFKA_ADVERTISED_HOST_NAME}:19092 is for connections from the Docker host
-ENV KAFKA_ADVERTISED_HOST_NAME=localhost \
-    KAFKA_HEAP_OPTS="-Xms256m -Xmx256m -XX:+ExitOnOutOfMemoryError"
+ENV KAFKA_ADVERTISED_HOST_NAME=localhost
+# Use to set heap, trust store or other system properties.
+ENV ZOOKEEPER_JAVA_OPTS="-Xms32m -Xmx32m -XX:+ExitOnOutOfMemoryError"
+ENV JAVA_OPTS="-Xms256m -Xmx256m -XX:+ExitOnOutOfMemoryError"
 
 EXPOSE 2181 9092 19092

--- a/docker/collector/kafka/docker-bin/start-kafka-zookeeper
+++ b/docker/collector/kafka/docker-bin/start-kafka-zookeeper
@@ -27,7 +27,9 @@ KAFKA_CONFIG=./config/server.properties
 grep -qF -- "$ADVERTISED_LISTENERS" $KAFKA_CONFIG || echo "$ADVERTISED_LISTENERS" >> $KAFKA_CONFIG
 
 echo Starting ZooKeeper
-bin/kafka-run-class.sh \
+exec java -cp 'libs/*' ${ZOOKEEPER_JAVA_OPTS} \
+  -Djava.io.tmpdir=/tmp \
+  -Dzookeeper.jmx.log4j.disable=true \
   -Dlog4j.configuration=file:./config/log4j.properties \
   org.apache.zookeeper.server.quorum.QuorumPeerMain ./config/zookeeper.properties &
 
@@ -35,6 +37,4 @@ bin/kafka-run-class.sh \
 until echo ruok | nc 127.0.0.1 2181 > /dev/null; do sleep 1; done
 
 echo Starting Kafka
-exec bin/kafka-run-class.sh -name kafkaServer \
-  -Dlog4j.configuration=file:./config/log4j.properties \
-  kafka.Kafka ./config/server.properties
+exec bin/kafka-run-class.sh kafka.Kafka ./config/server.properties "$@"


### PR DESCRIPTION
This buys back 800K plus startup time by disabling things that need JMX.
The 800K is not saved here, rather in our base docker image once this is
done.