### PR TITLE
Deprecates Cassandra v1 schema for removal in Zipkin 2.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,18 +173,6 @@ This store does not require a [job to aggregate](https://github.com/openzipkin/z
 However, running the job will improve performance of dependencies
 queries.
 
-#### Cassandra
-The [Cassandra v1](zipkin-storage/cassandra-v1) component uses Cassandra
-2.2+ features, but is tested against the latest patch of Cassandra 3.11.
-
-The CQL was written in 2015, based on the original Cassandra schema from
-Twitter, and since been extended. Spans are stored as opaque thrifts,
-which means you cannot query fields in cqlsh. The schema was designed
-for scale, including manually implemented indexes to make querying
-larger data more performant.
-
-Note: This store requires a [job to aggregate](https://github.com/openzipkin/zipkin-dependencies) dependency links.
-
 ## Running the server from source
 The [Zipkin server](zipkin-server) receives spans via HTTP POST and respond to queries
 from its UI. It can also run collectors, such as RabbitMQ or Kafka.

--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -97,10 +97,6 @@ class ServerIntegratedBenchmark {
     runBenchmark(elasticsearch);
   }
 
-  @Test void cassandra() throws Exception {
-    runBenchmark(createCassandra("cassandra"));
-  }
-
   @Test void cassandra3() throws Exception {
     runBenchmark(createCassandra("cassandra3"));
   }

--- a/docker/examples/docker-compose-cassandra.yml
+++ b/docker/examples/docker-compose-cassandra.yml
@@ -23,6 +23,10 @@ version: '2.4'
 services:
   storage:
     image: openzipkin/zipkin-cassandra:${TAG:-latest}
+    # Uncomment to use DSE instead (minimum version 5.1)
+    # image: datastax/dse-server:5.1.20
+    # environment:
+    #  - DS_LICENSE=accept
     container_name: cassandra
     # Uncomment to expose the storage port for testing
     # ports:
@@ -36,13 +40,14 @@ services:
     # slim doesn't include Cassandra support, so switch to the larger image
     image: openzipkin/zipkin:${TAG:-latest}
     environment:
-      # To test legacy storage, use STORAGE_TYPE=cassandra
-      - STORAGE_TYPE=${STORAGE_TYPE:-cassandra3}
-      # When using the test docker image, or have schema pre-installed, you don't need to re-install it
+      - STORAGE_TYPE=cassandra3
+      # When using the test docker image, or have schema pre-installed, you don't need to ensure it
       - CASSANDRA_ENSURE_SCHEMA=false
-      # When overriding this value, note the minimum supported version is 3.9
-      # If you you cannot run 3.9+, but can run 2.2+, set STORAGE_TYPE=cassandra
+      # When overriding this value, note the minimum supported version is 3.11.3
       - CASSANDRA_CONTACT_POINTS=cassandra
+      # Uncomment to configure authentication
+      # - CASSANDRA_USERNAME=cassandra
+      # - CASSANDRA_PASSWORD=cassandra
     # Uncomment to enable request logging (TRACE shows query values)
     # command: --logging.level.com.datastax.oss.driver.internal.core.tracker.RequestLogger=TRACE
     depends_on:

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -142,7 +142,7 @@ A value of 0 will disable the timeout completely. Defaults to 11s.
 * `QUERY_NAMES_MAX_AGE`: Controls the value of the `max-age` header zipkin-server responds with on
  http requests for autocompleted values in the UI (service names for example). Defaults to 300 seconds.
 * `QUERY_LOOKBACK`: How many milliseconds queries can look back from endTs; Defaults to 24 hours (two daily buckets: one for today and one for yesterday)
-* `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra`, `elasticsearch`
+* `STORAGE_TYPE`: SpanStore implementation: one of `mem`, `mysql`, `cassandra3`, `elasticsearch`
 * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 * `AUTOCOMPLETE_KEYS`: list of span tag keys which will be returned by the `/api/v2/autocompleteTags` endpoint; Tag keys should be comma separated e.g. "instance_id,user_id,env"
 * `AUTOCOMPLETE_TTL`: How long in milliseconds to suppress calls to write the same autocomplete key/value pair. Default 3600000 (1 hr)
@@ -222,8 +222,8 @@ $ MEM_MAX_SPANS=1000000 java -Xmx1G -jar zipkin.jar
 ```
 
 ### Cassandra Storage
-Zipkin's [Cassandra storage component](../zipkin-storage/cassandra)
-supports version 3.11+ and applies when `STORAGE_TYPE` is set to `cassandra3`:
+Zipkin's [Cassandra storage component](../zipkin-storage/cassandra) supports Cassandra 3.11.3+
+and applies when `STORAGE_TYPE` is set to `cassandra3`:
 
     * `CASSANDRA_KEYSPACE`: The keyspace to use. Defaults to "zipkin2"
     * `CASSANDRA_CONTACT_POINTS`: Comma separated list of host addresses part of Cassandra cluster. You can also specify a custom port with 'host:port'. Defaults to localhost on port 9042.
@@ -356,19 +356,6 @@ Example usage:
 
 ```bash
 $ STORAGE_TYPE=mysql MYSQL_USER=root java -jar zipkin.jar
-```
-
-#### Cassandra Storage
-Zipkin's [Legacy (v1) Cassandra storage component](../zipkin-storage/cassandra-v1)
-supports version 2.2+ and applies when `STORAGE_TYPE` is set to `cassandra`:
-
-The environment variables are the same as `STORAGE_TYPE=cassandra3`,
-except the default keyspace name is "zipkin".
-
-Example usage:
-
-```bash
-$ STORAGE_TYPE=cassandra java -jar zipkin.jar
 ```
 
 ### Throttled Storage (Experimental)

--- a/zipkin-server/src/main/java/zipkin2/server/internal/cassandra/ZipkinCassandraStorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/cassandra/ZipkinCassandraStorageConfiguration.java
@@ -14,6 +14,8 @@
 package zipkin2.server.internal.cassandra;
 
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -41,6 +43,7 @@ import zipkin2.storage.cassandra.v1.SessionFactory;
 @ConditionalOnMissingBean(StorageComponent.class)
 @Import(ZipkinCassandraStorageConfiguration.TracingSessionFactoryEnhancer.class)
 public class ZipkinCassandraStorageConfiguration {
+  static final Logger LOG = LoggerFactory.getLogger(ZipkinCassandraStorageConfiguration.class);
 
   @Bean SessionFactory sessionFactory() {
     return new SessionFactory.Default();
@@ -49,14 +52,18 @@ public class ZipkinCassandraStorageConfiguration {
   @Bean
   @ConditionalOnMissingBean
   StorageComponent storage(
-      ZipkinCassandraStorageProperties properties,
-      SessionFactory sessionFactory,
-      @Value("${zipkin.storage.strict-trace-id:true}") boolean strictTraceId,
-      @Value("${zipkin.storage.search-enabled:true}") boolean searchEnabled,
-      @Value("${zipkin.storage.autocomplete-keys:}") List<String> autocompleteKeys,
-      @Value("${zipkin.storage.autocomplete-ttl:3600000}") int autocompleteTtl,
-      @Value("${zipkin.storage.autocomplete-cardinality:20000}") int autocompleteCardinality) {
-   return properties.toBuilder()
+    ZipkinCassandraStorageProperties properties,
+    SessionFactory sessionFactory,
+    @Value("${zipkin.storage.strict-trace-id:true}") boolean strictTraceId,
+    @Value("${zipkin.storage.search-enabled:true}") boolean searchEnabled,
+    @Value("${zipkin.storage.autocomplete-keys:}") List<String> autocompleteKeys,
+    @Value("${zipkin.storage.autocomplete-ttl:3600000}") int autocompleteTtl,
+    @Value("${zipkin.storage.autocomplete-cardinality:20000}") int autocompleteCardinality) {
+    LOG.warn(
+      "\"STORAGE_TYPE=cassandra\" is deprecated and will be removed in Zipkin v2.23.\n"
+        + "Please change to \"STORAGE_TYPE=cassandra3\", noting this requires Cassandra v3.11.3+ with SASI enabled.\n"
+        + "Contact https://gitter.im/openzipkin/zipkin for more information.");
+    return properties.toBuilder()
       .strictTraceId(strictTraceId)
       .searchEnabled(searchEnabled)
       .autocompleteKeys(autocompleteKeys)

--- a/zipkin-storage/cassandra-v1/README.md
+++ b/zipkin-storage/cassandra-v1/README.md
@@ -1,4 +1,4 @@
-# storage-cassandra
+# This is deprecated and will be removed in v2.23. Use [zipkin-storage-cassandra](../cassandra) instead.
 
 This is a CQL-based Cassandra storage component, built upon the [Zipkin v1 thrift model](https://github.com/openzipkin/zipkin-api/tree/master/thrift).
 This uses Cassandra 2.2+ features, but is tested against the latest patch of Cassandra 3.11.

--- a/zipkin-storage/cassandra-v1/pom.xml
+++ b/zipkin-storage/cassandra-v1/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>zipkin-storage-cassandra-v1</artifactId>
-  <name>Storage: Cassandra (v1)</name>
+  <name>Storage: Cassandra (Deprecated)</name>
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>

--- a/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/main/java/zipkin2/storage/cassandra/v1/CassandraStorage.java
@@ -43,8 +43,10 @@ import zipkin2.storage.cassandra.v1.Schema.Metadata;
  * This feature is implemented by {@link DeduplicatingInsert}.
  *
  * <p>Schema is installed by default from "/cassandra-schema.cql"
+ *
+ * @deprecated use {@link zipkin2.storage.cassandra.CassandraStorage} instead
  */
-public class CassandraStorage extends StorageComponent { // not final for mocking
+@Deprecated public class CassandraStorage extends StorageComponent { // not final for mocking
 
   public static Builder newBuilder() {
     return new Builder();

--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -1,4 +1,4 @@
-# storage-cassandra
+# zipkin-storage-cassandra
 
 This is a CQL-based Cassandra storage component, built upon the [Zipkin v2 api and model](https://zipkin.io/zipkin-api/#/default/post_spans).
 This uses Cassandra 3.11.3+ features, but is tested against the latest patch of Cassandra 3.11.

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>zipkin-storage-cassandra</artifactId>
-  <name>Storage: Cassandra (Zipkin V2)</name>
+  <name>Storage: Cassandra</name>
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>


### PR DESCRIPTION
The "cassandra3" storage type relies on Cassandra v3.11.3+. This has
been out for over 2 years. We will soon need to support v4 which is
coming out of beta soon. Maintenance on the v1 schema has been immense
and I don't think volunteers would do any more refactors of it. It is
time to deprecate and remove the v1 schema.

"cassandra3" uses UDTs and optimized SASI indexing.  While SASI is
marked experimental, it is enabled by default in recent Cassandra
versions. Some clones of Cassandra may choose to not support SASI, but
this does not mean we must maintain an ancient schema. Those who must
use a clone can disable search, which avoids SASI.

It is likely that when Cassandra 4 comes out, we will use SAI indexing
instead with some migration instructions. However, SASI as used today
has been used in production for 2 years. Even if the feature is marked
experimental, it is well practiced here.