### PR TITLE
Switches to run tests with release profile and using parallel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
 
 # Override default travis to use the maven wrapper
 # * Use the "release" profile as that ensures the core jar ends up JRE 1.6 compatible
-install: ./mvnw install -DskipTests=true -Dlicense.skip=true -Dmaven.javadoc.skip=true -B -V -Prelease
+install: ./mvnw -T1C install -DskipTests=true -Dlicense.skip=true -Dmaven.javadoc.skip=true -B -V -Prelease
 script: ./travis/publish.sh
 
 branches:

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -167,8 +167,8 @@ fi
 if is_release_commit; then
   true
 else
-  # Ensure no tests rely on the actuator library
-  MYSQL_USER=root ./mvnw verify -nsu -DskipActuator
+  # Ensure no tests rely on the actuator library, ensure nothing in release profile will fail
+  ./mvnw -T1C verify -nsu -DskipActuator -Prelease
 fi
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -129,7 +129,7 @@
                     <!-- JDK 12+ can no longer generate Java 1.6 bytecode, so we require JDK 11.
                          https://www.oracle.com/java/technologies/javase/12-relnote-issues.html -->
                     <requireJavaVersion>
-                      <version>[1.8,12)</version>
+                      <version>[11,12)</version>
                     </requireJavaVersion>
                   </rules>
                 </configuration>


### PR DESCRIPTION
This makes travis run tests in the same profile as the release build, ensuring no surprises on release.