### PR TITLE
Changes base images to pull GitHub Container Registry instead of Docker Hub

### DIFF
--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -151,14 +151,14 @@ class ServerIntegratedBenchmark {
 
   void runBenchmark(@Nullable GenericContainer<?> storage, GenericContainer<?> zipkin)
     throws Exception {
-    GenericContainer<?> backend = new GenericContainer<>(parse("openzipkin/example-brave:armeria"))
+    GenericContainer<?> backend = new GenericContainer<>(parse("ghcr.io/openzipkin/brave-example:armeria"))
       .withNetwork(Network.SHARED)
       .withNetworkAliases("backend")
       .withCommand("backend")
       .withExposedPorts(9000)
       .waitingFor(Wait.forHealthcheck());
 
-    GenericContainer<?> frontend = new GenericContainer<>(parse("openzipkin/example-brave:armeria"))
+    GenericContainer<?> frontend = new GenericContainer<>(parse("ghcr.io/openzipkin/brave-example:armeria"))
       .withNetwork(Network.SHARED)
       .withNetworkAliases("frontend")
       .withCommand("frontend")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN /tmp/install.sh && rm /tmp/install.sh
 #
 # zipkin-builder is JDK + artifact caches because DockerHub doesn't support another way to update
 # cache between builds.
-FROM openzipkin/java:${java_version} as zipkin-builder
+FROM ghcr.io/openzipkin/java:${java_version} as zipkin-builder
 
 COPY --from=install /root/.m2 /root/.m2
 COPY --from=install /root/.npm /root/.npm
@@ -52,7 +52,8 @@ COPY --from=install /root/.npm /root/.npm
 # zipkin-ui - An image containing the Zipkin web frontend only, served by NGINX
 #####
 
-FROM nginx:1.18-alpine as zipkin-ui
+# Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
+FROM quay.io/app-sre/nginx:1.19-alpine as zipkin-ui
 LABEL MAINTAINER OpenZipkin "http://zipkin.io/"
 
 ENV ZIPKIN_BASE_URL=http://zipkin:9411
@@ -72,7 +73,7 @@ RUN mkdir -p /var/tmp/nginx && chown -R nginx:nginx /var/tmp/nginx
 EXPOSE 80
 
 # Almost everything is common between the slim and normal build
-FROM openzipkin/java:${java_version}-jre as base-server
+FROM ghcr.io/openzipkin/java:${java_version}-jre as base-server
 
 # All content including binaries and logs write under WORKDIR
 ARG USER=zipkin

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -21,7 +21,7 @@ FROM scratch as scratch
 
 COPY . /code/
 
-FROM openzipkin/java:${java_version} as built
+FROM ghcr.io/openzipkin/java:${java_version} as built
 
 # Copy Maven source tree into the Docker context
 COPY --from=scratch /code /code
@@ -34,7 +34,7 @@ RUN mvn -T1C -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zip
 
 # zipkin-builder is JDK + artifact caches because DockerHub doesn't support another way to update
 # cache between builds.
-FROM openzipkin/java:${java_version} as zipkin-builder
+FROM ghcr.io/openzipkin/java:${java_version} as zipkin-builder
 
 COPY --from=built /root/.m2 /root/.m2
 COPY --from=built /root/.npm /root/.npm

--- a/docker/collector/kafka/Dockerfile
+++ b/docker/collector/kafka/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=scratch /install/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 
 # Share the same base image to reduce layers used in testing
-FROM openzipkin/java:${java_version}-jre as zipkin-kafka
+FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-kafka
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/

--- a/docker/examples/docker-compose-example.yml
+++ b/docker/examples/docker-compose-example.yml
@@ -20,7 +20,7 @@ services:
   # Generate traffic by hitting http://localhost:8081
   frontend:
     container_name: frontend
-    image: openzipkin/example-brave:${PROJECT:-armeria}
+    image: ghcr.io/openzipkin/brave-example:${PROJECT:-armeria}
     command: frontend
     ports:
       - 8081:8081
@@ -30,7 +30,7 @@ services:
   # Serves the /api endpoint the frontend uses
   backend:
     container_name: backend
-    image: openzipkin/example-brave:${PROJECT:-armeria}
+    image: ghcr.io/openzipkin/brave-example:${PROJECT:-armeria}
     command: backend
     depends_on:
       - zipkin

--- a/docker/storage/cassandra/Dockerfile
+++ b/docker/storage/cassandra/Dockerfile
@@ -25,7 +25,7 @@ COPY docker/storage/cassandra/install.sh /install/
 COPY docker/storage/cassandra/docker-bin/* /docker-bin/
 
 # Until Cassandra supports recent JDKs, we can't re-use our builder
-FROM openzipkin/java:${java_version} as install
+FROM ghcr.io/openzipkin/java:${java_version} as install
 
 # Use latest stable release here.
 ENV CASSANDRA_VERSION=3.11.8
@@ -36,7 +36,7 @@ COPY --from=scratch /zipkin-schemas/* ./zipkin-schemas/
 COPY --from=scratch /install/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 
-FROM openzipkin/java:${java_version} as zipkin-cassandra
+FROM ghcr.io/openzipkin/java:${java_version} as zipkin-cassandra
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/

--- a/docker/storage/elasticsearch6/Dockerfile
+++ b/docker/storage/elasticsearch6/Dockerfile
@@ -34,7 +34,7 @@ RUN wget -qO- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch
 
 COPY --from=scratch /config/ ./config/
 
-FROM openzipkin/java:${java_version}-jre as zipkin-elasticsearch6
+FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-elasticsearch6
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/

--- a/docker/storage/elasticsearch7/Dockerfile
+++ b/docker/storage/elasticsearch7/Dockerfile
@@ -35,7 +35,7 @@ RUN wget -qO- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch
 
 COPY --from=scratch /config/ ./config/
 
-FROM openzipkin/java:${java_version}-jre as zipkin-elasticsearch7
+FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-elasticsearch7
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/

--- a/docker/storage/mysql/Dockerfile
+++ b/docker/storage/mysql/Dockerfile
@@ -24,7 +24,7 @@ COPY zipkin-storage/mysql-v1/src/main/resources/mysql.sql /zipkin-schemas/
 COPY docker/storage/mysql/install.sh /install/
 COPY docker/storage/mysql/docker-bin/* /docker-bin/
 
-FROM alpine:${alpine_version} as install
+FROM ghcr.io/openzipkin/java:${java_version}-jre as install
 
 WORKDIR /install
 

--- a/docker/storage/mysql/Dockerfile
+++ b/docker/storage/mysql/Dockerfile
@@ -12,7 +12,8 @@
 # the License.
 #
 
-ARG alpine_version
+# We don't use Java in this image, but we switch to a base layer that is managed by OpenZipkin
+ARG java_version
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -31,8 +32,8 @@ COPY --from=scratch /zipkin-schemas/* ./zipkin-schemas/
 COPY --from=scratch /install/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 
-# Use a small base image at runtime
-FROM alpine:${alpine_version} as zipkin-mysql
+# Re-use the base layer other images use
+FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-mysql
 
 # Add the mysql binary and handle installation edge cases
 RUN apk add --no-cache mysql && \


### PR DESCRIPTION
This is the first step in removing a build outage risk due to Docker Hub
pull limits. This changes the base images used to something not Docker Hub,
mostly GitHub Container Registry except an edge case for our base NGINX
layer.

Notably, this does not fix zipkin-builder as that will be done in a
separate PR.

See https://github.com/openzipkin/docker-java/pull/33