### PR TITLE
Stops pushing master tags zipkin-builder to Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ before_install:
 
   # Disable testcontainers checks
   - echo checks.disable=true > ~/.testcontainers.properties
+  # Log in to Docker Hub for releasing the image
+  - echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
   # allocate commits to CI, not the owner of the deploy key
   - git config user.name "zipkinci"
   - git config user.email "zipkinci+zipkin-dev@googlegroups.com"
@@ -70,8 +72,10 @@ env:
     - secure: "HvCQa4ZC7dexW8Iddbwtox4NY4yvoZtyYtkwlRG5Jh/h7MY1rFwghpqv42WunOnq+hgpVUWCJPM2sM1WY+JQQXSRFFfkUxSnVGfyqIRW3oHf6uK4Sw4rtX+Q/nthliu5QNqReMcg0+rr/UD2Nxat4QZqtnlVm2MQJNu8oxcm0hw="
     # Ex. travis encrypt BINTRAY_KEY=xxx-https://bintray.com/profile/edit-xxx
     - secure: "JC8sJHol2tGQT8QK00L8YQZjeo8gUnGS3x+kuYwF4UknJrJbz4+UU4uz2VDQJNdomjROngO6qLZrZmHOuV9l2LswZ7atlvMdEA16lxwKUQKK9xq4Qs5RxdZsz+zJwmEW5QcocjM1bRAQv+y4MPY9rHmoWEjtFQzfEovBpwFjafM="
+    # Ex. travis encrypt GH_USER=your_github_account
+    - secure: "DOR/FJHQ5O9zUKd3NMfPxs9qbKewd8BngJprLOKHY7X2ytxEHt+nYC0oReJYafNDCSkmB6TqFoFqUCOVHq3MV1+JyB7AE4Wnv5uSBuXc6PPLhFAbvk8t4K93ZcP7dtQ2fMivXow9Biwifsb86hxE2cbugAPzK0u4P/K0I+jR83w="
     # Ex. travis encrypt GH_TOKEN=XXX-https://github.com/settings/tokens-XXX
-    - secure: "MHpcpzQD/IVIDYtqK8DTJZ8qRsOUjUQhMqgLRCUtgOJUT/viM4QyrTZ1Yy+RkMsk5yO1+0wzteUuKJdni6Qo9PGBKU6arNPovf3/6vBZIeGPzFSeW+Mv9f83xLtvmneactNUBshJVr9jERycBy0/CRRWZqHwlWxXm9AfIZWzIDA="
+    - secure: "iXguaqYanWISgCtzyvEh7qj5JzTkCQfAzzuCpmEouSfUtkLMjn89p1wz+MMoSYsyswoeyZ+U19vyYCUkFv61XuskYXwa/2h2cVB7PGCu9Wevmjiog6LekfaRFzrdwHbvTEe0l2b7MfGmblzc/OB49phNjhTMqTcGI2dkR/O9qgQ="
     # Ex. travis encrypt SONATYPE_USER=your_sonatype_account
     - secure: "RF2kzoNPeQO6As/2VcNAxb8HDptXLf3dejJBiZHNNTSYTDWeAIjGQeW0edu908+OQwuhC1y94oXWADzuaAgLTg32YU8rwU0esNjTp4e2QL7EsELVzoTUPJrvoG2DasF8wOXd+Vr2nPEIZiuUonrFQR75Bb7OWq1FQjtXemfVksI="
     # Ex. travis encrypt SONATYPE_PASSWORD=your_sonatype_password

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ COPY . /code/
 # zipkin-builder - An image that caches build repositories (.m2, .npm) to speed up subsequent builds.
 #####
 
-FROM openzipkin/zipkin-builder as install
+FROM ghcr.io/openzipkin/zipkin-builder as install
 
 WORKDIR /install
 
@@ -37,16 +37,6 @@ ARG release_version
 ENV RELEASE_VERSION=$release_version
 COPY docker/bin/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
-
-# docker/hooks/post_push will republish what is otherwise built in docker/build/Dockerfile
-# This is a copy/paste from builder/Dockerfile:
-#
-# zipkin-builder is JDK + artifact caches because DockerHub doesn't support another way to update
-# cache between builds.
-FROM ghcr.io/openzipkin/java:${java_version} as zipkin-builder
-
-COPY --from=install /root/.m2 /root/.m2
-COPY --from=install /root/.npm /root/.npm
 
 #####
 # zipkin-ui - An image containing the Zipkin web frontend only, served by NGINX

--- a/docker/builder/README.md
+++ b/docker/builder/README.md
@@ -9,9 +9,10 @@ accumulated too much cruft, it can be refreshed with the following:
 
 ```bash
 # Build the builder and publish it
-$ docker login
 $ docker/build_image zipkin-builder latest
-$ docker push openzipkin/zipkin-builder
+$ docker tag openzipkin/zipkin-builder ghcr.io/openzipkin/zipkin-builder
+$ echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
+$ docker push ghcr.io/openzipkin/zipkin-builder
 ```
 
 We'll add a weekly cron at some point to do this automatically.

--- a/docker/collector/kafka/Dockerfile
+++ b/docker/collector/kafka/Dockerfile
@@ -22,7 +22,7 @@ FROM scratch as scratch
 COPY docker/collector/kafka/install.sh /install/
 COPY docker/collector/kafka/docker-bin/* /docker-bin/
 
-FROM openzipkin/zipkin-builder as install
+FROM ghcr.io/openzipkin/zipkin-builder as install
 
 # Use latest stable release here. Scala 2.13+ supports JRE 14
 ENV KAFKA_VERSION=2.6.0 SCALA_VERSION=2.13

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -20,6 +20,11 @@
 # substitutions like: ${DOCKER_TAG//,/ }
 set -eux
 
+if [ "${DOCKER_TAG}" = "master" ]; then
+  echo Travis builds master, not Docker Hub
+  exit 1
+fi
+
 # Docker Hub's default build command seems to not handle .dockerignore correctly. Doing a simple
 # build command ourselves works fine.
 

--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -20,6 +20,11 @@
 # substitutions like: ${DOCKER_TAG//,/ }
 set -eux
 
+if [ "${DOCKER_TAG}" = "master" ]; then
+  echo Travis builds master, not Docker Hub
+  exit 1
+fi
+
 # This hook is called with the current directory set to the same as the Dockerfile, so we go back
 # to top level.
 cd ..
@@ -32,16 +37,4 @@ if [ "${DOCKER_REPO}" = "index.docker.io/openzipkin/zipkin" ]; then
       docker push ${image}
     done
   done
-
-  if [ "${DOCKER_TAG}" = "master" ]; then
-    # We re-push the builder image on master, not on release branches.
-    echo Building zipkin-builder
-
-    docker/build_image zipkin-builder latest
-
-    echo Pushing zipkin-builder
-    # zipkin-builder is just a cache of maven / npm dependencies, there's no need to version it
-    # with docker tags.
-    docker push openzipkin/zipkin-builder
-  fi
 fi

--- a/docker/storage/elasticsearch6/Dockerfile
+++ b/docker/storage/elasticsearch6/Dockerfile
@@ -22,7 +22,7 @@ FROM scratch as scratch
 COPY docker/storage/elasticsearch6/config/ /config/
 COPY docker/storage/elasticsearch7/docker-bin/* /docker-bin/
 
-FROM openzipkin/zipkin-builder as install
+FROM ghcr.io/openzipkin/zipkin-builder as install
 
 ENV ELASTICSEARCH_VERSION 6.8.12
 

--- a/docker/storage/elasticsearch7/Dockerfile
+++ b/docker/storage/elasticsearch7/Dockerfile
@@ -22,7 +22,7 @@ FROM scratch as scratch
 COPY docker/storage/elasticsearch7/config/ /config/
 COPY docker/storage/elasticsearch7/docker-bin/* /docker-bin/
 
-FROM openzipkin/zipkin-builder as install
+FROM ghcr.io/openzipkin/zipkin-builder as install
 
 ENV ELASTICSEARCH_VERSION 7.9.2
 


### PR DESCRIPTION
This pushes zipkin-builder and master tags to GitHub Container Registry
instead of Docker Hub. The release builds are still pushes solely to
Docker Hub at this point, but they will also be pushed to GHCR in a
later pull request.

See https://github.com/openzipkin/docker-java/pull/33