### PR TITLE
Adds RELEASE_FROM_CONTEXT to allow Docker to re-use binaries just built

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
 **/.*
 !.dockerignore
 !.mvn
@@ -21,3 +22,7 @@
 **/Dockerfile
 docker/hooks/**
 travis/**
+
+# Allow re-use of built artifacts when building docker from master or a release tag
+!/zipkin-exec.jar
+!/zipkin-slim.jar

--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,8 @@ _site/
 .idea
 *.iml
 *.swp
-# .travis.yml installs things
-/apache-cassandra-*
-/elasticsearch-*
-/kafka_*
+# quickstart or temporary copies of zipkin's jar
+*.jar
 # temporary directory used by travis/publish.sh for building gh-pages
 /javadoc-builddir
 .DS_Store

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,9 @@ COPY --from=scratch /code /code
 # This will either be "master" or a real version ex. "2.4.5"
 ARG release_version
 ENV RELEASE_VERSION=$release_version
+# When true, main images reuse zipkin-exec.jar and zipkin-slim.jar in the context root
+ARG release_from_context=false
+ENV RELEASE_FROM_CONTEXT=$release_from_context
 COPY docker/bin/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 

--- a/docker/bin/install.sh
+++ b/docker/bin/install.sh
@@ -15,9 +15,11 @@
 
 set -eux
 
-# This script decides based on $RELEASE_VERSION whether to build or download the binaries we need.
-if [ "$RELEASE_VERSION" = "master" ]
-then
+# This script decides based on $RELEASE_FROM_CONTEXT and $RELEASE_VERSION whether to reuse, build,
+# or download the binaries we need.
+if [ "$RELEASE_FROM_CONTEXT" = "true" ]; then
+  echo "*** Reusing binaries in the Docker context..."
+elif [ "$RELEASE_VERSION" = "master" ]; then
   echo "*** Building from source..."
   # Use the same command as we suggest in zipkin-server/README.md
   #  * Uses mvn not ./mvnw to reduce layer size: we control the Maven version in Docker

--- a/docker/build_image
+++ b/docker/build_image
@@ -21,6 +21,8 @@ set -ue
 
 TARGET=${1:-zipkin}
 TAG=${2:-test}
+# When true, main images reuse zipkin-exec.jar and zipkin-slim.jar in the context root
+RELEASE_FROM_CONTEXT=${RELEASE_FROM_CONTEXT:-false}
 RELEASE_VERSION=${RELEASE_VERSION:-master}
 
 # When publishing jars, we build with JDK 11 to ensure we can write 1.6 zipkin.jar for Brave.
@@ -67,5 +69,7 @@ esac
 IMAGE=openzipkin/${TARGET}:${TAG}
 echo "Building image ${IMAGE} with java_version ${JAVA_VERSION}"
 docker build -f "${DOCKERFILE_PATH}" -t "${IMAGE}" \
-    --build-arg "java_version=${JAVA_VERSION}" --build-arg release_version="${RELEASE_VERSION}" \
+    --build-arg java_version="${JAVA_VERSION}" \
+    --build-arg release_from_context="${RELEASE_FROM_CONTEXT}" \
+    --build-arg release_version="${RELEASE_VERSION}" \
     --target "${TARGET}" .

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -147,10 +147,13 @@ javadoc_to_gh_pages() {
 }
 
 push_docker_master() {
+  # Stage artifacts just built to re-use in the zipkin, zipkin-slim and zipkin-ui images
+  cp zipkin-server/target/zipkin-server-*-exec.jar zipkin-exec.jar
+  cp zipkin-server/target/zipkin-server-*-slim.jar zipkin-slim.jar
   for target in $(docker/bin/targets-to-build); do
     image=openzipkin/${target}
     echo Building ${image}
-    docker/build_image ${target} master
+    RELEASE_FROM_CONTEXT=true docker/build_image ${target} master
     docker tag "${image}:master" "ghcr.io/${image}:master"
     docker push "ghcr.io/${image}:master"
   done


### PR DESCRIPTION
We currently have a race condition waiting for readback of remote repositories
containing zipkin and zipkin-slim jars. This introduces `RELEASE_FROM_CONTEXT`
which lets us re-use jars explictly allowed into the Docker context. The first
test is to re-use these on master build. After this, we can switch release
similarly.