### PR TITLE
Rejigs travis build to ensure binaries are available to Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
     - name: default
       # Override default travis to use the maven wrapper
       # * Use the "release" profile as that ensures the core jar ends up JRE 1.6 compatible
-      install: ./mvnw install -DskipTests=true -Dlicense.skip=true -Dmaven.javadoc.skip=true -B -V -Prelease
+      install: ./build-bin/go_offline
       script: ./travis/publish.sh
     # Only on master when not a release tag. See https://github.com/travis-ci/travis-conditions/
     - name: Republish zipkin-builder Docker image
@@ -85,20 +85,32 @@ notifications:
     on_success: change
     on_failure: always
 
+
+# Secure variables needed for release and publication
+#
+# When Travis, add to https://travis-ci.org/github/openzipkin/${REPO}/settings
+#
+# GH_TOKEN=XXX-https://github.com/settings/tokens-XXX
+#   - makes release commits and tags, also writes to GHCR if Docker
+#   - needs repo:status, public_repo and if Docker write:packages, delete:packages
+#   - referenced in .settings.xml
+#   - store like this: echo "https://$GH_TOKEN:@github.com" > .git/credentials
+# GH_USER=user_that_created_GH_TOKEN
+# SONATYPE_USER=your_sonatype_account_token
+#   - used to publish to Maven Central via https://oss.sonatype.org/#stagingRepositories
+#   - needs access to io.zipkin via https://issues.sonatype.org/browse/OSSRH-16669
+#   - generate via https://oss.sonatype.org/#profile;User%20Token
+#   - referenced in .settings.xml
+# SONATYPE_PASSWORD=password_to_SONATYPE_USER
+#   - referenced in .settings.xml
+#
+# Legacy variables are listed here:
 env:
   global:
     # Ex. travis encrypt BINTRAY_USER=your_github_account
     - secure: "HvCQa4ZC7dexW8Iddbwtox4NY4yvoZtyYtkwlRG5Jh/h7MY1rFwghpqv42WunOnq+hgpVUWCJPM2sM1WY+JQQXSRFFfkUxSnVGfyqIRW3oHf6uK4Sw4rtX+Q/nthliu5QNqReMcg0+rr/UD2Nxat4QZqtnlVm2MQJNu8oxcm0hw="
     # Ex. travis encrypt BINTRAY_KEY=xxx-https://bintray.com/profile/edit-xxx
     - secure: "JC8sJHol2tGQT8QK00L8YQZjeo8gUnGS3x+kuYwF4UknJrJbz4+UU4uz2VDQJNdomjROngO6qLZrZmHOuV9l2LswZ7atlvMdEA16lxwKUQKK9xq4Qs5RxdZsz+zJwmEW5QcocjM1bRAQv+y4MPY9rHmoWEjtFQzfEovBpwFjafM="
-    # Ex. travis encrypt GH_USER=your_github_account
-    - secure: "DOR/FJHQ5O9zUKd3NMfPxs9qbKewd8BngJprLOKHY7X2ytxEHt+nYC0oReJYafNDCSkmB6TqFoFqUCOVHq3MV1+JyB7AE4Wnv5uSBuXc6PPLhFAbvk8t4K93ZcP7dtQ2fMivXow9Biwifsb86hxE2cbugAPzK0u4P/K0I+jR83w="
-    # Ex. travis encrypt GH_TOKEN=XXX-https://github.com/settings/tokens-XXX
-    - secure: "iXguaqYanWISgCtzyvEh7qj5JzTkCQfAzzuCpmEouSfUtkLMjn89p1wz+MMoSYsyswoeyZ+U19vyYCUkFv61XuskYXwa/2h2cVB7PGCu9Wevmjiog6LekfaRFzrdwHbvTEe0l2b7MfGmblzc/OB49phNjhTMqTcGI2dkR/O9qgQ="
-    # Ex. travis encrypt SONATYPE_USER=your_sonatype_account
-    - secure: "RF2kzoNPeQO6As/2VcNAxb8HDptXLf3dejJBiZHNNTSYTDWeAIjGQeW0edu908+OQwuhC1y94oXWADzuaAgLTg32YU8rwU0esNjTp4e2QL7EsELVzoTUPJrvoG2DasF8wOXd+Vr2nPEIZiuUonrFQR75Bb7OWq1FQjtXemfVksI="
-    # Ex. travis encrypt SONATYPE_PASSWORD=your_sonatype_password
-    - secure: "SJHHBfEu2iTyz1zvdJBi21NvJlBrN2ATZBV6ko2qhotOqc0CgUSAg7i6+7F4R/DjvI42/ufwQTCcy0bYKj+xCb6JXjLa8l28sfprv8thM7eExg9Fq4qWVgQUVX4BSHSYd1kBxod5kj/S+esRiREbbjfNAOhuQZXxjzrsjyRlzWc="
 
     # To trigger Docker image publication, we need the Trigger Url from https://cloud.docker.com/u/openzipkin/repository/docker/openzipkin/zipkin/builds/edit
     # However, this is too big for travis encrypt. Instead, we decompose it into

--- a/build-bin/go_offline
+++ b/build-bin/go_offline
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Copyright 2015-2020 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -ue
+
+# This script hydrates the Maven and NPM cache to make later processes operate with less chance of
+# network problems.
+
+# Prefetch all plugin and build dependencies in normal Maven projects
+MAVEN_COMMAND="mvn -q --batch-mode -nsu --fail-never"
+${MAVEN_COMMAND} -Prelease dependency:go-offline
+# Prefetch dependencies used by zipkin-ui (NPM and NodeJS binary and dependencies of our build)
+${MAVEN_COMMAND}  -pl zipkin-lens com.github.eirslett:frontend-maven-plugin:install-node-and-npm com.github.eirslett:frontend-maven-plugin:npm
+# TODO: restructure integration tests so that they are also pre-fetched

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -28,9 +28,8 @@ COPY --from=scratch /code /code
 
 WORKDIR /code
 
-# Use the same command as we suggest in zipkin-server/README.md to hydrate the Maven and NPM cache
-#  * Uses mvn not ./mvnw to reduce layer size: we control the Maven version independently in Docker
-RUN mvn -T1C -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server package
+# Run our script to hydrate the Maven and NPM cache
+RUN /code/build-bin/go_offline
 
 # zipkin-builder is JDK + artifact caches because DockerHub doesn't support another way to update
 # cache between builds.

--- a/pom.xml
+++ b/pom.xml
@@ -657,6 +657,7 @@
                 <block-on-health>SCRIPT_STYLE</block-on-health>
                 <targets-to-build>SCRIPT_STYLE</targets-to-build>
                 <build_image>SCRIPT_STYLE</build_image>
+                <go_offline>SCRIPT_STYLE</go_offline>
                 <start-cassandra>SCRIPT_STYLE</start-cassandra>
                 <start-elasticsearch>SCRIPT_STYLE</start-elasticsearch>
                 <start-kafka-zookeeper>SCRIPT_STYLE</start-kafka-zookeeper>


### PR DESCRIPTION
We used "install" when we didn't need to. I think this caused deploy to
skip. This is more precise in dependency caching, though it misses where
invoker could pull more deps (more of an issue in Brave than here).