### PR TITLE
Updates so that lens can be built with arm64 (fixes skipTests on lens)

### DIFF
--- a/build-bin/go_offline
+++ b/build-bin/go_offline
@@ -18,10 +18,13 @@ set -ue
 # This script hydrates the Maven and NPM cache to make later processes operate with less chance of
 # network problems.
 
+# Defensively avoid arm64+alpine problems with posix_spawn
+export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+
 # Prefetch all plugin and build dependencies in normal Maven projects
 MAVEN_COMMAND="mvn -q --batch-mode -nsu"
 set -x
 ${MAVEN_COMMAND} -Prelease de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
 # Prefetch dependencies used by zipkin-ui (NPM and NodeJS binary and dependencies of our build)
-${MAVEN_COMMAND} -pl zipkin-lens com.github.eirslett:frontend-maven-plugin:install-node-and-npm com.github.eirslett:frontend-maven-plugin:npm
+${MAVEN_COMMAND} -pl zipkin-lens generate-resources
 # TODO: restructure integration tests so that they are also pre-fetched or add as dynamic dependency

--- a/build-bin/maybe-install-npm
+++ b/build-bin/maybe-install-npm
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright 2015-2020 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# ARM64 is not supported with musl, yet https://github.com/nodejs/node/blob/master/BUILDING.md
+# Workaround this by installing node and npm directly. See issue #3166
+set -uex
+
+# Skip if we aren't Alpine
+test -f /etc/alpine-release || exit 0
+
+# Skip if we aren't arm64
+ARCH=$(uname -m)
+case ${ARCH} in
+  arm64* )
+    ;;
+  aarch64* )
+    ;;
+  * )
+    exit 0
+esac
+
+# Get the version of nodejs the build uses. Note: this will take time as it downloads Maven plugins
+NODE_VERSION=$(mvn help:evaluate -Dexpression=node.version -q -DforceStdout -pl zipkin-lens)
+
+# Repos for https://pkgs.alpinelinux.org/packages?name=nodejs-current are already in the base image
+apk add --update --no-cache nodejs-current=~${NODE_VERSION} npm

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -28,6 +28,7 @@ COPY --from=scratch /code /code
 
 WORKDIR /code
 
+RUN /code/build-bin/maybe-install-npm
 # Run our script to hydrate the Maven and NPM cache
 RUN /code/build-bin/go_offline
 

--- a/pom.xml
+++ b/pom.xml
@@ -664,6 +664,7 @@
                 <targets-to-build>SCRIPT_STYLE</targets-to-build>
                 <build_image>SCRIPT_STYLE</build_image>
                 <go_offline>SCRIPT_STYLE</go_offline>
+                <maybe-install-npm>SCRIPT_STYLE</maybe-install-npm>
                 <start-cassandra>SCRIPT_STYLE</start-cassandra>
                 <start-elasticsearch>SCRIPT_STYLE</start-elasticsearch>
                 <start-kafka-zookeeper>SCRIPT_STYLE</start-kafka-zookeeper>

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -3942,35 +3942,30 @@
       "integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA=="
     },
     "adjust-sourcemap-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz",
-      "integrity": "sha512-4hFsTsn58+YjrU9qKzML2JSSDqKvN8mUGQ0nNIrfPi8hmIONT4L3uUaT6MKdMsZ9AjsU6D2xDkZxCkbQPxChrA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-3.0.0.tgz",
+      "integrity": "sha512-YBrGyT2/uVQ/c6Rr+t6ZJXniY03YtHGMJQYal368burRGYKqhx9qGTWqcBU5s1CwYY9E/ri63RYyG1IacMZtqw==",
       "requires": {
-        "assert": "1.4.1",
-        "camelcase": "5.0.0",
-        "loader-utils": "1.2.3",
-        "object-path": "0.11.4",
-        "regex-parser": "2.2.10"
+        "loader-utils": "^2.0.0",
+        "regex-parser": "^2.2.11"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
         },
         "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
           "requires": {
             "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
           }
         }
       }
@@ -15856,11 +15851,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
-    "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -18102,9 +18092,9 @@
       }
     },
     "react-scripts": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.3.tgz",
-      "integrity": "sha512-oSnoWmii/iKdeQiwaO6map1lUaZLmG0xIUyb/HwCVFLT7gNbj8JZ9RmpvMCZ4fB98ZUMRfNmp/ft8uy/xD1RLA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.4.tgz",
+      "integrity": "sha512-7J7GZyF/QvZkKAZLneiOIhHozvOMHey7hO9cdO9u68jjhGZlI8hDdOm6UyuHofn6Ajc9Uji5I6Psm/nKNuWdyw==",
       "requires": {
         "@babel/core": "7.9.0",
         "@svgr/webpack": "4.3.3",
@@ -18148,7 +18138,7 @@
         "react-app-polyfill": "^1.0.6",
         "react-dev-utils": "^10.2.1",
         "resolve": "1.15.0",
-        "resolve-url-loader": "3.1.1",
+        "resolve-url-loader": "3.1.2",
         "sass-loader": "8.0.2",
         "semver": "6.3.0",
         "style-loader": "0.23.1",
@@ -18622,9 +18612,9 @@
       }
     },
     "regex-parser": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.10.tgz",
-      "integrity": "sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA=="
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
+      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
     },
     "regexp.prototype.flags": {
       "version": "1.3.0",
@@ -18851,11 +18841,11 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "resolve-url-loader": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.1.tgz",
-      "integrity": "sha512-K1N5xUjj7v0l2j/3Sgs5b8CjrrgtC70SmdCuZiJ8tSyb5J+uk3FoeZ4b7yTnH6j7ngI+Bc5bldHJIa8hYdu2gQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.2.tgz",
+      "integrity": "sha512-QEb4A76c8Mi7I3xNKXlRKQSlLBwjUV/ULFMP+G7n3/7tJZ8MG5wsZ3ucxP1Jz8Vevn6fnJsxDx9cIls+utGzPQ==",
       "requires": {
-        "adjust-sourcemap-loader": "2.0.0",
+        "adjust-sourcemap-loader": "3.0.0",
         "camelcase": "5.3.1",
         "compose-function": "3.0.3",
         "convert-source-map": "1.7.0",

--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -29,10 +31,13 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <!-- Update occasionally based on LTS. Upon update, push a new zipkin-builder image
-         per /docker/builder/README.md -->
-    <node.version>12.18.4</node.version>
-    <frontend-maven-plugin.version>1.10.2</frontend-maven-plugin.version>
+    <npm.skipTests>false</npm.skipTests>
+
+    <!-- Update occasionally based on LTS, but don't overrun what's in Alpine:
+         https://pkgs.alpinelinux.org/packages?name=nodejs-current -->
+    <node.version>14.14.0</node.version>
+    <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
+    <frontend-maven-plugin.version>1.10.3</frontend-maven-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
   </properties>
@@ -42,10 +47,32 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${exec-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>com.github.eirslett</groupId>
+          <artifactId>frontend-maven-plugin</artifactId>
+          <version>${frontend-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${maven-clean-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${maven-resources-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>${maven-clean-plugin.version}</version>
         <executions>
           <execution>
             <id>remove existing NPM build</id>
@@ -67,7 +94,6 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>${frontend-maven-plugin.version}</version>
         <configuration>
           <installDirectory>target</installDirectory>
           <nodeVersion>v${node.version}</nodeVersion>
@@ -121,6 +147,7 @@
             </goals>
             <phase>test</phase>
             <configuration>
+              <skipTests>${npm.skipTests}</skipTests>
               <arguments>run test</arguments>
             </configuration>
           </execution>
@@ -151,4 +178,142 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Allows us to use a true value in maven-exec-plugin when skipTests exist only in name -->
+    <profile>
+      <id>normalize skipTests</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+        </property>
+      </activation>
+      <properties>
+        <npm.skipTests>true</npm.skipTests>
+      </properties>
+    </profile>
+
+    <!-- frontend-maven-plugin requires downloading via a public URL, and suggests exec-maven-plugin
+         otherwise.
+
+         ARM64 is not supported with musl, yet https://github.com/nodejs/node/blob/master/BUILDING.md
+         See issue #3166
+
+         There are problems on alpine+arm64 with posix_spawn. https://github.com/openzipkin/docker-java/issues/34
+         So, always execute exporting MAVEN_OPTS=-Djdk.lang.Process.launchMechanism=vfork -->
+    <profile>
+      <id>exec-maven-plugin</id>
+      <activation>
+        <os>
+          <arch>aarch64</arch>
+        </os>
+        <file>
+          <exists>/etc/alpine-release</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <!-- It isn't currently possible to disable frontend-maven-plugin.
+               Instead, we set each execution to none -->
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install node and npm</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>npm install</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>npm lint</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>npm run build</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>npm run test</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- This duplicates exactly what we did in frontend-maven-plugin -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <configuration>
+              <environmentVariables>
+                <!--
+                create-react-app runs tests in watch mode unless this is defined. We define it here for running Maven locally.
+                -->
+                <CI>true</CI>
+              </environmentVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <id>npm install</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <executable>npm</executable>
+                  <arguments>
+                    <argument>install</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>npm lint</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <executable>npm</executable>
+                  <arguments>
+                    <argument>run</argument>
+                    <argument>lint</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>npm run build</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <executable>npm</executable>
+                  <arguments>
+                    <argument>run</argument>
+                    <argument>build</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>npm run test</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>test</phase>
+                <configuration>
+                  <executable>npm</executable>
+                  <skip>${npm.skipTests}</skip>
+                  <arguments>
+                    <argument>run</argument>
+                    <argument>test</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
This notably changes the build so that when alpine+musl is in use,
frontend-maven-plugin isn't used. Instead, the same version it would
install is installed by the OS.

See #3166