### PR TITLE
Adds standard labels and references non-docker hub qemu

### DIFF
--- a/build-bin/setup_multiarch_docker
+++ b/build-bin/setup_multiarch_docker
@@ -42,5 +42,5 @@ docker version
 
 # Enable execution of different multi-architecture containers by QEMU and binfmt_misc
 # See https://github.com/multiarch/qemu-user-static
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker run --rm --privileged ghcr.io/openzipkin/multiarch-qemu-user-static --reset -p yes
 docker buildx create --name builder --use

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@
 #
 
 ARG java_version
+ARG nginx_version
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -37,9 +38,9 @@ ENV ZIPKIN_FROM_MAVEN_BUILD=$zipkin_from_maven_build
 COPY docker/bin/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 
-ARG nginx_version=1.19.1
 # Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
-FROM quay.io/app-sre/nginx:${nginx_version}-alpine as zipkin-ui
+FROM quay.io/app-sre/nginx:$nginx_version-alpine as zipkin-ui
+
 ARG maintainer="OpenZipkin https://gitter.im/openzipkin/zipkin"
 LABEL maintainer=$maintainer
 LABEL org.opencontainers.image.authors=$maintainer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,13 +37,13 @@ ENV ZIPKIN_FROM_MAVEN_BUILD=$zipkin_from_maven_build
 COPY docker/bin/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 
-#####
-# zipkin-ui - An image containing the Zipkin web frontend only, served by NGINX
-#####
-
+ARG nginx_version=1.19.1
 # Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
-FROM quay.io/app-sre/nginx:1.19-alpine as zipkin-ui
-LABEL MAINTAINER OpenZipkin "http://zipkin.io/"
+FROM quay.io/app-sre/nginx:${nginx_version}-alpine as zipkin-ui
+ARG maintainer="OpenZipkin https://gitter.im/openzipkin/zipkin"
+LABEL maintainer=$maintainer
+LABEL org.opencontainers.image.authors=$maintainer
+LABEL org.opencontainers.image.description="NGINX on Alpine Linux hosting the Zipkin UI with Zipkin API proxy_pass"
 
 ENV ZIPKIN_BASE_URL=http://zipkin:9411
 
@@ -89,17 +89,13 @@ USER ${USER}
 
 EXPOSE 9411
 
-#####
-# zipkin-slim - An image containing the slim distribution of Zipkin server.
-#####
 FROM base-server as zipkin-slim
+LABEL org.opencontainers.image.description="Zipkin slim distribution on OpenJDK and Alpine Linux"
 
 COPY --from=install --chown=${USER} /install/zipkin-slim/ /zipkin/
 
-#####
-# zipkin-server - An image containing the full distribution of Zipkin server.
-#####
 FROM base-server as zipkin
+LABEL org.opencontainers.image.description="Zipkin full distribution on OpenJDK and Alpine Linux"
 
 # 3rd party modules like zipkin-aws will apply profile settings with this
 ENV MODULE_OPTS=

--- a/docker/build_image
+++ b/docker/build_image
@@ -31,7 +31,7 @@ TARGET=$(echo $TAG|sed -e 's~.*/\(.*\):.*~\1~g')
 # When true and building zipkin zipkin-slim or zipkin-ui, use zipkin-exec.jar and zipkin-slim.jar
 # produced by a Maven build. This is implicitly true when a SNAPSHOT version.
 ZIPKIN_FROM_MAVEN_BUILD=${ZIPKIN_FROM_MAVEN_BUILD:-false}
-POM_VERSION=${POM_VERSION:-$(mvn help:evaluate -N -Dexpression=project-version -q -DforceStdout)}
+POM_VERSION=${POM_VERSION:-$(mvn help:evaluate -N -Dexpression=project.version -q -DforceStdout)}
 ZIPKIN_VERSION=${ZIPKIN_VERSION:-${POM_VERSION}}
 
 # When publishing jars, we build with JDK 11 to ensure we can write 1.6 zipkin.jar for Brave.
@@ -39,7 +39,6 @@ ZIPKIN_VERSION=${ZIPKIN_VERSION:-${POM_VERSION}}
 # Hence, we use one version to keep the layer count manageable and centralized here.
 JAVA_VERSION=${JAVA_VERSION:-15.0.1_p9}
 
-DOCKER_ARGS=""
 case ${TARGET} in
   zipkin )
     DOCKERFILE_PATH=docker/Dockerfile
@@ -49,9 +48,6 @@ case ${TARGET} in
     ;;
   zipkin-ui )
     DOCKERFILE_PATH=docker/Dockerfile
-    # Use latest from https://quay.io/repository/app-sre/nginx?tab=tags
-    NGINX_VERSION=1.19.2
-    DOCKER_ARGS=" --build-arg nginx_version=${NGINX_VERSION} --label nginx-version=${NGINX_VERSION}"
     ;;
   zipkin-kafka )
     DOCKERFILE_PATH=docker/collector/kafka/Dockerfile
@@ -96,6 +92,11 @@ esac
 # is a local build or a pull request. Look to see if the files the build would produce are present.
 # This allows skipping the build when an upstream step or stage has already produced them.
 if [ ${DOCKERFILE_PATH} = docker/Dockerfile ]; then
+  # Set NGINX build arg always as the default Docker file uses it
+  # Use latest from https://quay.io/repository/app-sre/nginx?tab=tags
+  NGINX_VERSION=1.19.2
+  DOCKER_ARGS=" --build-arg nginx_version=${NGINX_VERSION} --label nginx-version=${NGINX_VERSION}"
+
   case ${ZIPKIN_VERSION} in
     *-SNAPSHOT )
       if [[ -f "zipkin-server/target/zipkin-server-${ZIPKIN_VERSION}-exec.jar" &&

--- a/docker/build_image
+++ b/docker/build_image
@@ -39,6 +39,9 @@ ZIPKIN_VERSION=${ZIPKIN_VERSION:-${POM_VERSION}}
 # Hence, we use one version to keep the layer count manageable and centralized here.
 JAVA_VERSION=${JAVA_VERSION:-15.0.1_p9}
 
+# Use latest from https://quay.io/repository/app-sre/nginx?tab=tags
+NGINX_VERSION=1.19.2
+DOCKER_ARGS=""
 case ${TARGET} in
   zipkin )
     DOCKERFILE_PATH=docker/Dockerfile
@@ -48,6 +51,7 @@ case ${TARGET} in
     ;;
   zipkin-ui )
     DOCKERFILE_PATH=docker/Dockerfile
+    DOCKER_ARGS=" --label nginx-version=${NGINX_VERSION}"
     ;;
   zipkin-kafka )
     DOCKERFILE_PATH=docker/collector/kafka/Dockerfile
@@ -93,9 +97,7 @@ esac
 # This allows skipping the build when an upstream step or stage has already produced them.
 if [ ${DOCKERFILE_PATH} = docker/Dockerfile ]; then
   # Set NGINX build arg always as the default Docker file uses it
-  # Use latest from https://quay.io/repository/app-sre/nginx?tab=tags
-  NGINX_VERSION=1.19.2
-  DOCKER_ARGS=" --build-arg nginx_version=${NGINX_VERSION} --label nginx-version=${NGINX_VERSION}"
+  DOCKER_ARGS="${DOCKER_ARGS} --build-arg nginx_version=${NGINX_VERSION}"
 
   case ${ZIPKIN_VERSION} in
     *-SNAPSHOT )

--- a/docker/build_image
+++ b/docker/build_image
@@ -31,7 +31,7 @@ TARGET=$(echo $TAG|sed -e 's~.*/\(.*\):.*~\1~g')
 # When true and building zipkin zipkin-slim or zipkin-ui, use zipkin-exec.jar and zipkin-slim.jar
 # produced by a Maven build. This is implicitly true when a SNAPSHOT version.
 ZIPKIN_FROM_MAVEN_BUILD=${ZIPKIN_FROM_MAVEN_BUILD:-false}
-POM_VERSION=${POM_VERSION:-$(mvn help:evaluate -N -Dexpression=project.version -q -DforceStdout)}
+POM_VERSION=${POM_VERSION:-$(mvn help:evaluate -N -Dexpression=project-version -q -DforceStdout)}
 ZIPKIN_VERSION=${ZIPKIN_VERSION:-${POM_VERSION}}
 
 # When publishing jars, we build with JDK 11 to ensure we can write 1.6 zipkin.jar for Brave.
@@ -39,6 +39,7 @@ ZIPKIN_VERSION=${ZIPKIN_VERSION:-${POM_VERSION}}
 # Hence, we use one version to keep the layer count manageable and centralized here.
 JAVA_VERSION=${JAVA_VERSION:-15.0.1_p9}
 
+DOCKER_ARGS=""
 case ${TARGET} in
   zipkin )
     DOCKERFILE_PATH=docker/Dockerfile
@@ -48,23 +49,43 @@ case ${TARGET} in
     ;;
   zipkin-ui )
     DOCKERFILE_PATH=docker/Dockerfile
+    # Use latest from https://quay.io/repository/app-sre/nginx?tab=tags
+    NGINX_VERSION=1.19.2
+    DOCKER_ARGS=" --build-arg nginx_version=${NGINX_VERSION} --label nginx-version=${NGINX_VERSION}"
     ;;
   zipkin-kafka )
     DOCKERFILE_PATH=docker/collector/kafka/Dockerfile
+    # Use latest release from: https://kafka.apache.org/downloads
+    KAFKA_VERSION=2.6.0
+    DOCKER_ARGS=" --build-arg kafka_version=${KAFKA_VERSION} --label kafka-version=${KAFKA_VERSION}"
+    # Note: Scala 2.13+ supports JRE 14
+    DOCKER_ARGS="${DOCKER_ARGS} --build-arg scala_version=2.13"
     ;;
   zipkin-cassandra )
     DOCKERFILE_PATH=docker/storage/cassandra/Dockerfile
     # Until Cassandra v4, we are stuck on JRE 8 for Cassandra
     JAVA_VERSION=8.252.09
+    # Use latest stable version: https://cassandra.apache.org/download/
+    CASSANDRA_VERSION=3.11.8
+    DOCKER_ARGS=" --build-arg cassandra_version=${CASSANDRA_VERSION} --label cassandra-version=${CASSANDRA_VERSION}"
     ;;
   zipkin-elasticsearch6 )
     DOCKERFILE_PATH=docker/storage/elasticsearch6/Dockerfile
+    # Use latest 6.x version from https://www.elastic.co/downloads/past-releases#elasticsearch
+    ELASTICSEARCH_VERSION=6.8.13
+    DOCKER_ARGS=" --build-arg elasticsearch_version=${ELASTICSEARCH_VERSION} --label elasticsearch-version=${ELASTICSEARCH_VERSION}"
     ;;
   zipkin-elasticsearch7 )
     DOCKERFILE_PATH=docker/storage/elasticsearch7/Dockerfile
+    # Use latest 7.x version from https://www.elastic.co/downloads/past-releases#elasticsearch
+    ELASTICSEARCH_VERSION=7.9.3
+    DOCKER_ARGS=" --build-arg elasticsearch_version=${ELASTICSEARCH_VERSION} --label elasticsearch-version=${ELASTICSEARCH_VERSION}"
     ;;
   zipkin-mysql )
     DOCKERFILE_PATH=docker/storage/mysql/Dockerfile
+    # Use latest from https://pkgs.alpinelinux.org/packages?name=mysql
+    MYSQL_VERSION=10.5.6
+    DOCKER_ARGS=" --build-arg mysql_version=${MYSQL_VERSION} --label mysql-version=${MYSQL_VERSION}"
     ;;
   * )
     echo "Invalid TAG: ${TAG}, Ex. openzipkin/zipkin:test"
@@ -97,7 +118,9 @@ fi
 DOCKER_ARGS="-f ${DOCKERFILE_PATH} --target ${TARGET} --tag ${TAG} \
 --build-arg zipkin_version=${ZIPKIN_VERSION} --label zipkin-version=${ZIPKIN_VERSION} \
 --build-arg zipkin_from_maven_build=${ZIPKIN_FROM_MAVEN_BUILD} \
---build-arg java_version=${JAVA_VERSION} ."
+--build-arg java_version=${JAVA_VERSION} \
+--label org.opencontainers.image.source=https://github.com/openzipkin/zipkin \
+--label org.opencontainers.image.version=${ZIPKIN_VERSION} ."
 
 # Avoid buildx for two reasons:
 #  * It only supports one platform/arch on load https://github.com/docker/buildx/issues/59

--- a/docker/build_image
+++ b/docker/build_image
@@ -115,7 +115,7 @@ if [ ${DOCKERFILE_PATH} = docker/Dockerfile ]; then
   esac
 fi
 
-DOCKER_ARGS="-f ${DOCKERFILE_PATH} --target ${TARGET} --tag ${TAG} \
+DOCKER_ARGS="-f ${DOCKERFILE_PATH} --target ${TARGET} --tag ${TAG} ${DOCKER_ARGS} \
 --build-arg zipkin_version=${ZIPKIN_VERSION} --label zipkin-version=${ZIPKIN_VERSION} \
 --build-arg zipkin_from_maven_build=${ZIPKIN_FROM_MAVEN_BUILD} \
 --build-arg java_version=${JAVA_VERSION} \

--- a/docker/collector/kafka/Dockerfile
+++ b/docker/collector/kafka/Dockerfile
@@ -24,8 +24,10 @@ COPY docker/collector/kafka/docker-bin/* /docker-bin/
 
 FROM ghcr.io/openzipkin/java:${java_version} as install
 
-# Use latest stable release here. Scala 2.13+ supports JRE 14
-ENV KAFKA_VERSION=2.6.0 SCALA_VERSION=2.13
+ARG kafka_version
+ENV KAFKA_VERSION=$kafka_version
+ARG scala_version
+ENV SCALA_VERSION=$scala_version
 
 WORKDIR /install
 COPY --from=scratch /install/install.sh /tmp/
@@ -33,6 +35,7 @@ RUN /tmp/install.sh && rm /tmp/install.sh
 
 # Share the same base image to reduce layers used in testing
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-kafka
+LABEL org.opencontainers.image.description="Kafka and ZooKeeper on OpenJDK and Alpine Linux"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/

--- a/docker/storage/cassandra/Dockerfile
+++ b/docker/storage/cassandra/Dockerfile
@@ -26,8 +26,8 @@ COPY docker/storage/cassandra/docker-bin/* /docker-bin/
 
 FROM ghcr.io/openzipkin/java:${java_version}-jre as install
 
-# Use latest stable release here.
-ENV CASSANDRA_VERSION=3.11.8
+ARG cassandra_version
+ENV CASSANDRA_VERSION=$cassandra_version
 
 WORKDIR /install
 
@@ -36,6 +36,7 @@ COPY --from=scratch /install/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-cassandra
+LABEL org.opencontainers.image.description="Cassandra on OpenJDK and Alpine Linux with Zipkin keyspaces pre-installed"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/

--- a/docker/storage/elasticsearch6/Dockerfile
+++ b/docker/storage/elasticsearch6/Dockerfile
@@ -24,17 +24,16 @@ COPY docker/storage/elasticsearch7/docker-bin/* /docker-bin/
 
 FROM ghcr.io/openzipkin/java:${java_version} as install
 
-ENV ELASTICSEARCH_VERSION 6.8.12
-
 WORKDIR /install
 
 # We don't download bin scripts as we customize for reasons including BusyBox problems
-RUN wget -qO- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION.tar.gz| tar xz \
+RUN wget -qO- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${elasticsearch_version}.tar.gz| tar xz \
     --wildcards --strip=1 --exclude=*/bin
 
 COPY --from=scratch /config/ ./config/
 
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-elasticsearch6
+LABEL org.opencontainers.image.description="Elasticsearch OSS distribution on OpenJDK and Alpine Linux"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/

--- a/docker/storage/elasticsearch6/Dockerfile
+++ b/docker/storage/elasticsearch6/Dockerfile
@@ -26,6 +26,8 @@ FROM ghcr.io/openzipkin/java:${java_version} as install
 
 WORKDIR /install
 
+ARG elasticsearch_version
+
 # We don't download bin scripts as we customize for reasons including BusyBox problems
 RUN wget -qO- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${elasticsearch_version}.tar.gz| tar xz \
     --wildcards --strip=1 --exclude=*/bin

--- a/docker/storage/elasticsearch7/Dockerfile
+++ b/docker/storage/elasticsearch7/Dockerfile
@@ -24,18 +24,19 @@ COPY docker/storage/elasticsearch7/docker-bin/* /docker-bin/
 
 FROM ghcr.io/openzipkin/java:${java_version} as install
 
-ENV ELASTICSEARCH_VERSION 7.9.2
+ARG elasticsearch_version
 
 WORKDIR /install
 
 # Download only the OSS distribution (lacks X-Pack)
 # We don't download bin scripts as we customize for reasons including BusyBox problems
-RUN wget -qO- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ELASTICSEARCH_VERSION-no-jdk-linux-x86_64.tar.gz| tar xz \
+RUN wget -qO- https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${elasticsearch_version}-no-jdk-linux-x86_64.tar.gz| tar xz \
     --wildcards --strip=1 --exclude=*/bin
 
 COPY --from=scratch /config/ ./config/
 
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-elasticsearch7
+LABEL org.opencontainers.image.description="Elasticsearch OSS distribution on OpenJDK and Alpine Linux"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/

--- a/docker/storage/elasticsearch7/Dockerfile
+++ b/docker/storage/elasticsearch7/Dockerfile
@@ -24,9 +24,9 @@ COPY docker/storage/elasticsearch7/docker-bin/* /docker-bin/
 
 FROM ghcr.io/openzipkin/java:${java_version} as install
 
-ARG elasticsearch_version
-
 WORKDIR /install
+
+ARG elasticsearch_version
 
 # Download only the OSS distribution (lacks X-Pack)
 # We don't download bin scripts as we customize for reasons including BusyBox problems

--- a/docker/storage/mysql/Dockerfile
+++ b/docker/storage/mysql/Dockerfile
@@ -30,6 +30,9 @@ WORKDIR /install
 
 COPY --from=scratch /zipkin-schemas/* ./zipkin-schemas/
 COPY --from=scratch /install/install.sh /tmp/
+
+ARG mysql_version
+ENV MYSQL_VERSION=$mysql_version
 RUN /tmp/install.sh && rm /tmp/install.sh
 
 # Re-use the base layer other images use
@@ -38,7 +41,7 @@ LABEL org.opencontainers.image.description="MySQL on Alpine Linux with Zipkin sc
 
 ARG mysql_version
 # Add the mysql binary and handle installation edge cases
-RUN apk add --no-cache mysql=$mysql_version && \
+RUN apk add --no-cache mysql=~$mysql_version && \
     # Prevent "Bind on unix socket: No such file or directory"
     mkdir -p /run/mysqld/ && chown -R mysql /run/mysqld/ && \
     # Enable networking

--- a/docker/storage/mysql/Dockerfile
+++ b/docker/storage/mysql/Dockerfile
@@ -34,9 +34,11 @@ RUN /tmp/install.sh && rm /tmp/install.sh
 
 # Re-use the base layer other images use
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-mysql
+LABEL org.opencontainers.image.description="MySQL on Alpine Linux with Zipkin schema pre-installed"
 
+ARG mysql_version
 # Add the mysql binary and handle installation edge cases
-RUN apk add --no-cache mysql && \
+RUN apk add --no-cache mysql=$mysql_version && \
     # Prevent "Bind on unix socket: No such file or directory"
     mkdir -p /run/mysqld/ && chown -R mysql /run/mysqld/ && \
     # Enable networking

--- a/docker/storage/mysql/install.sh
+++ b/docker/storage/mysql/install.sh
@@ -16,7 +16,7 @@
 set -eux
 
 echo "*** Installing MySQL"
-apk add --update --no-cache mysql mysql-client
+apk add --update --no-cache mysql=~${MYSQL_VERSION} mysql-client=~${MYSQL_VERSION}
 # Fake auth tools install as 10.4.0 install dies otherwise
 mkdir -p /auth_pam_tool_dir/auth_pam_tool
 


### PR DESCRIPTION
Without this, packages like https://github.com/orgs/openzipkin/packages/container/package/zipkin
have no details whatsoever.

The qemu thing is to obviate a docker pull which is only needed during
release, but easy to mistake.