### PR TITLE
Publishes directly to Sonatype

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -20,19 +20,13 @@
                           http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>sonatype</id>
+      <id>gpg.passphrase</id>
+      <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+    </server>
+    <server>
+      <id>ossrh</id>
       <username>${env.SONATYPE_USER}</username>
       <password>${env.SONATYPE_PASSWORD}</password>
-    </server>
-    <server>
-      <id>bintray</id>
-      <username>${env.BINTRAY_USER}</username>
-      <password>${env.BINTRAY_KEY}</password>
-    </server>
-    <server>
-      <id>jfrog-snapshots</id>
-      <username>${env.BINTRAY_USER}</username>
-      <password>${env.BINTRAY_KEY}</password>
     </server>
     <server>
       <id>github.com</id>

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,11 @@ before_install:
       # Log in to GitHub Container Registry and Docker Hub for releasing images
       echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
       echo "$DOCKERHUB_PASSWORD"| docker login -u "$DOCKERHUB_USER" --password-stdin
+
+      # ensure GPG commands work non-interactively
+      export GPG_TTY=$(tty)
+      # import signing key used for jar files
+      echo ${GPG_SIGNING_KEY} | base64 --decode | gpg --batch --passphrase ${GPG_PASSPHRASE} --import
     fi
 
 install: ./build-bin/go_offline
@@ -100,6 +105,12 @@ notifications:
 #   - referenced in .settings.xml
 #   - store like this: echo "https://$GH_TOKEN:@github.com" > .git/credentials
 # GH_USER=user_that_created_GH_TOKEN
+# GPG_SIGNING_KEY=$(gpg -a --export-secret-keys zipkin-admin@googlegroups.com |base64)
+#   - used to sign jars in release commands
+#   - sent to keyserver.ubuntu.com
+#   - import like this: echo ${GPG_SIGNING_KEY} | base64 --decode | gpg --batch --passphrase ${GPG_PASSPHRASE} --import
+# GPG_PASSPHRASE=passphrase_for_GPG_SIGNING_KEY
+#   - referenced in .settings.xml
 # SONATYPE_USER=your_sonatype_account_token
 #   - used to publish to Maven Central via https://oss.sonatype.org/#stagingRepositories
 #   - needs access to io.zipkin via https://issues.sonatype.org/browse/OSSRH-16669
@@ -111,11 +122,3 @@ notifications:
 #   - only push top-level projects: zipkin zipkin-aws zipkin-dependencies zipkin-gcp to Docker Hub, only on release
 #   - login like this: echo "$DOCKERHUB_PASSWORD"| docker login -u "$DOCKERHUB_USER" --password-stdin
 # DOCKERHUB_PASSWORD=password_to_DOCKERHUB_USER
-#
-# Legacy secure variables are listed here:
-env:
-  global:
-    # Ex. travis encrypt BINTRAY_USER=your_github_account
-    - secure: "HvCQa4ZC7dexW8Iddbwtox4NY4yvoZtyYtkwlRG5Jh/h7MY1rFwghpqv42WunOnq+hgpVUWCJPM2sM1WY+JQQXSRFFfkUxSnVGfyqIRW3oHf6uK4Sw4rtX+Q/nthliu5QNqReMcg0+rr/UD2Nxat4QZqtnlVm2MQJNu8oxcm0hw="
-    # Ex. travis encrypt BINTRAY_KEY=xxx-https://bintray.com/profile/edit-xxx
-    - secure: "JC8sJHol2tGQT8QK00L8YQZjeo8gUnGS3x+kuYwF4UknJrJbz4+UU4uz2VDQJNdomjROngO6qLZrZmHOuV9l2LswZ7atlvMdEA16lxwKUQKK9xq4Qs5RxdZsz+zJwmEW5QcocjM1bRAQv+y4MPY9rHmoWEjtFQzfEovBpwFjafM="

--- a/README.md
+++ b/README.md
@@ -193,9 +193,10 @@ Server artifacts are under the maven group id `io.zipkin`
 Library artifacts are under the maven group id `io.zipkin.zipkin2`
 
 ### Library Releases
-Releases are uploaded to [Bintray](https://bintray.com/openzipkin/maven/zipkin) and synchronized to [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.zipkin%22)
+Releases are at [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.zipkin%22)
 ### Library Snapshots
-Snapshots are uploaded to [JFrog](https://oss.jfrog.org/artifactory/oss-snapshot-local) after commits to master.
+Snapshots are uploaded to [Sonatype](https://oss.sonatype.org/content/repositories/snapshots) after
+commits to master.
 ### Docker Images
 Released versions of zipkin-server are published to Docker Hub as `openzipkin/zipkin` and GitHub
 Container Registry as `ghcr.io/openzipkin/zipkin`. See [docker](./docker) for details.

--- a/pom.xml
+++ b/pom.xml
@@ -138,14 +138,14 @@
   </developers>
 
   <distributionManagement>
-    <repository>
-      <id>bintray</id>
-      <url>https://api.bintray.com/maven/openzipkin/maven/zipkin/;publish=1</url>
-    </repository>
     <snapshotRepository>
-      <id>jfrog-snapshots</id>
-      <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
   </distributionManagement>
 
   <issueManagement>
@@ -591,15 +591,6 @@
       </plugin>
 
       <plugin>
-        <groupId>io.zipkin.centralsync-maven-plugin</groupId>
-        <artifactId>centralsync-maven-plugin</artifactId>
-        <version>0.1.1</version>
-        <configuration>
-          <packageName>zipkin</packageName>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>${maven-enforcer-plugin.version}</version>
         <executions>
@@ -788,6 +779,39 @@
       <id>release</id>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
           <!-- disable license plugin since it should have already checked things and #1512 -->
           <plugin>
             <groupId>com.mycila</groupId>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -172,7 +172,8 @@ if is_pull_request; then
   true
 
 # If we are on master, we will deploy the latest snapshot or release version
-#   - If a release commit fails to deploy for a transient reason, delete the broken version from bintray and click rebuild
+#  * If a release commit fails to deploy for a transient reason, drop to staging repository in
+#    Sonatype and try again: https://oss.sonatype.org/#stagingRepositories
 elif is_travis_branch_master; then
   # -Prelease ensures the core jar ends up JRE 1.6 compatible
   ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
@@ -181,10 +182,6 @@ elif is_travis_branch_master; then
   ZIPKIN_FROM_MAVEN_BUILD=true docker/bin/push_all print_project_version
 
   if is_release_version; then
-    # If the deployment succeeded, sync it to Maven Central.
-    # Note: this needs to be done once per project, not module, hence -N
-    ./mvnw --batch-mode -s ./.settings.xml -nsu -N io.zipkin.centralsync-maven-plugin:centralsync-maven-plugin:sync
-
     # cleanup the release trigger, but don't fail if it was already there
     git push origin :"release-$(print_project_version)" || true
     javadoc_to_gh_pages


### PR DESCRIPTION
As discussed, this decouples our release process from Bintray per
https://github.com/openzipkin/zipkin-gcp/pull/181

Notably, we have no references to bintray anymore, particularly not in
Docker following #3274