### PR TITLE
Removes Docker Hub from integrated tests

### DIFF
--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -88,7 +88,7 @@ class ServerIntegratedBenchmark {
 
   @Test void elasticsearch() throws Exception {
     GenericContainer<?> elasticsearch =
-      new GenericContainer<>(parse("openzipkin/zipkin-elasticsearch7:latest"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:latest"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("elasticsearch")
         .withLabel("name", "elasticsearch")
@@ -106,7 +106,7 @@ class ServerIntegratedBenchmark {
 
   private GenericContainer<?> createCassandra(String storageType) {
     GenericContainer<?> cassandra =
-      new GenericContainer<>(parse("openzipkin/zipkin-cassandra:latest"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:latest"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("cassandra")
         .withLabel("name", "cassandra")
@@ -118,7 +118,7 @@ class ServerIntegratedBenchmark {
   }
 
   @Test void mysql() throws Exception {
-    GenericContainer<?> mysql = new GenericContainer<>(parse("openzipkin/zipkin-mysql:latest"))
+    GenericContainer<?> mysql = new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:latest"))
       .withNetwork(Network.SHARED)
       .withNetworkAliases("mysql")
       .withLabel("name", "mysql")
@@ -134,7 +134,7 @@ class ServerIntegratedBenchmark {
   // send to, we can reuse our benchmark logic here to check it. Note, this benchmark always uses
   // a docker image and ignores RELEASED_ZIPKIN_SERVER.
   @Test void xrayUdp() throws Exception {
-    GenericContainer<?> zipkin = new GenericContainer<>(parse("openzipkin/zipkin-aws:latest"))
+    GenericContainer<?> zipkin = new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-aws:latest"))
       .withNetwork(Network.SHARED)
       .withNetworkAliases("zipkin")
       .withEnv("STORAGE_TYPE", "xray")
@@ -280,7 +280,7 @@ class ServerIntegratedBenchmark {
 
     final GenericContainer<?> zipkin;
     if (RELEASED_ZIPKIN_VERSION == null) {
-      zipkin = new GenericContainer<>(parse("openzipkin/zipkin-builder:latest"));
+      zipkin = new GenericContainer<>(parse("ghcr.io/openzipkin/java:15.0.1_p9"));
       List<String> classpath = new ArrayList<>();
       for (String item : System.getProperty("java.class.path").split(File.pathSeparator)) {
         Path path = Paths.get(item);
@@ -311,7 +311,7 @@ class ServerIntegratedBenchmark {
       // Don't fail on classpath problem from missing lens, as we don't use it.
       env.put("ZIPKIN_UI_ENABLED", "false");
     } else {
-      zipkin = new GenericContainer<>(parse("openzipkin/zipkin:" + RELEASED_ZIPKIN_VERSION));
+      zipkin = new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin:" + RELEASED_ZIPKIN_VERSION));
     }
 
     zipkin

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageExtension.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -43,11 +44,11 @@ import static zipkin2.storage.cassandra.v1.Tables.TRACES;
 public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCallback {
   static final Logger LOGGER = LoggerFactory.getLogger(CassandraStorageExtension.class);
   static final int CASSANDRA_PORT = 9042;
-  final String image;
+  final DockerImageName image;
   CassandraContainer container;
   CqlSession globalSession;
 
-  CassandraStorageExtension(String image) {
+  CassandraStorageExtension(DockerImageName image) {
     this.image = image;
   }
 
@@ -144,7 +145,7 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
   }
 
   static final class CassandraContainer extends GenericContainer<CassandraContainer> {
-    CassandraContainer(String image) {
+    CassandraContainer(DockerImageName image) {
       super(image);
     }
 

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.utility.DockerImageName;
 import zipkin2.Span;
 import zipkin2.storage.StorageComponent;
 
@@ -39,8 +40,8 @@ class ITCassandraStorage {
     Tables.SERVICE_SPAN_NAME_INDEX
   );
 
-  @RegisterExtension CassandraStorageExtension backend =
-    new CassandraStorageExtension("openzipkin/zipkin-cassandra:2.21.7");
+  @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.0"));
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<CassandraStorage> {

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorageHeavy.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorageHeavy.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.utility.DockerImageName;
 import zipkin2.Span;
 import zipkin2.storage.QueryRequest;
 
@@ -30,11 +31,9 @@ import static zipkin2.Span.Kind.CLIENT;
 import static zipkin2.Span.Kind.SERVER;
 import static zipkin2.TestObjects.DAY;
 import static zipkin2.TestObjects.FRONTEND;
-import static zipkin2.TestObjects.TODAY;
 import static zipkin2.TestObjects.appendSuffix;
 import static zipkin2.TestObjects.newClientSpan;
 import static zipkin2.TestObjects.newTrace;
-import static zipkin2.TestObjects.spanBuilder;
 import static zipkin2.storage.ITDependencies.aggregateLinks;
 import static zipkin2.storage.cassandra.v1.CassandraStorageExtension.rowCount;
 import static zipkin2.storage.cassandra.v1.InternalForTests.writeDependencyLinks;
@@ -50,8 +49,8 @@ import static zipkin2.storage.cassandra.v1.InternalForTests.writeDependencyLinks
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ITCassandraStorageHeavy {
 
-  @RegisterExtension CassandraStorageExtension backend =
-    new CassandraStorageExtension("openzipkin/zipkin-cassandra:2.21.7");
+  @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.0"));
 
   @Nested
   class ITSpanStoreHeavy extends zipkin2.storage.ITSpanStoreHeavy<CassandraStorage> {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -43,11 +44,11 @@ import static zipkin2.storage.cassandra.Schema.TABLE_SPAN;
 public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCallback {
   static final Logger LOGGER = LoggerFactory.getLogger(CassandraStorageExtension.class);
   static final int CASSANDRA_PORT = 9042;
-  final String image;
+  final DockerImageName image;
   CassandraContainer container;
   CqlSession globalSession;
 
-  CassandraStorageExtension(String image) {
+  CassandraStorageExtension(DockerImageName image) {
     this.image = image;
   }
 
@@ -144,7 +145,7 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
   }
 
   static final class CassandraContainer extends GenericContainer<CassandraContainer> {
-    CassandraContainer(String image) {
+    CassandraContainer(DockerImageName image) {
       super(image);
     }
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.utility.DockerImageName;
 import zipkin2.Span;
 import zipkin2.storage.StorageComponent.Builder;
 
@@ -44,7 +45,7 @@ class ITCassandraStorage {
   );
 
   @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
-    "openzipkin/zipkin-cassandra:2.21.7");
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.0"));
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<CassandraStorage> {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorageHeavy.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorageHeavy.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.utility.DockerImageName;
 import zipkin2.Span;
 import zipkin2.storage.QueryRequest;
 
@@ -43,8 +44,8 @@ import static zipkin2.storage.cassandra.InternalForTests.writeDependencyLinks;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ITCassandraStorageHeavy {
 
-  @RegisterExtension CassandraStorageExtension backend =
-    new CassandraStorageExtension("openzipkin/zipkin-cassandra:2.21.7");
+  @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.0"));
 
   @Nested
   class ITSpanStoreHeavy extends zipkin2.storage.ITSpanStoreHeavy<CassandraStorage> {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchStorageExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchStorageExtension.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
 import zipkin2.CheckResult;
 import zipkin2.elasticsearch.ElasticsearchStorage;
 import zipkin2.elasticsearch.ElasticsearchStorage.Builder;
@@ -39,11 +40,11 @@ class ElasticsearchStorageExtension implements BeforeAllCallback, AfterAllCallba
   static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchStorageExtension.class);
 
   static final int ELASTICSEARCH_PORT = 9200;
-  final String image;
+  final DockerImageName image;
   final Integer priority;
   GenericContainer<?> container;
 
-  ElasticsearchStorageExtension(String image, Integer priority) {
+  ElasticsearchStorageExtension(DockerImageName image, Integer priority) {
     this.image = image;
 
     // This is so that both legacy and composable templates can be tested with this class
@@ -65,7 +66,7 @@ class ElasticsearchStorageExtension implements BeforeAllCallback, AfterAllCallba
             .waitingFor(new HttpWaitStrategy().forPath("/"));
         container.start();
         if (Boolean.parseBoolean(System.getenv("ES_DEBUG"))) {
-          container.followOutput(new Slf4jLogConsumer(LoggerFactory.getLogger(image)));
+          container.followOutput(new Slf4jLogConsumer(LoggerFactory.getLogger(image.toString())));
         }
         LOGGER.info("Starting docker image " + image);
       } catch (RuntimeException e) {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -15,12 +15,13 @@ package zipkin2.elasticsearch.integration;
 
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.utility.DockerImageName;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ITElasticsearchStorageV6 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch6:2.21.7", null);
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-elasticsearch6:2.22.0"), null);
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.utility.DockerImageName;
 import zipkin2.elasticsearch.ElasticsearchStorage;
 
 import static zipkin2.elasticsearch.integration.ElasticsearchStorageExtension.index;
@@ -25,7 +26,7 @@ import static zipkin2.elasticsearch.integration.ElasticsearchStorageExtension.in
 class ITElasticsearchStorageV7 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch7:2.21.7", null);
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-elasticsearch7:2.22.0"), null);
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.utility.DockerImageName;
 import zipkin2.DependencyLink;
 import zipkin2.storage.StorageComponent;
 
@@ -38,7 +39,7 @@ import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinDependenc
 class ITMySQLStorage {
 
   @RegisterExtension MySQLStorageExtension backend = new MySQLStorageExtension(
-    "openzipkin/zipkin-mysql:2.21.7");
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-mysql:2.22.0"));
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<MySQLStorage> {

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageExtension.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.utility.DockerImageName;
 import zipkin2.CheckResult;
 
 import static org.junit.Assume.assumeTrue;
@@ -28,11 +29,11 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 class MySQLStorageExtension implements BeforeAllCallback, AfterAllCallback {
   static final Logger LOGGER = LoggerFactory.getLogger(MySQLStorageExtension.class);
 
-  final String image;
+  final DockerImageName image;
 
   ZipkinMySQLContainer container;
 
-  MySQLStorageExtension(String image) {
+  MySQLStorageExtension(DockerImageName image) {
     this.image = image;
   }
 

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLContainer.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.jdbc.ContainerLessJdbcDelegate;
+import org.testcontainers.utility.DockerImageName;
 
 import static org.testcontainers.ext.ScriptUtils.runInitScript;
 
@@ -26,7 +27,7 @@ final class ZipkinMySQLContainer extends GenericContainer<ZipkinMySQLContainer> 
 
   MariaDbDataSource dataSource;
 
-  ZipkinMySQLContainer(String image) {
+  ZipkinMySQLContainer(DockerImageName image) {
     super(image);
     withExposedPorts(3306);
   }


### PR DESCRIPTION
Except ad-hoc tests that use Grafana and Prometheus, this rids remaining
use of Docker Hub registry images. This helps us avoid hitting rate
limits while debugging tests.