### PR TITLE
Re-enables license plugin

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -43,6 +43,7 @@ jobs:
           path: ~/.m2/repository
           key: m2-repository-${{ hashFiles('**/pom.xml') }}
       - name: Execute Server Build
+        # Skips tests and license to run faster and allow shallow clones
         run: ./mvnw -T1C -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server clean package
         shell: bash
         env:

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -38,6 +38,7 @@ jobs:
           path: ~/.m2/repository
           key: m2-repository-${{ hashFiles('**/pom.xml') }}
       - name: Execute Server Build
+        # Skips tests and license to run faster and allow shallow clones
         run: ./mvnw -T1C -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server clean package
         shell: bash
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ arch: amd64           # arm64 is LXD containers which we can't use because we ru
 os: linux             # required for arch different than amd64
 dist: focal           # newest available distribution
 
-language: java
-
-# Don't do a shallow clone to allow license plugin to correctly read git history.
+# license-maven-plugin needs the full history to generate copyright year range. Ex. 2013-2020
+# Don't do a shallow clone, as it interferes with this.
 git:
   depth: false
+
+language: java
 
 cache:
   directories:
@@ -77,10 +78,10 @@ jobs:
           git push origin :"${TRAVIS_TAG}"
       if: 'type IN (push) and tag =~ /^docker-/'
 
+# Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
+# See https://github.com/travis-ci/travis-ci/issues/1532
 branches:
   except:
-    # Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
-    # See https://github.com/travis-ci/travis-ci/issues/1532
     - /^[0-9]/
 
 notifications:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ This repo uses semantic versions. Please keep this in mind when choosing version
    Release automation invokes [`travis/publish.sh`](travis/publish.sh), which does the following:
      * Creates commits, N.N.N tag, and increments the version (maven-release-plugin)
      * Publishes jars to https://oss.sonatype.org/service/local/staging/deploy/maven2 (maven-deploy-plugin)
-       * Upon close, this synchronizes jars to Maven Central
+       * Upon close, this synchronizes jars to Maven Central (nexus-staging-maven-plugin)
      * Invokes [DockerHub](docker/RELEASE.md] build (docker/bin/push_all_images)
      * Publishes Javadoc to https://zipkin.io/zipkin into a versioned subdirectory
 
@@ -58,12 +58,12 @@ Before you do the first release of the year, move the SNAPSHOT version back and 
 In-between, re-apply the licenses.
 ```bash
 $ ./mvnw versions:set -DnewVersion=1.3.3-SNAPSHOT -DgenerateBackupPoms=false
-$ ./mvnw com.mycila:license-maven-plugin:format -pl -:zipkin-lens
+$ ./mvnw com.mycila:license-maven-plugin:format
 $ ./mvnw versions:set -DnewVersion=1.3.2-SNAPSHOT -DgenerateBackupPoms=false
 $ git commit -am"Adjusts copyright headers for this year"
 ```
 
-### Manually releasing
+## Manually releasing
 
 If for some reason, you lost access to CI or otherwise cannot get automation to work, bear in mind
 this is a normal maven project, and can be released accordingly.
@@ -79,7 +79,7 @@ export SONATYPE_PASSWORD=your_sonatype_password
 VERSION=xx-version-to-release-xx
 
 # now from latest master, prepare the release. We are intentionally deferring pushing commits
-./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion=$VERSION -Darguments="-DskipTests -Dlicense.skip=true" release:prepare  -DpushChanges=false
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion=$VERSION -Darguments="-DskipTests" release:prepare -DpushChanges=false
 
 # once this works, deploy and synchronize to maven central
 git checkout $VERSION

--- a/docker/build_image
+++ b/docker/build_image
@@ -124,6 +124,7 @@ if [ ${DOCKERFILE_PATH} = docker/Dockerfile ]; then
         fi
 
         echo Building ${PROJECT} ${RELEASE_VERSION}...
+        # Skips tests and license to run faster and allow shallow clones
         ./mvnw -T1C -q --batch-mode -DskipTests -Dlicense.skip=true --also-make -pl zipkin-server clean package
       fi
       RELEASE_FROM_MAVEN_BUILD=true

--- a/pom.xml
+++ b/pom.xml
@@ -819,18 +819,6 @@
             </executions>
           </plugin>
 
-          <!-- disable license plugin since it should have already checked things and #1512 -->
-          <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-            <version>${license-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <phase>none</phase>
-              </execution>
-            </executions>
-          </plugin>
-
           <!-- Creates source jar -->
           <plugin>
             <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
We've long since gotten to the bottom of this. Rather than always skipping the
license plugin in CI, causing a poor experience for people who have local builds
fail over it, this re-enables after underscoring the CI config needed to make it
work.

After this change, pull requests won't be green unless the headers are correct.