### PR TITLE
Fixes where benchmarks (40m jar) accidentally pushed to maven central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
 
       # Log in to GitHub Container Registry and Docker Hub for releasing images
       echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
-      echo "$DOCKERHUB_PASSWORD"| docker login -u "$DOCKERHUB_USER" --password-stdin
+      echo "$DOCKERHUB_TOKEN"| docker login -u "$DOCKERHUB_USER" --password-stdin
 
       # ensure GPG commands work non-interactively
       export GPG_TTY=$(tty)
@@ -118,5 +118,6 @@ notifications:
 #   - referenced in .settings.xml
 # DOCKERHUB_USER=typically_dockerzipkindeployer
 #   - only push top-level projects: zipkin zipkin-aws zipkin-dependencies zipkin-gcp to Docker Hub, only on release
-#   - login like this: echo "$DOCKERHUB_PASSWORD"| docker login -u "$DOCKERHUB_USER" --password-stdin
-# DOCKERHUB_PASSWORD=password_to_DOCKERHUB_USER
+#   - login like this: echo "$DOCKERHUB_TOKEN"| docker login -u "$DOCKERHUB_USER" --password-stdin
+# DOCKERHUB_TOKEN=access_token_for_DOCKERHUB_USER
+#   -  Access Token from here https://hub.docker.com/settings/security

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,7 +83,8 @@ VERSION=xx-version-to-release-xx
 
 # once this works, deploy and synchronize to maven central
 git checkout $VERSION
-./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
+# -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests -DskipBenchmarks deploy
 
 # if all the above worked, clean up stuff and push the local changes.
 ./mvnw release:clean

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -200,28 +200,6 @@
         <groupId>com.squareup.wire</groupId>
         <artifactId>wire-maven-plugin</artifactId>
       </plugin>
-      <!-- The benchmark test suite is not a valid dependency to others -->
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
 
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>

--- a/docker/build_image
+++ b/docker/build_image
@@ -72,9 +72,9 @@ case ${DOCKER_TARGET} in
     # Until Cassandra v4, we are stuck on JRE 8 for Cassandra
     JAVA_VERSION=8.252.09
     # Use latest stable version: https://cassandra.apache.org/download/
-    CASSANDRA_VERSION=3.11.8
+    CASSANDRA_VERSION=3.11.9
     DOCKER_ARGS=" --build-arg cassandra_version=${CASSANDRA_VERSION} --label cassandra-version=${CASSANDRA_VERSION}"
-    # Currently crashes on arm64 per: https://issues.apache.org/jira/browse/CASSANDRA-16212#
+    # Currently crashes on arm64 per: https://issues.apache.org/jira/browse/CASSANDRA-16212
     # When this works, we'll also need to fix the install script to use a different port because
     # buildx will run the two arch builds simultaneously.
     PLATFORMS="linux/amd64"

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
     <module>zipkin</module>
     <module>zipkin-tests</module>
     <module>zipkin-junit</module>
-    <module>benchmarks</module>
     <module>zipkin-storage</module>
     <module>zipkin-collector</module>
     <module>zipkin-server</module>
@@ -477,6 +476,18 @@
         <module>zipkin-lens</module>
       </modules>
     </profile>
+    <!-- -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central -->
+    <profile>
+      <id>include-benchmarks</id>
+      <activation>
+        <property>
+          <name>!skipBenchmarks</name>
+        </property>
+      </activation>
+      <modules>
+        <module>benchmarks</module>
+      </modules>
+    </profile>
     <profile>
       <id>license-check</id>
       <activation>
@@ -640,6 +651,10 @@
             <configuration>
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <!-- Zipkin release is about ~100M mostly from the two server distributions. Default
+                   will timeout after 5 minutes, which can trigger fairly easily with this size. -->
+              <stagingProgressPauseDurationSeconds>20</stagingProgressPauseDurationSeconds>
+              <stagingProgressTimeoutMinutes>20</stagingProgressTimeoutMinutes>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -175,7 +175,8 @@ if is_pull_request; then
 #    Sonatype and try again: https://oss.sonatype.org/#stagingRepositories
 elif is_travis_branch_master; then
   # -Prelease ensures the core jar ends up JRE 1.6 compatible
-  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
+  # -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Centra
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests -DskipBenchmarks deploy
 
   # Regardless of if this is a release build or not, push to corresponding Docker Registries
   RELEASE_FROM_MAVEN_BUILD=true docker/bin/push_all_images $(print_project_version)

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -175,7 +175,7 @@ if is_pull_request; then
 #    Sonatype and try again: https://oss.sonatype.org/#stagingRepositories
 elif is_travis_branch_master; then
   # -Prelease ensures the core jar ends up JRE 1.6 compatible
-  # -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Centra
+  # -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central
   ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests -DskipBenchmarks deploy
 
   # Regardless of if this is a release build or not, push to corresponding Docker Registries


### PR DESCRIPTION
This ensures benchmarks doesn't end up deployed to maven central, which
both clutters and delays our deployment. Before, it didn't actually skip
nexus-maven-plugin. Rather that attempt to disable 3 plugins, this makes
the benchmarks module itself optional, disabling on deployment.

This also increase the sync timeout as when I tried to re-sync a failed
attempt it.. timed out. It seems most overriding this set the value to
20m which makes sense as likely double the time needed.