### PR TITLE
Extract javax.annotation-api version into parent pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,9 @@
 
     <java-driver.version>4.9.0</java-driver.version>
     <micrometer.version>1.6.0</micrometer.version>
+    
+    <!-- Used for Generated annotations -->
+    <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
     <spring-boot.version>2.3.5.RELEASE</spring-boot.version>

--- a/zipkin-collector/scribe/pom.xml
+++ b/zipkin-collector/scribe/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.1</version>
+      <version>${javax-annotation-api.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/zipkin-storage/mysql-v1/pom.xml
+++ b/zipkin-storage/mysql-v1/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.1</version>
+      <version>${javax-annotation-api.version}</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
Follow-up on https://github.com/openzipkin/zipkin/pull/3284, extracting `javax.annotation-api` version into parent `pom.xml`