### PR TITLE
Avoids docker.io pulls from testcontainers (and removes a JDK install)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 
-# We need a full VM so that testcontainers can use Docker
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
-arch: amd64           # arm64 is LXD containers which we can't use because we run Docker tests
-os: linux             # required for arch different than amd64
-dist: focal           # newest available distribution
+arch: amd64 # Not arm64 for multi-platform Docker builds (qemu is amd64->arm64, not vice versa)
+os: linux   # required for arch different than amd64
+dist: focal # newest available distribution
 
 # license-maven-plugin needs the full history to generate copyright year range. Ex. 2013-2020
 # Don't do a shallow clone, as it interferes with this.
@@ -22,23 +21,27 @@ cache:
 services:
   - docker
 
+# Re-use JDK 11 from focal release instead of delaying build with installation
 before_install:
   - |
-    # Intentionally don't use "jdk" Travis apt key as it is coupled to jdk.java.net availability.
-    # Use JDK 11, so we can release Java 6 bytecode
-    OPENJDK_VERSION=11
-    sudo apt-get -y install openjdk-${OPENJDK_VERSION}-jdk
-    export JAVA_HOME=/usr/lib/jvm/java-${OPENJDK_VERSION}-openjdk-${TRAVIS_CPU_ARCH}/
-    ./mvnw -version
-  - |
-    # Quiet Maven invoker logs (Downloading... when running zipkin-server/src/it)
-    echo "MAVEN_OPTS='-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'" > ~/.mavenrc
-
     # Cache as help:evaluate is not quick
     export POM_VERSION=$(./mvnw help:evaluate -N -Dexpression=project.version -q -DforceStdout)
+  - |
+    # Defend against build outages caused by Docker Hub (docker.io) pull rate limits
 
-    # Disable testcontainers checks
-    echo checks.disable=true > ~/.testcontainers.properties
+    # We don't use any docker.io images, but add a Google's mirror in case something implicitly does
+    # * See https://cloud.google.com/container-registry/docs/pulling-cached-images
+    echo '{ "registry-mirrors": ["https://mirror.gcr.io"] }' | sudo tee /etc/docker/daemon.json
+    sudo service docker restart
+    # * Ensure buildx and related features are disabled
+    mkdir -p ${HOME}/.docker && echo '{"experimental":"disabled"}' > ${HOME}/.docker/config.json
+
+    # Change testcontainers configuration so that it doesn't pull from docker.io
+    # * See https://www.testcontainers.org/supported_docker_environment/image_registry_rate_limiting/
+    # * checks.disable=true - saves time and a docker.io pull of alpine
+    echo checks.disable=true >> ~/.testcontainers.properties
+    # * change ryuk to ghcr.io until: https://github.com/testcontainers/moby-ryuk/issues/15 and 16
+    echo ryuk.container.image=ghcr.io/openzipkin/testcontainers-ryuk:latest >> ~/.testcontainers.properties
   - |
     # Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
     # controlled by branch (typically only master). Check to see if a well-known env is available


### PR DESCRIPTION
This avoids docker.io pulls implicitly done by testcontainers, in order
to prvent build outages due to pull limits.

This also removes a redundant JDK 11 install step, to speed up Travis.