### PR TITLE
Changes docker tests to use HEALTHCHECK where defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,8 @@ jobs:
     - stage: test
       name: "Run unit and integration tests including Docker [arm64]"
       arch: arm64-graviton2 # Runs in AWS cloud and significantly faster than arm64
-      virt: lxd   # LXD containers where possible as they boot much faster than full VMs
-      group: edge
+      virt: lxd             # LXD containers where possible as they boot faster than full VMs
+      group: edge           # Needed for graviton2: https://blog.travis-ci.com/2020-09-11-arm-on-aws
       # We run tests on non-tagged pushes to master that aren't commit made by the release plugin
       # We also run tests on pull requests targeted at the master branch.
       if: |

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
@@ -13,6 +13,14 @@
  */
 package zipkin2.collector.kafka;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -34,15 +42,6 @@ import zipkin2.collector.InMemoryCollectorMetrics;
 import zipkin2.storage.ForwardingStorageComponent;
 import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.StorageComponent;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.CLIENT_SPAN;
@@ -76,7 +75,7 @@ public class ITKafkaCollector {
   @Before
   public void setup() {
     final Properties config = new Properties();
-    config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaCollectorRule.KAFKA_BOOTSTRAP_SERVERS);
+    config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.bootstrapServers());
     producer = new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer());
   }
 
@@ -117,10 +116,11 @@ public class ITKafkaCollector {
    * If the Kafka broker(s) specified in the connection string are not available, the Kafka consumer
    * library will attempt to reconnect indefinitely. The Kafka consumer will not throw an exception
    * and does not expose the status of its connection to the Kafka broker(s) in its API.
-   *
+   * <p>
    * An AdminClient API instance has been added to the connector to validate that connection with
    * Kafka is available in every health check. This AdminClient reuses Consumer's properties to
-   * Connect to the cluster, and request a Cluster description to validate communication with Kafka.
+   * Connect to the cluster, and request a Cluster description to validate communication with
+   * Kafka.
    */
   @Test
   public void reconnectsIndefinitelyAndReportsUnhealthyWhenKafkaUnavailable() throws Exception {
@@ -314,7 +314,7 @@ public class ITKafkaCollector {
 
       assertThat(collector).hasToString(
         String.format("KafkaCollector{bootstrapServers=%s, topic=%s}",
-          KafkaCollectorRule.KAFKA_BOOTSTRAP_SERVERS, "muah")
+          kafka.bootstrapServers(), "muah")
       );
     }
   }

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
@@ -51,7 +51,6 @@ import static zipkin2.codec.SpanBytesEncoder.JSON_V2;
 import static zipkin2.codec.SpanBytesEncoder.THRIFT;
 
 public class ITKafkaCollector {
-
   @ClassRule public static KafkaCollectorRule kafka = new KafkaCollectorRule();
 
   @Rule public Timeout globalTimeout = Timeout.seconds(30);
@@ -64,28 +63,24 @@ public class ITKafkaCollector {
 
   CopyOnWriteArraySet<Thread> threadsProvidingSpans = new CopyOnWriteArraySet<>();
   LinkedBlockingQueue<List<Span>> receivedSpans = new LinkedBlockingQueue<>();
-  SpanConsumer consumer =
-    (spans) -> {
-      threadsProvidingSpans.add(Thread.currentThread());
-      receivedSpans.add(spans);
-      return Call.create(null);
-    };
-  private KafkaProducer<byte[], byte[]> producer;
+  SpanConsumer consumer = (spans) -> {
+    threadsProvidingSpans.add(Thread.currentThread());
+    receivedSpans.add(spans);
+    return Call.create(null);
+  };
+  KafkaProducer<byte[], byte[]> producer;
 
-  @Before
-  public void setup() {
+  @Before public void setup() {
     final Properties config = new Properties();
     config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.bootstrapServers());
     producer = new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer());
   }
 
-  @After
-  public void teardown() {
+  @After public void teardown() {
     producer.close();
   }
 
-  @Test
-  public void checkPasses() {
+  @Test public void checkPasses() {
     try (KafkaCollector collector = builder("check_passes").build()) {
       assertThat(collector.check().ok()).isTrue();
     }
@@ -95,8 +90,7 @@ public class ITKafkaCollector {
    * Don't raise exception (crash process), rather fail status check! This allows the health check
    * to report the cause.
    */
-  @Test
-  public void check_failsOnInvalidBootstrapServers() throws Exception {
+  @Test public void check_failsOnInvalidBootstrapServers() throws Exception {
 
     KafkaCollector.Builder builder =
       builder("fail_invalid_bootstrap_servers").bootstrapServers("1.1.1.1");
@@ -135,8 +129,7 @@ public class ITKafkaCollector {
   }
 
   /** Ensures legacy encoding works: a single TBinaryProtocol encoded span */
-  @Test
-  public void messageWithSingleThriftSpan() throws Exception {
+  @Test public void messageWithSingleThriftSpan() throws Exception {
     KafkaCollector.Builder builder = builder("single_span");
 
     byte[] bytes = THRIFT.encode(CLIENT_SPAN);
@@ -155,26 +148,22 @@ public class ITKafkaCollector {
   }
 
   /** Ensures list encoding works: a TBinaryProtocol encoded list of spans */
-  @Test
-  public void messageWithMultipleSpans_thrift() throws Exception {
+  @Test public void messageWithMultipleSpans_thrift() throws Exception {
     messageWithMultipleSpans(builder("multiple_spans_thrift"), THRIFT);
   }
 
   /** Ensures list encoding works: a json encoded list of spans */
-  @Test
-  public void messageWithMultipleSpans_json() throws Exception {
+  @Test public void messageWithMultipleSpans_json() throws Exception {
     messageWithMultipleSpans(builder("multiple_spans_json"), SpanBytesEncoder.JSON_V1);
   }
 
   /** Ensures list encoding works: a version 2 json list of spans */
-  @Test
-  public void messageWithMultipleSpans_json2() throws Exception {
+  @Test public void messageWithMultipleSpans_json2() throws Exception {
     messageWithMultipleSpans(builder("multiple_spans_json2"), SpanBytesEncoder.JSON_V2);
   }
 
   /** Ensures list encoding works: proto3 ListOfSpans */
-  @Test
-  public void messageWithMultipleSpans_proto3() throws Exception {
+  @Test public void messageWithMultipleSpans_proto3() throws Exception {
     messageWithMultipleSpans(builder("multiple_spans_proto3"), SpanBytesEncoder.PROTO3);
   }
 
@@ -197,8 +186,7 @@ public class ITKafkaCollector {
   }
 
   /** Ensures malformed spans don't hang the collector */
-  @Test
-  public void skipsMalformedData() throws Exception {
+  @Test public void skipsMalformedData() throws Exception {
     KafkaCollector.Builder builder = builder("decoder_exception");
 
     byte[] malformed1 = "[\"='".getBytes(UTF_8); // screwed up json
@@ -225,8 +213,7 @@ public class ITKafkaCollector {
   }
 
   /** Guards against errors that leak from storage, such as InvalidQueryException */
-  @Test
-  public void skipsOnSpanStorageException() throws Exception {
+  @Test public void skipsOnSpanStorageException() throws Exception {
     AtomicInteger counter = new AtomicInteger();
     consumer = (input) -> new Call.Base<Void>() {
       @Override protected Void doExecute() {
@@ -267,8 +254,7 @@ public class ITKafkaCollector {
     assertThat(kafkaMetrics.spansDropped()).isEqualTo(spans.size()); // only one dropped
   }
 
-  @Test
-  public void messagesDistributedAcrossMultipleThreadsSuccessfully() throws Exception {
+  @Test public void messagesDistributedAcrossMultipleThreadsSuccessfully() throws Exception {
     KafkaCollector.Builder builder = builder("multi_thread", 2);
 
     kafka.prepareTopic(builder.topic, 2);
@@ -293,8 +279,7 @@ public class ITKafkaCollector {
     assertThat(kafkaMetrics.spansDropped()).isZero();
   }
 
-  @Test
-  public void multipleTopicsCommaDelimited() {
+  @Test public void multipleTopicsCommaDelimited() {
     try (KafkaCollector collector = builder("topic1,topic2").build()) {
       collector.start();
 
@@ -329,14 +314,14 @@ public class ITKafkaCollector {
    * not necessary if the test broker is re-created for each test, but that increases execution time
    * for the suite by a factor of 10x (2-3s to ~25s on my local machine).
    */
-  private void warmUpTopic(String topic) {
+  void warmUpTopic(String topic) {
     produceSpans(new byte[0], topic);
   }
 
   /**
    * Wait until all kafka consumers created by the collector have at least one partition assigned.
    */
-  private void waitForPartitionAssignments(KafkaCollector collector) throws Exception {
+  void waitForPartitionAssignments(KafkaCollector collector) throws Exception {
     long consumersWithAssignments = 0;
     while (consumersWithAssignments < collector.kafkaWorkers.streams) {
       Thread.sleep(10);
@@ -350,11 +335,11 @@ public class ITKafkaCollector {
     }
   }
 
-  private void produceSpans(byte[] spans, String topic) {
+  void produceSpans(byte[] spans, String topic) {
     produceSpans(spans, topic, 0);
   }
 
-  private void produceSpans(byte[] spans, String topic, Integer partition) {
+  void produceSpans(byte[] spans, String topic, Integer partition) {
     producer.send(new ProducerRecord<>(topic, partition, null, spans));
     producer.flush();
   }

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageExtension.java
@@ -23,15 +23,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.rnorth.ducttape.unreliables.Unreliables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +43,7 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
   static final Logger LOGGER = LoggerFactory.getLogger(CassandraStorageExtension.class);
   static final int CASSANDRA_PORT = 9042;
   final DockerImageName image;
-  CassandraContainer container;
+  GenericContainer<?> container;
   CqlSession globalSession;
 
   CassandraStorageExtension(DockerImageName image) {
@@ -61,7 +59,9 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
     if (!"true".equals(System.getProperty("docker.skip"))) {
       try {
         LOGGER.info("Starting docker image " + image);
-        container = new CassandraContainer(image).withExposedPorts(CASSANDRA_PORT);
+        container = new GenericContainer<>(image)
+          .withExposedPorts(CASSANDRA_PORT)
+          .waitingFor(Wait.forHealthcheck());
         container.start();
       } catch (RuntimeException e) {
         LOGGER.warn("Couldn't start docker image " + image + ": " + e.getMessage(), e);
@@ -142,25 +142,6 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
       return;
     }
     if (globalSession != null) globalSession.close();
-  }
-
-  static final class CassandraContainer extends GenericContainer<CassandraContainer> {
-    CassandraContainer(DockerImageName image) {
-      super(image);
-    }
-
-    @Override protected void waitUntilContainerStarted() {
-      Unreliables.retryUntilSuccess(120, TimeUnit.SECONDS, () -> {
-        if (!isRunning()) throw new ContainerLaunchException("Container failed to start");
-
-        String contactPoint = getContainerIpAddress() + ":" + getMappedPort(9042);
-        try (CqlSession session = tryToInitializeSession(contactPoint)) {
-          session.execute("SELECT now() FROM system.local");
-          logger().info("Obtained a connection to container ({})", contactPoint);
-          return null; // unused value
-        }
-      });
-    }
   }
 
   static long rowCount(CassandraStorage storage, String table) {

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorage.java
@@ -41,7 +41,7 @@ class ITCassandraStorage {
   );
 
   @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
-    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.1"));
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.2"));
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<CassandraStorage> {

--- a/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorageHeavy.java
+++ b/zipkin-storage/cassandra-v1/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraStorageHeavy.java
@@ -50,7 +50,7 @@ import static zipkin2.storage.cassandra.v1.InternalForTests.writeDependencyLinks
 class ITCassandraStorageHeavy {
 
   @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
-    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.1"));
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.2"));
 
   @Nested
   class ITSpanStoreHeavy extends zipkin2.storage.ITSpanStoreHeavy<CassandraStorage> {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -23,15 +23,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.rnorth.ducttape.unreliables.Unreliables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +43,7 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
   static final Logger LOGGER = LoggerFactory.getLogger(CassandraStorageExtension.class);
   static final int CASSANDRA_PORT = 9042;
   final DockerImageName image;
-  CassandraContainer container;
+  GenericContainer<?> container;
   CqlSession globalSession;
 
   CassandraStorageExtension(DockerImageName image) {
@@ -61,7 +59,9 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
     if (!"true".equals(System.getProperty("docker.skip"))) {
       try {
         LOGGER.info("Starting docker image " + image);
-        container = new CassandraContainer(image).withExposedPorts(CASSANDRA_PORT);
+        container = new GenericContainer<>(image)
+          .withExposedPorts(CASSANDRA_PORT)
+          .waitingFor(Wait.forHealthcheck());
         container.start();
       } catch (RuntimeException e) {
         LOGGER.warn("Couldn't start docker image " + image + ": " + e.getMessage(), e);
@@ -142,25 +142,6 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
       return;
     }
     if (globalSession != null) globalSession.close();
-  }
-
-  static final class CassandraContainer extends GenericContainer<CassandraContainer> {
-    CassandraContainer(DockerImageName image) {
-      super(image);
-    }
-
-    @Override protected void waitUntilContainerStarted() {
-      Unreliables.retryUntilSuccess(120, TimeUnit.SECONDS, () -> {
-        if (!isRunning()) throw new ContainerLaunchException("Container failed to start");
-
-        String contactPoint = getContainerIpAddress() + ":" + getMappedPort(9042);
-        try (CqlSession session = tryToInitializeSession(contactPoint)) {
-          session.execute("SELECT now() FROM system.local");
-          logger().info("Obtained a connection to container ({})", contactPoint);
-          return null; // unused value
-        }
-      });
-    }
   }
 
   static void blockWhileInFlight(CassandraStorage storage) {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -45,7 +45,7 @@ class ITCassandraStorage {
   );
 
   @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
-    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.1"));
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.2"));
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<CassandraStorage> {

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorageHeavy.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorageHeavy.java
@@ -45,7 +45,7 @@ import static zipkin2.storage.cassandra.InternalForTests.writeDependencyLinks;
 class ITCassandraStorageHeavy {
 
   @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
-    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.1"));
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-cassandra:2.22.2"));
 
   @Nested
   class ITSpanStoreHeavy extends zipkin2.storage.ITSpanStoreHeavy<CassandraStorage> {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV6.java
@@ -21,7 +21,7 @@ import org.testcontainers.utility.DockerImageName;
 class ITElasticsearchStorageV6 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    DockerImageName.parse("ghcr.io/openzipkin/zipkin-elasticsearch6:2.22.1"), null);
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-elasticsearch6:2.22.2"));
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
@@ -26,7 +26,7 @@ import static zipkin2.elasticsearch.integration.ElasticsearchStorageExtension.in
 class ITElasticsearchStorageV7 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    DockerImageName.parse("ghcr.io/openzipkin/zipkin-elasticsearch7:2.22.1"), null);
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-elasticsearch7:2.22.2"));
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -39,7 +39,7 @@ import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinDependenc
 class ITMySQLStorage {
 
   @RegisterExtension MySQLStorageExtension backend = new MySQLStorageExtension(
-    DockerImageName.parse("ghcr.io/openzipkin/zipkin-mysql:2.22.1"));
+    DockerImageName.parse("ghcr.io/openzipkin/zipkin-mysql:2.22.2"));
 
   @Nested
   class ITTraces extends zipkin2.storage.ITTraces<MySQLStorage> {

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLContainer.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLContainer.java
@@ -18,6 +18,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.jdbc.ContainerLessJdbcDelegate;
 import org.testcontainers.utility.DockerImageName;
 
@@ -30,6 +31,7 @@ final class ZipkinMySQLContainer extends GenericContainer<ZipkinMySQLContainer> 
   ZipkinMySQLContainer(DockerImageName image) {
     super(image);
     withExposedPorts(3306);
+    waitStrategy = Wait.forHealthcheck();
   }
 
   MariaDbDataSource getDataSource() {


### PR DESCRIPTION
Note: we currently don't publish a standard rabbitmq image.. the one we copied
doesn't include a HEALTHCHECK so we inline one.

Fixes #3295