### PR TITLE
Makes zipkin-cassandra work with normal Java

### DIFF
--- a/docker/build_image
+++ b/docker/build_image
@@ -70,14 +70,10 @@ case ${DOCKER_TARGET} in
   zipkin-cassandra )
     DOCKERFILE_PATH=docker/storage/cassandra/Dockerfile
     # Until Cassandra v4, we are stuck on JRE 8 for Cassandra
-    JAVA_VERSION=8.252.09
+    JAVA_VERSION=8.272.10
     # Use latest stable version: https://cassandra.apache.org/download/
     CASSANDRA_VERSION=3.11.9
     DOCKER_ARGS=" --build-arg cassandra_version=${CASSANDRA_VERSION} --label cassandra-version=${CASSANDRA_VERSION}"
-    # Currently crashes on arm64 per: https://issues.apache.org/jira/browse/CASSANDRA-16212
-    # When this works, we'll also need to fix the install script to use a different port because
-    # buildx will run the two arch builds simultaneously.
-    PLATFORMS="linux/amd64"
     ;;
   zipkin-elasticsearch6 )
     DOCKERFILE_PATH=docker/storage/elasticsearch6/Dockerfile

--- a/docker/collector/kafka/install.sh
+++ b/docker/collector/kafka/install.sh
@@ -37,8 +37,8 @@ cat > pom.xml <<-'EOF'
   <dependencies>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_${SCALA_VERSION}</artifactId>
-      <version>${KAFKA_VERSION}</version>
+      <artifactId>kafka_${scala.version}</artifactId>
+      <version>${kafka.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -48,7 +48,10 @@ cat > pom.xml <<-'EOF'
   </dependencies>
 </project>
 EOF
-mvn -q --batch-mode dependency:copy-dependencies -DoutputDirectory=libs && rm pom.xml
+mvn -q --batch-mode -DoutputDirectory=libs \
+    -Dscala.version=${SCALA_VERSION} -Dkafka.version=${KAFKA_VERSION} \
+    dependency:copy-dependencies
+rm pom.xml
 
 # Make sure you use relative paths in references like this, so that installation
 # is decoupled from runtime

--- a/docker/examples/docker-compose-cassandra.yml
+++ b/docker/examples/docker-compose-cassandra.yml
@@ -22,7 +22,7 @@ version: '2.4'
 
 services:
   storage:
-    image: ghcr.io/ghcr.io/openzipkin/zipkin-cassandra:${TAG:-latest}
+    image: ghcr.io/openzipkin/zipkin-cassandra:${TAG:-latest}
     # Uncomment to use DSE instead (minimum version 5.1)
     # image: datastax/dse-server:5.1.20
     # environment:
@@ -38,7 +38,7 @@ services:
       file: docker-compose.yml
       service: zipkin
     # slim doesn't include Cassandra support, so switch to the larger image
-    image: ghcr.io/ghcr.io/openzipkin/zipkin:${TAG:-latest}
+    image: ghcr.io/openzipkin/zipkin:${TAG:-latest}
     environment:
       - STORAGE_TYPE=cassandra3
       # When using the test docker image, or have schema pre-installed, you don't need to ensure it

--- a/docker/examples/docker-compose-dependencies.yml
+++ b/docker/examples/docker-compose-dependencies.yml
@@ -20,7 +20,7 @@ services:
   #
   # For more details, see https://github.com/openzipkin/docker-zipkin-dependencies
   dependencies:
-    image: ghcr.io/ghcr.io/openzipkin/zipkin-dependencies
+    image: ghcr.io/openzipkin/zipkin-dependencies
     container_name: dependencies
     entrypoint: crond -f
     # environment:

--- a/docker/examples/docker-compose-elasticsearch.yml
+++ b/docker/examples/docker-compose-elasticsearch.yml
@@ -22,7 +22,7 @@ version: '2.4'
 
 services:
   storage:
-    image: ghcr.io/ghcr.io/openzipkin/zipkin-elasticsearch7:${TAG:-latest}
+    image: ghcr.io/openzipkin/zipkin-elasticsearch7:${TAG:-latest}
     container_name: elasticsearch
     # Uncomment to expose the storage port for testing
     # ports:

--- a/docker/examples/docker-compose-kafka.yml
+++ b/docker/examples/docker-compose-kafka.yml
@@ -22,7 +22,7 @@ version: '2.4'
 
 services:
   kafka-zookeeper:
-    image: ghcr.io/ghcr.io/openzipkin/zipkin-kafka:${TAG:-latest}
+    image: ghcr.io/openzipkin/zipkin-kafka:${TAG:-latest}
     container_name: kafka-zookeeper
     # If using docker machine, uncomment the below and set your bootstrap
     # server list to 192.168.99.100:19092
@@ -37,7 +37,7 @@ services:
       file: docker-compose.yml
       service: zipkin
     # slim doesn't include Kafka support, so switch to the larger image
-    image: ghcr.io/ghcr.io/openzipkin/zipkin:${TAG:-latest}
+    image: ghcr.io/openzipkin/zipkin:${TAG:-latest}
     environment:
       - KAFKA_BOOTSTRAP_SERVERS=kafka-zookeeper:9092
     depends_on:

--- a/docker/examples/docker-compose-mysql.yml
+++ b/docker/examples/docker-compose-mysql.yml
@@ -24,7 +24,7 @@ version: '2.4'
 
 services:
   storage:
-    image: ghcr.io/ghcr.io/openzipkin/zipkin-mysql:${TAG:-latest}
+    image: ghcr.io/openzipkin/zipkin-mysql:${TAG:-latest}
     container_name: mysql
     # Uncomment to expose the storage port for testing
     # ports:
@@ -36,7 +36,7 @@ services:
       file: docker-compose.yml
       service: zipkin
     # slim doesn't include MySQL support, so switch to the larger image
-    image: ghcr.io/ghcr.io/openzipkin/zipkin:${TAG:-latest}
+    image: ghcr.io/openzipkin/zipkin:${TAG:-latest}
     environment:
       - STORAGE_TYPE=mysql
       - MYSQL_HOST=storage

--- a/docker/examples/docker-compose-ui.yml
+++ b/docker/examples/docker-compose-ui.yml
@@ -22,7 +22,7 @@ version: '2.4'
 
 services:
   zipkin-ui:
-    image: ghcr.io/ghcr.io/openzipkin/zipkin-ui:${TAG:-latest}
+    image: ghcr.io/openzipkin/zipkin-ui:${TAG:-latest}
     container_name: zipkin-ui
     environment:
       # Change this if connecting to a different zipkin server

--- a/docker/storage/cassandra/Dockerfile
+++ b/docker/storage/cassandra/Dockerfile
@@ -32,7 +32,6 @@ ENV CASSANDRA_VERSION=$cassandra_version
 WORKDIR /install
 
 COPY --from=scratch /zipkin-schemas/* ./zipkin-schemas/
-COPY --from=scratch /docker-bin/start-cassandra .
 COPY --from=scratch /install/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 

--- a/docker/storage/cassandra/Dockerfile
+++ b/docker/storage/cassandra/Dockerfile
@@ -32,6 +32,7 @@ ENV CASSANDRA_VERSION=$cassandra_version
 WORKDIR /install
 
 COPY --from=scratch /zipkin-schemas/* ./zipkin-schemas/
+COPY --from=scratch /docker-bin/start-cassandra .
 COPY --from=scratch /install/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh
 

--- a/docker/storage/cassandra/Dockerfile
+++ b/docker/storage/cassandra/Dockerfile
@@ -24,7 +24,7 @@ COPY zipkin-storage/cassandra-v1/src/main/resources/cassandra-schema.cql /zipkin
 COPY docker/storage/cassandra/install.sh /install/
 COPY docker/storage/cassandra/docker-bin/* /docker-bin/
 
-FROM ghcr.io/openzipkin/java:${java_version}-jre as install
+FROM ghcr.io/openzipkin/java:${java_version} as install
 
 ARG cassandra_version
 ENV CASSANDRA_VERSION=$cassandra_version
@@ -56,9 +56,6 @@ USER ${USER}
 COPY --from=install --chown=${USER} /install .
 
 # Set variables Cassandra's start script wants
-#
-# Integration test currently use a single container for all suites, without cleaning up keyspaces
-# per method. For this reason, we use a higher heap size than 256m, which would be otherwise fine.
-ENV JVM_OPTS="-Xms512m -Xmx512m -XX:+ExitOnOutOfMemoryError -Djava.net.preferIPv4Stack=true"
+ENV JAVA_OPTS="-Xms256m -Xmx256m -XX:+ExitOnOutOfMemoryError -Djava.net.preferIPv4Stack=true"
 
 EXPOSE 9042

--- a/docker/storage/cassandra/docker-bin/start-cassandra
+++ b/docker/storage/cassandra/docker-bin/start-cassandra
@@ -13,7 +13,7 @@
 # the License.
 #
 
-# ENTRYPOINT script that starts ZooKeeper and then Kafka
+# ENTRYPOINT script that starts Cassandra
 #
 # This intentionally locates config using the current working directory, in order to consolidate
 # Dockerfile instructions to WORKDIR
@@ -22,26 +22,20 @@ set -eu
 # Apply one-time deferred configuration that relies on ENV variables
 #
 # If the schema has been removed due to mounting, restore from our backup. see: install
-if [ ! -d "data/data/zipkin2" ]; then
-    cp -rf data-backup/* data/
+if [ ! -d "data/zipkin2" ]; then
+  cp -rf data-backup/* data/
 fi
 
-_ip_address() {
-	# scrape the first non-localhost IP address of the container
-	ip address | awk '
-		$1 == "inet" && $NF != "lo" {
-			gsub(/\/.+$/, "", $2)
-			print $2
-			exit
-		}
-	'
-}
-
-IP="$(_ip_address)"
-sed -i "/listen_address: localhost/clisten_address: $IP" conf/cassandra.yaml
-sed -i '/rpc_address: localhost/crpc_address: 0.0.0.0' conf/cassandra.yaml
-sed -i "/# broadcast_address: 1.2.3.4/cbroadcast_address: $IP" conf/cassandra.yaml
-sed -i "/# broadcast_rpc_address: 1.2.3.4/cbroadcast_rpc_address: $IP" conf/cassandra.yaml
+IP="$(hostname -i || echo '127.0.0.1')"
+sed -i "/listen_address: 127.0.0.1/clisten_address: $IP" conf/cassandra.yaml
+sed -i "/rpc_address: 127.0.0.1/crpc_address: $IP" conf/cassandra.yaml
 sed -i "/          - seeds: \"127.0.0.1\"/c\          - seeds: $IP" conf/cassandra.yaml
 
-exec bin/cassandra -f
+echo Starting Cassandra
+exec java -cp 'libs/*' ${JAVA_OPTS} \
+  -Djava.io.tmpdir=/tmp \
+  -Dcassandra-foreground=yes \
+  -Dcassandra.storagedir=${PWD}/data \
+  -Dcassandra.config=file:${PWD}/conf/cassandra.yaml \
+  -Dlog4j.configuration=file:${PWD}/conf/log4j.properties \
+  org.apache.cassandra.service.CassandraDaemon "$@"

--- a/docker/storage/cassandra/docker-bin/start-cassandra
+++ b/docker/storage/cassandra/docker-bin/start-cassandra
@@ -22,7 +22,7 @@ set -eu
 # Apply one-time deferred configuration that relies on ENV variables
 #
 # If the schema has been removed due to mounting, restore from our backup. see: install
-if [ -d data-backup ] && [ ! -d data/zipkin2 ]; then
+if [ ! -d data/zipkin2 ]; then
   cp -rf data-backup/* data/
 fi
 

--- a/docker/storage/cassandra/docker-bin/start-cassandra
+++ b/docker/storage/cassandra/docker-bin/start-cassandra
@@ -22,20 +22,21 @@ set -eu
 # Apply one-time deferred configuration that relies on ENV variables
 #
 # If the schema has been removed due to mounting, restore from our backup. see: install
-if [ ! -d "data/zipkin2" ]; then
+if [ -d data-backup ] && [ ! -d data/zipkin2 ]; then
   cp -rf data-backup/* data/
 fi
 
 IP="$(hostname -i || echo '127.0.0.1')"
-sed -i "/listen_address: 127.0.0.1/clisten_address: $IP" conf/cassandra.yaml
-sed -i "/rpc_address: 127.0.0.1/crpc_address: $IP" conf/cassandra.yaml
-sed -i "/          - seeds: \"127.0.0.1\"/c\          - seeds: $IP" conf/cassandra.yaml
+sed -i "s/listen_address:.*/listen_address: $IP/" conf/cassandra.yaml
+sed -i "s/rpc_address:.*/rpc_address: $IP/" conf/cassandra.yaml
+sed -i "s/          - seeds: \".*\"/          - seeds: \"$IP\"/" conf/cassandra.yaml
 
 echo Starting Cassandra
 exec java -cp 'libs/*' ${JAVA_OPTS} \
   -Djava.io.tmpdir=/tmp \
   -Dcassandra-foreground=yes \
-  -Dcassandra.storagedir=${PWD}/data \
+  -Dcassandra.storagedir=${PWD} \
+  -Dcassandra.triggers_dir=${PWD}/triggers \
   -Dcassandra.config=file:${PWD}/conf/cassandra.yaml \
   -Dlog4j.configuration=file:${PWD}/conf/log4j.properties \
   org.apache.cassandra.service.CassandraDaemon "$@"

--- a/docker/storage/cassandra/install.sh
+++ b/docker/storage/cassandra/install.sh
@@ -114,7 +114,7 @@ case ${ARCH} in
     ;;
 esac
 
-JAVA_OPTS="-Xms64m -Xmx64m -XX:+ExitOnOutOfMemoryError \
+JAVA_OPTS="-Xms128m -Xmx128m -XX:+ExitOnOutOfMemoryError \
 -Dcassandra.storage_port=${TEMP_STORAGE_PORT} \
 -Dcassandra.native_transport_port=${TEMP_NATIVE_TRANSPORT_PORT}" ./start-cassandra &
 CASSANDRA_PID=$!
@@ -134,9 +134,6 @@ while [ "$timeout" -gt 0 ] && ! cql -e 'SHOW VERSION' > /dev/null 2>&1; do
     sleep 1
     timeout=$(($timeout - 1))
 done
-
-# Sleep to settle in order to avoid flakes in CI
-sleep 2
 
 echo "*** Importing Scheme"
 cat zipkin-schemas/cassandra-schema.cql | cql --debug

--- a/docker/storage/cassandra/install.sh
+++ b/docker/storage/cassandra/install.sh
@@ -18,63 +18,141 @@
 # This also trims dependencies to only those used at runtime.
 set -eux
 
-echo "*** Installing Cassandra and dependencies"
-# BusyBux built-in tar doesn't support --strip=1
-apk add --update --no-cache python2 tar
-APACHE_MIRROR=$(wget -qO- https://www.apache.org/dyn/closer.cgi\?as_json\=1 | sed -n '/preferred/s/.*"\(.*\)"/\1/gp')
-wget -qO- $APACHE_MIRROR/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz | tar xz \
-  --strip=1
+echo "*** Installing Cassandra"
 
-# Merge in our custom configuration
-sed -i '/enable_user_defined_functions: false/cenable_user_defined_functions: true' conf/cassandra.yaml
+cat > pom.xml <<-'EOF'
+<project>
+  <modelVersion>4.0.0</modelVersion>
 
-# Default conf for Cassandra 3.x does not work on modern JVMs due to many deprecated flags
-sed -i '/-XX:ThreadPriorityPolicy=42/c\#-XX:ThreadPriorityPolicy=42' conf/jvm.options
-sed -i '/-XX:+UseParNewGC/c\#-XX:+UseParNewGC' conf/jvm.options
-sed -i '/-XX:+UseConcMarkSweepGC/c\#-XX:+UseConcMarkSweepGC' conf/jvm.options
-sed -i '/-XX:+PrintGCDateStamps/c\#-XX:+PrintGCDateStamps' conf/jvm.options
-sed -i '/-XX:+PrintHeapAtGC/c\#-XX:+PrintHeapAtGC' conf/jvm.options
-sed -i '/-XX:+PrintTenuringDistribution/c\#-XX:+PrintTenuringDistribution' conf/jvm.options
-sed -i '/-XX:+PrintGCApplicationStoppedTime/c\#-XX:+PrintGCApplicationStoppedTime' conf/jvm.options
-sed -i '/-XX:+PrintPromotionFailure/c\#-XX:+PrintPromotionFailure' conf/jvm.options
-sed -i '/-XX:+UseGCLogFileRotation/c\#-XX:+UseGCLogFileRotation' conf/jvm.options
-sed -i '/-XX:NumberOfGCLogFiles=10/c\#-XX:NumberOfGCLogFiles=10' conf/jvm.options
-sed -i '/-XX:GCLogFileSize=10M/c\#-XX:GCLogFileSize=10M' conf/jvm.options
+  <groupId>io.zipkin.cassandra</groupId>
+  <artifactId>get-cassandra</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
-# TODO: Add native snappy lib. Native loader stacktraces in the cassandra log as a results, which is distracting.
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
+      <version>${cassandra.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+  </dependencies>
+</project>
+EOF
+mvn -q --batch-mode -DoutputDirectory=libs \
+    -Dcassandra.version=${CASSANDRA_VERSION} \
+    dependency:copy-dependencies
+rm pom.xml
 
-# Remove bash as Cassandra scripts we use don't have it, and it isn't required
-sed -i 's~#!/bin/bash~#!/bin/sh~g' bin/*sh
+# Make sure you use relative paths in references like this, so that installation
+# is decoupled from runtime
+mkdir -p conf data commitlog saved_caches hints
+
+# Make a basic log4j conf which only logs warnings (to stderr)
+cat > conf/log4j.properties <<-'EOF'
+log4j.rootLogger=WARN, stderr
+
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.stderr.Target=System.err
+
+# Ignore that we are using log4j as we aren't starting JMX anyway
+log4j.logger.org.apache.cassandra.utils.logging=ERROR
+# Ignore that we cannot increase RLIMIT_MEMLOCK or run Cassandra as root
+log4j.logger.org.apache.cassandra.utils.NativeLibrary=ERROR
+# Ignore that we disabled JMX and haven't installed jemalloc (not available on Alpine)
+log4j.logger.org.apache.cassandra.service.StartupChecks=OFF
+# Ignore warnings about less than 64GB disk
+log4j.logger.org.apache.cassandra.config.DatabaseDescriptor=ERROR
+EOF
+
+# Generate basic required configuration from default values
+cat > conf/cassandra.yaml <<-'EOF'
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+endpoint_snitch: SimpleSnitch
+
+# override via -Dcassandra.storage_port=7000
+storage_port: 7000
+# override via -Dcassandra.native_transport_port=9042
+native_transport_port: 9042
+listen_address: 127.0.0.1
+rpc_address: 127.0.0.1
+start_native_transport: true
+seed_provider:
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          - seeds: "127.0.0.1"
+EOF
+
+# Avoid conflicts during multi-arch build (buildx starting two archs in the same container)
+ARCH=$(uname -m)
+case ${ARCH} in
+  aarch64* )
+    TEMP_STORAGE_PORT=7020
+    TEMP_NATIVE_TRANSPORT_PORT=9062
+    ;;
+  * )
+    TEMP_STORAGE_PORT=7010
+    TEMP_NATIVE_TRANSPORT_PORT=9052
+    ;;
+esac
 
 echo "*** Starting Cassandra"
-bin/cassandra -R
+TEMP_JAVA_OPTS="-Xms64m -Xmx64m -XX:+ExitOnOutOfMemoryError"
+java -cp 'libs/*' ${TEMP_JAVA_OPTS} \
+  -Dcassandra.storage_port=${TEMP_STORAGE_PORT} \
+  -Dcassandra.native_transport_port=${TEMP_NATIVE_TRANSPORT_PORT} \
+  -Dcassandra.storagedir=${PWD} \
+  -Dcassandra.config=file:${PWD}/conf/cassandra.yaml \
+  -Dlog4j.configuration=file:${PWD}/conf/log4j.properties \
+  org.apache.cassandra.service.CassandraDaemon &
+CASSANDRA_PID=$!
+
+echo "*** Installing cqlsh"
+apk add --update --no-cache python2 py2-setuptools
+python2 -m easy_install pip
+pip install -Iq cqlsh
+function cql() {
+  cqlsh --cqlversion=3.4.4 "$@" 127.0.0.1 ${TEMP_NATIVE_TRANSPORT_PORT}
+}
 
 # Excessively long timeout to avoid having to create an ENV variable, decide its name, etc.
 timeout=180
 echo "Will wait up to ${timeout} seconds for Cassandra to come up before installing Schema"
-while [ "$timeout" -gt 0 ] && ! bin/cqlsh -e 'SHOW VERSION' localhost > /dev/null 2>&1; do
+while [ "$timeout" -gt 0 ] && ! cql -e 'SHOW VERSION' > /dev/null 2>&1; do
     sleep 1
     timeout=$(($timeout - 1))
 done
 
 echo "*** Importing Scheme"
-cat zipkin-schemas/cassandra-schema.cql | bin/cqlsh --debug localhost
-cat zipkin-schemas/zipkin2-schema.cql | bin/cqlsh --debug localhost
-cat zipkin-schemas/zipkin2-schema-indexes.cql | bin/cqlsh --debug localhost
-
-echo "*** Adding custom UDFs to zipkin2 keyspace"
-bin/cqlsh -e "CREATE FUNCTION zipkin2.plus (x bigint, y bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return x+y;';"
-bin/cqlsh -e "CREATE FUNCTION zipkin2.minus (x bigint, y bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return x-y;';"
-bin/cqlsh -e "CREATE FUNCTION zipkin2.toTimestamp (x bigint) RETURNS NULL ON NULL INPUT RETURNS timestamp LANGUAGE java AS 'return new java.util.Date(x/1000);';"
-bin/cqlsh -e "CREATE FUNCTION zipkin2.value (x map<text,text>, y text) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE java AS 'return x.get(y);';"
+cat zipkin-schemas/cassandra-schema.cql | cql --debug
+cat zipkin-schemas/zipkin2-schema.cql | cql --debug
+cat zipkin-schemas/zipkin2-schema-indexes.cql | cql --debug
 
 echo "*** Stopping Cassandra"
-pkill -f java
+kill ${CASSANDRA_PID}
 
 # Take a backup so that we can safely mount an empty volume over the data directory and maintain the schema
 cp -R data/ data-backup/
 
 echo "*** Cleaning Up"
-rm -rf javadoc/ pylib/ tools/ lib/*.zip zipkin-schemas/
+rm -rf zipkin-schemas/ data/* commitlog/* saved_caches/* hints/*
 
 echo "*** Image build complete"

--- a/docker/storage/cassandra/install.sh
+++ b/docker/storage/cassandra/install.sh
@@ -135,6 +135,9 @@ while [ "$timeout" -gt 0 ] && ! cql -e 'SHOW VERSION' > /dev/null 2>&1; do
     timeout=$(($timeout - 1))
 done
 
+# Sleep to settle in order to avoid flakes in CI
+sleep 2
+
 echo "*** Importing Scheme"
 cat zipkin-schemas/cassandra-schema.cql | cql --debug
 cat zipkin-schemas/zipkin2-schema.cql | cql --debug


### PR DESCRIPTION
This *should* avoid problems with Arm64, but needs to be tested post
merge. This does the following:

* significantly trim the image size by downloading from maven
* use less JVM-specific flags
* reduce memory usage for reasons including shutting off JMX
* dodge conflict during install by using a different port per arch

```
REPOSITORY                                      TAG                 IMAGE ID            CREATED             SIZE
openzipkin/zipkin-cassandra                     test                7b591f5d12cc        13 minutes ago      138MB
ghcr.io/openzipkin/zipkin-cassandra             2.22.2              ab5d087d0800        43 hours ago        262MB
```