### PR TITLE
WIP: Support docker build for s390x

### DIFF
--- a/docker/build_image
+++ b/docker/build_image
@@ -42,7 +42,7 @@ RELEASE_FROM_MAVEN_BUILD=${RELEASE_FROM_MAVEN_BUILD:-false}
 JAVA_VERSION=${JAVA_VERSION:-15.0.1_p9}
 
 # Platforms to eventually push to the registry
-PLATFORMS="linux/amd64,linux/arm64"
+PLATFORMS="linux/amd64,linux/arm64,linux/s390x"
 
 # Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
 # Use latest from https://quay.io/repository/app-sre/nginx?tab=tags


### PR DESCRIPTION
As part of the work to support the [Knative](https://github.com/knative) pipeline for the s390x architecture, the dependency of the docker image `openzipkin/zipkin` was identified (https://github.com/knative/eventing/blob/master/test/config/monitoring.yaml#L46).

This PR is to resolve the dependency. 

The review can be started after the PR in `docker-java` (https://github.com/openzipkin/docker-java/pull/46) is merged. It will be on hold until then.