### PR TITLE
Runs docker tests in parallel in CI

### DIFF
--- a/.github/workflows/readme_test.yml
+++ b/.github/workflows/readme_test.yml
@@ -6,12 +6,8 @@ name: readme_test
 #
 # This doesn't literally scrape the README.md, so we don't test documentation-only commits.
 on:
-  # We run tests on non-tagged pushes to master that aren't a commit made by the release plugin
-  push:
-    tags: ''
-    branches: master
-    paths-ignore: '**/*.md'
-  # We also run tests on pull requests targeted at the master branch.
+  # We run tests on only on pull requests targeted at the master branch.
+  # * This skips master pushes as it is rare things not done in PRs break, and conserves resources
   pull_request:
     branches: master
     paths-ignore: '**/*.md'

--- a/.github/workflows/readme_test.yml
+++ b/.github/workflows/readme_test.yml
@@ -77,36 +77,8 @@ jobs:
           path: zipkin-lens/target/zipkin-lens-*-SNAPSHOT.jar
 
   docker:
-    name: ${{ matrix.readme }}
     needs: zipkin-server
     runs-on: ubuntu-20.04  # newest available distribution, aka focal
-    strategy:
-      matrix:
-        include:
-          - name: zipkin
-            readme: docker/README.md
-            env: DOCKER_TARGET=zipkin
-          - name: zipkin-cassandra
-            readme: docker/test-images/zipkin-cassandra/README.md
-            env: DOCKER_FILE=docker/test-images/zipkin-cassandra/Dockerfile
-          - name: zipkin-elasticsearch6
-            readme: docker/test-images/zipkin-elasticsearch6/README.md
-            env: DOCKER_FILE=docker/test-images/zipkin-elasticsearch6/Dockerfile
-          - name: zipkin-elasticsearch7
-            readme: docker/test-images/zipkin-elasticsearch7/README.md
-            env: DOCKER_FILE=docker/test-images/zipkin-elasticsearch7/Dockerfile
-          - name: zipkin-kafka
-            readme: docker/test-images/zipkin-kafka/README.md
-            env: DOCKER_FILE=docker/test-images/zipkin-kafka/Dockerfile
-          - name: zipkin-mysql
-            readme: docker/test-images/zipkin-mysql/README.md
-            env: DOCKER_FILE=docker/test-images/zipkin-mysql/Dockerfile
-          - name: zipkin-slim
-            readme: docker/README.md
-            env: DOCKER_TARGET=zipkin-slim
-          - name: zipkin-ui
-            readme: docker/test-images/zipkin-ui/README.md
-            env: DOCKER_FILE=docker/test-images/zipkin-ui/Dockerfile
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -126,10 +98,59 @@ jobs:
           path: ~/.docker
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-docker
-      - name: Building and verifying openzipkin/${{ matrix.name }}:test
+      - name: docker/README.md - openzipkin/zipkin
         run: |
-          build-bin/docker/configure_docker &&
-          ${{ matrix.env }} build-bin/docker/docker_build openzipkin/${{ matrix.name }}:test &&
-          build-bin/docker/docker_test_image openzipkin/${{ matrix.name }}
+          build-bin/docker/docker_build openzipkin/zipkin:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin
         env:
+          RELEASE_FROM_MAVEN_BUILD: true
+      - name: docker/README.md - openzipkin/zipkin-slim
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-slim:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-slim
+        env:
+          DOCKER_TARGET: zipkin-slim
+          RELEASE_FROM_MAVEN_BUILD: true
+      - name: docker/test-images/zipkin-cassandra/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-cassandra:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-cassandra
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-cassandra/Dockerfile
+      - name: docker/test-images/zipkin-elasticsearch6/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-elasticsearch6:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-elasticsearch6
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-elasticsearch6/Dockerfile
+      - name: docker/test-images/zipkin-elasticsearch7/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-elasticsearch7:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-elasticsearch7
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-elasticsearch7/Dockerfile
+      - name: docker/test-images/zipkin-kafka/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-kafka:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-kafka
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-kafka/Dockerfile
+      - name: docker/test-images/zipkin-mysql/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-mysql:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-mysql
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-mysql/Dockerfile
+      - name: docker/test-images/zipkin-mysql/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-mysql:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-mysql
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-mysql/Dockerfile
+      - name: docker/test-images/zipkin-ui/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-ui:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-ui
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-ui/Dockerfile
           RELEASE_FROM_MAVEN_BUILD: true

--- a/.github/workflows/readme_test.yml
+++ b/.github/workflows/readme_test.yml
@@ -18,9 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - name: ubuntu
-            os: ubuntu-20.04  # newest available distribution, aka focal
+        include:  # ubuntu is tested as a part of the docker job
           - name: macos
             os: macos-latest
           - name: windows
@@ -29,13 +27,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 10
-      # Remove apt repos that are known to break from time to time.
-      # See https://github.com/actions/virtual-environments/issues/323
-      - name: Remove broken apt repos [ubuntu]
-        if: matrix.name == 'ubuntu'
-        run: |
-          for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
+          fetch-depth: 1
       # Setup latest JDK. We do this to ensure users don't need to use the same version as our
       # release process. Release uses JDK 11, the last version that can target 1.6 bytecode.
       - name: Setup java
@@ -53,51 +45,46 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
-      - name: Execute Server Build
-        # command from zipkin-server/README.md
+      - name: Execute Server Build  # command from zipkin-server/README.md
         run: ./mvnw -T1C -q --batch-mode -DskipTests --also-make -pl zipkin-server clean package
-        shell: bash
-        env:
-          CI: true
-      - name: upload zipkin-server-*.jar [ubuntu]
-        uses: actions/upload-artifact@v2
-        if: matrix.name == 'ubuntu'
-        with:
-          name: zipkin-server-jars
-          if-no-files-found: error
-          path: |
-            zipkin-server/target/zipkin-server-*-exec.jar
-            zipkin-server/target/zipkin-server-*-slim.jar
-      - name: upload zipkin-lens-*.jar [ubuntu]
-        uses: actions/upload-artifact@v2
-        if: matrix.name == 'ubuntu'
-        with:
-          name: zipkin-lens-jar
-          if-no-files-found: error
-          path: zipkin-lens/target/zipkin-lens-*-SNAPSHOT.jar
 
   docker:
-    needs: zipkin-server
     runs-on: ubuntu-20.04  # newest available distribution, aka focal
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      # Remove apt repos that are known to break from time to time.
+      # See https://github.com/actions/virtual-environments/issues/323
+      - name: Remove broken apt repos
+        run: |
+          for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
+      # Setup latest JDK. We do this to ensure users don't need to use the same version as our
+      # release process. Release uses JDK 11, the last version that can target 1.6 bytecode.
+      - name: Setup java
+        uses: actions/setup-java@v1
         with:
-          name: zipkin-server-jars
-          path: zipkin-server/target/
-      - uses: actions/download-artifact@v2
-        with:
-          name: zipkin-lens-jar
-          path: zipkin-lens/target/
+          java-version: 15
       - name: Cache Docker
         uses: actions/cache@v2
         with:
           path: ~/.docker
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-docker
+      - name: Cache NPM Packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-packages-${{ hashFiles('zipkin-lens/package-lock.json') }}
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      - name: zipkin-server/README.md  # Tests the build which is re-used for a few images
+        run: ./mvnw -T1C -q --batch-mode -DskipTests --also-make -pl zipkin-server clean package
       - name: docker/README.md - openzipkin/zipkin
         run: |
           build-bin/docker/docker_build openzipkin/zipkin:test &&
@@ -110,6 +97,13 @@ jobs:
           build-bin/docker/docker_test_image openzipkin/zipkin-slim
         env:
           DOCKER_TARGET: zipkin-slim
+          RELEASE_FROM_MAVEN_BUILD: true
+      - name: docker/test-images/zipkin-ui/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-ui:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-ui
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-ui/Dockerfile
           RELEASE_FROM_MAVEN_BUILD: true
       - name: docker/test-images/zipkin-cassandra/README.md
         run: |
@@ -147,10 +141,3 @@ jobs:
           build-bin/docker/docker_test_image openzipkin/zipkin-mysql
         env:
           DOCKER_FILE: docker/test-images/zipkin-mysql/Dockerfile
-      - name: docker/test-images/zipkin-ui/README.md
-        run: |
-          build-bin/docker/docker_build openzipkin/zipkin-ui:test &&
-          build-bin/docker/docker_test_image openzipkin/zipkin-ui
-        env:
-          DOCKER_FILE: docker/test-images/zipkin-ui/Dockerfile
-          RELEASE_FROM_MAVEN_BUILD: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,37 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-packages-${{ hashFiles('zipkin-lens/package-lock.json') }}
+      - name: Test without Docker
+        run: build-bin/maven_go_offline && build-bin/test -Ddocker.skip=true
+  test_docker:
+    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    strategy:
+      matrix:
+        include:
+          - name: zipkin-collector-kafka
+          - name: zipkin-collector-rabbitmq
+          - name: zipkin-storage-cassandra
+          - name: zipkin-storage-elasticsearch
+          - name: zipkin-storage-mysql-v1
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1  # -Dlicense.skip=true so we don't need a full clone
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
       - name: Cache Docker
         uses: actions/cache@v2
         with:
           path: ~/.docker
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-docker
-      - name: Test
-        run: build-bin/configure_test && build-bin/test
+      - name: Test with Docker
+        run: |
+          build-bin/maven/maven_go_offline &&
+          build-bin/docker/configure_docker &&
+          build-bin/test -pl :${{ matrix.name }} --am -Dlicense.skip=true

--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -11,8 +11,9 @@ On test:
 * [test], used by [../.github/workflows/test.yml] runs Maven unit and integration tests.
   * Its "test" job skips docker, as they are run in parallel in "test_docker"
 * [../.github/workflows/readme_test.yml] tests build commands in [../zipkin-server] and [../docker]
-* zipkin, zipkin-lens and zipkin-slim Docker builds use `RELEASE_FROM_MAVEN_BUILD=true`
-  * this avoids invoking Maven builds from within Docker, which are costly and fragile
+  * zipkin, zipkin-lens and zipkin-slim Docker builds use `RELEASE_FROM_MAVEN_BUILD=true`
+    * this avoids invoking Maven builds from within Docker, which are costly and fragile
+  * Docker tests run in sequence to avoid queueing delays, which take longer than builds themselves.
 
 On deploy:
 * [deploy], used by [../.github/workflows/deploy.yml] publishes jars and Docker images.

--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -9,6 +9,7 @@ On [../zipkin-lens]:
 
 On test:
 * [test], used by [../.github/workflows/test.yml] runs Maven unit and integration tests.
+  * Its "test" job skips docker, as they are run in parallel in "test_docker"
 * [../.github/workflows/readme_test.yml] tests build commands in [../zipkin-server] and [../docker]
 * zipkin, zipkin-lens and zipkin-slim Docker builds use `RELEASE_FROM_MAVEN_BUILD=true`
   * this avoids invoking Maven builds from within Docker, which are costly and fragile

--- a/build-bin/maven_go_offline
+++ b/build-bin/maven_go_offline
@@ -15,10 +15,9 @@
 
 set -ue
 
-export MAVEN_OPTS="$(build-bin/maven/maven_opts)"
+build-bin/maven/maven_go_offline
 
-# Use a go-offline that properly works with multi-module builds
-./mvnw -q --batch-mode -nsu -Prelease de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+export MAVEN_OPTS="$(build-bin/maven/maven_opts)"
 
 # Prefetch dependencies used by zipkin-ui (NPM and NodeJS binary and dependencies of our build)
 ./mvnw -q --batch-mode -nsu -pl zipkin-lens generate-resources

--- a/build-bin/test
+++ b/build-bin/test
@@ -7,4 +7,4 @@ set -ue
 # See [README.md] for an explanation of this and how CI should use it.
 
 # -DskipActuator ensures no tests rely on the actuator library
-./mvnw verify -nsu -DskipActuator "$@"
+./mvnw -T1C verify -nsu -DskipActuator "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,8 @@
     <gson.version>2.8.6</gson.version>
     <unpack-proto.directory>${project.build.directory}/test/proto</unpack-proto.directory>
 
+    <license.skip>${skipTests}</license.skip>
+
     <animal-sniffer-maven-plugin.version>1.19</animal-sniffer-maven-plugin.version>
     <go-offline-maven-plugin.version>1.2.7</go-offline-maven-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
@@ -501,7 +503,7 @@
         <artifactId>license-maven-plugin</artifactId>
         <version>${license-maven-plugin.version}</version>
         <configuration>
-          <skip>${skipTests}</skip>
+          <skip>${license.skip}</skip>
           <!-- session.executionRootDirectory resolves properly even with nested modules -->
           <header>${main.basedir}/src/etc/header.txt</header>
           <mapping>


### PR DESCRIPTION
This splits normal tests from docker-based ones, doing the latter in
parallel as different jobs. The goal is to speed up the build which is
currently about 20 minutes.

Fixes #3312