### PR TITLE
Adjusts Cassandra image to work with JRE 11 and preps for Cassandra 4

### DIFF
--- a/docker/test-images/zipkin-cassandra/Dockerfile
+++ b/docker/test-images/zipkin-cassandra/Dockerfile
@@ -12,7 +12,7 @@
 # the License.
 #
 
-# java_version is used for install and runtime layers of zipkin-elasticsearch6
+# java_version is used for install and runtime layers of zipkin-cassandra
 #
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use

--- a/docker/test-images/zipkin-cassandra/Dockerfile
+++ b/docker/test-images/zipkin-cassandra/Dockerfile
@@ -12,10 +12,12 @@
 # the License.
 #
 
-# java_version is used for install and runtime layers of zipkin-cassandra
+# java_version is used for install and runtime layers of zipkin-elasticsearch6
 #
-# Until Cassandra v4, we are stuck on JRE 8 for Cassandra
-ARG java_version=8.272.10
+# Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
+# This is defined in many places because Docker has no "env" script functionality unless you use
+# docker-compose: When updating, update everywhere.
+ARG java_version=15.0.1_p9
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -31,9 +33,8 @@ FROM ghcr.io/openzipkin/java:${java_version} as install
 # Use latest stable version: https://cassandra.apache.org/download/
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG cassandra3_version=3.11.9
-ENV CASSANDRA_VERSION=$cassandra3_version
-
+ARG cassandra_version=3.11.9
+ENV CASSANDRA_VERSION=$cassandra_version
 WORKDIR /install
 
 COPY --from=scratch /zipkin-schemas/* ./zipkin-schemas/
@@ -42,8 +43,9 @@ RUN /tmp/install.sh && rm /tmp/install.sh
 
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-cassandra
 LABEL org.opencontainers.image.description="Cassandra on OpenJDK and Alpine Linux with Zipkin keyspaces pre-installed"
-ARG cassandra3_version=3.11.9
-LABEL cassandra-version=$cassandra3_version
+ARG cassandra_version=3.11.9
+LABEL cassandra-version=$cassandra_version
+ENV CASSANDRA_VERSION=$cassandra_version
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/

--- a/docker/test-images/zipkin-cassandra/docker-bin/start-cassandra
+++ b/docker/test-images/zipkin-cassandra/docker-bin/start-cassandra
@@ -31,8 +31,33 @@ sed -i "s/listen_address:.*/listen_address: $IP/" conf/cassandra.yaml
 sed -i "s/rpc_address:.*/rpc_address: $IP/" conf/cassandra.yaml
 sed -i "s/          - seeds: \".*\"/          - seeds: \"$IP\"/" conf/cassandra.yaml
 
+case ${CASSANDRA_VERSION} in
+  4* )
+    # Normal exports and opens, except RMI which we don't include in our JRE image
+    # See https://github.com/apache/cassandra/blob/cassandra-4.0-beta3/conf/jvm11-server.options
+    JAVA_OPTS="${JAVA_OPTS} \
+      -Djdk.attach.allowAttachSelf=true \
+      --add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+      --add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
+      --add-exports java.base/sun.nio.ch=ALL-UNNAMED \
+      --add-exports java.sql/java.sql=ALL-UNNAMED \
+      --add-opens java.base/java.lang.module=ALL-UNNAMED \
+      --add-opens java.base/jdk.internal.loader=ALL-UNNAMED \
+      --add-opens java.base/jdk.internal.ref=ALL-UNNAMED \
+      --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED \
+      --add-opens java.base/jdk.internal.math=ALL-UNNAMED \
+      --add-opens java.base/jdk.internal.module=ALL-UNNAMED \
+      --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED \
+      --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
+    ;;
+esac
+
+# Use agent to allow instrumentation of a lambda: CASSANDRA-16304
+JAMM_JAR=$(ls libs/jamm-*.jar)
+
 echo Starting Cassandra
 exec java -cp 'libs/*' ${JAVA_OPTS} \
+  -Xbootclasspath/a:${JAMM_JAR} -javaagent:${JAMM_JAR} \
   -Djava.io.tmpdir=/tmp \
   -Dcassandra-foreground=yes \
   -Dcassandra.storagedir=${PWD} \

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraSpanConsumer.java
@@ -63,9 +63,9 @@ class CassandraSpanConsumer implements SpanConsumer { // not final for testing
   }
 
   // Exposed to allow tests to switch from strictTraceId to not
-  CassandraSpanConsumer(CqlSession session, Schema.Metadata metadata,
-    boolean strictTraceId, boolean searchEnabled,
-    Set<String> autocompleteKeys, int autocompleteTtl, int autocompleteCardinality) {
+  CassandraSpanConsumer(CqlSession session, Schema.Metadata metadata, boolean strictTraceId,
+    boolean searchEnabled, Set<String> autocompleteKeys, int autocompleteTtl,
+    int autocompleteCardinality) {
     this.session = session;
     this.strictTraceId = strictTraceId;
     this.searchEnabled = searchEnabled;

--- a/zipkin-storage/cassandra/src/main/resources/zipkin2-schema.cql
+++ b/zipkin-storage/cassandra/src/main/resources/zipkin2-schema.cql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS zipkin2.span (
     AND default_time_to_live =  604800
     AND gc_grace_seconds = 3600
     AND read_repair_chance = 0
-    AND dclocal_read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0
     AND speculative_retry = '95percentile'
     AND comment = 'Primary table for holding trace data';
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
@@ -63,6 +64,9 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
           .withExposedPorts(CASSANDRA_PORT)
           .waitingFor(Wait.forHealthcheck());
         container.start();
+        if (Boolean.parseBoolean(System.getenv("CASSANDRA_DEBUG"))) {
+          container.followOutput(new Slf4jLogConsumer(LoggerFactory.getLogger(image.toString())));
+        }
       } catch (RuntimeException e) {
         LOGGER.warn("Couldn't start docker image " + image + ": " + e.getMessage(), e);
       }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/InternalForTests.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/InternalForTests.java
@@ -14,15 +14,19 @@
 package zipkin2.storage.cassandra;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.TestInfo;
 import zipkin2.DependencyLink;
 
@@ -34,6 +38,13 @@ class InternalForTests {
   static CqlSession mockSession() {
     CqlSession session = mock(CqlSession.class);
     Metadata metadata = mock(Metadata.class);
+    Node node = mock(Node.class);
+
+    when(session.getMetadata()).thenReturn(metadata);
+    when(metadata.getNodes()).thenReturn(Collections.singletonMap(
+      UUID.fromString("11111111-1111-1111-1111-111111111111"), node
+    ));
+    when(node.getCassandraVersion()).thenReturn(Version.parse("3.11.9"));
 
     KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
     when(session.getMetadata()).thenReturn(metadata);


### PR DESCRIPTION
This adds some workarounds for Cassandra when used on JRE 11, allowing
us a single base image in this repo (note zipkin-dependencies still
uses JRE 8 until Elasticsearch updates their spark support).

A single base image helps us as we don't need to download a couple
hundred meg only for one storage option. This also carves in Cassandra
4 support based on 4.0.0-beta-3 which passes almost all tests, but
deserves to wait until the next beta before we formalize in any way.