### PR TITLE
Stops using buildx completely

### DIFF
--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -17,6 +17,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1  # only needed to get the sha label
+      - name: Cache Docker
+        uses: actions/cache@v2
+        with:
+          path: ~/.docker
+          key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
+          restore-keys: ${{ runner.os }}-docker
       - name: Docker Push
         run: |  # GITHUB_REF will be refs/tags/docker-MAJOR.MINOR.PATCH
           build-bin/git/login_git &&

--- a/build-bin/docker/configure_docker_push
+++ b/build-bin/docker/configure_docker_push
@@ -13,7 +13,7 @@
 # the License.
 #
 
-# Ensures Docker is logged in, buildx is available and it can build multi-architecture.
+# Ensures Docker is logged in and it can build multi-architecture.
 # This should be used instead of `configure_docker` when a push will occur.
 #
 # This should only happen when we are publishing multi-arch builds, as otherwise the setup could use
@@ -32,7 +32,7 @@ fi
 echo '{ "experimental":true, "registry-mirrors": ["https://mirror.gcr.io"] }' | sudo tee /etc/docker/daemon.json
 
 sudo service docker restart
-# Enable experimental client features (eg docker buildx)
+# Enable experimental client features (multi-arch)
 mkdir -p ${HOME}/.docker && echo '{"experimental":"enabled"}' > ${HOME}/.docker/config.json
 
 # Log in to GitHub Container Registry and Docker Hub for releasing images

--- a/build-bin/docker/configure_docker_push
+++ b/build-bin/docker/configure_docker_push
@@ -35,10 +35,6 @@ sudo service docker restart
 # Enable experimental client features (eg docker buildx)
 mkdir -p ${HOME}/.docker && echo '{"experimental":"enabled"}' > ${HOME}/.docker/config.json
 
-# temporarily purge cache as there's no way in github to do this
-docker buildx rm builder || true
-docker system prune -af || true
-
 # Log in to GitHub Container Registry and Docker Hub for releasing images
 # This effects ${HOME}/.docker/config.json, which was created above
 
@@ -50,21 +46,9 @@ if [ -n "${DOCKERHUB_USER:-}" ]; then
   echo "${DOCKERHUB_TOKEN}" | docker login -u "${DOCKERHUB_USER}" --password-stdin
 fi
 
-# Connection resets are frequent in GitHub Actions workflows
-alias wget="wget --random-wait --tries=5 -qO-"
-
-# Latest version from https://github.com/docker/buildx/releases
-buildx_version=0.4.2
-buildx_url=https://github.com/docker/buildx/releases/download/v${buildx_version}/buildx-v${buildx_version}.linux-${arch}
-mkdir -p $HOME/.docker/cli-plugins
-( cd $HOME/.docker/cli-plugins && wget ${buildx_url} > docker-buildx && chmod 755 docker-buildx)
-docker version
-
 # Enable execution of different multi-architecture containers by QEMU and binfmt_misc
 # See https://github.com/multiarch/qemu-user-static
 #
 # Mirrored image use to avoid docker.io pulls:
 # docker tag multiarch/qemu-user-static:5.1.0-7 ghcr.io/openzipkin/multiarch-qemu-user-static:latest
 docker run --rm --privileged ghcr.io/openzipkin/multiarch-qemu-user-static --reset -p yes
-# don't fail if there's already a builder
-docker buildx create --name builder --use || true

--- a/build-bin/docker/docker_arch
+++ b/build-bin/docker/docker_arch
@@ -20,24 +20,24 @@
 
 set -ue
 
-# Normalize arch to what's available
-arch=${ARCH:-$(uname -m)}
-case ${arch} in
+# Normalize docker_arch to what's available
+docker_arch=${DOCKER_ARCH:-$(uname -m)}
+case ${docker_arch} in
   amd64* )
-    arch=amd64
+    docker_arch=amd64
     ;;
   x86_64* )
-    arch=amd64
+    docker_arch=amd64
     ;;
   arm64* )
-    arch=arm64
+    docker_arch=arm64
     ;;
   aarch64* )
-    arch=arm64
+    docker_arch=arm64
     ;;
   * )
-    >&2 echo "Unsupported arch: ${arch}"
+    >&2 echo "Unsupported DOCKER_ARCH: ${docker_arch}"
     exit 1;
 esac
 
-echo ${arch}
+echo ${docker_arch}

--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -19,7 +19,8 @@ docker_tag=${1?full docker_tag is required. Ex openzipkin/zipkin:test}
 version=${2:-}
 docker_args=$($(dirname "$0")/docker_args ${version})
 
-# Avoid buildx on load for two reasons:
+# Avoid buildx on load for reasons including:
+#  * Caching is more complex as builder instances must be considered
 #  * It only supports one platform/arch on load https://github.com/docker/buildx/issues/59
 #  * It would pull Docker Hub for moby/buildkit or multiarch/qemu-user-static images, using up quota
 echo "Building image ${docker_tag}"

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -23,6 +23,7 @@ set -ue
 
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}
 version=${2:-master}
+export DOCKER_BUILDKIT=0
 
 case ${version} in
   master )
@@ -58,16 +59,40 @@ for repo in ${docker_repos}; do
   done
 done
 
-# plaforms to eventually push to the registry
-docker_platforms=${DOCKER_PLATFORMS:-linux/amd64,linux/arm64}
-
-echo "Will push the following tags with platform ${docker_platforms}:${tags}\n"
-
 docker_args=$($(dirname "$0")/docker_args ${version})
+docker_archs=${DOCKER_PLATFORMS:-amd64 arm64}
 
-docker_push="docker buildx build --pull --progress plain --platform=${docker_platforms} ${docker_args} . --output=type=registry"
+echo "Will build the following architectures: ${docker_archs}"
 
-for tag in $(echo ${tags}|xargs); do
-  echo "Pushing tag ${tag}..."
-  ${docker_push} --tag ${tag}
+docker_tag0="$(echo ${docker_tags} | awk '{print $1;}')"
+arch_tags=""
+for docker_arch in ${docker_archs}; do
+  arch_tag=${docker_image}:${docker_tag0}-${docker_arch}
+  echo "Building tag ${arch_tag}..."
+  docker build --pull ${docker_args} --platform linux/${docker_arch} --tag ${arch_tag} .
+  arch_tags="${arch_tags} ${arch_tag}"
+done
+
+echo "Will push the following tags:\n${tags}"
+
+for tag in $(echo ${tags} | xargs); do
+  manifest_tags=""
+  for arch_tag in ${arch_tags}; do
+    docker_arch=$(echo ${arch_tag} | sed 's/.*-//g')
+    manifest_tag=${tag}-${docker_arch}
+    docker tag ${arch_tag} ${manifest_tag}
+    echo "Pushing tag ${manifest_tag}..."
+    docker push ${manifest_tag}
+    manifest_tags="${manifest_tags} ${manifest_tag}"
+  done
+
+  docker manifest create ${tag} ${manifest_tags}
+
+  for manifest_tag in ${manifest_tags}; do
+    docker_arch=$(echo ${manifest_tag} | sed 's/.*-//g')
+    docker manifest annotate ${tag} ${manifest_tag} --os linux --arch ${docker_arch}
+  done
+
+  echo "Pushing manifest ${manifest_tag}..."
+  docker manifest push -p ${tag}
 done

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -30,15 +30,15 @@ version=${2:-master}
 export DOCKER_BUILDKIT=0
 
 case ${version} in
-master)
-  is_release=false
-  ;;
-*-SNAPSHOT)
-  is_release=false
-  ;;
-*)
-  is_release=true
-  ;;
+  master)
+    is_release=false
+    ;;
+  *-SNAPSHOT)
+    is_release=false
+    ;;
+  *)
+    is_release=true
+    ;;
 esac
 
 if [ "${is_release}" = "true" ]; then

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -19,9 +19,10 @@
 #
 # Note: In CI, `configure_docker_push` must be called before invoking this.
 #
-# Avoid buildx on push for two reasons:
-#  * It runs archs in parallel and can create port conflicts (ex in cassandra)
-#  * Sometimes the cache has used the wrong layer leading to flakey builds
+# Avoid buildx on push for reasons including:
+#  * Caching is more complex as builder instances must be considered
+#  * Platform builds run in parallel, leading to port conflict failures (ex in cassandra)
+#  * 0.4.2 multi-platform builds have failed due to picking the wrong image for a FROM instruction
 set -ue
 
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}
@@ -29,15 +30,15 @@ version=${2:-master}
 export DOCKER_BUILDKIT=0
 
 case ${version} in
-  master )
-    is_release=false
-    ;;
-  *-SNAPSHOT )
-    is_release=false
-    ;;
-  * )
-    is_release=true
-    ;;
+master)
+  is_release=false
+  ;;
+*-SNAPSHOT)
+  is_release=false
+  ;;
+*)
+  is_release=true
+  ;;
 esac
 
 if [ "${is_release}" = "true" ]; then
@@ -63,7 +64,7 @@ for repo in ${docker_repos}; do
 done
 
 docker_args=$($(dirname "$0")/docker_args ${version})
-docker_archs=${DOCKER_PLATFORMS:-amd64 arm64}
+docker_archs=${DOCKER_ARCHS:-amd64 arm64}
 
 echo "Will build the following architectures: ${docker_archs}"
 

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -30,13 +30,13 @@ version=${2:-master}
 export DOCKER_BUILDKIT=0
 
 case ${version} in
-  master)
+  master )
     is_release=false
     ;;
-  *-SNAPSHOT)
+  *-SNAPSHOT )
     is_release=false
     ;;
-  *)
+  * )
     is_release=true
     ;;
 esac

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -18,7 +18,10 @@
 # When a release, and DOCKER_RELEASE_REPOS is unset they also push to Docker Hub (docker.io).
 #
 # Note: In CI, `configure_docker_push` must be called before invoking this.
-
+#
+# Avoid buildx on push for two reasons:
+#  * It runs archs in parallel and can create port conflicts (ex in cassandra)
+#  * Sometimes the cache has used the wrong layer leading to flakey builds
 set -ue
 
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}

--- a/docker/test-images/zipkin-cassandra/install.sh
+++ b/docker/test-images/zipkin-cassandra/install.sh
@@ -119,18 +119,8 @@ seed_provider:
 enable_sasi_indexes: true
 EOF
 
-# Avoid conflicts during multi-arch build (buildx starting two archs in the same container)
-arch=$(uname -m)
-case ${arch} in
-  aarch64* )
-    TEMP_STORAGE_PORT=7020
-    TEMP_NATIVE_TRANSPORT_PORT=9062
-    ;;
-  * )
-    TEMP_STORAGE_PORT=7010
-    TEMP_NATIVE_TRANSPORT_PORT=9052
-    ;;
-esac
+temp_storage_port=7010
+temp_native_transport_port=9052
 
 # Keep INFO logs as if this fails in CI, we'll get more insight. These aren't displayed unless we
 # have a crash.
@@ -173,8 +163,8 @@ java -cp 'classes:lib/*' -Xms64m -Xmx64m -XX:+ExitOnOutOfMemoryError -verbose:gc
   --add-opens java.base/jdk.internal.module=ALL-UNNAMED \
   --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED \
   --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
-  -Dcassandra.storage_port=${TEMP_STORAGE_PORT} \
-  -Dcassandra.native_transport_port=${TEMP_NATIVE_TRANSPORT_PORT} \
+  -Dcassandra.storage_port=${temp_storage_port} \
+  -Dcassandra.native_transport_port=${temp_native_transport_port} \
   -Dcassandra.storagedir=${PWD} \
   -Dcassandra.triggers_dir=${PWD}/triggers \
   -Dcassandra.config=file:${PWD}/conf/cassandra.yaml \
@@ -199,7 +189,7 @@ apk add --update --no-cache python2 py2-setuptools
 python2 -m easy_install pip
 pip install -Iq cqlsh
 function cql() {
-  cqlsh --cqlversion=${cqlversion} "$@" 127.0.0.1 ${TEMP_NATIVE_TRANSPORT_PORT}
+  cqlsh --cqlversion=${cqlversion} "$@" 127.0.0.1 ${temp_native_transport_port}
 }
 
 # Excessively long timeout to avoid having to create an ENV variable, decide its name, etc.


### PR DESCRIPTION
It is frequently the case that buildx uses the wrong image for cassandra
(the jre not the JDK) when arm64. This moves to the older but more
direct manifest approach to assembling multi-arch images until buildx
matures.

This follows from similar work in openzipkin/docker-alpine and -java