### PR TITLE
WIP Try to diagnose test failure on ES 7.10

### DIFF
--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/IgnoredDeprecationWarnings.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/IgnoredDeprecationWarnings.java
@@ -31,6 +31,7 @@ abstract class IgnoredDeprecationWarnings {
   // warning header for it to be ignored
   static List<Pattern> IGNORE_THESE_WARNINGS = asList(
     compile("Elasticsearch 7\\.x will read, but not allow creation of new indices containing ':'"),
-    compile("has index patterns \\[.*] matching patterns from existing older templates")
+    compile("has index patterns \\[.*] matching patterns from existing older templates"),
+    compile("has index patterns \\[.*] matching patterns from existing composable templates")
   );
 }

--- a/zipkin-storage/elasticsearch/src/test/resources/simplelogger.properties
+++ b/zipkin-storage/elasticsearch/src/test/resources/simplelogger.properties
@@ -7,3 +7,6 @@ org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS
 
 # stop huge spam
 org.slf4j.simpleLogger.log.org.testcontainers.dockerclient=off
+
+# Ensure when ES_DEBUG=true tests dump trace output
+org.slf4j.simpleLogger.log.com.linecorp.armeria.client.logging=info


### PR DESCRIPTION
@xeraa The note about deprecation was valid, but actually the test fails, which is something I didn't raise a PR on before as was out of time..


Here's an http trace of the failing test which is related to composable templates. If you run this with environment ES_DEBUG=true you would see what I do ideally, but anyway maybe you can look and see what is wrong or if another http command in the test would make what is wrong easier to know.
[httptrace.txt](https://github.com/openzipkin/zipkin/files/5683989/httptrace.txt)

Here's the actual /_template output just prior to writing the first document

```json

  "eatezipkinindextemplate_gettraces_returnssuccess-dependency_template": {
    "order": 0,
    "index_patterns": [
      "eatezipkinindextemplate_gettraces_returnssuccess-dependency-*"
    ],
    "settings": {
      "index": {
        "number_of_shards": "5",
        "number_of_replicas": "1",
        "requests": {
          "cache": {
            "enable": "true"
          }
        }
      }
    },
    "mappings": {
      "enabled": false
    },
    "aliases": {}
  },
  "eatezipkinindextemplate_gettraces_returnssuccess-span_template": {
    "order": 0,
    "index_patterns": [
      "eatezipkinindextemplate_gettraces_returnssuccess-span-*"
    ],
    "settings": {
      "index": {
        "number_of_shards": "5",
        "number_of_replicas": "1",
        "requests": {
          "cache": {
            "enable": "true"
          }
        }
      }
    },
    "mappings": {
      "_source": {
        "excludes": [
          "_q"
        ]
      },
      "dynamic_templates": [
        {
          "strings": {
            "mapping": {
              "norms": false,
              "ignore_above": 256,
              "type": "keyword"
            },
            "match_mapping_type": "string",
            "match": "*"
          }
        }
      ],
      "properties": {
        "traceId": {
          "norms": false,
          "type": "keyword"
        },
        "duration": {
          "type": "long"
        },
        "remoteEndpoint": {
          "dynamic": false,
          "type": "object",
          "properties": {
            "serviceName": {
              "norms": false,
              "type": "keyword"
            }
          }
        },
        "localEndpoint": {
          "dynamic": false,
          "type": "object",
          "properties": {
            "serviceName": {
              "norms": false,
              "type": "keyword"
            }
          }
        },
        "_q": {
          "norms": false,
          "type": "keyword"
        },
        "timestamp_millis": {
          "format": "epoch_millis",
          "type": "date"
        },
        "name": {
          "norms": false,
          "type": "keyword"
        },
        "annotations": {
          "enabled": false
        },
        "tags": {
          "enabled": false
        }
      }
    },
    "aliases": {}
  },
  "eatezipkinindextemplate_gettraces_returnssuccess-autocomplete_template": {
    "order": 0,
    "index_patterns": [
      "eatezipkinindextemplate_gettraces_returnssuccess-autocomplete-*"
    ],
    "settings": {
      "index": {
        "number_of_shards": "5",
        "number_of_replicas": "1",
        "requests": {
          "cache": {
            "enable": "true"
          }
        }
      }
    },
    "mappings": {
      "enabled": true,
      "properties": {
        "tagValue": {
          "norms": false,
          "type": "keyword"
        },
        "tagKey": {
          "norms": false,
          "type": "keyword"
        }
      }
    },
    "aliases": {}
  }
}
```

