### PR TITLE
Polishes the build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,12 +34,8 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-packages-${{ hashFiles('zipkin-lens/package-lock.json') }}
-      - name: Cache Docker
-        uses: actions/cache@v2
-        with:
-          path: ~/.docker
-          key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: ${{ runner.os }}-docker
+      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
+      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
       - name: Deploy
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -17,12 +17,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1  # only needed to get the sha label
-      - name: Cache Docker
-        uses: actions/cache@v2
-        with:
-          path: ~/.docker
-          key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: ${{ runner.os }}-docker
+      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
+      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
       - name: Docker Push
         run: |  # GITHUB_REF will be refs/tags/docker-MAJOR.MINOR.PATCH
           build-bin/git/login_git &&

--- a/.github/workflows/readme_test.yml
+++ b/.github/workflows/readme_test.yml
@@ -66,12 +66,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 15
-      - name: Cache Docker
-        uses: actions/cache@v2
-        with:
-          path: ~/.docker
-          key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: ${{ runner.os }}-docker
+      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
+      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
       - name: Cache NPM Packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,8 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
-      - name: Cache Docker
-        uses: actions/cache@v2
-        with:
-          path: ~/.docker
-          key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: ${{ runner.os }}-docker
+      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
+      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
       - name: Test with Docker
         run: |  # configure_test seeds NPM cache, which isn't needed for these tests
           build-bin/maven/maven_go_offline &&

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -25,7 +25,7 @@ if ! test -f ${docker_file}; then
 fi
 
 # Add default labels for the day and the SHA we're building from
-docker_args="-f ${docker_file} \
+docker_args="${DOCKER_ARGS:-} -f ${docker_file} \
 --label org.opencontainers.image.created=$(date +%Y-%m-%d) \
 --label org.opencontainers.image.revision=$(git rev-parse --short HEAD)"
 
@@ -48,13 +48,13 @@ fi
 # When non-empty, becomes the base layer including tag appropriate for the image being built.
 # Ex. ghcr.io/openzipkin/java:15.0.1_p9-jre
 #
-# This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.12.1
+# This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.12.3
 # See https://docs.docker.com/glossary/#parent-image
 if [ -n "${DOCKER_PARENT_IMAGE}" ]; then
   docker_args="${docker_args} --build-arg docker_parent_image=${DOCKER_PARENT_IMAGE}"
 fi
 
-# When non-empty, becomes the build-arg alpine_version. Ex. "3.12.1"
+# When non-empty, becomes the build-arg alpine_version. Ex. "3.12.3"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/alpine
 if [ -n "${ALPINE_VERSION}" ]; then
   docker_args="${docker_args} --build-arg alpine_version=${ALPINE_VERSION}"

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -69,6 +69,7 @@ docker_archs=${DOCKER_ARCHS:-amd64 arm64}
 echo "Will build the following architectures: ${docker_archs}"
 
 docker_tag0="$(echo ${docker_tags} | awk '{print $1;}')"
+docker_arch0="$(echo ${docker_archs} | awk '{print $1;}')"
 arch_tags=""
 for docker_arch in ${docker_archs}; do
   arch_tag=${docker_image}:${docker_tag0}-${docker_arch}
@@ -79,24 +80,38 @@ done
 
 echo "Will push the following tags:\n${tags}"
 
-for tag in $(echo ${tags} | xargs); do
-  manifest_tags=""
-  for arch_tag in ${arch_tags}; do
-    docker_arch=$(echo ${arch_tag} | sed 's/.*-//g')
-    manifest_tag=${tag}-${docker_arch}
-    docker tag ${arch_tag} ${manifest_tag}
-    echo "Pushing tag ${manifest_tag}..."
-    docker push ${manifest_tag}
-    manifest_tags="${manifest_tags} ${manifest_tag}"
+if [ "${docker_arch0}" = "${docker_archs}" ]; then
+  # single architecture
+  arch_tag=${docker_image}:${docker_tag0}-${docker_arch0}
+
+  for tag in $(echo ${tags} | xargs); do
+    docker tag ${arch_tag} ${tag}
+    echo "Pushing tag ${tag}..."
+    docker push ${tag}
   done
 
-  docker manifest create ${tag} ${manifest_tags}
+else
+  # multi-architecture: make a manifest
+  for tag in $(echo ${tags} | xargs); do
+    manifest_tags=""
+    for arch_tag in ${arch_tags}; do
+      docker_arch=$(echo ${arch_tag} | sed 's/.*-//g')
+      manifest_tag=${tag}-${docker_arch}
+      docker tag ${arch_tag} ${manifest_tag}
+      echo "Pushing tag ${manifest_tag}..."
+      docker push ${manifest_tag}
+      manifest_tags="${manifest_tags} ${manifest_tag}"
+    done
 
-  for manifest_tag in ${manifest_tags}; do
-    docker_arch=$(echo ${manifest_tag} | sed 's/.*-//g')
-    docker manifest annotate ${tag} ${manifest_tag} --os linux --arch ${docker_arch}
+    docker manifest create ${tag} ${manifest_tags}
+
+    for manifest_tag in ${manifest_tags}; do
+      docker_arch=$(echo ${manifest_tag} | sed 's/.*-//g')
+      docker manifest annotate ${tag} ${manifest_tag} --os linux --arch ${docker_arch}
+    done
+
+    echo "Pushing manifest ${manifest_tag}..."
+    docker manifest push -p ${tag}
   done
+fi
 
-  echo "Pushing manifest ${manifest_tag}..."
-  docker manifest push -p ${tag}
-done

--- a/build-bin/maven/maven_build
+++ b/build-bin/maven/maven_build
@@ -16,6 +16,9 @@
 set -ue
 
 export MAVEN_OPTS="$($(dirname "$0")/maven_opts)"
+if [ -x ./mvnw ]; then alias mvn=${PWD}/mvnw; fi
 
-(if [ "${MAVEN_PROJECT_BASEDIR:-.}" != "." ]; then cd ${MAVEN_PROJECT_BASEDIR}; fi && \
-mvn -T1C -q --batch-mode -DskipTests package "$@")
+(
+  if [ "${MAVEN_PROJECT_BASEDIR:-.}" != "." ]; then cd ${MAVEN_PROJECT_BASEDIR}; fi
+  mvn -T1C -q --batch-mode -DskipTests package "$@"
+)

--- a/build-bin/maven/maven_go_offline
+++ b/build-bin/maven/maven_go_offline
@@ -13,9 +13,14 @@
 # the License.
 #
 
+# This is a go-offline that properly works with multi-module builds
+
 set -ue
 
 export MAVEN_OPTS="$($(dirname "$0")/maven_opts)"
+if [ -x ./mvnw ]; then alias mvn=${PWD}/mvnw; fi
 
-# Use a go-offline that properly works with multi-module builds
-./mvnw -q --batch-mode -nsu -Prelease de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+(
+  if [ "${MAVEN_PROJECT_BASEDIR:-.}" != "." ]; then cd ${MAVEN_PROJECT_BASEDIR}; fi
+  mvn -q --batch-mode -nsu -Prelease de.qaware.maven:go-offline-maven-plugin:resolve-dependencies "$@"
+)

--- a/build-bin/maven/maven_opts
+++ b/build-bin/maven/maven_opts
@@ -32,10 +32,10 @@ case ${arch} in
     ;;
 esac
 
-maven_opts=""
+maven_opts="${MAVEN_OPTS:-}"
 if [ ${arch} = "arm64" ] && [ -f /etc/alpine-release ]; then
   # Defensively avoid arm64+alpine problems with posix_spawn
-  maven_opts="-Djdk.lang.Process.launchMechanism=vfork"
+  maven_opts="${maven_opts} -Djdk.lang.Process.launchMechanism=vfork"
 fi
 
 echo ${maven_opts}

--- a/build-bin/maven/maven_unjar
+++ b/build-bin/maven/maven_unjar
@@ -28,6 +28,9 @@
 
 set -eu
 
+export MAVEN_OPTS="$($(dirname "$0")/maven_opts)"
+if [ -x ./mvnw ]; then alias mvn=${PWD}/mvnw; fi
+
 group_id=${1?group_id is required}
 artifact_id=${2?artifact_id is required}
 version=${3?version is required}
@@ -48,8 +51,11 @@ case ${version} in
     ;;
 esac
 
-local_repo=$HOME/.m2/repository
-local_repo_path=${local_repo}/$(echo ${group_id}|tr '.' '/')/${artifact_id}/${version}/${qualified_jar}
+# Parse MAVEN_OPTS as it may have overridden .m2/repository
+local_repo=$(echo ${MAVEN_OPTS} | sed -n 's/.*maven.repo.local=\([^ ]*\).*/\1/p')
+if [ "${local_repo}" = "" ]; then local_repo=$HOME/.m2/repository; fi
+
+local_repo_path=${local_repo}/$(echo ${group_id} | tr '.' '/')/${artifact_id}/${version}/${qualified_jar}
 
 if test -f ${local_repo_path}; then
   echo "*** Reusing ${qualified_jar} from Maven local repository..."

--- a/docker/test-images/zipkin-mysql/Dockerfile
+++ b/docker/test-images/zipkin-mysql/Dockerfile
@@ -15,7 +15,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG alpine_version=3.12.1
+ARG alpine_version=3.12.3
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-ui/Dockerfile
+++ b/docker/test-images/zipkin-ui/Dockerfile
@@ -15,7 +15,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG alpine_version=3.12.1
+ARG alpine_version=3.12.3
 
 # java_version is used during the installation process to build or download the zipkin-lens jar.
 #

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+    <!-- Use same version as https://github.com/openzipkin/docker-java -->
+    <maven-help-plugin.version>3.2.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
     <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
@@ -258,13 +260,6 @@
           <configuration>
             <!-- Add dependencies indirectly referenced by build plugins -->
             <dynamicDependencies>
-              <!-- animal sniffer implicitly uses this -->
-              <DynamicDependency>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven-dependency-plugin.version}</version>
-                <repositoryType>PLUGIN</repositoryType>
-              </DynamicDependency>
               <DynamicDependency>
                 <groupId>org.codehaus.mojo.signature</groupId>
                 <artifactId>${main.signature.artifact}</artifactId>
@@ -429,6 +424,16 @@
     </pluginManagement>
 
     <plugins>
+      <!-- Ensure common utility commands use coherent versions (avoid lazy downloads) -->
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>${maven-help-plugin.version}</version>
+      </plugin>
+
       <!-- Top-level to ensure our server can use JDK 1.8
              (by checking we don't accidentally use later apis) -->
       <plugin>


### PR DESCRIPTION
* removes useless docker cache instructions
* properly handles single-arch docker (not used here, but still)
* ensures no lazy download of maven help plugin
* ensures jar can see an overridden local repository (MAVEN_OPTS)
* uses maven wrapper when possible
* bumps to latest alpine 3.12.3