### PR TITLE
Avoid fetching service names twice

### DIFF
--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.tsx
@@ -23,23 +23,29 @@ import { ThunkDispatch } from 'redux-thunk';
 import DiscoverPageContent from './DiscoverPageContent';
 import { useUiConfig } from '../UiConfig';
 import { loadAutocompleteKeys } from '../../slices/autocompleteKeysSlice';
+import { loadServices } from '../../slices/servicesSlice';
 import { RootState } from '../../store';
 
 interface DiscoverPageImplProps {
   autocompleteKeys: string[];
   isLoadingAutocompleteKeys: boolean;
+  isLoadingServices: boolean;
   loadAutocompleteKeys: () => void;
+  loadServices: () => void;
 }
 
 const DiscoverPageImpl: React.FC<DiscoverPageImplProps> = ({
   autocompleteKeys,
   isLoadingAutocompleteKeys,
+  isLoadingServices,
   loadAutocompleteKeys,
+  loadServices,
 }) => {
   const config = useUiConfig();
 
   useEffect(() => {
     loadAutocompleteKeys();
+    loadServices();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -55,7 +61,7 @@ const DiscoverPageImpl: React.FC<DiscoverPageImplProps> = ({
     );
   }
 
-  if (isLoadingAutocompleteKeys) {
+  if (isLoadingAutocompleteKeys || isLoadingServices) {
     // Need to fetch autocompleteKeys before displaying a search bar,
     // because SearchBar uses autocompleteKeys inside.
     return (
@@ -81,6 +87,7 @@ const DiscoverPageImpl: React.FC<DiscoverPageImplProps> = ({
 const mapStateToProps = (state: RootState) => ({
   autocompleteKeys: state.autocompleteKeys.autocompleteKeys,
   isLoadingAutocompleteKeys: state.autocompleteKeys.isLoading,
+  isLoadingServices: state.services.isLoading,
 });
 
 const mapDispatchToProps = (
@@ -88,6 +95,9 @@ const mapDispatchToProps = (
 ) => ({
   loadAutocompleteKeys: () => {
     dispatch(loadAutocompleteKeys());
+  },
+  loadServices: () => {
+    dispatch(loadServices());
   },
 });
 

--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPage.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.test.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.test.jsx
@@ -54,15 +54,9 @@ describe('<SearchBar />', () => {
     autocompleteKeys: [],
     autocompleteValues: [],
     isLoadingAutocompleteValues: false,
-    loadServices: jest.fn(),
     loadRemoteServices: jest.fn(),
     loadSpans: jest.fn(),
   };
-
-  it('should load services when mounted', () => {
-    render(<SearchBarImpl {...commonProps} />);
-    expect(commonProps.loadServices.mock.calls.length).toBe(1);
-  });
 
   it('should add an empty criterion when add button is clicked', () => {
     const { getByTestId } = render(<SearchBarImpl {...commonProps} />);

--- a/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.test.jsx
+++ b/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.tsx
@@ -31,7 +31,6 @@ import Criterion, { newCriterion } from '../Criterion';
 import CriterionBox from './CriterionBox';
 import { loadAutocompleteValues } from '../../../slices/autocompleteValuesSlice';
 import { loadRemoteServices } from '../../../slices/remoteServicesSlice';
-import { loadServices } from '../../../slices/servicesSlice';
 import { loadSpans } from '../../../slices/spansSlice';
 import { RootState } from '../../../store';
 
@@ -59,7 +58,6 @@ type SearchBarProps = {
   autocompleteKeys: string[];
   autocompleteValues: string[];
   isLoadingAutocompleteValues: boolean;
-  loadServices: () => void;
   loadRemoteServices: (serviceName: string) => void;
   loadSpans: (serviceName: string) => void;
   loadAutocompleteValues: (autocompleteKey: string) => void;
@@ -78,7 +76,6 @@ export const SearchBarImpl: React.FC<SearchBarProps> = ({
   autocompleteKeys,
   autocompleteValues,
   isLoadingAutocompleteValues,
-  loadServices,
   loadRemoteServices,
   loadSpans,
   loadAutocompleteValues,
@@ -128,11 +125,6 @@ export const SearchBarImpl: React.FC<SearchBarProps> = ({
     const nextCriterionIndex = criteria.length;
     setCriterionIndex(nextCriterionIndex);
   }, [criteria, onChange]);
-
-  useEffect(() => {
-    loadServices();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const prevServiceName = useRef('');
   useEffect(() => {
@@ -249,9 +241,6 @@ const mapStateToProps = (state: RootState) => ({
 const mapDispatchToProps = (
   dispatch: ThunkDispatch<RootState, undefined, any>,
 ) => ({
-  loadServices: () => {
-    dispatch(loadServices());
-  },
   loadRemoteServices: (serviceName: string) => {
     dispatch(loadRemoteServices(serviceName));
   },

--- a/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
When I open the FindTrace page, the list of service names is fetched twice.

![スクリーンショット 2021-01-04 15 28 58](https://user-images.githubusercontent.com/19551419/103507154-ded2f300-4ea1-11eb-8ffd-5e055d2fa234.png)

I fixed it.

![スクリーンショット 2021-01-04 15 28 31](https://user-images.githubusercontent.com/19551419/103507192-f316f000-4ea1-11eb-9a45-447c2f2b15ca.png)
