### PR TITLE
Limit usage of ES template parameter "include_type_name".

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -46,7 +46,9 @@ import zipkin2.storage.StorageComponent;
 import zipkin2.storage.Traces;
 
 import static com.linecorp.armeria.common.HttpMethod.GET;
-import static zipkin2.elasticsearch.ElasticsearchVersion.*;
+import static zipkin2.elasticsearch.ElasticsearchVersion.V7_0;
+import static zipkin2.elasticsearch.ElasticsearchVersion.V6_7;
+import static zipkin2.elasticsearch.ElasticsearchVersion.V7_8;
 import static zipkin2.elasticsearch.EnsureIndexTemplate.ensureIndexTemplate;
 import static zipkin2.elasticsearch.VersionSpecificTemplates.TYPE_AUTOCOMPLETE;
 import static zipkin2.elasticsearch.VersionSpecificTemplates.TYPE_DEPENDENCY;

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -46,8 +46,7 @@ import zipkin2.storage.StorageComponent;
 import zipkin2.storage.Traces;
 
 import static com.linecorp.armeria.common.HttpMethod.GET;
-import static zipkin2.elasticsearch.ElasticsearchVersion.V7_0;
-import static zipkin2.elasticsearch.ElasticsearchVersion.V7_8;
+import static zipkin2.elasticsearch.ElasticsearchVersion.*;
 import static zipkin2.elasticsearch.EnsureIndexTemplate.ensureIndexTemplate;
 import static zipkin2.elasticsearch.VersionSpecificTemplates.TYPE_AUTOCOMPLETE;
 import static zipkin2.elasticsearch.VersionSpecificTemplates.TYPE_DEPENDENCY;
@@ -361,12 +360,15 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
     if (version().compareTo(V7_8) >= 0 && templatePriority() != null) {
       return "/_index_template/" + indexPrefix + type + "_template";
     }
-    if (version().compareTo(V7_0) < 0) {
-      // because deprecation warning on 6 to prepare for 7 :
+    if (version().compareTo(V6_7) >= 0 && version().compareTo(V7_0) < 0) {
+      // because deprecation warning on 6 to prepare for 7:
       //
       // [types removal] The parameter include_type_name should be explicitly specified in get
       // template requests to prepare for 7.0. In 7.0 include_type_name will default to 'false',
-      // which means responses will omit the type name in mapping definitions."
+      // which means responses will omit the type name in mapping definitions.
+      //
+      // The parameter include_type_name was added in 6.7. Using this with ES older than
+      // 6.7 will result in unrecognized parameter: [include_type_name].
       return "/_template/" + indexPrefix + type + "_template?include_type_name=true";
     }
     return "/_template/" + indexPrefix + type + "_template";

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
@@ -29,6 +29,7 @@ import static zipkin2.elasticsearch.internal.JsonReaders.enterPath;
 public final class ElasticsearchVersion implements Comparable<ElasticsearchVersion> {
   public static final ElasticsearchVersion V5_0 = new ElasticsearchVersion(5, 0);
   public static final ElasticsearchVersion V6_0 = new ElasticsearchVersion(6, 0);
+  public static final ElasticsearchVersion V6_7 = new ElasticsearchVersion(6, 7);
   public static final ElasticsearchVersion V7_0 = new ElasticsearchVersion(7, 0);
   public static final ElasticsearchVersion V7_8 = new ElasticsearchVersion(7, 8);
   public static final ElasticsearchVersion V8_0 = new ElasticsearchVersion(8, 0);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Using parameter "include_type_name" with versions of ES that didn't yet support the parameter failes with `unrecognized parameter: [include_type_name]`

This change addresses that by limiting the usage to ES >= 6.7 < 7.0