### PR TITLE
Bump Armeria, Cassandra, Micrometer and Jackson deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,15 +51,15 @@
 
     <!-- This allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
-    <armeria.version>1.3.0</armeria.version>
+    <armeria.version>1.12.0</armeria.version>
     <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
-    <netty.version>4.1.54.Final</netty.version>
+    <netty.version>4.1.69.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
-    <jackson.version>2.12.0</jackson.version>
+    <jackson.version>2.12.4</jackson.version>
 
-    <java-driver.version>4.9.0</java-driver.version>
-    <micrometer.version>1.6.2</micrometer.version>
+    <java-driver.version>4.11.3</java-driver.version>
+    <micrometer.version>1.6.10</micrometer.version>
 
     <!-- Used for Generated annotations -->
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
@@ -96,7 +96,7 @@
 
     <license.skip>${skipTests}</license.skip>
 
-    <animal-sniffer-maven-plugin.version>1.19</animal-sniffer-maven-plugin.version>
+    <animal-sniffer-maven-plugin.version>1.20</animal-sniffer-maven-plugin.version>
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,10 @@
     <netty.version>4.1.69.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
-    <jackson.version>2.12.4</jackson.version>
+    <jackson.version>2.12.5</jackson.version>
 
     <java-driver.version>4.11.3</java-driver.version>
-    <micrometer.version>1.6.10</micrometer.version>
+    <micrometer.version>1.6.12</micrometer.version>
 
     <!-- Used for Generated annotations -->
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinGrpcCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinGrpcCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,6 +20,7 @@ import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -57,7 +58,7 @@ final class ZipkinGrpcCollector {
       this.metrics = metrics;
     }
 
-    @Override protected CompletableFuture<ByteBuf> handleMessage(ByteBuf bytes) {
+    @Override protected CompletionStage<ByteBuf> handleMessage(ServiceRequestContext srCtx, ByteBuf bytes) {
       metrics.incrementMessages();
       metrics.incrementBytes(bytes.readableBytes());
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerTimeout.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -73,7 +73,7 @@ public class ITZipkinServerTimeout {
     Response response = get("/api/v2/trace/" + TRACE.get(0).traceId());
     assertThat(response.isSuccessful()).isFalse();
 
-    assertThat(response.code()).isEqualTo(503);
+    assertThat(response.code()).isEqualTo(500);
   }
 
   Response get(String path) throws IOException {


### PR DESCRIPTION
There are a few CVEs with Netty. This change bumps a few Netty related dependencies to align on the latest Netty version.