### PR TITLE
chore: adds support for yaml license headers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,10 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.zipkin</groupId>
@@ -610,6 +613,7 @@
             <exclude>**/generated/**</exclude>
             <exclude>.dockerignore</exclude>
             <exclude>build-bin/*</exclude>
+            <exclude>chart/**</exclude>
           </excludes>
           <strictCheck>true</strictCheck>
         </configuration>


### PR DESCRIPTION
We chose to skip the check in chart repository because although it is a yaml file, the comment structure for the helm templates requires a different format than yaml (see #3378) and even with custom header type we can't match both.

Ping @jonkerj 