### PR TITLE
Add Helm CD for linting PRs and releasing charts

### DIFF
--- a/.github/ct.yml
+++ b/.github/ct.yml
@@ -1,0 +1,1 @@
+check-version-increment: False

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,25 @@
+name: helm-release
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'chart/**'
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    - name: Run chart-releaser
+      uses: helm/chart-releaser-action@v1.2.1
+      with:
+        charts_dir: chart
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,0 +1,22 @@
+name: helm-lint
+
+on:
+  pull_request:
+    paths:
+    - 'chart/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    - name: Lint the charts
+      uses: helm/chart-testing-action@v2.1.0
+      with:
+        command: lint
+        config: .github/ct.yaml


### PR DESCRIPTION
[chart-releaser-action](https://github.com/helm/chart-releaser-action) creates chart tarballs, puts them under releases, and maintains a file `index.yaml` in branch `gh-pages`, which refers to these tgz release files.