### PR TITLE
fix: chart: remove unneeded `tracing` service port

### DIFF
--- a/chart/zipkin-server/Chart.yaml
+++ b/chart/zipkin-server/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v2
 name: zipkin-server
 description: a distributed tracing system
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "2.21.0"

--- a/chart/zipkin-server/templates/NOTES.txt
+++ b/chart/zipkin-server/templates/NOTES.txt
@@ -18,16 +18,16 @@ the License.
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.zipkin.type }}
+{{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "zipkin.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.zipkin.type }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "zipkin.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "zipkin.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.zipkin.port }}
-{{- else if contains "ClusterIP" .Values.service.zipkin.type }}
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "zipkin.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"

--- a/chart/zipkin-server/templates/ingress.yaml
+++ b/chart/zipkin-server/templates/ingress.yaml
@@ -13,7 +13,7 @@ the License.
 */}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "zipkin.fullname" . -}}
-{{- $svcPort := .Values.service.zipkin.port -}}
+{{- $svcPort := .Values.service.port -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}

--- a/chart/zipkin-server/templates/service.yaml
+++ b/chart/zipkin-server/templates/service.yaml
@@ -14,29 +14,13 @@ the License.
 apiVersion: v1
 kind: Service
 metadata:
-  name: tracing
-  labels:
-    {{- include "zipkin.labels" . | nindent 4 }}
-spec:
-  type: {{ .Values.service.tracing.type }}
-  ports:
-    - port: {{ .Values.service.tracing.port }}
-      targetPort: 9411
-      protocol: TCP
-      name: http-query
-  selector:
-    {{- include "zipkin.selectorLabels" . | nindent 4 }}
----
-apiVersion: v1
-kind: Service
-metadata:
   name: {{ include "zipkin.fullname" . }}
   labels:
     {{- include "zipkin.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.zipkin.type }}
+  type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.zipkin.port }}
+    - port: {{ .Values.service.port }}
       targetPort: 9411
       protocol: TCP
       name: http-query

--- a/chart/zipkin-server/values.yaml
+++ b/chart/zipkin-server/values.yaml
@@ -48,12 +48,8 @@ securityContext:
   runAsUser: 1000
 
 service:
-  tracing:
-    type: ClusterIP
-    port: 80
-  zipkin:
-    type: ClusterIP
-    port: 9411
+  type: ClusterIP
+  port: 9411
 
 ingress:
   enabled: false


### PR DESCRIPTION
In #3378 we've accidentally added two services to expose Zipkin, instead of only one. This PR fixes that.