### PR TITLE
log4j 2 fix for CVE-2021-44228

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -33,6 +33,7 @@
 
     <!-- Sometimes we need to override Armeria's Brave version -->
     <brave.version>5.13.2</brave.version>
+    <log4j2.version>2.15.0</log4j2.version>
     <proto.generatedSourceDirectory>${project.build.directory}/generated-test-sources/wire</proto.generatedSourceDirectory>
   </properties>
 
@@ -100,6 +101,36 @@
           <artifactId>spring-boot-starter-logging</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- Override log4j 2 version to avoid CVE-2021-44228 -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j2.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+      <version>${log4j2.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
     </dependency>
 
     <!-- Use log4j 2 as default logging implementation -->


### PR DESCRIPTION
This diff overrides the log4j 2 version from transitive dependency in spring boot.
See https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot for details.

Test Plan:
> ./mvnw dependency:tree | grep log4j
[INFO] +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.15.0:compile
[INFO] +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] +- org.apache.logging.log4j:log4j-jul:jar:2.15.0:compile
[INFO] +- org.springframework.boot:spring-boot-starter-log4j2:jar:2.4.1:compile
[INFO] |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-core:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-jul:jar:2.15.0:compile
[INFO] |  +- org.springframework.boot:spring-boot-starter-log4j2:jar:2.4.1:compile