### PR TITLE
Upgrade Armeria to fix CVE-2021-43795

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
 
     <!-- This allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
-    <armeria.version>1.13.3</armeria.version>
+    <armeria.version>1.13.4</armeria.version>
     <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
-    <netty.version>4.1.69.Final</netty.version>
+    <netty.version>4.1.70.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
     <jackson.version>2.13.0</jackson.version>


### PR DESCRIPTION
```
+------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
|           LIBRARY            | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| com.linecorp.armeria:armeria | CVE-2021-43795   | HIGH     | 1.13.3            | 1.13.4        | Path Traversal in                     |
|                              |                  |          |                   |               | com.linecorp.armeria:armeria          |
|                              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-43795 |
+------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
```