### PR TITLE
Increase Sonatype staging timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -726,7 +726,7 @@
               <!-- Zipkin release is about ~100M mostly from the two server distributions. Default
                    will timeout after 5 minutes, which can trigger fairly easily with this size. -->
               <stagingProgressPauseDurationSeconds>20</stagingProgressPauseDurationSeconds>
-              <stagingProgressTimeoutMinutes>20</stagingProgressTimeoutMinutes>
+              <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>


### PR DESCRIPTION
Staging timeouts have been occurring lately due to backups with Sonatype servers. Bumping this is just an attempt at getting a clean build and I have no idea what a realistic threshold should be but 20 minutes isn't enough.