### PR TITLE
chore: update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -33,7 +33,7 @@
 
     <!-- Sometimes we need to override Armeria's Brave version -->
     <brave.version>5.13.2</brave.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <proto.generatedSourceDirectory>${project.build.directory}/generated-test-sources/wire</proto.generatedSourceDirectory>
   </properties>
 


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105