### PR TITLE
feature: support elasticsearch as output in Helm chart

### DIFF
--- a/chart/zipkin-server/Chart.yaml
+++ b/chart/zipkin-server/Chart.yaml
@@ -13,5 +13,5 @@ apiVersion: v2
 name: zipkin-server
 description: a distributed tracing system
 type: application
-version: 0.1.5
-appVersion: "2.21.0"
+version: 0.2.0
+appVersion: "2.23.16"

--- a/chart/zipkin-server/README.md
+++ b/chart/zipkin-server/README.md
@@ -1,0 +1,48 @@
+# zipkin-server
+
+A distributed tracing system
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"openzipkin/zipkin-slim"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.host | string | `"chart-example.local"` |  kubernetes.io/tls-acme: "true" className: nginx |
+| ingress.path | string | `"/"` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations."sidecar.istio.io/inject" | string | `"false"` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{"cpu":"500m","memory":"4096Mi"}` |  choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you do want to specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'resources:'. limits:   cpu: 100m   memory: 128Mi requests:   cpu: 100m   memory: 128Mi |
+| resources.requests.cpu | string | `"100m"` |  |
+| resources.requests.memory | string | `"128Mi"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |    drop:   - ALL |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `1000` |  |
+| service.port | int | `9411` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  If not set and create is true, a name is generated using the fullname template |
+| serviceAccount.psp | bool | `false` |  |
+| tolerations | list | `[]` |  |
+| zipkin.storage.elasticsearch.hosts | string | `"hostA hostB"` |  |
+| zipkin.storage.elasticsearch.index | string | `"fooIndex"` |  |
+| zipkin.storage.type | string | `"elasticsearch"` |  |
+
+The values are validated using a JSON schema, which contains logic to enforce either:
+- `zipkin.storage.type` is set to `mem`
+- `zipkin.storage.type` is set to `elasticsearch` *AND* both `z.s.elasticsearch.hosts` and `z.s.elasticsearch.index` is set

--- a/chart/zipkin-server/templates/deployment.yaml
+++ b/chart/zipkin-server/templates/deployment.yaml
@@ -48,7 +48,15 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
             - name: STORAGE_METHOD
-              value: mem
+              value: "{{ .Values.zipkin.storage.type }}"
+            {{- if eq .Values.zipkin.storage.type "elasticsearch" }}
+            {{- with .Values.zipkin.storage.elasticsearch }}
+            - name: ES_HOSTS
+              value: "{{ .hosts }}"
+            - name: ES_INDEX
+              value: "{{ .index }}"
+            {{- end }}
+            {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:

--- a/chart/zipkin-server/values.schema.json
+++ b/chart/zipkin-server/values.schema.json
@@ -1,0 +1,197 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxReplicas": {
+                    "type": "integer"
+                },
+                "minReplicas": {
+                    "type": "integer"
+                },
+                "targetCPUUtilizationPercentage": {
+                    "type": "integer"
+                }
+            }
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "tls": {
+                    "type": "array"
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "podAnnotations": {
+            "type": "object",
+            "properties": {
+                "sidecar.istio.io/inject": {
+                    "type": "string"
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object"
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "port": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "psp": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array"
+        },
+        "zipkin": {
+            "type": "object",
+            "properties": {
+                "storage": {
+                    "type": "object",
+                    "properties": {
+                        "elasticsearch": {
+                            "type": "object",
+                            "properties": {
+                                "hosts": {
+                                    "type": "string"
+                                },
+                                "index": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["hosts", "index"]
+                        },
+                        "type": {
+                            "enum": ["mem", "elasticsearch"]
+                        }
+                    },
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "type": {"const": "mem"}
+                            },
+                            "required": []
+                        },
+                        {
+                            "properties": {
+                                "type": {"const": "elasticsearch"}
+                            },
+                            "required": ["elasticsearch"]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/chart/zipkin-server/values.yaml
+++ b/chart/zipkin-server/values.yaml
@@ -95,3 +95,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+zipkin:
+  storage:
+    type: mem
+#    elasticsearch:
+#      hosts: hostA hostB
+#      index: fooIndex


### PR DESCRIPTION
It took a while for me to tackle #3401, but this seems to do the trick. I tried to avoid complex logic in the template (like @mrfelek suggested), but opted for a JSON schema that includes logic to do the same. In the process, I bumped the image from 2.21.0 to 2.23.11 (someone still needs to look at a CI for this, will try that later on).

I tested it by feeding it these values and looking at the output of `helm template -f <test values files>`:

```
# this should only render memory env var
zipkin:
  storage:
    type: memory
```

```
# this should error gracefully
zipkin:
  storage:
    type: elasticsearch
```

```
# this should render correct ES env vars
zipkin:
  storage:
    type: elasticsearch
    elasticsearch:
      hosts: hostA hostB
      index: fooIndex
```

If anyone actually running Zipkin with ES can confirm this (I dont), I would be thankful.