### PR TITLE
fix NullPointerException when parser.currentName() is null

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
@@ -64,10 +64,7 @@ public final class JsonSerializers {
       if (value == JsonToken.VALUE_NULL) {
         continue;
       }
-      System.out.println("current Name " + parser.currentName());
-      System.out.println("value " + value);
       if (parser.currentName() == null) {
-        System.out.println("parser current name " + parser.currentName());
         continue;
       }
       switch (parser.currentName()) {

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
@@ -64,6 +64,9 @@ public final class JsonSerializers {
       if (value == JsonToken.VALUE_NULL) {
         continue;
       }
+      if (parser.currentName() == null) {
+        continue;
+      }
       switch (parser.currentName()) {
         case "traceId":
           result.traceId(parser.getText());

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
@@ -110,7 +110,10 @@ public final class JsonSerializers {
             throw new IOException("Invalid span, expecting tags object, got: " + value);
           }
           while (parser.nextValue() != JsonToken.END_OBJECT) {
-            result.putTag(parser.currentName(), parser.getValueAsString());
+            String parserCurrentName = parser.currentName();
+            String parserValue = parser.getValueAsString();
+            if (parserCurrentName == null || parserValue == null) continue;
+            result.putTag(parserCurrentName, parserValue);
           }
           break;
         case "debug":

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
@@ -64,7 +64,10 @@ public final class JsonSerializers {
       if (value == JsonToken.VALUE_NULL) {
         continue;
       }
+      System.out.println("current Name " + parser.currentName());
+      System.out.println("value " + value);
       if (parser.currentName() == null) {
+        System.out.println("parser current name " + parser.currentName());
         continue;
       }
       switch (parser.currentName()) {
@@ -110,7 +113,10 @@ public final class JsonSerializers {
             throw new IOException("Invalid span, expecting tags object, got: " + value);
           }
           while (parser.nextValue() != JsonToken.END_OBJECT) {
-            result.putTag(parser.currentName(), parser.getValueAsString());
+            String parserCurrentName = parser.currentName();
+            String parserValue = parser.getValueAsString();
+            if (parserCurrentName == null || parserValue == null) continue;
+            result.putTag(parserCurrentName, parserValue);
           }
           break;
         case "debug":

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/JsonSerializersTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/JsonSerializersTest.java
@@ -103,6 +103,34 @@ public class JsonSerializersTest {
   }
 
   @Test
+  public void span_ignoreArray_value() {
+    String json =
+      "{\n"
+        + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+        + "  \"name\": \"get-traces\",\n"
+        + "  \"id\": \"6b221d5bc9e6496c\",\n"
+        + "  \"nums\": [1, 2, 3]"
+        + "}";
+
+    parse(SPAN_PARSER, json);
+  }
+
+  @Test
+  public void span_tag_ignoreArray_value() {
+    String json =
+      "{\n"
+        + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+        + "  \"name\": \"get-traces\",\n"
+        + "  \"id\": \"6b221d5bc9e6496c\",\n"
+        + "  \"tags\": {"
+        + "      \"nums\": [1, 2, 3]"
+        + "  }"
+        + "}";
+
+    parse(SPAN_PARSER, json);
+  }
+
+  @Test
   public void span_tag_long_read() {
     String json =
       "{\n"


### PR DESCRIPTION
when parser.currentName() is null, switch will throw NullPointerException 