### PR TITLE
Update SpringBoot to 2.6.6 and Spring to 5.3.18 to address CVE-2022-2…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
-    <spring-boot.version>2.4.13</spring-boot.version>
-    <spring.version>5.3.7</spring.version>
+    <spring-boot.version>2.6.6</spring-boot.version>
+    <spring.version>5.3.18</spring.version>
 
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/


### PR DESCRIPTION
PR to address issue https://github.com/openzipkin/zipkin/issues/3440 and CVE-2022-22965, as documented here: https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement. I'm not too familiar with zipkin, let me know if anything else is needed here!

Also would like to request an upgrade to zipkin-gcp as well for the same vulnerability: https://github.com/openzipkin/zipkin-gcp