### PR TITLE
Update Spring Boot to 2.5.14 and Spring to 5.3.20

### DIFF
--- a/docker/test-images/zipkin-mysql/Dockerfile
+++ b/docker/test-images/zipkin-mysql/Dockerfile
@@ -37,7 +37,7 @@ HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthche
 ENTRYPOINT ["start-mysql"]
 
 # Use latest from https://pkgs.alpinelinux.org/packages?name=mysql
-ARG mysql_version=10.6.7-r0
+ARG mysql_version=10.6.8-r0
 LABEL mysql-version=$mysql_version
 ENV MYSQL_VERSION=$mysql_version
 

--- a/docker/test-images/zipkin-mysql/Dockerfile
+++ b/docker/test-images/zipkin-mysql/Dockerfile
@@ -37,7 +37,7 @@ HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthche
 ENTRYPOINT ["start-mysql"]
 
 # Use latest from https://pkgs.alpinelinux.org/packages?name=mysql
-ARG mysql_version=10.6.4
+ARG mysql_version=10.6.7-r0
 LABEL mysql-version=$mysql_version
 ENV MYSQL_VERSION=$mysql_version
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <netty.version>4.1.70.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
-    <jackson.version>2.13.0</jackson.version>
+    <jackson.version>2.13.2.1</jackson.version>
 
     <java-driver.version>4.11.3</java-driver.version>
     <micrometer.version>1.6.12</micrometer.version>
@@ -68,8 +68,8 @@
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
-    <spring-boot.version>2.4.13</spring-boot.version>
-    <spring.version>5.3.7</spring.version>
+    <spring-boot.version>2.5.13</spring-boot.version>
+    <spring.version>5.3.20</spring.version>
 
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
-    <spring-boot.version>2.5.13</spring-boot.version>
+    <spring-boot.version>2.5.14</spring-boot.version>
     <spring.version>5.3.20</spring.version>
 
     <!-- MySQL connector is GPL, even if it has an OSS exception.


### PR DESCRIPTION
My organization is tagging zipkin with several vulnerabilities, this fixes most of them:
CVE-2022-22965
CVE-2020-36518
CVE-2021-22060

Superseeds https://github.com/openzipkin/zipkin/pull/3442