### PR TITLE
fix: upgrade gson to 2.8.9 to fix CVE-2022-25647 (#3458)

### DIFF
--- a/docker/test-images/zipkin-mysql/Dockerfile
+++ b/docker/test-images/zipkin-mysql/Dockerfile
@@ -37,7 +37,7 @@ HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthche
 ENTRYPOINT ["start-mysql"]
 
 # Use latest from https://pkgs.alpinelinux.org/packages?name=mysql
-ARG mysql_version=10.6.4
+ARG mysql_version=10.6.8
 LABEL mysql-version=$mysql_version
 ENV MYSQL_VERSION=$mysql_version
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <kryo.version>5.0.3</kryo.version>
     <!-- Only used for proto interop testing; wire-maven-plugin is usually behind latest. -->
     <wire.version>3.0.2</wire.version>
-    <gson.version>2.8.6</gson.version>
+    <gson.version>2.8.9</gson.version>
     <unpack-proto.directory>${project.build.directory}/test/proto</unpack-proto.directory>
 
     <!--


### PR DESCRIPTION
This includes two commits
* chore: upgrade mysql 10.6.8 in test
* fix: upgrade gson to 2.8.9 to fix CVE-2022-25647 (#3458)

I accidentally closed my previous pull request when I tried to add fix for the failing docker build https://github.com/openzipkin/zipkin/pull/3459 - sorry.

Not sure if this two commits have to go in different pull requests or in one (as they are currently).