### PR TITLE
Upgrade java base container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=15.0.5_p3
+ARG java_version=15.0.7_p4
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.


### PR DESCRIPTION
Use latest Java base container based on Alpine 3.15.4 with Java 15.0.7_p4.

CVE-2022-28391
CVE-2022-0778
CVE-2022-28391
CVE-2018-25032