### PR TITLE
Fix docker readme docker-compose links

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -61,13 +61,13 @@ When in Docker, the following environment variables also apply
   environment variable is typically set by linking a container running
   `zipkin-kafka` as "kafka" when you start the container.
 
-For example, to increase heap size, set `JAVA_OPTS` as shown in our [docker-compose](docker-compose.yml) file:
+For example, to increase heap size, set `JAVA_OPTS` as shown in our [docker-compose](examples/docker-compose.yml) file:
 ```yaml
     environment:
       - JAVA_OPTS=-Xms128m -Xmx128m -XX:+ExitOnOutOfMemoryError
 ```
 
-For example, to add debug logging, set `command` as shown in our [docker-compose](docker-compose.yml) file:
+For example, to add debug logging, set `command` as shown in our [docker-compose](examples/docker-compose.yml) file:
 ```yaml
     command: --logging.level.zipkin2=DEBUG
 ```


### PR DESCRIPTION
Currently the docker-compose links lead to a file that is no longer there. This pr updates the links to the new location.