### PR TITLE
Remove exception on traceIds of length 15

### DIFF
--- a/zipkin/src/main/java/zipkin2/Span.java
+++ b/zipkin/src/main/java/zipkin2/Span.java
@@ -635,7 +635,6 @@ public final class Span implements Serializable { // for Spark and Flink jobs
     if (length > 32) throw new IllegalArgumentException("traceId.length > 32");
     int zeros = validateHexAndReturnZeroPrefix(traceId);
     if (zeros == length) throw new IllegalArgumentException("traceId is all zeros");
-    if (length == 15) throw new RuntimeException("WTF");
     if (length == 32 || length == 16) {
       if (length == 32 && zeros >= 16) return traceId.substring(16);
       return traceId;


### PR DESCRIPTION
References https://github.com/openzipkin/zipkin/pull/3249#discussion_r553047076

From the linked PR it seems this exception was incorrectly added as the code would prepend a trace of length 15 with a single leading zero (just like it would add two leading zeros for a trace of length 14). 