### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.16.1

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.14.0</version>
+      <version>3.16.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Upgrade com.google.protobuf:protobuf-java from v3.14.0 to v3.16.1 for vulnerability fix:

- [CVE-2021-22569](https://www.oscs1024.com/hd/MPS-2021-19066)