### PR TITLE
Render ingress host

### DIFF
--- a/charts/zipkin/Chart.yaml
+++ b/charts/zipkin/Chart.yaml
@@ -14,7 +14,7 @@ appVersion: 2.23.16
 name: zipkin
 description: A Zipkin helm chart for kubernetes
 type: application
-version: 0.3.0
+version: 0.3.1
 maintainers:
   - name: openzipkin
     email: zipkin-dev@googlegroups.com

--- a/charts/zipkin/templates/ingress.yaml
+++ b/charts/zipkin/templates/ingress.yaml
@@ -39,13 +39,13 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host | quote }}
+    - host: {{ tpl .Values.ingress.host . | quote }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}


### PR DESCRIPTION
Support rendering hostnames like `my-app-{{ .Release.Name}}.example.com` to be more flexible with providing default-values with a common pattern