### PR TITLE
Adjust styling of Search page

### DIFF
--- a/zipkin-lens/src/components/DiscoverPage/DiscoverPageContent.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/DiscoverPageContent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,9 +23,8 @@ import {
   ButtonGroup,
   ButtonProps,
   Collapse,
-  Container,
   Divider,
-  Paper,
+  makeStyles,
   TextField,
   Typography,
 } from '@material-ui/core';
@@ -38,7 +37,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-
 import Criterion, { newCriterion } from './Criterion';
 import LookbackMenu from './LookbackMenu';
 import SearchBar from './SearchBar';
@@ -426,9 +424,31 @@ const useTraceSummaryOpenState = (traceSummaries: TraceSummary[]) => {
   };
 };
 
+const useStyles = makeStyles((theme) => ({
+  searchRow: {
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    display: 'flex',
+    padding: theme.spacing(1.5, 3),
+  },
+  settings: {
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    padding: theme.spacing(1, 3),
+  },
+  resultHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: theme.spacing(1.5, 3),
+  },
+}));
+
 const DiscoverPageContent: React.FC<DiscoverPageContentProps> = ({
   autocompleteKeys,
 }) => {
+  const classes = useStyles();
   // Retrieve search criteria from the URL query string and use them to search for traces.
   const { setQueryParams, criteria, lookback, limit } = useQueryParams(
     autocompleteKeys,
@@ -559,14 +579,12 @@ const DiscoverPageContent: React.FC<DiscoverPageContentProps> = ({
     );
   } else {
     content = (
-      <Paper elevation={3}>
-        <TraceSummaryTable
-          traceSummaries={filteredTraceSummaries}
-          toggleFilter={toggleFilter}
-          traceSummaryOpenMap={traceSummaryOpenMap}
-          toggleTraceSummaryOpen={toggleTraceSummaryOpen}
-        />
-      </Paper>
+      <TraceSummaryTable
+        traceSummaries={filteredTraceSummaries}
+        toggleFilter={toggleFilter}
+        traceSummaryOpenMap={traceSummaryOpenMap}
+        toggleTraceSummaryOpen={toggleTraceSummaryOpen}
+      />
     );
   }
 
@@ -576,125 +594,97 @@ const DiscoverPageContent: React.FC<DiscoverPageContentProps> = ({
       height="calc(100vh - 64px)"
       display="flex"
       flexDirection="column"
+      bgcolor="background.paper"
     >
-      <Box
-        bgcolor="background.paper"
-        boxShadow={3}
-        pt={2}
-        pb={1.5}
-        zIndex={1000}
-      >
-        <Container>
-          <Box display="flex">
-            <Box flexGrow={1} mr={1}>
-              <SearchBar
-                criteria={tempCriteria}
-                onChange={setTempCriteria}
-                searchTraces={searchTraces}
-              />
-            </Box>
-            <SearchButton onClick={searchTraces}>
-              <Trans>Run Query</Trans>
-            </SearchButton>
-            <SettingsButton
-              onClick={handleSettingsButtonClick}
-              isOpening={isOpeningSettings}
-              data-testid="settings-button"
-            >
-              <SettingsIcon />
-            </SettingsButton>
+      <Box flex="0 0">
+        <Box className={classes.searchRow}>
+          <Box flexGrow={1} mr={1}>
+            <SearchBar
+              criteria={tempCriteria}
+              onChange={setTempCriteria}
+              searchTraces={searchTraces}
+            />
           </Box>
-        </Container>
+          <SearchButton onClick={searchTraces}>
+            <Trans>Run Query</Trans>
+          </SearchButton>
+          <SettingsButton
+            onClick={handleSettingsButtonClick}
+            isOpening={isOpeningSettings}
+            data-testid="settings-button"
+          >
+            <SettingsIcon />
+          </SettingsButton>
+        </Box>
         <Collapse in={isOpeningSettings}>
-          <Box mt={1.5} mb={1.5}>
+          <Box className={classes.settings}>
             <Divider />
-          </Box>
-          <Container>
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="flex-end"
-              mt={1.75}
-            >
-              <TextField
-                label={<Trans>Limit</Trans>}
-                type="number"
-                variant="outlined"
-                value={tempLimit}
-                onChange={handleLimitChange}
-                size="small"
-                inputProps={{
-                  'data-testid': 'query-limit',
-                }}
-              />
-              <Box ml={1} position="relative">
-                <LookbackButton
-                  onClick={toggleLookbackMenu}
-                  isShowingLookbackMenu={isShowingLookbackMenu}
-                >
-                  {lookbackDisplay}
-                </LookbackButton>
-                {isShowingLookbackMenu && (
-                  <LookbackMenu
-                    close={closeLookbackMenu}
-                    onChange={setTempLookback}
-                    lookback={tempLookback}
-                  />
-                )}
-              </Box>
+            <TextField
+              label={<Trans>Limit</Trans>}
+              type="number"
+              variant="outlined"
+              value={tempLimit}
+              onChange={handleLimitChange}
+              size="small"
+              inputProps={{
+                'data-testid': 'query-limit',
+              }}
+            />
+            <Box ml={1} position="relative">
+              <LookbackButton
+                onClick={toggleLookbackMenu}
+                isShowingLookbackMenu={isShowingLookbackMenu}
+              >
+                {lookbackDisplay}
+              </LookbackButton>
+              {isShowingLookbackMenu && (
+                <LookbackMenu
+                  close={closeLookbackMenu}
+                  onChange={setTempLookback}
+                  lookback={tempLookback}
+                />
+              )}
             </Box>
-          </Container>
+          </Box>
         </Collapse>
         {traceSummaries.length > 0 && (
-          <>
-            <Box mt={1.5} mb={1.5}>
-              <Divider />
-            </Box>
-            <Container>
-              <Box
-                display="flex"
-                justifyContent="space-between"
-                alignItems="center"
-              >
-                <Typography variant="h6">
-                  {filteredTraceSummaries.length === 1 ? (
-                    <Trans>1 Result</Trans>
-                  ) : (
-                    <Trans>{filteredTraceSummaries.length} Results</Trans>
-                  )}
-                </Typography>
-
-                <Box display="flex">
-                  <ButtonGroup>
-                    <Button onClick={expandAll}>Expand All</Button>
-                    <Button onClick={collapseAll}>Collapse All</Button>
-                  </ButtonGroup>
-                  <Box width={300} ml={2}>
-                    <Autocomplete
-                      multiple
-                      value={filters}
-                      options={filterOptions}
-                      renderInput={(params) => (
-                        <TextField
-                          {...params}
-                          variant="outlined"
-                          label="Service filters"
-                          placeholder="Service filters"
-                          size="small"
-                        />
-                      )}
+          <Box className={classes.resultHeader}>
+            <Typography variant="body1">
+              {filteredTraceSummaries.length === 1 ? (
+                <Trans>1 Result</Trans>
+              ) : (
+                <Trans>{filteredTraceSummaries.length} Results</Trans>
+              )}
+            </Typography>
+            <Box display="flex">
+              <ButtonGroup>
+                <Button onClick={expandAll}>Expand All</Button>
+                <Button onClick={collapseAll}>Collapse All</Button>
+              </ButtonGroup>
+              <Box width={300} ml={2}>
+                <Autocomplete
+                  multiple
+                  value={filters}
+                  options={filterOptions}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      variant="outlined"
+                      label="Service filters"
+                      placeholder="Service filters"
                       size="small"
-                      onChange={handleFiltersChange}
                     />
-                  </Box>
-                </Box>
+                  )}
+                  size="small"
+                  onChange={handleFiltersChange}
+                />
               </Box>
-            </Container>
-          </>
+            </Box>
+          </Box>
         )}
       </Box>
-      <Box flexGrow={1} overflow="auto" pt={3} pb={3}>
-        <Container>{content}</Container>
+      <Box flexGrow={1} overflow="auto">
+        {content}
       </Box>
     </Box>
   );
@@ -726,8 +716,6 @@ const SearchButton = styled(Button).attrs({
   startIcon: <FontAwesomeIcon icon={faSync} />,
 })`
   flex-shrink: 0;
-  height: 60px;
-  min-width: 60px;
   color: ${({ theme }) => theme.palette.common.white};
 `;
 
@@ -741,7 +729,5 @@ const SettingsButton = styled(
   ),
 )`
   flex-shrink: 0;
-  height: 60px;
-  min-width: 0px;
   margin-left: ${({ theme }) => theme.spacing(1)}px;
 `;

--- a/zipkin-lens/src/components/DiscoverPage/SearchBar/CriterionBox.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/SearchBar/CriterionBox.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,10 +27,10 @@ import React, {
 } from 'react';
 import { useMount } from 'react-use';
 import styled, { keyframes } from 'styled-components';
-
+import Criterion, { newCriterion } from '../Criterion';
+import { CRITERION_BOX_HEIGHT } from './constants';
 import HowToUse from './HowToUse';
 import SuggestionList from './SuggestionList';
-import Criterion, { newCriterion } from '../Criterion';
 
 const fadeIn = keyframes`
   0% { opacity: 0 }
@@ -41,12 +41,11 @@ const fadeIn = keyframes`
 
 const Root = styled(Box)`
   display: flex;
-  height: 40px;
+  height: ${CRITERION_BOX_HEIGHT}px;
   border-radius: 3px;
   box-shadow: ${({ theme }) => theme.shadows[1]};
   overflow: hidden;
-  margin-right: ${({ theme }) => theme.spacing(1)}px;
-  font-size: 1.1rem;
+  font-size: 1rem;
   color: ${({ theme }) => theme.palette.common.white};
   cursor: pointer;
   & > *:hover {
@@ -78,10 +77,10 @@ const Input = styled.input.attrs(() => ({
   'data-testid': 'criterion-input',
 }))`
   width: 350px;
-  height: 40px;
+  height: ${CRITERION_BOX_HEIGHT}px;
   padding: 10px;
   box-sizing: border-box;
-  font-size: 1.1rem;
+  font-size: 1rem;
 `;
 
 interface CriterionBoxProps {
@@ -432,10 +431,11 @@ const CriterionBox: React.FC<CriterionBoxProps> = ({
           maxWidth={150}
           height="100%"
           bgcolor="primary.dark"
-          p={1}
           overflow="hidden"
           whiteSpace="nowrap"
           textOverflow="ellipsis"
+          lineHeight={`${CRITERION_BOX_HEIGHT}px`}
+          px={1}
         >
           {criterion.key}
         </Box>
@@ -444,10 +444,11 @@ const CriterionBox: React.FC<CriterionBoxProps> = ({
             maxWidth={200}
             height="100%"
             bgcolor="primary.main"
-            p={1}
             overflow="hidden"
             whiteSpace="nowrap"
             textOverflow="ellipsis"
+            lineHeight={`${CRITERION_BOX_HEIGHT}px`}
+            px={1}
           >
             {criterion.value}
           </Box>

--- a/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/SearchBar/SearchBar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 The OpenZipkin Authors
+ * Copyright 2015-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,20 +26,30 @@ import {
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
-
-import Criterion, { newCriterion } from '../Criterion';
-import CriterionBox from './CriterionBox';
 import { loadAutocompleteValues } from '../../../slices/autocompleteValuesSlice';
 import { loadRemoteServices } from '../../../slices/remoteServicesSlice';
 import { loadSpans } from '../../../slices/spansSlice';
 import { RootState } from '../../../store';
+import Criterion, { newCriterion } from '../Criterion';
+import { CRITERION_BOX_HEIGHT } from './constants';
+import CriterionBox from './CriterionBox';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
+    root: {
+      display: 'flex',
+      gap: `${theme.spacing(1)}px`,
+      alignItems: 'center',
+      padding: theme.spacing(1),
+      borderRadius: 3,
+      backgroundColor: theme.palette.background.paper,
+      flexWrap: 'wrap',
+      border: `1px solid ${theme.palette.divider}`,
+    },
     addButton: {
-      height: 40,
-      width: 40,
-      minWidth: 40,
+      height: CRITERION_BOX_HEIGHT,
+      width: CRITERION_BOX_HEIGHT,
+      minWidth: 0,
       color: theme.palette.common.white,
     },
   }),
@@ -172,20 +182,7 @@ export const SearchBarImpl: React.FC<SearchBarProps> = ({
   }, [handleKeyDown]);
 
   return (
-    <Box
-      minHeight={60}
-      display="flex"
-      alignItems="center"
-      pr={2}
-      pl={2}
-      pt={1}
-      pb={1}
-      borderRadius={3}
-      bgcolor="background.paper"
-      flexWrap="wrap"
-      borderColor="grey.400"
-      border={1}
-    >
+    <Box className={classes.root}>
       {criteria.map((criterion, index) => (
         <CriterionBox
           key={criterion.id}

--- a/zipkin-lens/src/components/DiscoverPage/SearchBar/SuggestionList.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/SearchBar/SuggestionList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -43,7 +43,7 @@ const List = styled.ul`
   list-style-type: none;
   margin: 0px;
   padding: 0px;
-  font-size: 1.1rem;
+  font-size: 1rem;
 `;
 
 const ListItem = styled.li<{ isFocused: boolean }>`

--- a/zipkin-lens/src/components/DiscoverPage/SearchBar/constants.ts
+++ b/zipkin-lens/src/components/DiscoverPage/SearchBar/constants.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2015-2022 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export const CRITERION_BOX_HEIGHT = 34;

--- a/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/TraceSummaryRow.tsx
@@ -27,7 +27,6 @@ import moment from 'moment';
 import React, { useMemo, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-
 import { selectColorByInfoClass } from '../../constants/color';
 import TraceSummary from '../../models/TraceSummary';
 import { formatDuration } from '../../util/timestamp';
@@ -70,12 +69,7 @@ const TraceSummaryRow: React.FC<TraceSummaryRowProps> = ({
         </TableCell>
         <TableCell>
           <Box display="flex" alignItems="center">
-            <ServiceNameTypography variant="body1">
-              {traceSummary.root.serviceName}
-            </ServiceNameTypography>
-            <Typography variant="body2" color="textSecondary">
-              {traceSummary.root.spanName}
-            </Typography>
+            {`${traceSummary.root.serviceName}: ${traceSummary.root.spanName}`}
           </Box>
         </TableCell>
         <TableCell>
@@ -106,7 +100,7 @@ const TraceSummaryRow: React.FC<TraceSummaryRowProps> = ({
         </TableCell>
         <TableCell>
           <Button
-            variant="contained"
+            variant="outlined"
             size="small"
             component={Link}
             to={`traces/${traceSummary.traceId}`}
@@ -119,15 +113,10 @@ const TraceSummaryRow: React.FC<TraceSummaryRowProps> = ({
         <CollapsibleTableCell>
           <Collapse in={open} timeout="auto" unmountOnExit>
             <Box margin={1}>
-              <Box display="flex" alignItems="center">
-                <Typography variant="body1" color="textSecondary">
-                  Trace ID:
-                </Typography>
-                <TraceIdTypography>{traceSummary.traceId}</TraceIdTypography>
-              </Box>
               <BadgesWrapper>
                 {sortedServiceSummaries.map((serviceSummary) => (
                   <ServiceBadge
+                    key={serviceSummary.serviceName}
                     serviceName={serviceSummary.serviceName}
                     count={serviceSummary.spanCount}
                     onClick={toggleFilter}
@@ -147,15 +136,6 @@ export default TraceSummaryRow;
 const Root = styled(TableRow)`
   & > * {
     border-bottom: unset;
-  }
-`;
-
-const ServiceNameTypography = styled(Typography).attrs({
-  variant: 'body1',
-})`
-  margin-right: ${({ theme }) => theme.spacing(1)}px;
-  &::after {
-    content: ':';
   }
 `;
 
@@ -185,16 +165,8 @@ const CollapsibleTableCell = styled(TableCell).attrs({
   padding-top: 0;
 `;
 
-const TraceIdTypography = styled(Typography).attrs({
-  variant: 'body1',
-})`
-  margin-left: ${({ theme }) => theme.spacing(0.5)}px;
-`;
-
 const BadgesWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
-  & > * {
-    margin: ${({ theme }) => theme.spacing(0.5)}px;
-  }
+  gap: ${({ theme }) => theme.spacing(0.5)}px;
 `;

--- a/zipkin-lens/src/components/DiscoverPage/TraceSummaryTable.tsx
+++ b/zipkin-lens/src/components/DiscoverPage/TraceSummaryTable.tsx
@@ -17,15 +17,13 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TableRow,
   TableSortLabel,
 } from '@material-ui/core';
 import React, { useState, useCallback } from 'react';
-
-import TraceSummaryRow from './TraceSummaryRow';
 import TraceSummary from '../../models/TraceSummary';
+import TraceSummaryRow from './TraceSummaryRow';
 
 interface TraceSummaryTableProps {
   traceSummaries: TraceSummary[];
@@ -71,57 +69,55 @@ const TraceSummaryTable: React.FC<TraceSummaryTableProps> = ({
   );
 
   return (
-    <TableContainer>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell />
-            <TableCell>
-              <Trans>Root</Trans>
-            </TableCell>
-            {[
-              { label: <Trans>Start Time</Trans>, key: 'timestamp' },
-              { label: <Trans>Spans</Trans>, key: 'spanCount' },
-              { label: <Trans>Duration</Trans>, key: 'duration' },
-            ].map(({ label, key }) => (
-              <TableCell
-                key={key}
-                align="right"
-                sortDirection={orderBy === key ? order : false}
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell />
+          <TableCell>
+            <Trans>Root</Trans>
+          </TableCell>
+          {[
+            { label: <Trans>Start Time</Trans>, key: 'timestamp' },
+            { label: <Trans>Spans</Trans>, key: 'spanCount' },
+            { label: <Trans>Duration</Trans>, key: 'duration' },
+          ].map(({ label, key }) => (
+            <TableCell
+              key={key}
+              align="right"
+              sortDirection={orderBy === key ? order : false}
+            >
+              <TableSortLabel
+                active={orderBy === key}
+                direction={orderBy === key ? order : 'asc'}
+                data-cellkey={key}
+                onClick={handleSortButtonClick}
               >
-                <TableSortLabel
-                  active={orderBy === key}
-                  direction={orderBy === key ? order : 'asc'}
-                  data-cellkey={key}
-                  onClick={handleSortButtonClick}
-                >
-                  {label}
-                </TableSortLabel>
-              </TableCell>
-            ))}
-            <TableCell />
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {traceSummaries
-            .sort((a, b) => {
-              if (order === 'asc') {
-                return a[orderBy] - b[orderBy];
-              }
-              return b[orderBy] - a[orderBy];
-            })
-            .map((traceSummary) => (
-              <TraceSummaryRow
-                key={traceSummary.traceId}
-                traceSummary={traceSummary}
-                toggleFilter={toggleFilter}
-                open={!!traceSummaryOpenMap[traceSummary.traceId]}
-                toggleOpen={toggleTraceSummaryOpen}
-              />
-            ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+                {label}
+              </TableSortLabel>
+            </TableCell>
+          ))}
+          <TableCell />
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {traceSummaries
+          .sort((a, b) => {
+            if (order === 'asc') {
+              return a[orderBy] - b[orderBy];
+            }
+            return b[orderBy] - a[orderBy];
+          })
+          .map((traceSummary) => (
+            <TraceSummaryRow
+              key={traceSummary.traceId}
+              traceSummary={traceSummary}
+              toggleFilter={toggleFilter}
+              open={!!traceSummaryOpenMap[traceSummary.traceId]}
+              toggleOpen={toggleTraceSummaryOpen}
+            />
+          ))}
+      </TableBody>
+    </Table>
   );
 };
 

--- a/zipkin-lens/src/components/common/ExplainBox.tsx
+++ b/zipkin-lens/src/components/common/ExplainBox.tsx
@@ -26,17 +26,13 @@ interface ExplainBoxProps {
 const ExplainBox = React.memo<ExplainBoxProps>(({ icon, headerText, text }) => {
   return (
     <Box
-      top={64}
-      left={0}
-      right={0}
-      bottom={0}
-      position="fixed"
+      height="100%"
+      width="100%"
       display="flex"
       alignItems="center"
       justifyContent="center"
       flexDirection="column"
       color="text.secondary"
-      zIndex={-1}
     >
       <FontAwesomeIcon icon={icon} size="10x" />
       <Box mt={3} mb={2}>


### PR DESCRIPTION
This PR adjusts styling of Search page. The changes are as follows

* Wider page width.
    * Previously, due to the narrow width, the number of search criteria that can be arranged in a row is small.
* Reduce unnecessary vertical empty space.
    * Previously, since there is a lot of unnecessary vertical empty space, fewer search results are displayed on the screen.
* Remove  trace ID from search results.
    * If the Trace ID is already known, you can search for traces directly from "Search by trace ID" of the Navbar.
    * So there is no use case for using trace IDs in a search page in a useful way.
* Nothing has changed in the logic.
 
### Before

![Screenshot 2022-12-24 1 06 14](https://user-images.githubusercontent.com/19551419/209367212-bb510944-ebd1-4975-b5ef-03cb77e42f1e.png)

### After

![Screenshot 2022-12-24 1 40 32](https://user-images.githubusercontent.com/19551419/209369442-f006e594-15eb-4774-b712-c83a8ef104c4.png)



https://user-images.githubusercontent.com/19551419/209363433-f8bbe66c-2eaf-4935-ae59-7a120ba7134b.mov