### PR TITLE
Replace some packages of lens

### DIFF
--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -3634,6 +3634,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-virtualized-auto-sizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz",
+      "integrity": "sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-window": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
@@ -18435,18 +18444,10 @@
         "tslib": "^1.10.0"
       }
     },
-    "react-virtualized": {
-      "version": "9.22.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
+    "react-virtualized-auto-sizer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz",
+      "integrity": "sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA=="
     },
     "react-window": {
       "version": "1.8.8",

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -18387,14 +18387,6 @@
         }
       }
     },
-    "react-spinners": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.9.0.tgz",
-      "integrity": "sha512-+x6eD8tn/aYLdxZjNW7fSR1uoAXLb9qq6TFYZR1dFweJvckcf/HfP8Pa/cy5HOvB/cvI4JgrYXTjh2Me3S6Now==",
-      "requires": {
-        "@emotion/core": "^10.0.15"
-      }
-    },
     "react-test-renderer": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -3538,16 +3538,6 @@
         "@types/react-router": "*"
       }
     },
-    "@types/react-select": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-3.0.14.tgz",
-      "integrity": "sha512-hfsLVHYZ3245+ESfOJDCKGFGGZ+hunTKO1tPe6Dg9bTjjh/NZIo7WaRHIyql5rnQd5hMUScul0V4wqCbI6omng==",
-      "requires": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "@types/react-transition-group": "*"
-      }
-    },
     "@types/react-test-renderer": {
       "version": "16.9.3",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz",
@@ -3561,15 +3551,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
       "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@types/react-virtualized": {
-      "version": "9.21.10",
-      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.21.10.tgz",
-      "integrity": "sha512-f5Ti3A7gGdLkPPFNHTrvKblpsPNBiQoSorOEOD+JPx72g/Ng2lOt4MYfhvQFQNgyIrAro+Z643jbcKafsMW2ag==",
-      "requires": {
-        "@types/prop-types": "*",
         "@types/react": "*"
       }
     },

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -1307,40 +1307,6 @@
         "@date-io/core": "^1.3.13"
       }
     },
-    "@emotion/cache": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-      "requires": {
-        "@emotion/sheet": "0.9.4",
-        "@emotion/stylis": "0.8.5",
-        "@emotion/utils": "0.11.3",
-        "@emotion/weak-memoize": "0.2.5"
-      }
-    },
-    "@emotion/core": {
-      "version": "10.0.28",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.28.tgz",
-      "integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/cache": "^10.0.27",
-        "@emotion/css": "^10.0.27",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/sheet": "0.9.4",
-        "@emotion/utils": "0.11.3"
-      }
-    },
-    "@emotion/css": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-      "requires": {
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3",
-        "babel-plugin-emotion": "^10.0.27"
-      }
-    },
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -1359,23 +1325,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
-    "@emotion/serialize": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-      "requires": {
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/unitless": "0.7.5",
-        "@emotion/utils": "0.11.3",
-        "csstype": "^2.5.7"
-      }
-    },
-    "@emotion/sheet": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
-    },
     "@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
@@ -1385,16 +1334,6 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-    },
-    "@emotion/utils": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-    },
-    "@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.29",
@@ -4661,23 +4600,6 @@
       "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "requires": {
         "object.assign": "^4.1.0"
-      }
-    },
-    "babel-plugin-emotion": {
-      "version": "10.0.33",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
-      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/serialize": "^0.11.16",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^1.0.5",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7"
       }
     },
     "babel-plugin-istanbul": {
@@ -8783,11 +8705,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
-    },
-    "find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "2.1.0",
@@ -18050,14 +17967,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
-    "react-input-autosize": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
-      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -18347,21 +18256,6 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
-      }
-    },
-    "react-select": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.0.tgz",
-      "integrity": "sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==",
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/cache": "^10.0.9",
-        "@emotion/core": "^10.0.9",
-        "@emotion/css": "^10.0.9",
-        "memoize-one": "^5.0.0",
-        "prop-types": "^15.6.0",
-        "react-input-autosize": "^2.2.2",
-        "react-transition-group": "^4.3.0"
       }
     },
     "react-smooth": {

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -74,7 +74,6 @@
     "react-router-dom": "^5.0.1",
     "react-scripts": "^3.4.3",
     "react-select": "^3.1.0",
-    "react-spinners": "^0.9.0",
     "react-use": "^14.2.0",
     "react-virtualized": "^9.22.3",
     "react-window": "^1.8.8",

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -75,7 +75,7 @@
     "react-scripts": "^3.4.3",
     "react-select": "^3.1.0",
     "react-use": "^14.2.0",
-    "react-virtualized": "^9.22.3",
+    "react-virtualized-auto-sizer": "1.0.7",
     "react-window": "^1.8.8",
     "recharts": "^1.8.5",
     "redux": "^4.0.0",
@@ -107,6 +107,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react-virtualized-auto-sizer": "^1.0.1",
     "@types/react-window": "^1.8.5",
     "typescript": "4.9.4"
   }

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -40,8 +40,6 @@
     "@types/react-dom": "^16.9.5",
     "@types/react-redux": "^7.1.7",
     "@types/react-router-dom": "^5.1.3",
-    "@types/react-select": "^3.0.11",
-    "@types/react-virtualized": "^9.21.8",
     "@types/recharts": "^1.8.14",
     "@types/redux-mock-store": "^1.0.2",
     "@types/shortid": "0.0.29",

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -73,7 +73,6 @@
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "^3.4.3",
-    "react-select": "^3.1.0",
     "react-use": "^14.2.0",
     "react-virtualized-auto-sizer": "1.0.7",
     "react-window": "^1.8.8",

--- a/zipkin-lens/src/components/DependenciesPage/DependenciesGraph.tsx
+++ b/zipkin-lens/src/components/DependenciesPage/DependenciesGraph.tsx
@@ -20,10 +20,11 @@ import {
   createStyles,
   makeStyles,
   useTheme,
+  TextField,
 } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
 import moment from 'moment';
-import React, { CSSProperties, useState, useCallback, useMemo } from 'react';
-import ReactSelect, { ValueType, ActionMeta } from 'react-select';
+import React, { useState, useCallback, useMemo } from 'react';
 import Dependencies from '../../models/Dependencies';
 import NodeDetailData from './NodeDetailData';
 import { Edge } from './types';
@@ -82,27 +83,6 @@ export const getNodesAndEdges = (dependencies: Dependencies) => {
   return { nodes, edges };
 };
 
-// IntelliJ may miss on "Unused property" analysis. Double-check here as we don't test CSS:
-// https://github.com/JedWatson/react-select/blob/cba15309c4d7523ab6a785c8d5c0c7ec1048e22f/packages/react-select/src/styles.js#L38-L61
-const reactSelectStyles = {
-  control: (base: CSSProperties) => ({
-    ...base,
-    width: '15rem',
-  }),
-  option: (base: CSSProperties) => ({
-    ...base,
-    cursor: 'pointer',
-  }),
-  clearIndicator: (base: CSSProperties) => ({
-    ...base,
-    cursor: 'pointer',
-  }),
-  dropdownIndicator: (base: CSSProperties) => ({
-    ...base,
-    cursor: 'pointer',
-  }),
-};
-
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     detailWrapper: {
@@ -142,22 +122,10 @@ const DependenciesGraph: React.FC<DependenciesGraphProps> = ({
 
   const [focusedNodeName, setFocusedNodeName] = useState('');
 
-  const [filter, setFilter] = useState('');
+  const [filter, setFilter] = useState<string | null>();
   const handleFilterChange = useCallback(
-    (
-      selected: ValueType<{ value: string }>,
-      actionMeta: ActionMeta<{ value: string; label: string }>,
-    ) => {
-      setFocusedNodeName('');
-      if (actionMeta.action === 'clear') {
-        setFilter('');
-        return;
-      }
-      if (actionMeta.action === 'select-option') {
-        if (selected && 'value' in selected /* Type refinement */) {
-          setFilter(selected.value);
-        }
-      }
+    (_event: any, value: string | null) => {
+      setFilter(value);
     },
     [],
   );
@@ -211,17 +179,6 @@ const DependenciesGraph: React.FC<DependenciesGraphProps> = ({
     return 0;
   }, [edges]);
 
-  const filterOptions = useMemo(
-    () =>
-      nodes
-        .map((node) => ({
-          value: node.name,
-          label: node.name,
-        }))
-        .sort((a, b) => a.value.localeCompare(b.value)),
-    [nodes],
-  );
-
   return (
     <Box
       width="100%"
@@ -268,13 +225,21 @@ const DependenciesGraph: React.FC<DependenciesGraphProps> = ({
             },
           ]}
         />
-        <Box position="absolute" left={20} top={20}>
-          <ReactSelect
-            isClearable
-            options={filterOptions}
+        <Box position="absolute" left={20} top={20} width={200}>
+          <Autocomplete
+            value={filter}
             onChange={handleFilterChange}
-            value={!filter ? undefined : { value: filter, label: filter }}
-            styles={reactSelectStyles}
+            options={nodes.map((node) => node.name)}
+            fullWidth
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                variant="outlined"
+                label="Filter"
+                placeholder="Select..."
+                size="small"
+              />
+            )}
           />
         </Box>
       </Box>

--- a/zipkin-lens/src/components/DependenciesPage/DependenciesGraph.tsx
+++ b/zipkin-lens/src/components/DependenciesPage/DependenciesGraph.tsx
@@ -225,7 +225,7 @@ const DependenciesGraph: React.FC<DependenciesGraphProps> = ({
             },
           ]}
         />
-        <Box position="absolute" left={20} top={20} width={200}>
+        <Box position="absolute" left={20} top={20} width={300}>
           <Autocomplete
             value={filter}
             onChange={handleFilterChange}

--- a/zipkin-lens/src/components/TracePage/Timeline/Timeline.tsx
+++ b/zipkin-lens/src/components/TracePage/Timeline/Timeline.tsx
@@ -14,7 +14,7 @@
 
 import { Box, makeStyles } from '@material-ui/core';
 import React, { useCallback, useEffect, useRef } from 'react';
-import { AutoSizer } from 'react-virtualized';
+import AutoSizer from 'react-virtualized-auto-sizer';
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 import { useMeasure } from 'react-use';
 import { AdjustedSpan } from '../../../models/AdjustedTrace';

--- a/zipkin-lens/src/components/common/LoadingIndicator.tsx
+++ b/zipkin-lens/src/components/common/LoadingIndicator.tsx
@@ -12,22 +12,16 @@
  * the License.
  */
 
-import { Box, useTheme } from '@material-ui/core';
+import { Box, CircularProgress } from '@material-ui/core';
 import React from 'react';
-import { ScaleLoader } from 'react-spinners';
 
-export const LoadingIndicator: React.FC = () => {
-  const theme = useTheme();
-
-  return (
-    <Box
-      display="flex"
-      justifyContent="center"
-      mt={10}
-      mb={10}
-      data-testid="loading-indicator"
-    >
-      <ScaleLoader color={theme.palette.primary.light} />
-    </Box>
-  );
-};
+export const LoadingIndicator = () => (
+  <Box
+    display="flex"
+    justifyContent="center"
+    mt={10}
+    data-testid="loading-indicator"
+  >
+    <CircularProgress />
+  </Box>
+);


### PR DESCRIPTION
* Replace `react-virtualized` with `react-virtualized-auto-sizer`.
    * Now lens is using `react-window` for virtualized components instead of `react-virtualized`, so we can use stand-alone version of AutoSizer.
* Replace `react-spinner` with Material-UI's loading indicator.
* Replace `react-select` with Material-UI's Autocomplete component. 