### PR TITLE
Address the case where the root span parentId is not empty

### DIFF
--- a/zipkin-lens/src/components/TracePage/TracePageContent.tsx
+++ b/zipkin-lens/src/components/TracePage/TracePageContent.tsx
@@ -42,9 +42,10 @@ export const TracePageContent = ({ trace }: TracePageContentProps) => {
   const [isMiniTimelineOpen, toggleIsMiniTimelineOpen] = useToggle(true);
   const [isSpanTableOpen, toggleIsSpanTableOpen] = useToggle(false);
 
-  const roots = useMemo(() => convertSpansToSpanTree(trace.spans), [
-    trace.spans,
-  ]);
+  const roots = useMemo(
+    () => convertSpansToSpanTree(trace.spans, trace.traceId),
+    [trace.spans, trace.traceId],
+  );
 
   const { spanRows, minTimestamp, maxTimestamp } = useMemo(
     () =>

--- a/zipkin-lens/src/components/TracePage/helpers.ts
+++ b/zipkin-lens/src/components/TracePage/helpers.ts
@@ -22,6 +22,7 @@ type SpanTreeNode = AdjustedSpan & {
 
 export const convertSpansToSpanTree = (
   spans: AdjustedSpan[],
+  traceId: string,
 ): SpanTreeNode[] => {
   const idToSpan = spans.reduce<{ [id: string]: AdjustedSpan }>((acc, cur) => {
     acc[cur.spanId] = cur;
@@ -29,7 +30,12 @@ export const convertSpansToSpanTree = (
   }, {});
   const unconsumedSpans = { ...idToSpan };
 
-  const roots = spans.filter((span) => !span.parentId);
+  let roots = spans.filter((span) => !span.parentId);
+  // There are cases where the parentId of the root span is not empty but traceId.
+  // As a fallback, will address that case.
+  if (roots.length === 0) {
+    roots = spans.filter((span) => span.parentId === traceId);
+  }
   roots.forEach((root) => {
     delete unconsumedSpans[root.spanId];
   });


### PR DESCRIPTION
There may be cases where the parentId of the root span is not empty but traceId..
This PR addresses that case.