### PR TITLE
feat: elasticsearch storage contains unknown fields

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonReaders.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonReaders.java
@@ -66,7 +66,6 @@ public final class JsonReaders {
   }
 
   static void visitObject(JsonParser parser, String name, Set<String> result) throws IOException {
-    checkStartObject(parser, true);
     JsonToken value;
     while ((value = parser.nextValue()) != JsonToken.END_OBJECT) {
       if (value == null) {
@@ -91,7 +90,9 @@ public final class JsonReaders {
             // End of input so ignore.
             return;
           }
-          visitObject(parser, name, result);
+          if (checkStartObject(parser, false)) {
+            visitObject(parser, name, result);
+          }
         }
         break;
       case START_OBJECT:

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/internal/JsonSerializers.java
@@ -117,7 +117,7 @@ public final class JsonSerializers {
           result.shared(parser.getBooleanValue());
           break;
         default:
-          // Skip
+          skipUnknownValue(parser);
       }
     }
 
@@ -153,7 +153,7 @@ public final class JsonSerializers {
           port = parser.getIntValue();
           break;
         default:
-          // Skip
+          skipUnknownValue(parser);
       }
     }
 
@@ -184,7 +184,7 @@ public final class JsonSerializers {
           value = parser.getValueAsString();
           break;
         default:
-          // Skip
+          skipUnknownValue(parser);
       }
     }
 
@@ -192,6 +192,19 @@ public final class JsonSerializers {
       throw new IllegalArgumentException("Incomplete annotation at " + parser.currentToken());
     }
     return Annotation.create(timestamp, value);
+  }
+
+  private static void skipUnknownValue(JsonParser parser) throws IOException {
+    JsonToken value = parser.getCurrentToken();
+    if (value == JsonToken.START_OBJECT) {
+      while (parser.nextValue() != JsonToken.END_OBJECT) {
+        skipUnknownValue(parser);
+      }
+    } else if (value == JsonToken.START_ARRAY) {
+      while (parser.nextValue() != JsonToken.END_ARRAY) {
+        skipUnknownValue(parser);
+      }
+    }
   }
 
   public static final ObjectParser<DependencyLink> DEPENDENCY_LINK_PARSER = parser -> {


### PR DESCRIPTION
Optimize data parsing exception when elasticsearch storage contains unknown fields. For example, we record user-agent through tags, and then use elasticsearch's Ingest Pipeline to parse user-agent for easy query.