### PR TITLE
Span with missing parent should be root

### DIFF
--- a/zipkin-lens/src/components/TracePage/helpers.test.jsx
+++ b/zipkin-lens/src/components/TracePage/helpers.test.jsx
@@ -21,72 +21,76 @@
 import { convertSpansToSpanTree } from './helpers';
 
 describe('convertSpansToSpanTree', () => {
+  it('should return an empty array when there are no spans', () => {
+    const spans = [];
+    const result = convertSpansToSpanTree(spans);
+    expect(result).toEqual([]);
+  });
 
-    it('should return an empty array when there are no spans', () => {
-        const spans = [];
-        const result = convertSpansToSpanTree(spans);
-        expect(result).toEqual([]);
-    });
+  it('should return an array with correct root span', () => {
+    const spans = [
+      {
+        spanId: 'a',
+        spanName: 'root',
+        parentId: null,
+        childIds: ['b'],
+      },
+      {
+        spanId: 'b',
 
-    it('should return an array with correct root span', () => {
-        const spans = [{
-            spanId: 'a',
-            spanName: 'root',
-            parentId: null,
-            childIds: ['b'],
-        },
-        {
-            spanId: 'b',
-            
-            spanName: 'child',
-            parentId: 'a',
-            childIds: [],
-        }];
+        spanName: 'child',
+        parentId: 'a',
+        childIds: [],
+      },
+    ];
 
-        const result = convertSpansToSpanTree(spans);
-        expect(result.length).toEqual(1);
-        expect(result[0].spanId).toEqual('a');
-    });
+    const result = convertSpansToSpanTree(spans);
+    expect(result.length).toEqual(1);
+    expect(result[0].spanId).toEqual('a');
+  });
 
-    // This test is consistent with 'should work when missing root span' in
-    // span-cleaner.test.js
-    it('should return an array with the root element which is missing parent', () => {
-        const spans = [{
-            spanId: 'a',
-            spanName: 'missing parent',
-            parentId: 'm',
-            childIds: ['b'],
-        },
-        {
-            spanId: 'b',
-            spanName: 'child',
-            parentId: 'a',
-            childIds: [],
-        }];
+  // This test is consistent with 'should work when missing root span' in
+  // span-cleaner.test.js
+  it('should return an array with the root element which is missing parent', () => {
+    const spans = [
+      {
+        spanId: 'a',
+        spanName: 'missing parent',
+        parentId: 'm',
+        childIds: ['b'],
+      },
+      {
+        spanId: 'b',
+        spanName: 'child',
+        parentId: 'a',
+        childIds: [],
+      },
+    ];
 
-        const result = convertSpansToSpanTree(spans);
-        expect(result.length).toEqual(1);
-        expect(result[0].spanId).toEqual('a');
-    });
+    const result = convertSpansToSpanTree(spans);
+    expect(result.length).toEqual(1);
+    expect(result[0].spanId).toEqual('a');
+  });
 
-    it('should return an array with two root elements which are missing parent', () => {
-        const spans = [{
-            spanId: 'a',
-            spanName: 'missing parent',
-            parentId: 'm',
-            childIds: [],
-        },
-        {
-            spanId: 'b',
-            spanName: 'missing parent',
-            parentId: 'm',
-            childIds: [],
-        }];
+  it('should return an array with two root elements which are missing parent', () => {
+    const spans = [
+      {
+        spanId: 'a',
+        spanName: 'missing parent',
+        parentId: 'm',
+        childIds: [],
+      },
+      {
+        spanId: 'b',
+        spanName: 'missing parent',
+        parentId: 'm',
+        childIds: [],
+      },
+    ];
 
-        const result = convertSpansToSpanTree(spans);
-        expect(result.length).toEqual(2);
-        expect(result[0].spanId).toEqual('a');
-        expect(result[1].spanId).toEqual('b');
-
-    });
+    const result = convertSpansToSpanTree(spans);
+    expect(result.length).toEqual(2);
+    expect(result[0].spanId).toEqual('a');
+    expect(result[1].spanId).toEqual('b');
+  });
 });

--- a/zipkin-lens/src/components/TracePage/helpers.test.jsx
+++ b/zipkin-lens/src/components/TracePage/helpers.test.jsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+// Create tests for convertSpansToSpanTree
+// Define input data for a test that has two spans, parent and child, and parent span has
+// a parent span ID that is not in the list of spans
+// Define input data for a test that has two spans, parent and child, and parent span has
+// a parent span ID that is in the list of spans
+
+import { convertSpansToSpanTree } from './helpers';
+
+describe('convertSpansToSpanTree', () => {
+
+    it('should return an empty array when there are no spans', () => {
+        const spans = [];
+        const result = convertSpansToSpanTree(spans);
+        expect(result).toEqual([]);
+    });
+
+    it('should return an array with correct root span', () => {
+        const spans = [{
+            spanId: 'a',
+            spanName: 'root',
+            parentId: null,
+            childIds: ['b'],
+        },
+        {
+            spanId: 'b',
+            
+            spanName: 'child',
+            parentId: 'a',
+            childIds: [],
+        }];
+
+        const result = convertSpansToSpanTree(spans);
+        expect(result.length).toEqual(1);
+        expect(result[0].spanId).toEqual('a');
+    });
+
+    // This test is consistent with 'should work when missing root span' in
+    // span-cleaner.test.js
+    it('should return an array with the root element which is missing parent', () => {
+        const spans = [{
+            spanId: 'a',
+            spanName: 'missing parent',
+            parentId: 'm',
+            childIds: ['b'],
+        },
+        {
+            spanId: 'b',
+            spanName: 'child',
+            parentId: 'a',
+            childIds: [],
+        }];
+
+        const result = convertSpansToSpanTree(spans);
+        expect(result.length).toEqual(1);
+        expect(result[0].spanId).toEqual('a');
+    });
+
+    it('should return an array with two root elements which are missing parent', () => {
+        const spans = [{
+            spanId: 'a',
+            spanName: 'missing parent',
+            parentId: 'm',
+            childIds: [],
+        },
+        {
+            spanId: 'b',
+            spanName: 'missing parent',
+            parentId: 'm',
+            childIds: [],
+        }];
+
+        const result = convertSpansToSpanTree(spans);
+        expect(result.length).toEqual(2);
+        expect(result[0].spanId).toEqual('a');
+        expect(result[1].spanId).toEqual('b');
+
+    });
+});

--- a/zipkin-lens/src/components/TracePage/helpers.ts
+++ b/zipkin-lens/src/components/TracePage/helpers.ts
@@ -29,7 +29,9 @@ export const convertSpansToSpanTree = (
   }, {});
   const unconsumedSpans = { ...idToSpan };
 
-  const roots = spans.filter((span) => !span.parentId);
+  const roots = spans.filter((span) => {
+    return !span.parentId || !spans.find((p) => p.spanId === span.parentId);
+  });
   roots.forEach((root) => {
     delete unconsumedSpans[root.spanId];
   });


### PR DESCRIPTION
When all spans in a trace have a parentId, there is no root and an error occurs. Spans that have a parentId specified, but the parent does not exist should be treated as root. 

An example trace (abbreviated) looks like. Span with id "ebec1841bdb48ba1" is missing.

```
[
    {
        "traceId": "b523777284bbb42aa6304c7a5cd35fd7",
        "parentId": "ebec1841bdb48ba1",
        "id": "3eca62ab99ac8e84",
        "timestamp": 1675053275397814,
    },
    {
        "traceId": "b523777284bbb42aa6304c7a5cd35fd7",
        "parentId": "3eca62ab99ac8e84",
        "id": "7021b3404bd7b9d6",
        "timestamp": 1675053275401192,
    }
]
```
Here is the full trace: [gist](https://gist.github.com/drewby/1782583a17c5930905de11e2c97db320)

close #3505
