### PR TITLE
Added support for prefetch count and upgraded RabbitMQ client lib to …

### DIFF
--- a/zipkin-collector/rabbitmq/README.md
+++ b/zipkin-collector/rabbitmq/README.md
@@ -11,6 +11,7 @@ The following configuration can be set for the RabbitMQ Collector.
 Property | Environment Variable | Description
 --- | --- | ---
 `zipkin.collector.rabbitmq.concurrency` | `RABBIT_CONCURRENCY` | Number of concurrent consumers. Defaults to `1`
+`zipkin.collector.rabbitmq.prefetchCount` | `RABBIT_PREFETCH_COUNT` | Channel prefetch count. Defaults to `0` (infinite)
 `zipkin.collector.rabbitmq.connection-timeout` | `RABBIT_CONNECTION_TIMEOUT` | Milliseconds to wait establishing a connection. Defaults to `60000` (1 minute)
 `zipkin.collector.rabbitmq.queue` | `RABBIT_QUEUE` | Queue from which to collect span messages. Defaults to `zipkin`
 `zipkin.collector.rabbitmq.uri` | `RABBIT_URI` | [RabbitMQ URI spec](https://www.rabbitmq.com/uri-spec.html)-compliant URI, ex. `amqp://user:pass@host:10000/vhost`
@@ -58,7 +59,7 @@ $ RABBIT_ADDRESSES=localhost java -jar zipkin.jar
 ```json
 [{"traceId":"9032b04972e475c5","id":"9032b04972e475c5","kind":"SERVER","name":"get","timestamp":1505990621526000,"duration":612898,"localEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"192.168.1.113"},"remoteEndpoint":{"serviceName":"","ipv4":"127.0.0.1","port":60149},"tags":{"error":"500 Internal Server Error","http.path":"/a"}}]
 ```
-4. Publish them using the CLI 
+4. Publish them using the CLI
 ```bash
 $ rabbitmqadmin publish exchange=amq.default routing_key=zipkin < sample-spans.json
 ```

--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <amqp-client.version>4.12.0</amqp-client.version>
+    <amqp-client.version>5.16.0</amqp-client.version>
   </properties>
 
   <dependencies>

--- a/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorProperties.java
@@ -31,6 +31,8 @@ class ZipkinRabbitMQCollectorProperties {
   private List<String> addresses;
   /** Number of concurrent consumers */
   private Integer concurrency = 1;
+  /** Channel prefetch count */
+  private Integer prefetchCount = 0;
   /** TCP connection timeout in milliseconds */
   private Integer connectionTimeout;
   /** RabbitMQ user password */
@@ -63,6 +65,14 @@ class ZipkinRabbitMQCollectorProperties {
 
   public void setConcurrency(int concurrency) {
     this.concurrency = concurrency;
+  }
+
+  public int getPrefetchCount() {
+    return prefetchCount;
+  }
+
+  public void setPrefetchCount(int prefetchCount) {
+    this.prefetchCount = prefetchCount;
   }
 
   public Integer getConnectionTimeout() {
@@ -127,6 +137,7 @@ class ZipkinRabbitMQCollectorProperties {
     final RabbitMQCollector.Builder result = RabbitMQCollector.builder();
     ConnectionFactory connectionFactory = new ConnectionFactory();
     if (concurrency != null) result.concurrency(concurrency);
+    if (prefetchCount != null) result.prefetchCount(prefetchCount);
     if (connectionTimeout != null) connectionFactory.setConnectionTimeout(connectionTimeout);
     if (queue != null) result.queue(queue);
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -47,6 +47,7 @@ zipkin:
       # RabbitMQ server address list (comma-separated list of host:port)
       addresses: ${RABBIT_ADDRESSES:}
       concurrency: ${RABBIT_CONCURRENCY:1}
+      prefetchCount: ${RABBIT_PREFETCH_COUNT:0}
       # TCP connection timeout in milliseconds
       connection-timeout: ${RABBIT_CONNECTION_TIMEOUT:60000}
       password: ${RABBIT_PASSWORD:guest}


### PR DESCRIPTION
Added support for `prefetch count` to allow users to limit number of inflight/unacknowledged deliveries permitted on a consumer channel and upgraded RabbitMQ client library to latest supported version.