### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/helm_release.yml
+++ b/.github/workflows/helm_release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get current tag trigger
         id: trigger-tag
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | cut -d/ -f 3)
+        run: echo "tag=$(echo ${GITHUB_REF} | cut -d/ -f 3)" >> $GITHUB_OUTPUT
 
       - name: Removes trigger target
         uses: dev-drprasad/delete-tag-and-release@v0.2.0

--- a/.github/workflows/helm_test.yml
+++ b/.github/workflows/helm_test.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)


### PR DESCRIPTION
## Description

Resolve  #3517 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | cut -d/ -f 3)
```

```yml
echo "::set-output name=changed::true"
```

**TO-BE**

```yml
run: echo "tag=$(echo ${GITHUB_REF} | cut -d/ -f 3)" >> $GITHUB_OUTPUT
```

```yml
echo "changed=true" >> $GITHUB_OUTPUT
```