### PR TITLE
chore: bump kafka to 3.4

### DIFF
--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <kafka.version>2.8.1</kafka.version>
+    <kafka.version>3.4.0</kafka.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Fix #3522