### PR TITLE
chore: bump docker mysql version

### DIFF
--- a/docker/test-images/zipkin-mysql/Dockerfile
+++ b/docker/test-images/zipkin-mysql/Dockerfile
@@ -37,7 +37,7 @@ HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthche
 ENTRYPOINT ["start-mysql"]
 
 # Use latest from https://pkgs.alpinelinux.org/packages?name=mysql
-ARG mysql_version=10.6.11
+ARG mysql_version=10.11.2
 LABEL mysql-version=$mysql_version
 ENV MYSQL_VERSION=$mysql_version
 


### PR DESCRIPTION
Update MySQL version used on docker image building process.

Fixes #3527 