### PR TITLE
Add optional priorityClassName to Pod

### DIFF
--- a/charts/zipkin/Chart.yaml
+++ b/charts/zipkin/Chart.yaml
@@ -14,7 +14,7 @@ appVersion: 2.24.0
 name: zipkin
 description: A Zipkin helm chart for kubernetes
 type: application
-version: 0.5.0
+version: 0.6.0
 maintainers:
   - name: openzipkin
     email: zipkin-dev@googlegroups.com

--- a/charts/zipkin/README.md
+++ b/charts/zipkin/README.md
@@ -36,6 +36,7 @@ You can then run `helm search repo openzipkin` to see the charts.
 | nodeSelector | object | `{}` |  |
 | podAnnotations."sidecar.istio.io/inject" | string | `"false"` |  |
 | podSecurityContext | object | `{}` |  |
+| priorityClassName | string | `""` | priority class name for the Pod |
 | replicaCount | int | `1` |  |
 | resources.limits | object | `{"cpu":"500m","memory":"4096Mi"}` |  choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you do want to specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'resources:'. limits:   cpu: 100m   memory: 128Mi requests:   cpu: 100m   memory: 128Mi |
 | resources.requests.cpu | string | `"100m"` |  |

--- a/charts/zipkin/templates/deployment.yaml
+++ b/charts/zipkin/templates/deployment.yaml
@@ -82,3 +82,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}

--- a/charts/zipkin/values.schema.json
+++ b/charts/zipkin/values.schema.json
@@ -79,6 +79,9 @@
         "podSecurityContext": {
             "type": "object"
         },
+        "priorityClassName": {
+            "type": "string"
+        },
         "replicaCount": {
             "type": "integer"
         },

--- a/charts/zipkin/values.yaml
+++ b/charts/zipkin/values.yaml
@@ -97,6 +97,8 @@ tolerations: []
 
 affinity: {}
 
+priorityClassName: ""
+
 zipkin:
   storage:
     type: mem


### PR DESCRIPTION
Current chart has no mechanism to provision a `priorityClassName`, this change optionally adds that, defaulting to the old behavior (ie, no pcn).