### PR TITLE
Bump java docker and spring dependencies to fix CVEs

### DIFF
--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -282,7 +282,7 @@ class ServerIntegratedBenchmark {
 
     final GenericContainer<?> zipkin;
     if (RELEASE_VERSION == null) {
-      zipkin = new GenericContainer<>(parse("ghcr.io/openzipkin/java:17.0.5_p8"));
+      zipkin = new GenericContainer<>(parse("ghcr.io/openzipkin/java:17.0.7_p7"));
       List<String> classpath = new ArrayList<>();
       for (String item : System.getProperty("java.class.path").split(File.pathSeparator)) {
         Path path = Paths.get(item);

--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -162,7 +162,7 @@ explicitly defined and `on.tags` is a [glob pattern](https://docs.github.com/en/
 ```yaml
 on:
   push:
-    tags: '[0-9]+.[0-9]+.[0-9]+**'  # Ex. 8.272.10 or 17.0.5_p8
+    tags: '[0-9]+.[0-9]+.[0-9]+**'  # Ex. 8.272.10 or 17.0.7_p7
     branches: master
 
 jobs:
@@ -223,7 +223,7 @@ jobs:
         - if [ "${SHOULD_DEPLOY}" != "true" ]; then travis_terminate 0; fi
         - travis_wait ./build-bin/deploy master
     - stage: deploy
-      # Ex. 8.272.10 or 17.0.5_p8
+      # Ex. 8.272.10 or 17.0.7_p7
       if: tag =~ /^[0-9]+\.[0-9]+\.[0-9]+/ AND type = push AND env(GH_TOKEN) IS present
       install: ./build-bin/configure_deploy
       script: ./build-bin/deploy ${TRAVIS_TAG}

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -46,7 +46,7 @@ if [ -n "${DOCKER_TARGET}" ]; then
 fi
 
 # When non-empty, becomes the base layer including tag appropriate for the image being built.
-# Ex. ghcr.io/openzipkin/java:17.0.5_p8-jre
+# Ex. ghcr.io/openzipkin/java:17.0.7_p7-jre
 #
 # This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.14.2
 # See https://docs.docker.com/glossary/#parent-image
@@ -54,13 +54,13 @@ if [ -n "${DOCKER_PARENT_IMAGE}" ]; then
   docker_args="${docker_args} --build-arg docker_parent_image=${DOCKER_PARENT_IMAGE}"
 fi
 
-# When non-empty, becomes the build-arg alpine_version. Ex. "3.16.3"
+# When non-empty, becomes the build-arg alpine_version. Ex. "3.18.0"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/alpine
 if [ -n "${ALPINE_VERSION}" ]; then
   docker_args="${docker_args} --build-arg alpine_version=${ALPINE_VERSION}"
 fi
 
-# When non-empty, becomes the build-arg java_version. Ex. "17.0.5_p8"
+# When non-empty, becomes the build-arg java_version. Ex. "17.0.7_p7"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/java
 if [ -n "${JAVA_VERSION}" ]; then
   docker_args="${docker_args} --build-arg java_version=${JAVA_VERSION}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.5_p8
+ARG java_version=17.0.7_p7
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-cassandra/Dockerfile
+++ b/docker/test-images/zipkin-cassandra/Dockerfile
@@ -18,7 +18,7 @@
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
 # Note: Cassandra does not support Java 17 yet so use older JRE for testing
-ARG java_version=17.0.5_p8
+ARG java_version=17.0.7_p7
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-elasticsearch6/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch6/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.5_p8
+ARG java_version=17.0.7_p7
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-elasticsearch7/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch7/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.5_p8
+ARG java_version=17.0.7_p7
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-kafka/Dockerfile
+++ b/docker/test-images/zipkin-kafka/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.5_p8
+ARG java_version=17.0.7_p7
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-mysql/Dockerfile
+++ b/docker/test-images/zipkin-mysql/Dockerfile
@@ -15,7 +15,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG alpine_version=3.16.3
+ARG alpine_version=3.18.0
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -37,7 +37,7 @@ HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthche
 ENTRYPOINT ["start-mysql"]
 
 # Use latest from https://pkgs.alpinelinux.org/packages?name=mysql
-ARG mysql_version=10.11.2
+ARG mysql_version=10.11.3
 LABEL mysql-version=$mysql_version
 ENV MYSQL_VERSION=$mysql_version
 

--- a/docker/test-images/zipkin-ui/Dockerfile
+++ b/docker/test-images/zipkin-ui/Dockerfile
@@ -15,14 +15,14 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG alpine_version=3.16.3
+ARG alpine_version=3.18.0
 
 # java_version is used during the installation process to build or download the zipkin-lens jar.
 #
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.5_p8
+ARG java_version=17.0.7_p7
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -61,7 +61,7 @@ RUN /build-bin/maven/maven_build_or_unjar io.zipkin zipkin-lens ${VERSION}
 FROM ghcr.io/openzipkin/alpine:$alpine_version as zipkin-ui
 LABEL org.opencontainers.image.description="NGINX on Alpine Linux hosting the Zipkin UI with Zipkin API proxy_pass"
 # Use latest from https://pkgs.alpinelinux.org/packages?name=nginx
-ARG nginx_version=1.22.1
+ARG nginx_version=1.24.0
 LABEL nginx-version=$nginx_version
 
 ENV ZIPKIN_BASE_URL=http://zipkin:9411

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
     <!-- update together -->
     <spring-boot.version>2.5.14</spring-boot.version>
-    <spring.version>5.3.23</spring.version>
+    <spring.version>5.3.27</spring.version>
     <!-- override spring dependency version, CVE-2022-25857 -->
     <snakeyaml.version>1.33</snakeyaml.version>
 


### PR DESCRIPTION
Fixes CVEs:
CVE-2022-3996
CVE-2022-4450
CVE-2023-0215
CVE-2023-0216
CVE-2023-0217
CVE-2023-0286
CVE-2023-0401
CVE-2023-0464

CVE-2022-3996
CVE-2022-4450
CVE-2023-0215
CVE-2023-0216
CVE-2023-0217
CVE-2023-0286
CVE-2023-0401
CVE-2023-0464

CVE-2023-20863
~CVE-2022-1471~ still a problem until Spring 2.3 supports Snakeyaml 2.0, Snakeyaml releases a fix for 1.33 or possibly we upgrade to a newer version of Spring.