### PR TITLE
Resolve CVE-2022-1471: Securing the Vulnerability with SnakeYAML 2.0 and Spring Boot 2.7.10 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <spring-boot.version>2.5.14</spring-boot.version>
     <spring.version>5.3.27</spring.version>
     <!-- override spring dependency version, CVE-2022-25857 -->
-    <snakeyaml.version>1.33</snakeyaml.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
 
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <netty.version>4.1.78.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
-    <jackson.version>2.14.0</jackson.version>
+    <jackson.version>2.15.0</jackson.version>
 
     <java-driver.version>4.11.3</java-driver.version>
     <micrometer.version>1.9.3</micrometer.version>
@@ -66,9 +66,9 @@
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
-    <spring-boot.version>2.5.14</spring-boot.version>
+    <spring-boot.version>2.7.1</spring-boot.version>
     <spring.version>5.3.27</spring.version>
-    <!-- override spring dependency version, CVE-2022-25857 -->
+    <!-- override spring dependency version, CVE-2022-25857, CVE-2022-1471 -->
     <snakeyaml.version>2.0</snakeyaml.version>
 
     <!-- MySQL connector is GPL, even if it has an OSS exception.

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
-    <spring-boot.version>2.7.1</spring-boot.version>
+    <spring-boot.version>2.7.10</spring-boot.version>
     <spring.version>5.3.27</spring.version>
     <!-- override spring dependency version, CVE-2022-25857, CVE-2022-1471 -->
     <snakeyaml.version>2.0</snakeyaml.version>

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
@@ -78,7 +78,7 @@ public class ITZipkinMetrics {
 
     // ensure we don't track prometheus, UI requests in prometheus
     assertThat(scrape())
-      .doesNotContain("prometheus")
+      .doesNotContain("uri=\"/prometheus")
       .doesNotContain("uri=\"/zipkin")
       .doesNotContain("uri=\"/\"");
   }


### PR DESCRIPTION
Bump snakeyml to 2.0 to resolve[ CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471)