### PR TITLE
Adds gcc to Cassandra test scripts

### DIFF
--- a/docker/test-images/zipkin-cassandra/install.sh
+++ b/docker/test-images/zipkin-cassandra/install.sh
@@ -194,7 +194,7 @@ function is_cassandra_alive() {
 is_cassandra_alive || exit 1
 
 echo "*** Installing cqlsh"
-apk add --update --no-cache python3 py3-pip
+apk add --update --no-cache python3 py3-pip gcc
 pip install -Iq cqlsh
 function cql() {
   cqlsh --cqlversion=${cqlversion} "$@" 127.0.0.1 ${temp_native_transport_port}


### PR DESCRIPTION
Seems that a cqlsh dependency now requires gcc so adding it.

https://github.com/openzipkin/zipkin/actions/runs/4983765294/jobs/9159359954

```
#18 73.48 + pip install -Iq cqlsh
#18 189.5   error: subprocess-exited-with-error
#18 189.5       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DFFI_BUILDING=1 -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python3.11 -c c/_cffi_backend.c -o build/temp.linux-aarch64-cpython-311/c/_cffi_backend.o
#18 189.5       error: command 'gcc' failed: No such file or directory
#18 189.5       [end of output]```