### PR TITLE
Add py3-cffi package for cqlsh

### DIFF
--- a/docker/test-images/zipkin-cassandra/install.sh
+++ b/docker/test-images/zipkin-cassandra/install.sh
@@ -194,7 +194,7 @@ function is_cassandra_alive() {
 is_cassandra_alive || exit 1
 
 echo "*** Installing cqlsh"
-apk add --update --no-cache python3 py3-pip gcc
+apk add --update --no-cache python3 py3-pip py3-cffi
 pip install -Iq cqlsh
 function cql() {
   cqlsh --cqlversion=${cqlversion} "$@" 127.0.0.1 ${temp_native_transport_port}


### PR DESCRIPTION
Installing cqlsh for the cassandra test container is failing and the build attempts to compile cffi package, which requires gcc and other development packages, including python-dev which is huge. Bigger problem is this doesn't fail locally but does fail in CI consistently.

Another attempt at chasing my tail. Main issue here is that this fails with aarch64 and I haven't been able to reproduce the failure locally. I'm hoping that adding the python package directly will avoid PIP from trying to compile it which requires other development dependencies.