### PR TITLE
chore(deps): bump Spring Boot from 2.7.10 to 2.7.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
-    <spring-boot.version>2.7.10</spring-boot.version>
+    <spring-boot.version>2.7.12</spring-boot.version>
     <spring.version>5.3.27</spring.version>
     <!-- override spring dependency version, CVE-2022-25857, CVE-2022-1471 -->
     <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
Bump Spring Boot from 2.7.10 to 2.7.12

It has come to my attention after #3538 was merged that we may want to bump to the latest 2.7.x version.

Although I don't believe zipkin has this particular CVE, bumping to 2.7.12+ will reduce likelihood for a false positive for CVE-2023-20883

ref:
https://spring.io/blog/2023/05/18/spring-boot-2-7-12-available-now
https://spring.io/security/cve-2023-20883