### PR TITLE
Adds missing dependencies for installing cqlsh on aarch64

### DIFF
--- a/docker/test-images/zipkin-cassandra/install.sh
+++ b/docker/test-images/zipkin-cassandra/install.sh
@@ -194,7 +194,13 @@ function is_cassandra_alive() {
 is_cassandra_alive || exit 1
 
 echo "*** Installing cqlsh"
-apk add --update --no-cache python3 py3-pip py3-cffi
+apk add --update --no-cache python3 py3-pip
+# Installing cqlsh requires cffi package. Normally this doesn't need
+# to be compiled, but something isn't right with aarch64 and when installing
+# cqlsh it needs to build cffi. To unblock test support for aarch64, adding
+# the following are necessary for compiling cffi. If pip someday changes and
+# doesn't compile cffi on arrch64 then we can remove these dependencies.
+apk add --update --no-cache gcc python3-dev musl-dev libffi-dev
 pip install -Iq cqlsh
 function cql() {
   cqlsh --cqlversion=${cqlversion} "$@" 127.0.0.1 ${temp_native_transport_port}


### PR DESCRIPTION
When building the test image for cassandra we install cqlsh. On aarch64, the pip install compiles cffi and we need to add some extra dependencies to prevent the build from failing. These may be removed in the future if upstream deps change for aarch64.