### PR TITLE
Remove s390x from docker builds until cqlsh installation is fixed

### DIFF
--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -64,7 +64,7 @@ for repo in ${docker_repos}; do
 done
 
 docker_args=$($(dirname "$0")/docker_args ${version})
-docker_archs=${DOCKER_ARCHS:-amd64 arm64 s390x}
+docker_archs=${DOCKER_ARCHS:-amd64 arm64}
 
 echo "Will build the following architectures: ${docker_archs}"
 

--- a/docker/test-images/zipkin-cassandra/install.sh
+++ b/docker/test-images/zipkin-cassandra/install.sh
@@ -196,8 +196,8 @@ is_cassandra_alive || exit 1
 echo "*** Installing cqlsh"
 apk add --update --no-cache python3 py3-pip
 # Installing cqlsh requires cffi package. Normally this doesn't need
-# to be compiled, but something isn't right with aarch64 and when installing
-# cqlsh it needs to build cffi. To unblock test support for aarch64, adding
+# to be compiled, but something isn't right with aarch64 when installing
+# cqlsh it needs to build cffi. To unblock support for aarch64, adding
 # the following are necessary for compiling cffi. If pip someday changes and
 # doesn't compile cffi on arrch64 then we can remove these dependencies.
 apk add --update --no-cache gcc python3-dev musl-dev libffi-dev


### PR DESCRIPTION
Installing cqlsh for s390x is requiring new things like installing rust, cargo among other things. After attempting to resolve all build dependenices the build still fails. Since s390x is really a small subset of users, we need to find help fixing this to continue supporting s390x with docker.