### PR TITLE
chore(deps): Update netty from 4.1.78.Final to 4.1.95.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>1.17.2</armeria.version>
     <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
-    <netty.version>4.1.78.Final</netty.version>
+    <netty.version>4.1.92.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
     <jackson.version>2.15.0</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>1.17.2</armeria.version>
     <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
-    <netty.version>4.1.92.Final</netty.version>
+    <netty.version>4.1.95.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
     <jackson.version>2.15.0</jackson.version>
@@ -66,8 +66,8 @@
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
-    <spring-boot.version>2.7.12</spring-boot.version>
-    <spring.version>5.3.27</spring.version>
+    <spring-boot.version>2.7.14</spring-boot.version>
+    <spring.version>5.3.29</spring.version>
     <!-- override spring dependency version, CVE-2022-25857, CVE-2022-1471 -->
     <snakeyaml.version>2.0</snakeyaml.version>
 


### PR DESCRIPTION
Bump netty version to 4.1.92.Final to match Spring Boot v2.7.12
Remediates CVE-2022-41881
Ref issue: #3512