### PR TITLE
chore(deps): Update netty from 4.1.78.Final to 4.1.86.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>1.17.2</armeria.version>
     <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
-    <netty.version>4.1.78.Final</netty.version>
+    <netty.version>4.1.86.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
     <jackson.version>2.15.0</jackson.version>


### PR DESCRIPTION
Bump netty version from 4.1.78.Final to 4.1.86.Final  Remediates CVE-2022-41881
Ref issue: #3512