### PR TITLE
Add support for elasticsearch 8

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -167,8 +167,8 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
 
     /**
      * Only valid when the destination is Elasticsearch >= 7.8. Indicates the index template
-     * priority in case of multiple matching templates. The template with highest priority is used.
-     * Default to 0.
+     * priority in case of multiple matching templates. The template with the highest priority is
+     * used. Defaults to 0.
      *
      * <p>See https://www.elastic.co/guide/en/elasticsearch/reference/7.8/_index_template_and_settings_priority.html
      */
@@ -282,7 +282,7 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
   /**
    * Internal code and api responses coerce to {@link RejectedExecutionException} when work is
    * rejected. We also classify {@link ResponseTimeoutException} as a capacity related exception
-   * eventhough capacity is not the only reason (timeout could also result from a misconfiguration
+   * even though capacity is not the only reason (timeout could also result from a misconfiguration
    * or a network problem).
    */
   @Override public boolean isOverCapacity(Throwable e) {

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
@@ -33,6 +33,7 @@ public final class ElasticsearchVersion implements Comparable<ElasticsearchVersi
   public static final ElasticsearchVersion V7_0 = new ElasticsearchVersion(7, 0);
   public static final ElasticsearchVersion V7_8 = new ElasticsearchVersion(7, 8);
   public static final ElasticsearchVersion V8_0 = new ElasticsearchVersion(8, 0);
+  public static final ElasticsearchVersion V9_0 = new ElasticsearchVersion(9, 0);
 
   static ElasticsearchVersion get(HttpCall.Factory http) throws IOException {
     return Parser.INSTANCE.get(http);

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
@@ -18,6 +18,7 @@ import static zipkin2.elasticsearch.ElasticsearchVersion.V6_0;
 import static zipkin2.elasticsearch.ElasticsearchVersion.V7_0;
 import static zipkin2.elasticsearch.ElasticsearchVersion.V7_8;
 import static zipkin2.elasticsearch.ElasticsearchVersion.V8_0;
+import static zipkin2.elasticsearch.ElasticsearchVersion.V9_0;
 
 /** Returns version-specific index templates */
 // TODO: make a main class that spits out the index template using ENV variables for the server,
@@ -223,7 +224,7 @@ final class VersionSpecificTemplates {
   }
 
   IndexTemplates get(ElasticsearchVersion version) {
-    if (version.compareTo(V5_0) < 0 || version.compareTo(V8_0) >= 0) {
+    if (version.compareTo(V5_0) < 0 || version.compareTo(V9_0) >= 0) {
       throw new IllegalArgumentException(
         "Elasticsearch versions 5-7.x are supported, was: " + version);
     }

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV8.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV8.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.elasticsearch.integration;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import zipkin2.elasticsearch.ElasticsearchStorage;
+
+import static zipkin2.elasticsearch.integration.ElasticsearchExtension.index;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ITElasticsearchStorageV8 extends ITElasticsearchStorage {
+
+  @RegisterExtension ElasticsearchExtension elasticsearch = new ElasticsearchExtension(8);
+
+  @Override ElasticsearchExtension elasticsearch() {
+    return elasticsearch;
+  }
+
+  @Nested
+  class ITEnsureIndexTemplate extends zipkin2.elasticsearch.integration.ITEnsureIndexTemplate {
+    @Override protected ElasticsearchStorage.Builder newStorageBuilder(TestInfo testInfo) {
+      return elasticsearch().computeStorageBuilder().index(index(testInfo));
+    }
+  }
+}

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV8.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITEnsureIndexTemplate.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITEnsureIndexTemplate.java
@@ -76,7 +76,7 @@ abstract class ITEnsureIndexTemplate extends ITStorage<ElasticsearchStorage> {
           .build(),
         asList(span));
     } finally {
-      // Delete "catch-all" index template so it does not interfere with any other test
+      // Delete "catch-all" index template, so it does not interfere with any other test
       http(DELETE, catchAllIndexPath());
     }
   }
@@ -102,7 +102,7 @@ abstract class ITEnsureIndexTemplate extends ITStorage<ElasticsearchStorage> {
   String catchAllTemplate() {
     return "{\n"
       + "  \"index_patterns\" : [\"*\"],\n"
-      + "  \"priority\" : 0,\n"
+      + "  \"priority\" : 5,\n" // Priority 0 conflicts with ES 8.x monitoring templates
       + "  \"template\": {\n"
       + "    \"settings\" : {\n"
       + "      \"number_of_shards\" : 1\n"


### PR DESCRIPTION
**Issue** - https://github.com/openzipkin/zipkin/issues/3468

- Not able to connect zipkin with elasticsearch 8.* version

**Solution**
- Add version 9 to avoid the check with version 8