### PR TITLE
chores(deps): Bump armeria.version from 1.17.2 to 1.24.3

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.14.0</version>
+      <version>3.16.3</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,15 +52,15 @@
 
     <!-- This allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
-    <armeria.version>1.17.2</armeria.version>
+    <armeria.version>1.24.3</armeria.version>
     <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
-    <netty.version>4.1.95.Final</netty.version>
+    <netty.version>4.1.96.Final</netty.version>
 
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
-    <jackson.version>2.15.0</jackson.version>
+    <jackson.version>2.15.2</jackson.version>
 
     <java-driver.version>4.11.3</java-driver.version>
-    <micrometer.version>1.9.3</micrometer.version>
+    <micrometer.version>1.11.2</micrometer.version>
 
     <snappy.version>1.1.10.3</snappy.version>
 


### PR DESCRIPTION
Resolves CVE-2023-38493 (Issue #3556)
Bump netty.version to align to latest
Bump jackson.version to align to latest
Bump micrometer.version to align to latest

Ref: https://netty.io/news/2023/07/27/4-1-96-Final.html https://mvnrepository.com/artifact/com.linecorp.armeria/armeria/1.24.3