### PR TITLE
Upgrade testcontainers to 1.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <assertj.version>3.18.1</assertj.version>
     <awaitility.version>4.0.3</awaitility.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <testcontainers.version>1.15.1</testcontainers.version>
+    <testcontainers.version>1.19.0</testcontainers.version>
     <okhttp.version>4.9.0</okhttp.version>
     <okhttp5.version>5.0.0-alpha.11</okhttp5.version>
     <kryo.version>5.0.3</kryo.version>

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -160,6 +160,7 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }
+      addExposedPort(9042);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));
     }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -131,6 +131,7 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }
+      addExposedPort(9200);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));
     }

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
@@ -117,6 +117,7 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback {
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }
+      addExposedPort(3306);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));
     }


### PR DESCRIPTION
This allows integration tests to be run on Apple silicon (which helps me and anyone else running IT on their recent macbook). Ports need to be explicitly exposed now.