### PR TITLE
Adding receiver tests for v3 server

### DIFF
--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -1,0 +1,73 @@
+# yamllint --format github .github/workflows/test.yml
+---
+name: test-v3
+
+# We don't test documentation-only commits.
+on:
+  # We run tests on non-tagged pushes to master that aren't a commit made by the release plugin
+  push:
+    tags: ""
+    branches: zipkin-v3
+    paths-ignore:
+      - "**/*.md"
+      - "charts/**"
+  # We also run tests on pull requests targeted at the master branch.
+  pull_request:
+    branches: zipkin-v3
+    paths-ignore:
+      - "**/*.md"
+      - "charts/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04 # newest available distribution, aka focal
+    if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # full git history for license check
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      - name: Cache NPM Packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-packages-${{ hashFiles('zipkin-lens/package-lock.json') }}
+      - name: Test without Docker
+        run: build-bin/maven_go_offline && build-bin/test -Ddocker.skip=true
+  test_docker:
+    runs-on: ubuntu-20.04 # newest available distribution, aka focal
+    if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
+    strategy:
+      matrix:
+        include:
+          - name: receiver-zipkin-activemq
+          - name: receiver-zipkin-http
+          - name: receiver-zipkin-kafka
+          - name: receiver-zipkin-rabbitmq
+          - name: receiver-zipkin-scribe
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1 # -Dlicense.skip=true so we don't need a full clone
+          submodules: true
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
+      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      - name: Test with Docker
+        run:
+          | # configure_test seeds NPM cache, which isn't needed for these tests
+          build-bin/maven/maven_go_offline &&
+          build-bin/docker/configure_docker &&
+          build-bin/test -pl :${{ matrix.name }} --am -Dlicense.skip=true -Dcheckstyle.skip=true


### PR DESCRIPTION
Following https://github.com/openzipkin/zipkin/pull/3567#discussion_r1329802201, I need to add the CI tests into the main branch for `zipkin-v3` branches tests. 