### PR TITLE
Adding gRPC server for cluster mode

### DIFF
--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/CoreModuleConfig.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/CoreModuleConfig.java
@@ -17,6 +17,17 @@ import org.apache.skywalking.oap.server.core.Const;
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 
 public class CoreModuleConfig extends ModuleConfig {
+  private String gRPCHost;
+  private int gRPCPort;
+  private boolean gRPCSslEnabled = false;
+  private String gRPCSslKeyPath;
+  private String gRPCSslCertChainPath;
+  private String gRPCSslTrustedCAPath;
+  private int gRPCThreadPoolSize;
+  private int gRPCThreadPoolQueueSize;
+  private int gRPCMaxConcurrentCallsPerConnection;
+  private int gRPCMaxMessageSize;
+  
   /**
    * The max length of the service name.
    */
@@ -194,5 +205,85 @@ public class CoreModuleConfig extends ModuleConfig {
 
   public void setRemoteTimeout(int remoteTimeout) {
     this.remoteTimeout = remoteTimeout;
+  }
+
+  public String getGRPCHost() {
+    return gRPCHost;
+  }
+
+  public void setGRPCHost(String gRPCHost) {
+    this.gRPCHost = gRPCHost;
+  }
+
+  public int getGRPCPort() {
+    return gRPCPort;
+  }
+
+  public void setGRPCPort(int gRPCPort) {
+    this.gRPCPort = gRPCPort;
+  }
+
+  public boolean getGRPCSslEnabled() {
+    return gRPCSslEnabled;
+  }
+
+  public void setGRPCSslEnabled(boolean gRPCSslEnabled) {
+    this.gRPCSslEnabled = gRPCSslEnabled;
+  }
+
+  public String getGRPCSslKeyPath() {
+    return gRPCSslKeyPath;
+  }
+
+  public void setGRPCSslKeyPath(String gRPCSslKeyPath) {
+    this.gRPCSslKeyPath = gRPCSslKeyPath;
+  }
+
+  public String getGRPCSslCertChainPath() {
+    return gRPCSslCertChainPath;
+  }
+
+  public void setGRPCSslCertChainPath(String gRPCSslCertChainPath) {
+    this.gRPCSslCertChainPath = gRPCSslCertChainPath;
+  }
+
+  public String getGRPCSslTrustedCAPath() {
+    return gRPCSslTrustedCAPath;
+  }
+
+  public void setGRPCSslTrustedCAPath(String gRPCSslTrustedCAPath) {
+    this.gRPCSslTrustedCAPath = gRPCSslTrustedCAPath;
+  }
+
+  public int getGRPCThreadPoolSize() {
+    return gRPCThreadPoolSize;
+  }
+
+  public void setGRPCThreadPoolSize(int gRPCThreadPoolSize) {
+    this.gRPCThreadPoolSize = gRPCThreadPoolSize;
+  }
+
+  public int getGRPCThreadPoolQueueSize() {
+    return gRPCThreadPoolQueueSize;
+  }
+
+  public void setGRPCThreadPoolQueueSize(int gRPCThreadPoolQueueSize) {
+    this.gRPCThreadPoolQueueSize = gRPCThreadPoolQueueSize;
+  }
+
+  public int getGRPCMaxConcurrentCallsPerConnection() {
+    return gRPCMaxConcurrentCallsPerConnection;
+  }
+
+  public void setGRPCMaxConcurrentCallsPerConnection(int gRPCMaxConcurrentCallsPerConnection) {
+    this.gRPCMaxConcurrentCallsPerConnection = gRPCMaxConcurrentCallsPerConnection;
+  }
+
+  public int getGRPCMaxMessageSize() {
+    return gRPCMaxMessageSize;
+  }
+
+  public void setGRPCMaxMessageSize(int gRPCMaxMessageSize) {
+    this.gRPCMaxMessageSize = gRPCMaxMessageSize;
   }
 }

--- a/zipkin-server/server-starter/src/main/resources/application.yml
+++ b/zipkin-server/server-starter/src/main/resources/application.yml
@@ -38,6 +38,16 @@ core:
     prepareThreads: ${ZIPKIN_PREPARE_THREADS:2}
     # The period of doing data persistence. Unit is second.Default value is 25s
     persistentPeriod: ${ZIPKIN_PERSISTENT_PERIOD:25}
+    gRPCHost: ${ZIPKIN_GRPC_HOST:0.0.0.0}
+    gRPCPort: ${ZIPKIN_GRPC_PORT:11800}
+    gRPCThreadPoolQueueSize: ${ZIPKIN_GRPC_POOL_QUEUE_SIZE:-1}
+    gRPCThreadPoolSize: ${ZIPKIN_GRPC_THREAD_POOL_SIZE:-1}
+    gRPCSslEnabled: ${ZIPKIN_GRPC_SSL_ENABLED:false}
+    gRPCSslKeyPath: ${ZIPKIN_GRPC_SSL_KEY_PATH:""}
+    gRPCSslCertChainPath: ${ZIPKIN_GRPC_SSL_CERT_CHAIN_PATH:""}
+    gRPCSslTrustedCAPath: ${ZIPKIN_GRPC_SSL_TRUSTED_CA_PATH:""}
+    gRPCMaxConcurrentCallsPerConnection: ${ZIPKIN_GRPC_MAX_CONCURRENT_CALL:0}
+    gRPCMaxMessageSize: ${ZIPKIN_GRPC_MAX_MESSAGE_SIZE:0}
 
 storage:
   selector: ${ZIPKIN_STORAGE:h2}


### PR DESCRIPTION
In cluster mode, metric data needs to be exchanged between clusters using the gRPC protocol, so the gRPC is introduced in SkyWalking OAP for implementation.