### PR TITLE
Fix annotation scan not working in v3 server

### DIFF
--- a/zipkin-server/server-core/pom.xml
+++ b/zipkin-server/server-core/pom.xml
@@ -24,6 +24,11 @@
       <artifactId>zipkin-receiver-plugin</artifactId>
       <version>${skywalking.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+      <version>4.8.162</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/CoreModuleProvider.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/CoreModuleProvider.java
@@ -99,14 +99,14 @@ public class CoreModuleProvider extends ModuleProvider {
 
   private EndpointNameGrouping endpointNameGrouping;
   private final ZipkinSourceReceiverImpl receiver;
-  private final AnnotationScan annotationScan;
+  private final ZipkinAnnotationScan annotationScan;
   private final StorageModels storageModels;
   private RemoteClientManager remoteClientManager;
   private GRPCServer grpcServer;
   private HTTPServer httpServer;
 
   public CoreModuleProvider() {
-    this.annotationScan = new AnnotationScan();
+    this.annotationScan = new ZipkinAnnotationScan();
     this.receiver = new ZipkinSourceReceiverImpl();
     this.storageModels = new StorageModels();
   }
@@ -147,15 +147,8 @@ public class CoreModuleProvider extends ModuleProvider {
     );
     this.registerServiceImplementation(NamingControl.class, namingControl);
 
+    annotationScan.registerListener(new DefaultScopeDefine.Listener());
     annotationScan.registerListener(new ZipkinStreamAnnotationListener(getManager()));
-
-    AnnotationScan scopeScan = new AnnotationScan();
-    scopeScan.registerListener(new DefaultScopeDefine.Listener());
-    try {
-      scopeScan.scan();
-    } catch (Exception e) {
-      throw new ModuleStartException(e.getMessage(), e);
-    }
 
     HTTPServerConfig httpServerConfig = HTTPServerConfig.builder()
         .host(moduleConfig.getRestHost())

--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinAnnotationScan.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinAnnotationScan.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server.core;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
+import org.apache.skywalking.oap.server.core.annotation.AnnotationListener;
+import org.apache.skywalking.oap.server.core.storage.StorageException;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+
+public class ZipkinAnnotationScan {
+  private final List<AnnotationListenerCache> listeners;
+
+  public ZipkinAnnotationScan() {
+    this.listeners = new LinkedList<>();
+  }
+
+  /**
+   * Register the callback listener
+   *
+   * @param listener to be called after class found w/ annotation
+   */
+  public void registerListener(AnnotationListener listener) {
+    listeners.add(new AnnotationListenerCache(listener));
+  }
+
+  public void scan() throws IOException, StorageException {
+    ClassGraph classGraph = new ClassGraph();
+    classGraph.enableClassInfo();
+    final ScanResult scan = classGraph.scan();
+    for (ClassInfo classInfo : scan.getAllClasses()) {
+      // not skywalking package or a subclass should ignore
+      if (!classInfo.getName().startsWith("org.apache.skywalking") || classInfo.getName().contains("$")) {
+        continue;
+      }
+      final Class<?> aClass = classInfo.loadClass();
+      for (AnnotationListenerCache listener : listeners) {
+        if (aClass.isAnnotationPresent(listener.annotation())) {
+          listener.addMatch(aClass);
+        }
+      }
+    }
+
+    for (AnnotationListenerCache listener : listeners) {
+      listener.complete();
+    }
+  }
+
+  private class AnnotationListenerCache {
+    private AnnotationListener listener;
+    private List<Class<?>> matchedClass;
+
+    private AnnotationListenerCache(AnnotationListener listener) {
+      this.listener = listener;
+      matchedClass = new LinkedList<>();
+    }
+
+    private Class<? extends Annotation> annotation() {
+      return this.listener.annotation();
+    }
+
+    private void addMatch(Class aClass) {
+      matchedClass.add(aClass);
+    }
+
+    private void complete() throws StorageException {
+      matchedClass.sort(Comparator.comparing(Class::getName));
+      for (Class<?> aClass : matchedClass) {
+        listener.notify(aClass);
+      }
+    }
+  }
+
+}

--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinStreamAnnotationListener.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinStreamAnnotationListener.java
@@ -16,6 +16,7 @@ package zipkin.server.core;
 
 import org.apache.skywalking.oap.server.core.analysis.StreamAnnotationListener;
 import org.apache.skywalking.oap.server.core.analysis.manual.searchtag.TagAutocompleteData;
+import org.apache.skywalking.oap.server.core.analysis.manual.spanattach.SpanAttachedEventRecord;
 import org.apache.skywalking.oap.server.core.storage.StorageException;
 import org.apache.skywalking.oap.server.library.module.ModuleDefineHolder;
 
@@ -28,7 +29,7 @@ public class ZipkinStreamAnnotationListener extends StreamAnnotationListener {
   @Override
   public void notify(Class aClass) throws StorageException {
     // only including all zipkin streaming
-    if (aClass.getSimpleName().startsWith("Zipkin") || aClass.equals(TagAutocompleteData.class)) {
+    if (aClass.getSimpleName().startsWith("Zipkin") || aClass.equals(TagAutocompleteData.class) || aClass.equals(SpanAttachedEventRecord.class)) {
       super.notify(aClass);
     }
   }


### PR DESCRIPTION
Due to Zipkin packaging all dependencies into a single JAR, Skywalking's previous annotation scanning logic within the core does not support scanning files within sub-JARs. 
Therefore, we've replaced it with using the [ClassGraph](https://github.com/classgraph/classgraph) module to achieve the original annotation scanning logic.