### PR TITLE
Adaptation of Dependency Query Service in Server

### DIFF
--- a/zipkin-server/http-query-plugin/src/main/java/zipkin/server/query/http/HTTPQueryConfig.java
+++ b/zipkin-server/http-query-plugin/src/main/java/zipkin/server/query/http/HTTPQueryConfig.java
@@ -42,6 +42,10 @@ public class HTTPQueryConfig extends ModuleConfig {
   private boolean uiEnable = true;
   private String uiBasePath = "/zipkin";
 
+  private boolean dependencyEnabled = true;
+  private double dependencyLowErrorRate = 0.5;  // 50% of calls in error turns line yellow
+  private double dependencyHighErrorRate = 0.75;// 75% of calls in error turns line red
+
   public ZipkinQueryConfig toSkyWalkingConfig() {
     final ZipkinQueryConfig result = new ZipkinQueryConfig();
     result.setLookback(lookback);
@@ -187,5 +191,29 @@ public class HTTPQueryConfig extends ModuleConfig {
 
   public void setAllowedOrigins(String allowedOrigins) {
     this.allowedOrigins = allowedOrigins;
+  }
+
+  public boolean getDependencyEnabled() {
+    return dependencyEnabled;
+  }
+
+  public void setDependencyEnabled(boolean dependencyEnabled) {
+    this.dependencyEnabled = dependencyEnabled;
+  }
+
+  public double getDependencyLowErrorRate() {
+    return dependencyLowErrorRate;
+  }
+
+  public void setDependencyLowErrorRate(double dependencyLowErrorRate) {
+    this.dependencyLowErrorRate = dependencyLowErrorRate;
+  }
+
+  public double getDependencyHighErrorRate() {
+    return dependencyHighErrorRate;
+  }
+
+  public void setDependencyHighErrorRate(double dependencyHighErrorRate) {
+    this.dependencyHighErrorRate = dependencyHighErrorRate;
   }
 }

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -70,6 +70,8 @@
     <module>http-query-plugin</module>
     <module>health-query-plugin</module>
     <module>telemetry-zipkin</module>
+    <module>zipkin-dependency</module>
+    <module>zipkin-storage-ext</module>
   </modules>
 
   <dependencyManagement>

--- a/zipkin-server/server-starter/pom.xml
+++ b/zipkin-server/server-starter/pom.xml
@@ -56,6 +56,23 @@
       <version>${skywalking.version}</version>
     </dependency>
 
+    <!-- storage ext -->
+    <dependency>
+      <groupId>io.zipkin</groupId>
+      <artifactId>zipkin-dependency-storage-jdbc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin</groupId>
+      <artifactId>zipkin-dependency-storage-elasticsearch</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin</groupId>
+      <artifactId>zipkin-dependency-storage-banyandb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <!-- zipkin receiver -->
     <dependency>
       <groupId>io.zipkin</groupId>
@@ -111,6 +128,13 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+    </dependency>
+
+    <!-- for mysql -->
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.0.33</version>
     </dependency>
   </dependencies>
 

--- a/zipkin-server/server-starter/src/main/resources/application.yml
+++ b/zipkin-server/server-starter/src/main/resources/application.yml
@@ -56,7 +56,7 @@ core:
     restAcceptQueueSize: ${ZIPKIN_REST_QUEUE_SIZE:0}
     restMaxRequestHeaderSize: ${ZIPKIN_REST_MAX_REQUEST_HEADER_SIZE:8192}
 
-storage:
+storage: &storage
   selector: ${ZIPKIN_STORAGE:h2}
   elasticsearch:
     namespace: ${ZIPKIN_NAMESPACE:""}
@@ -147,6 +147,8 @@ storage:
     superDatasetSegmentIntervalDays: ${ZIPKIN_STORAGE_BANYANDB_SUPER_DATASET_SEGMENT_INTERVAL_DAYS:1} # Unit is day
     specificGroupSettings: ${ZIPKIN_STORAGE_BANYANDB_SPECIFIC_GROUP_SETTINGS:""} # For example, {"group1": {"blockIntervalHours": 4, "segmentIntervalDays": 1}}
 
+zipkin-dependency-storage-ext: *storage
+
 receiver-zipkin-http:
   selector: ${ZIPKIN_RECEIVER_ZIPKIN_HTTP:default}
   default:
@@ -232,6 +234,9 @@ query-zipkin:
     uiDefaultLookback: ${ZIPKIN_QUERY_UI_DEFAULT_LOOKBACK:900000}
     uiEnable: ${ZIPKIN_QUERY_UI_ENABLE:true}
     uiBasePath: ${ZIPKIN_QUERY_UI_BASE_PATH:/zipkin}
+    dependencyEnabled: ${ZIPKIN_QUERY_DEPENDENCY_ENABLED:true}
+    dependencyLowErrorRate: ${ZIPKIN_QUERY_DEPENDENCY_LOW_ERROR_RATE:0.5}
+    dependencyHighErrorRate: ${ZIPKIN_QUERY_DEPENDENCY_HIGH_ERROR_RATE:0.75}
 
 query-health:
   selector: ${ZIPKIN_QUERY_HEALTH:zipkin}

--- a/zipkin-server/zipkin-dependency/pom.xml
+++ b/zipkin-server/zipkin-dependency/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>zipkin-parent</artifactId>
+    <artifactId>zipkin-server-parent</artifactId>
     <groupId>io.zipkin</groupId>
     <version>2.24.4-SNAPSHOT</version>
   </parent>

--- a/zipkin-server/zipkin-dependency/pom.xml
+++ b/zipkin-server/zipkin-dependency/pom.xml
@@ -4,28 +4,18 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>zipkin-server-parent</artifactId>
+    <artifactId>zipkin-parent</artifactId>
     <groupId>io.zipkin</groupId>
     <version>2.24.4-SNAPSHOT</version>
   </parent>
 
-  <artifactId>http-query-plugin</artifactId>
-  <name>Zipkin HTTP Query</name>
+  <artifactId>zipkin-dependency</artifactId>
+  <name>Zipkin Dependency</name>
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.skywalking</groupId>
-      <artifactId>zipkin-query-plugin</artifactId>
-      <version>${skywalking.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.zipkin</groupId>
       <artifactId>zipkin-server-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.zipkin</groupId>
-      <artifactId>zipkin-dependency</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/zipkin-server/zipkin-dependency/src/main/java/org/apache/skywalking/zipkin/dependency/entity/ZipkinDependency.java
+++ b/zipkin-server/zipkin-dependency/src/main/java/org/apache/skywalking/zipkin/dependency/entity/ZipkinDependency.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.skywalking.zipkin.dependency.entity;
+
+import org.apache.skywalking.oap.server.core.analysis.MetricsExtension;
+import org.apache.skywalking.oap.server.core.analysis.Stream;
+import org.apache.skywalking.oap.server.core.analysis.metrics.Metrics;
+import org.apache.skywalking.oap.server.core.analysis.worker.MetricsStreamProcessor;
+import org.apache.skywalking.oap.server.core.remote.grpc.proto.RemoteData;
+import org.apache.skywalking.oap.server.core.source.ScopeDeclaration;
+import org.apache.skywalking.oap.server.core.storage.StorageID;
+import org.apache.skywalking.oap.server.core.storage.annotation.BanyanDB;
+import org.apache.skywalking.oap.server.core.storage.annotation.Column;
+import org.apache.skywalking.oap.server.core.storage.type.Convert2Entity;
+import org.apache.skywalking.oap.server.core.storage.type.Convert2Storage;
+import org.apache.skywalking.oap.server.core.storage.type.StorageBuilder;
+
+import java.util.Objects;
+
+@ScopeDeclaration(id = 10001, name = "ZipkinDependency")
+@Stream(name = ZipkinDependency.INDEX_NAME, scopeId = 10001, builder = ZipkinDependency.Builder.class, processor = MetricsStreamProcessor.class)
+@MetricsExtension(supportDownSampling = false, supportUpdate = false)
+@BanyanDB.TimestampColumn(ZipkinDependency.DAY)
+public class ZipkinDependency extends Metrics {
+  public static final String INDEX_NAME = "zipkin_dependency";
+  public static final String DAY = "analyze_day";
+  public static final String PARENT = "parent";
+  public static final String CHILD = "child";
+  public static final String CALL_COUNT = "call_count";
+  public static final String ERROR_COUNT = "error_count";
+
+  @Column(name = DAY)
+  @BanyanDB.SeriesID(index = 0)
+  private long day;
+  @Column(name = PARENT)
+  @BanyanDB.SeriesID(index = 1)
+  private String parent;
+  @Column(name = CHILD)
+  @BanyanDB.SeriesID(index = 2)
+  private String child;
+  @Column(name = CALL_COUNT)
+  @BanyanDB.MeasureField
+  private long callCount;
+  @Column(name = ERROR_COUNT)
+  @BanyanDB.MeasureField
+  private long errorCount;
+
+  @Override
+  public boolean combine(Metrics metrics) {
+    return true;
+  }
+
+  @Override
+  public void calculate() {
+  }
+
+  @Override
+  public Metrics toHour() {
+    return null;
+  }
+
+  @Override
+  public Metrics toDay() {
+    return null;
+  }
+
+  @Override
+  protected StorageID id0() {
+    return new StorageID().append(DAY, day)
+        .append(PARENT, parent).append(CHILD, child);
+  }
+
+  @Override
+  public void deserialize(RemoteData remoteData) {
+  }
+
+  @Override
+  public RemoteData.Builder serialize() {
+    // only query from the storage
+    return null;
+  }
+
+  @Override
+  public int remoteHashCode() {
+    return (int) this.day;
+  }
+
+  public static class Builder implements StorageBuilder<ZipkinDependency> {
+
+    @Override
+    public ZipkinDependency storage2Entity(Convert2Entity converter) {
+      final ZipkinDependency record = new ZipkinDependency();
+      record.setDay(((Number) converter.get(DAY)).longValue());
+      record.setParent((String) converter.get(PARENT));
+      record.setChild((String) converter.get(CHILD));
+      record.setCallCount(((Number) converter.get(CALL_COUNT)).longValue());
+      record.setErrorCount(((Number) converter.get(ERROR_COUNT)).longValue());
+      return record;
+    }
+
+    @Override
+    public void entity2Storage(ZipkinDependency entity, Convert2Storage converter) {
+      converter.accept(DAY, entity.getDay());
+      converter.accept(PARENT, entity.getParent());
+      converter.accept(CHILD, entity.getChild());
+      converter.accept(CALL_COUNT, entity.getCallCount());
+      converter.accept(ERROR_COUNT, entity.getErrorCount());
+    }
+  }
+
+  public Long getDay() {
+    return day;
+  }
+
+  public void setDay(Long day) {
+    this.day = day;
+  }
+
+  public String getParent() {
+    return parent;
+  }
+
+  public void setParent(String parent) {
+    this.parent = parent;
+  }
+
+  public String getChild() {
+    return child;
+  }
+
+  public void setChild(String child) {
+    this.child = child;
+  }
+
+  public Long getCallCount() {
+    return callCount;
+  }
+
+  public void setCallCount(Long callCount) {
+    this.callCount = callCount;
+  }
+
+  public Long getErrorCount() {
+    return errorCount;
+  }
+
+  public void setErrorCount(Long errorCount) {
+    this.errorCount = errorCount;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ZipkinDependency)) return false;
+    if (!super.equals(o)) return false;
+    ZipkinDependency that = (ZipkinDependency) o;
+    return getDay() == that.getDay() && Objects.equals(getParent(), that.getParent()) && Objects.equals(getChild(), that.getChild());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), getDay(), getParent(), getChild());
+  }
+}

--- a/zipkin-server/zipkin-dependency/src/main/java/zipkin/server/dependency/IZipkinDependencyQueryDAO.java
+++ b/zipkin-server/zipkin-dependency/src/main/java/zipkin/server/dependency/IZipkinDependencyQueryDAO.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency;
+
+import org.apache.skywalking.oap.server.library.module.Service;
+import zipkin2.DependencyLink;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface IZipkinDependencyQueryDAO extends Service {
+
+  List<DependencyLink> getDependencies(long endTs, long lookback) throws IOException;
+}

--- a/zipkin-server/zipkin-dependency/src/main/java/zipkin/server/dependency/ZipkinDependencyModule.java
+++ b/zipkin-server/zipkin-dependency/src/main/java/zipkin/server/dependency/ZipkinDependencyModule.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency;
+
+import org.apache.skywalking.oap.server.library.module.ModuleDefine;
+
+public class ZipkinDependencyModule extends ModuleDefine {
+  public static final String NAME = "zipkin-dependency-storage-ext";
+
+  public ZipkinDependencyModule() {
+    super(NAME);
+  }
+
+  @Override
+  public Class[] services() {
+    return new Class[] {IZipkinDependencyQueryDAO.class};
+  }
+}

--- a/zipkin-server/zipkin-dependency/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleDefine
+++ b/zipkin-server/zipkin-dependency/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleDefine
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+zipkin.server.dependency.ZipkinDependencyModule

--- a/zipkin-server/zipkin-storage-ext/pom.xml
+++ b/zipkin-server/zipkin-storage-ext/pom.xml
@@ -3,26 +3,23 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
   <parent>
     <artifactId>zipkin-server-parent</artifactId>
     <groupId>io.zipkin</groupId>
     <version>2.24.4-SNAPSHOT</version>
   </parent>
 
-  <artifactId>http-query-plugin</artifactId>
-  <name>Zipkin HTTP Query</name>
+  <artifactId>zipkin-storage-ext</artifactId>
+  <name>Zipkin Storage Extension</name>
+
+  <modules>
+    <module>zipkin-dependency-storage-jdbc</module>
+    <module>zipkin-dependency-storage-elasticsearch</module>
+    <module>zipkin-dependency-storage-banyandb</module>
+  </modules>
 
   <dependencies>
-    <dependency>
-      <groupId>org.apache.skywalking</groupId>
-      <artifactId>zipkin-query-plugin</artifactId>
-      <version>${skywalking.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.zipkin</groupId>
-      <artifactId>zipkin-server-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
     <dependency>
       <groupId>io.zipkin</groupId>
       <artifactId>zipkin-dependency</artifactId>

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-banyandb/pom.xml
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-banyandb/pom.xml
@@ -4,29 +4,19 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>zipkin-server-parent</artifactId>
+    <artifactId>zipkin-storage-ext</artifactId>
     <groupId>io.zipkin</groupId>
     <version>2.24.4-SNAPSHOT</version>
   </parent>
 
-  <artifactId>http-query-plugin</artifactId>
-  <name>Zipkin HTTP Query</name>
+  <artifactId>zipkin-dependency-storage-banyandb</artifactId>
+  <name>Zipkin Dependency BanyanDB Extension</name>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.skywalking</groupId>
-      <artifactId>zipkin-query-plugin</artifactId>
+      <artifactId>storage-banyandb-plugin</artifactId>
       <version>${skywalking.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.zipkin</groupId>
-      <artifactId>zipkin-server-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.zipkin</groupId>
-      <artifactId>zipkin-dependency</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-banyandb/src/main/java/zipkin/server/dependency/storage/banyandb/ZipkinDependencyBanyanDBQueryDAO.java
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-banyandb/src/main/java/zipkin/server/dependency/storage/banyandb/ZipkinDependencyBanyanDBQueryDAO.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency.storage.banyandb;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.skywalking.banyandb.v1.client.MeasureQuery;
+import org.apache.skywalking.banyandb.v1.client.MeasureQueryResponse;
+import org.apache.skywalking.banyandb.v1.client.TimestampRange;
+import org.apache.skywalking.oap.server.core.query.enumeration.Step;
+import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageClient;
+import org.apache.skywalking.oap.server.storage.plugin.banyandb.MetadataRegistry;
+import org.apache.skywalking.zipkin.dependency.entity.ZipkinDependency;
+import zipkin.server.dependency.IZipkinDependencyQueryDAO;
+import zipkin2.DependencyLink;
+import zipkin2.internal.DependencyLinker;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static zipkin2.internal.DateUtil.epochDays;
+
+public class ZipkinDependencyBanyanDBQueryDAO implements IZipkinDependencyQueryDAO {
+  protected BanyanDBStorageClient client;
+  final Set<String> tags = ImmutableSet.of(ZipkinDependency.DAY, ZipkinDependency.PARENT, ZipkinDependency.CHILD);
+  final Set<String> fields = ImmutableSet.of(ZipkinDependency.CALL_COUNT, ZipkinDependency.ERROR_COUNT);
+
+  @Override
+  public List<DependencyLink> getDependencies(long endTs, long lookback) throws IOException {
+    final List<Long> days = epochDays(endTs, lookback);
+    final TimestampRange timeRange = new TimestampRange(days.get(0), days.get(days.size() - 1) + 1);
+    MetadataRegistry.Schema schema = MetadataRegistry.INSTANCE.findMetadata(ZipkinDependency.INDEX_NAME, Step.MINUTE);
+    final MeasureQuery query = new MeasureQuery(schema.getMetadata().getGroup(), schema.getMetadata().name(), timeRange, tags, fields);
+    final MeasureQueryResponse result = client.query(query);
+    return DependencyLinker.merge(result.getDataPoints().stream().map(s -> DependencyLink.newBuilder()
+        .parent(s.getTagValue(ZipkinDependency.PARENT))
+        .child(s.getTagValue(ZipkinDependency.CHILD))
+        .callCount(((Number)s.getFieldValue(ZipkinDependency.CALL_COUNT)).longValue())
+        .errorCount(s.getFieldValue(ZipkinDependency.ERROR_COUNT) != null ? ((Number)s.getFieldValue(ZipkinDependency.ERROR_COUNT)).longValue() : 0)
+        .build()).collect(Collectors.toList()));
+  }
+
+  public void setClient(BanyanDBStorageClient client) {
+    this.client = client;
+  }
+
+}

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-banyandb/src/main/java/zipkin/server/dependency/storage/banyandb/ZipkinDependencyBanyanDBStorageProvider.java
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-banyandb/src/main/java/zipkin/server/dependency/storage/banyandb/ZipkinDependencyBanyanDBStorageProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency.storage.banyandb;
+
+import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.storage.StorageModule;
+import org.apache.skywalking.oap.server.library.module.ModuleConfig;
+import org.apache.skywalking.oap.server.library.module.ModuleDefine;
+import org.apache.skywalking.oap.server.library.module.ModuleProvider;
+import org.apache.skywalking.oap.server.library.module.ModuleStartException;
+import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
+import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageClient;
+import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageConfig;
+import org.apache.skywalking.oap.server.storage.plugin.banyandb.BanyanDBStorageProvider;
+import zipkin.server.dependency.IZipkinDependencyQueryDAO;
+import zipkin.server.dependency.ZipkinDependencyModule;
+
+import java.lang.reflect.Field;
+
+public class ZipkinDependencyBanyanDBStorageProvider extends ModuleProvider {
+  private BanyanDBStorageConfig config;
+  private ZipkinDependencyBanyanDBQueryDAO queryDAO;
+
+  @Override
+  public String name() {
+    return "banyandb";
+  }
+
+  @Override
+  public Class<? extends ModuleDefine> module() {
+    return ZipkinDependencyModule.class;
+  }
+
+  @Override
+  public ConfigCreator<? extends ModuleConfig> newConfigCreator() {
+    return new ConfigCreator<BanyanDBStorageConfig>() {
+
+      @Override
+      public Class<BanyanDBStorageConfig> type() {
+        return BanyanDBStorageConfig.class;
+      }
+
+      @Override
+      public void onInitialized(BanyanDBStorageConfig initialized) {
+        config = initialized;
+      }
+    };
+  }
+
+  @Override
+  public void prepare() throws ServiceNotProvidedException, ModuleStartException {
+    this.queryDAO = new ZipkinDependencyBanyanDBQueryDAO();
+    this.registerServiceImplementation(IZipkinDependencyQueryDAO.class, this.queryDAO);
+  }
+
+  @Override
+  public void start() throws ServiceNotProvidedException, ModuleStartException {
+
+  }
+
+  @Override
+  public void notifyAfterCompleted() throws ServiceNotProvidedException, ModuleStartException {
+    BanyanDBStorageProvider provider =
+        (BanyanDBStorageProvider) getManager().find(StorageModule.NAME).provider();
+    try {
+      Field field = BanyanDBStorageProvider.class.getDeclaredField("client");
+      field.setAccessible(true);
+      BanyanDBStorageClient client = (BanyanDBStorageClient) field.get(provider);
+      queryDAO.setClient(client);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new ModuleStartException("Failed to get BanyanDBStorageClient.", e);
+    }
+  }
+
+  @Override
+  public String[] requiredModules() {
+    return new String[] {CoreModule.NAME, StorageModule.NAME};
+  }
+}

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-banyandb/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-banyandb/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+zipkin.server.dependency.storage.banyandb.ZipkinDependencyBanyanDBStorageProvider

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-elasticsearch/pom.xml
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-elasticsearch/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>zipkin-storage-ext</artifactId>
+    <groupId>io.zipkin</groupId>
+    <version>2.24.4-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>zipkin-dependency-storage-elasticsearch</artifactId>
+  <name>Zipkin Dependency Elasticsearch Extension</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.skywalking</groupId>
+      <artifactId>storage-elasticsearch-plugin</artifactId>
+      <version>${skywalking.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-elasticsearch/src/main/java/zipkin/server/dependency/storage/elasticsearch/ZipkinDependencyElasticsearchQueryDAO.java
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-elasticsearch/src/main/java/zipkin/server/dependency/storage/elasticsearch/ZipkinDependencyElasticsearchQueryDAO.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency.storage.elasticsearch;
+
+import org.apache.skywalking.library.elasticsearch.requests.search.BoolQueryBuilder;
+import org.apache.skywalking.library.elasticsearch.requests.search.Query;
+import org.apache.skywalking.library.elasticsearch.requests.search.Search;
+import org.apache.skywalking.library.elasticsearch.requests.search.SearchBuilder;
+import org.apache.skywalking.library.elasticsearch.response.search.SearchResponse;
+import org.apache.skywalking.oap.server.library.client.elasticsearch.ElasticSearchClient;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.base.IndexController;
+import org.apache.skywalking.zipkin.dependency.entity.ZipkinDependency;
+import zipkin.server.dependency.IZipkinDependencyQueryDAO;
+import zipkin2.DependencyLink;
+import zipkin2.internal.DependencyLinker;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static zipkin2.internal.DateUtil.epochDays;
+
+public class ZipkinDependencyElasticsearchQueryDAO implements IZipkinDependencyQueryDAO {
+  private ElasticSearchClient client;
+  @Override
+  public List<DependencyLink> getDependencies(long endTs, long lookback) throws IOException {
+    final List<Long> days = epochDays(endTs, lookback);
+
+    final String index =
+        IndexController.LogicIndicesRegister.getPhysicalTableName(ZipkinDependency.INDEX_NAME);
+    final BoolQueryBuilder query = Query.bool();
+    if (IndexController.LogicIndicesRegister.isMergedTable(ZipkinDependency.INDEX_NAME)) {
+      query.must(Query.term(IndexController.LogicIndicesRegister.METRIC_TABLE_NAME, ZipkinDependency.INDEX_NAME));
+    }
+    query.must(Query.terms(ZipkinDependency.DAY, days));
+    final SearchBuilder search = Search.builder().query(query)
+        .size(days.size());
+
+    final SearchResponse response = client.search(index, search.build());
+    return DependencyLinker.merge(response.getHits().getHits().stream().map(h -> DependencyLink.newBuilder()
+        .parent((String) h.getSource().get(ZipkinDependency.PARENT))
+        .child((String) h.getSource().get(ZipkinDependency.CHILD))
+        .callCount(((Number) h.getSource().get(ZipkinDependency.CALL_COUNT)).longValue())
+        .errorCount(((Number) h.getSource().get(ZipkinDependency.ERROR_COUNT)).longValue())
+        .build()).collect(Collectors.toList()));
+  }
+
+  public void setClient(ElasticSearchClient client) {
+    this.client = client;
+  }
+}

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-elasticsearch/src/main/java/zipkin/server/dependency/storage/elasticsearch/ZipkinDependencyElasticsearchStorageProvider.java
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-elasticsearch/src/main/java/zipkin/server/dependency/storage/elasticsearch/ZipkinDependencyElasticsearchStorageProvider.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server.dependency.storage.elasticsearch;
+
+import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.storage.StorageModule;
+import org.apache.skywalking.oap.server.library.module.ModuleConfig;
+import org.apache.skywalking.oap.server.library.module.ModuleDefine;
+import org.apache.skywalking.oap.server.library.module.ModuleProvider;
+import org.apache.skywalking.oap.server.library.module.ModuleStartException;
+import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.StorageModuleElasticsearchConfig;
+import org.apache.skywalking.oap.server.storage.plugin.elasticsearch.StorageModuleElasticsearchProvider;
+import zipkin.server.dependency.IZipkinDependencyQueryDAO;
+import zipkin.server.dependency.ZipkinDependencyModule;
+
+import java.lang.reflect.Field;
+
+public class ZipkinDependencyElasticsearchStorageProvider extends ModuleProvider {
+  private StorageModuleElasticsearchConfig config;
+  private ZipkinDependencyElasticsearchQueryDAO queryDAO;
+
+  @Override
+  public String name() {
+    return "elasticsearch";
+  }
+
+  @Override
+  public Class<? extends ModuleDefine> module() {
+    return ZipkinDependencyModule.class;
+  }
+
+  @Override
+  public ConfigCreator<? extends ModuleConfig> newConfigCreator() {
+    return new ConfigCreator<StorageModuleElasticsearchConfig>() {
+
+      @Override
+      public Class<StorageModuleElasticsearchConfig> type() {
+        return StorageModuleElasticsearchConfig.class;
+      }
+
+      @Override
+      public void onInitialized(StorageModuleElasticsearchConfig initialized) {
+        config = initialized;
+      }
+    };
+  }
+
+  @Override
+  public void prepare() throws ServiceNotProvidedException, ModuleStartException {
+    this.queryDAO = new ZipkinDependencyElasticsearchQueryDAO();
+    this.registerServiceImplementation(IZipkinDependencyQueryDAO.class, this.queryDAO);
+  }
+
+  @Override
+  public void start() throws ServiceNotProvidedException, ModuleStartException {
+
+  }
+
+  @Override
+  public void notifyAfterCompleted() throws ServiceNotProvidedException, ModuleStartException {
+    StorageModuleElasticsearchProvider provider = (StorageModuleElasticsearchProvider) getManager().find(StorageModule.NAME)
+        .provider();
+    queryDAO.setClient(getFieldValue(provider, StorageModuleElasticsearchProvider.class, "elasticSearchClient"));
+  }
+
+  private <T> T getFieldValue(Object from, Class fieldBelongClass, String fieldName) throws ModuleStartException {
+    try {
+      Field field = fieldBelongClass.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (T) field.get(from);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new ModuleStartException("Failed to get " + fieldName, e);
+    }
+  }
+
+  @Override
+  public String[] requiredModules() {
+    return new String[] {CoreModule.NAME, StorageModule.NAME};
+  }
+}

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-elasticsearch/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-elasticsearch/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+zipkin.server.dependency.storage.elasticsearch.ZipkinDependencyElasticsearchStorageProvider

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/pom.xml
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>zipkin-storage-ext</artifactId>
+    <groupId>io.zipkin</groupId>
+    <version>2.24.4-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>zipkin-dependency-storage-jdbc</artifactId>
+  <name>Zipkin Dependency JDBC Extension</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.skywalking</groupId>
+      <artifactId>storage-jdbc-hikaricp-plugin</artifactId>
+      <version>${skywalking.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/common/ZipkinDependencyJDBCStorageProvider.java
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/common/ZipkinDependencyJDBCStorageProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency.storage.jdbc.common;
+
+import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.storage.StorageModule;
+import org.apache.skywalking.oap.server.library.module.ModuleConfig;
+import org.apache.skywalking.oap.server.library.module.ModuleDefine;
+import org.apache.skywalking.oap.server.library.module.ModuleProvider;
+import org.apache.skywalking.oap.server.library.module.ModuleStartException;
+import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedException;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCStorageConfig;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.JDBCStorageProvider;
+import zipkin.server.dependency.IZipkinDependencyQueryDAO;
+import zipkin.server.dependency.ZipkinDependencyModule;
+import zipkin.server.dependency.storage.jdbc.common.dao.ZipkinDependencyJDBCQueryDAO;
+
+import java.lang.reflect.Field;
+
+public abstract class ZipkinDependencyJDBCStorageProvider extends ModuleProvider {
+  private JDBCStorageConfig config;
+  private ZipkinDependencyJDBCQueryDAO queryDAO;
+
+  @Override
+  public Class<? extends ModuleDefine> module() {
+    return ZipkinDependencyModule.class;
+  }
+
+  @Override
+  public ConfigCreator<? extends ModuleConfig> newConfigCreator() {
+    return new ConfigCreator<JDBCStorageConfig>() {
+      @Override
+      public Class<JDBCStorageConfig> type() {
+        return JDBCStorageConfig.class;
+      }
+
+      @Override
+      public void onInitialized(JDBCStorageConfig initialized) {
+        config = initialized;
+      }
+    };
+  }
+
+  @Override
+  public void prepare() throws ServiceNotProvidedException, ModuleStartException {
+    this.queryDAO = new ZipkinDependencyJDBCQueryDAO();
+    this.registerServiceImplementation(IZipkinDependencyQueryDAO.class, queryDAO);
+  }
+
+  @Override
+  public void start() throws ServiceNotProvidedException, ModuleStartException {
+
+  }
+
+  @Override
+  public void notifyAfterCompleted() throws ServiceNotProvidedException, ModuleStartException {
+    JDBCStorageProvider provider =
+        (JDBCStorageProvider) getManager().find(StorageModule.NAME).provider();
+    queryDAO.setClient(getFieldValue(provider, JDBCStorageProvider.class, "jdbcClient"));
+    queryDAO.setTableHelper(getFieldValue(provider, JDBCStorageProvider.class, "tableHelper"));
+  }
+
+  private <T> T getFieldValue(Object from, Class fieldBelongClass, String fieldName) throws ModuleStartException {
+    try {
+      Field field = fieldBelongClass.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (T) field.get(from);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new ModuleStartException("Failed to get " + fieldName, e);
+    }
+  }
+
+  @Override
+  public String[] requiredModules() {
+    return new String[] {CoreModule.NAME, StorageModule.NAME};
+  }
+}

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/common/dao/ZipkinDependencyJDBCQueryDAO.java
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/common/dao/ZipkinDependencyJDBCQueryDAO.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency.storage.jdbc.common.dao;
+
+import org.apache.skywalking.oap.server.core.analysis.DownSampling;
+import org.apache.skywalking.oap.server.core.analysis.TimeBucket;
+import org.apache.skywalking.oap.server.library.client.jdbc.hikaricp.JDBCClient;
+import org.apache.skywalking.oap.server.storage.plugin.jdbc.common.TableHelper;
+import org.apache.skywalking.zipkin.dependency.entity.ZipkinDependency;
+import zipkin.server.dependency.IZipkinDependencyQueryDAO;
+import zipkin2.DependencyLink;
+import zipkin2.internal.DependencyLinker;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
+import static zipkin2.internal.DateUtil.epochDays;
+
+public class ZipkinDependencyJDBCQueryDAO implements IZipkinDependencyQueryDAO {
+  private JDBCClient client;
+  private TableHelper tableHelper;
+
+  @Override
+  public List<DependencyLink> getDependencies(long endTs, long lookback) throws IOException {
+    final List<Long> days = epochDays(endTs, lookback);
+
+    final long startBucket = TimeBucket.getTimeBucket(endTs - lookback, DownSampling.Day);
+    final long endBucket = TimeBucket.getTimeBucket(endTs, DownSampling.Day);
+    final List<DependencyLink> result = new ArrayList<>();
+
+    for (String table : tableHelper.getTablesForRead(ZipkinDependency.INDEX_NAME, startBucket, endBucket)) {
+      try {
+        client.executeQuery("select * from " + table + " where " + ZipkinDependency.DAY + " in "
+                + days.stream().map(it -> "?").collect(joining(",", "(", ")")),
+            resultSet -> {
+              while (resultSet.next()) {
+                result.add(DependencyLink.newBuilder()
+                    .parent(resultSet.getString(ZipkinDependency.PARENT))
+                    .child(resultSet.getString(ZipkinDependency.CHILD))
+                    .callCount(resultSet.getLong(ZipkinDependency.CALL_COUNT))
+                    .errorCount(resultSet.getLong(ZipkinDependency.ERROR_COUNT))
+                    .build());
+              }
+              return null;
+            }, days.toArray());
+      } catch (SQLException e) {
+        throw new IOException(e);
+      }
+    }
+    return DependencyLinker.merge(result);
+  }
+
+  public void setClient(JDBCClient client) {
+    this.client = client;
+  }
+
+  public void setTableHelper(TableHelper tableHelper) {
+    this.tableHelper = tableHelper;
+  }
+}

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/h2/ZipkinDependencyH2StorageProvider.java
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/h2/ZipkinDependencyH2StorageProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency.storage.jdbc.h2;
+
+import zipkin.server.dependency.storage.jdbc.common.ZipkinDependencyJDBCStorageProvider;
+
+public class ZipkinDependencyH2StorageProvider extends ZipkinDependencyJDBCStorageProvider {
+  @Override
+  public String name() {
+    return "h2";
+  }
+}

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/mysql/ZipkinDependencyMySQLStorageProvider.java
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/mysql/ZipkinDependencyMySQLStorageProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency.storage.jdbc.mysql;
+
+import zipkin.server.dependency.storage.jdbc.common.ZipkinDependencyJDBCStorageProvider;
+
+public class ZipkinDependencyMySQLStorageProvider extends ZipkinDependencyJDBCStorageProvider {
+  @Override
+  public String name() {
+    return "mysql";
+  }
+}

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/postgres/ZipkinDependencyPostgresStorageProvider.java
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/java/zipkin/server/dependency/storage/jdbc/postgres/ZipkinDependencyPostgresStorageProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.dependency.storage.jdbc.postgres;
+
+import zipkin.server.dependency.storage.jdbc.common.ZipkinDependencyJDBCStorageProvider;
+
+public class ZipkinDependencyPostgresStorageProvider extends ZipkinDependencyJDBCStorageProvider {
+  @Override
+  public String name() {
+    return "postgresql";
+  }
+}

--- a/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
+++ b/zipkin-server/zipkin-storage-ext/zipkin-dependency-storage-jdbc/src/main/resources/META-INF/services/org.apache.skywalking.oap.server.library.module.ModuleProvider
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+zipkin.server.dependency.storage.jdbc.h2.ZipkinDependencyH2StorageProvider
+zipkin.server.dependency.storage.jdbc.mysql.ZipkinDependencyMySQLStorageProvider
+zipkin.server.dependency.storage.jdbc.postgres.ZipkinDependencyPostgresStorageProvider


### PR DESCRIPTION
This PR is aimed at adapting the Dependency Query Service within the v3 server. 
The data generated is to be utilized in the [Zipkin Dependency Repository](https://github.com/openzipkin/zipkin-dependencies) (a separate PR will be provided in that repository for the integration). Primarily, the Zipkin Server is employed for schema definition and data query services. 

Currently, as the Cassandra storage PR has not been merged, this particular PR does not encompass the implementation related to Cassandra.