### PR TITLE
Support search enable configuration

### DIFF
--- a/zipkin-server/http-query-plugin/src/main/java/zipkin/server/query/http/HTTPQueryConfig.java
+++ b/zipkin-server/http-query-plugin/src/main/java/zipkin/server/query/http/HTTPQueryConfig.java
@@ -36,7 +36,6 @@ public class HTTPQueryConfig extends ModuleConfig {
   private int uiQueryLimit = 10;
   private String uiEnvironment = "";
   private long uiDefaultLookback = 900000L;
-  private boolean uiSearchEnabled = true;
   private String allowedOrigins = "*";
 
   private boolean uiEnable = true;
@@ -46,14 +45,14 @@ public class HTTPQueryConfig extends ModuleConfig {
   private double dependencyLowErrorRate = 0.5;  // 50% of calls in error turns line yellow
   private double dependencyHighErrorRate = 0.75;// 75% of calls in error turns line red
 
-  public ZipkinQueryConfig toSkyWalkingConfig() {
+  public ZipkinQueryConfig toSkyWalkingConfig(boolean searchEnabled) {
     final ZipkinQueryConfig result = new ZipkinQueryConfig();
     result.setLookback(lookback);
     result.setNamesMaxAge(namesMaxAge);
     result.setUiQueryLimit(uiQueryLimit);
     result.setUiEnvironment(uiEnvironment);
     result.setUiDefaultLookback(uiDefaultLookback);
-    result.setUiSearchEnabled(uiSearchEnabled);
+    result.setUiSearchEnabled(searchEnabled);
     return result;
   }
 
@@ -95,14 +94,6 @@ public class HTTPQueryConfig extends ModuleConfig {
 
   public void setUiDefaultLookback(long uiDefaultLookback) {
     this.uiDefaultLookback = uiDefaultLookback;
-  }
-
-  public boolean getUiSearchEnabled() {
-    return uiSearchEnabled;
-  }
-
-  public void setUiSearchEnabled(boolean uiSearchEnabled) {
-    this.uiSearchEnabled = uiSearchEnabled;
   }
 
   public boolean getStrictTraceId() {

--- a/zipkin-server/http-query-plugin/src/main/java/zipkin/server/query/http/HTTPQueryProvider.java
+++ b/zipkin-server/http-query-plugin/src/main/java/zipkin/server/query/http/HTTPQueryProvider.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.server.file.FileService;
 import com.linecorp.armeria.server.file.HttpFile;
 import org.apache.skywalking.oap.query.zipkin.ZipkinQueryModule;
 import org.apache.skywalking.oap.server.core.CoreModule;
+import org.apache.skywalking.oap.server.core.config.ConfigService;
 import org.apache.skywalking.oap.server.core.server.HTTPHandlerRegister;
 import org.apache.skywalking.oap.server.library.module.ModuleConfig;
 import org.apache.skywalking.oap.server.library.module.ModuleDefine;
@@ -37,6 +38,7 @@ import org.apache.skywalking.oap.server.library.module.ServiceNotProvidedExcepti
 import org.apache.skywalking.oap.server.library.server.http.HTTPServer;
 import org.apache.skywalking.oap.server.library.server.http.HTTPServerConfig;
 import zipkin.server.core.services.HTTPConfigurableServer;
+import zipkin.server.core.services.ZipkinConfigService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -115,7 +117,9 @@ public class HTTPQueryProvider extends ModuleProvider {
       server.decorator(corsBuilder::build);
     };
 
-    final HTTPQueryHandler httpService = new HTTPQueryHandler(moduleConfig, getManager());
+    final ConfigService configService = getManager().find(CoreModule.NAME).provider().getService(ConfigService.class);
+    final boolean searchEnable = ((ZipkinConfigService) configService).getSearchEnable();
+    final HTTPQueryHandler httpService = new HTTPQueryHandler(searchEnable, moduleConfig, getManager());
     if (httpServer != null) {
       httpServer.addHandler(httpService, Collections.singletonList(HttpMethod.GET));
       httpServer.addHandler(corsConfiguration, Arrays.asList(HttpMethod.GET, HttpMethod.POST));

--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/CoreModuleConfig.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/CoreModuleConfig.java
@@ -102,6 +102,8 @@ public class CoreModuleConfig extends ModuleConfig {
    */
   private int remoteTimeout = 20;
 
+  private boolean searchEnable = true;
+
   private static final String DEFAULT_SEARCHABLE_TAG_KEYS = String.join(
       Const.COMMA,
       "http.method"
@@ -353,5 +355,13 @@ public class CoreModuleConfig extends ModuleConfig {
 
   public void setRestMaxRequestHeaderSize(int restMaxRequestHeaderSize) {
     this.restMaxRequestHeaderSize = restMaxRequestHeaderSize;
+  }
+
+  public boolean getSearchEnable() {
+    return searchEnable;
+  }
+
+  public void setSearchEnable(boolean searchEnable) {
+    this.searchEnable = searchEnable;
   }
 }

--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/CoreModuleProvider.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/CoreModuleProvider.java
@@ -97,17 +97,16 @@ import java.util.Collections;
 public class CoreModuleProvider extends ModuleProvider {
   private CoreModuleConfig moduleConfig;
 
-  private EndpointNameGrouping endpointNameGrouping;
-  private final ZipkinSourceReceiverImpl receiver;
-  private final ZipkinAnnotationScan annotationScan;
   private final StorageModels storageModels;
+  private final ZipkinAnnotationScan annotationScan;
+  private EndpointNameGrouping endpointNameGrouping;
+  private ZipkinSourceReceiverImpl receiver;
   private RemoteClientManager remoteClientManager;
   private GRPCServer grpcServer;
   private HTTPServer httpServer;
 
   public CoreModuleProvider() {
     this.annotationScan = new ZipkinAnnotationScan();
-    this.receiver = new ZipkinSourceReceiverImpl();
     this.storageModels = new StorageModels();
   }
 
@@ -147,8 +146,9 @@ public class CoreModuleProvider extends ModuleProvider {
     );
     this.registerServiceImplementation(NamingControl.class, namingControl);
 
+    receiver = new ZipkinSourceReceiverImpl(moduleConfig.getSearchEnable());
     annotationScan.registerListener(new DefaultScopeDefine.Listener());
-    annotationScan.registerListener(new ZipkinStreamAnnotationListener(getManager()));
+    annotationScan.registerListener(new ZipkinStreamAnnotationListener(getManager(), moduleConfig.getSearchEnable()));
 
     HTTPServerConfig httpServerConfig = HTTPServerConfig.builder()
         .host(moduleConfig.getRestHost())

--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinDispatcherManager.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinDispatcherManager.java
@@ -19,10 +19,16 @@ import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ScanResult;
 import org.apache.skywalking.oap.server.core.analysis.DispatcherManager;
 import org.apache.skywalking.oap.server.core.analysis.manual.searchtag.TagAutocompleteDispatcher;
+import org.apache.skywalking.oap.server.core.zipkin.dispatcher.ZipkinSpanRecordDispatcher;
 
 import java.io.IOException;
 
 public class ZipkinDispatcherManager extends DispatcherManager {
+  private final boolean searchEnable;
+
+  public ZipkinDispatcherManager(boolean searchEnable) {
+    this.searchEnable = searchEnable;
+  }
 
   @Override
   public void scan() throws IOException, IllegalAccessException, InstantiationException {
@@ -42,6 +48,10 @@ public class ZipkinDispatcherManager extends DispatcherManager {
   @Override
   public void addIfAsSourceDispatcher(Class aClass) throws IllegalAccessException, InstantiationException {
     if (aClass.getSimpleName().startsWith("Zipkin") || aClass.equals(TagAutocompleteDispatcher.class)) {
+      // If search is disabled, only the span can be stored.
+      if (!searchEnable && !aClass.equals(ZipkinSpanRecordDispatcher.class)) {
+        return;
+      }
       super.addIfAsSourceDispatcher(aClass);
     }
   }

--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinSourceReceiverImpl.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinSourceReceiverImpl.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 public class ZipkinSourceReceiverImpl implements SourceReceiver {
   private final ZipkinDispatcherManager mgr;
 
-  public ZipkinSourceReceiverImpl() {
-    mgr = new ZipkinDispatcherManager();
+  public ZipkinSourceReceiverImpl(boolean searchEnable) {
+    mgr = new ZipkinDispatcherManager(searchEnable);
   }
 
   @Override

--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinStreamAnnotationListener.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/ZipkinStreamAnnotationListener.java
@@ -18,18 +18,24 @@ import org.apache.skywalking.oap.server.core.analysis.StreamAnnotationListener;
 import org.apache.skywalking.oap.server.core.analysis.manual.searchtag.TagAutocompleteData;
 import org.apache.skywalking.oap.server.core.analysis.manual.spanattach.SpanAttachedEventRecord;
 import org.apache.skywalking.oap.server.core.storage.StorageException;
+import org.apache.skywalking.oap.server.core.zipkin.ZipkinSpanRecord;
 import org.apache.skywalking.oap.server.library.module.ModuleDefineHolder;
 
 public class ZipkinStreamAnnotationListener extends StreamAnnotationListener {
+  private final boolean searchEnable;
 
-  public ZipkinStreamAnnotationListener(ModuleDefineHolder moduleDefineHolder) {
+  public ZipkinStreamAnnotationListener(ModuleDefineHolder moduleDefineHolder, boolean searchEnable) {
     super(moduleDefineHolder);
+    this.searchEnable = searchEnable;
   }
 
   @Override
   public void notify(Class aClass) throws StorageException {
     // only including all zipkin streaming
     if (aClass.getSimpleName().startsWith("Zipkin") || aClass.equals(TagAutocompleteData.class) || aClass.equals(SpanAttachedEventRecord.class)) {
+      if (!searchEnable && !aClass.equals(ZipkinSpanRecord.class)) {
+        return;
+      }
       super.notify(aClass);
     }
   }

--- a/zipkin-server/server-core/src/main/java/zipkin/server/core/services/ZipkinConfigService.java
+++ b/zipkin-server/server-core/src/main/java/zipkin/server/core/services/ZipkinConfigService.java
@@ -26,6 +26,10 @@ public class ZipkinConfigService extends ConfigService {
     this.moduleConfig = moduleConfig;
   }
 
+  public boolean getSearchEnable() {
+    return moduleConfig.getSearchEnable();
+  }
+
   public ZipkinReceiverConfig toZipkinReceiverConfig() {
     final ZipkinReceiverConfig config = new ZipkinReceiverConfig();
     config.setSearchableTracesTags(moduleConfig.getSearchableTracesTags());

--- a/zipkin-server/server-starter/src/main/resources/application.yml
+++ b/zipkin-server/server-starter/src/main/resources/application.yml
@@ -55,6 +55,7 @@ core:
     restIdleTimeOut: ${ZIPKIN_REST_IDLE_TIMEOUT:30000}
     restAcceptQueueSize: ${ZIPKIN_REST_QUEUE_SIZE:0}
     restMaxRequestHeaderSize: ${ZIPKIN_REST_MAX_REQUEST_HEADER_SIZE:8192}
+    searchEnable: ${ZIPKIN_SEARCH_ENABLED:true}
 
 storage: &storage
   selector: ${ZIPKIN_STORAGE:h2}


### PR DESCRIPTION
Support to configuration spans is searchable. If it is not searchable, no table would be created except for span, and trace data can only be queried by traceId.