### PR TITLE
Enhance the query performance and storage size of the Cassandra storage in v3 server

### DIFF
--- a/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/CassandraTableExtension.java
+++ b/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/CassandraTableExtension.java
@@ -65,7 +65,7 @@ public class CassandraTableExtension {
 
   public static int durationIndexBucket(long ts_milli) {
     // if the window constant has microsecond precision, the division produces negative getValues
-    return (int) (ts_milli / (DURATION_INDEX_BUCKET_WINDOW_SECONDS));
+    return (int) (ts_milli / (DURATION_INDEX_BUCKET_WINDOW_SECONDS)) / 1000;
   }
 
   private static CQLExecutor buildServiceSpan(String service, String span, int bucket, UUID ts, String trace_id, long durationMillis,

--- a/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/BaseQueryExecutor.java
+++ b/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/BaseQueryExecutor.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.storage.cassandra.dao.executor;
+
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.skywalking.oap.server.core.zipkin.ZipkinSpanRecord;
+import org.apache.skywalking.oap.server.library.util.StringUtil;
+import zipkin.server.storage.cassandra.CassandraClient;
+import zipkin.server.storage.cassandra.CassandraTableHelper;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public abstract class BaseQueryExecutor {
+  public static final int NAME_QUERY_MAX_SIZE = Integer.MAX_VALUE;
+  private static final Gson GSON = new Gson();
+
+  private final CassandraClient client;
+
+  public BaseQueryExecutor(CassandraClient client, CassandraTableHelper tableHelper) {
+    this.client = client;
+  }
+
+  protected <T> Query<T> buildQuery(Supplier<String> cql, CassandraClient.ResultHandler<T> handler) {
+    return new Query<>(client, cql, handler);
+  }
+
+  protected <T> List<T> executeSync(Query<T> query, Object... params) {
+    return this.client.executeQuery(query.getStatement(), query.handler, params);
+  }
+
+  public <T> CompletionStage<List<T>> executeAsync(Query<T> query, Object... params) {
+    return this.client.executeAsyncQuery(query.getStatement(), query.handler, params);
+  }
+
+  public <T, S extends Statement> CompletionStage<List<T>> executeAsyncWithCustomizeStatement(Query<T> query, Function<PreparedStatement, S> statement) {
+    final PreparedStatement original = query.getStatement();
+    final Statement stmt = statement.apply(original);
+    return this.client.executeAsyncQueryWithCustomBind(original, stmt, query.handler);
+  }
+
+  protected Span buildSpan(Row row) {
+    Span.Builder span = Span.newBuilder();
+    span.traceId(row.getString(ZipkinSpanRecord.TRACE_ID));
+    span.id(row.getString(ZipkinSpanRecord.SPAN_ID));
+    span.parentId(row.getString(ZipkinSpanRecord.PARENT_ID));
+    String kind = row.getString(ZipkinSpanRecord.KIND);
+    if (!StringUtil.isEmpty(kind)) {
+      span.kind(Span.Kind.valueOf(kind));
+    }
+    span.timestamp(row.getLong(ZipkinSpanRecord.TIMESTAMP));
+    span.duration(row.getLong(ZipkinSpanRecord.DURATION));
+    span.name(row.getString(ZipkinSpanRecord.NAME));
+
+    if (row.getInt(ZipkinSpanRecord.DEBUG) > 0) {
+      span.debug(Boolean.TRUE);
+    }
+    if (row.getInt(ZipkinSpanRecord.SHARED) > 0) {
+      span.shared(Boolean.TRUE);
+    }
+    //Build localEndpoint
+    Endpoint.Builder localEndpoint = Endpoint.newBuilder();
+    localEndpoint.serviceName(row.getString(ZipkinSpanRecord.LOCAL_ENDPOINT_SERVICE_NAME));
+    if (!StringUtil.isEmpty(row.getString(ZipkinSpanRecord.LOCAL_ENDPOINT_IPV4))) {
+      localEndpoint.parseIp(row.getString(ZipkinSpanRecord.LOCAL_ENDPOINT_IPV4));
+    } else {
+      localEndpoint.parseIp(row.getString(ZipkinSpanRecord.LOCAL_ENDPOINT_IPV6));
+    }
+    localEndpoint.port(row.getInt(ZipkinSpanRecord.LOCAL_ENDPOINT_PORT));
+    span.localEndpoint(localEndpoint.build());
+    //Build remoteEndpoint
+    Endpoint.Builder remoteEndpoint = Endpoint.newBuilder();
+    remoteEndpoint.serviceName(row.getString(ZipkinSpanRecord.REMOTE_ENDPOINT_SERVICE_NAME));
+    if (!StringUtil.isEmpty(row.getString(ZipkinSpanRecord.REMOTE_ENDPOINT_IPV4))) {
+      remoteEndpoint.parseIp(row.getString(ZipkinSpanRecord.REMOTE_ENDPOINT_IPV4));
+    } else {
+      remoteEndpoint.parseIp(row.getString(ZipkinSpanRecord.REMOTE_ENDPOINT_IPV6));
+    }
+    remoteEndpoint.port(row.getInt(ZipkinSpanRecord.REMOTE_ENDPOINT_PORT));
+    span.remoteEndpoint(remoteEndpoint.build());
+
+    //Build tags
+    String tagsString = row.getString(ZipkinSpanRecord.TAGS);
+    if (!StringUtil.isEmpty(tagsString)) {
+      JsonObject tagsJson = GSON.fromJson(tagsString, JsonObject.class);
+      for (Map.Entry<String, JsonElement> tag : tagsJson.entrySet()) {
+        span.putTag(tag.getKey(), tag.getValue().getAsString());
+      }
+    }
+    //Build annotation
+    String annotationString = row.getString(ZipkinSpanRecord.ANNOTATIONS);
+    if (!StringUtil.isEmpty(annotationString)) {
+      JsonObject annotationJson = GSON.fromJson(annotationString, JsonObject.class);
+      for (Map.Entry<String, JsonElement> annotation : annotationJson.entrySet()) {
+        span.addAnnotation(Long.parseLong(annotation.getKey()), annotation.getValue().getAsString());
+      }
+    }
+    return span.build();
+  }
+
+
+  protected class Query<T> {
+    private final Supplier<PreparedStatement> statementSupplier;
+    private volatile PreparedStatement statement;
+    private final CassandraClient.ResultHandler<T> handler;
+
+    public Query(CassandraClient client, Supplier<String> query, CassandraClient.ResultHandler<T> handler) {
+      this.statementSupplier = () -> client.prepare(query.get());
+      this.handler = handler;
+    }
+
+    public PreparedStatement getStatement() {
+      if (statement == null) {
+        synchronized (this) {
+          if (statement == null) {
+            statement = statementSupplier.get();
+          }
+        }
+      }
+      return statement;
+    }
+  }
+
+}

--- a/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/MultipleTraceQueryExecutor.java
+++ b/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/MultipleTraceQueryExecutor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.storage.cassandra.dao.executor;
+
+import org.apache.skywalking.oap.server.core.zipkin.ZipkinSpanRecord;
+import zipkin.server.storage.cassandra.CassandraClient;
+import zipkin.server.storage.cassandra.CassandraTableHelper;
+import zipkin2.Span;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import static java.util.stream.Collectors.toList;
+
+public class MultipleTraceQueryExecutor extends BaseQueryExecutor {
+  private final Query<Span> query;
+  public MultipleTraceQueryExecutor(CassandraClient client, CassandraTableHelper tableHelper) {
+    super(client, tableHelper);
+    this.query = buildQuery(
+        () -> "select * from " + tableHelper.getTableForRead(ZipkinSpanRecord.INDEX_NAME) + " where " + ZipkinSpanRecord.TRACE_ID + " = ?",
+        this::buildSpan
+    );
+  }
+
+  public List<List<Span>> get(Set<String> traceIds) {
+    return traceIds.stream().map(s -> executeAsync(query, s))
+        .map(CompletionStage::toCompletableFuture).map(CompletableFuture::join).collect(toList());
+  }
+}

--- a/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/RemoteServiceNameQueryExecutor.java
+++ b/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/RemoteServiceNameQueryExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.storage.cassandra.dao.executor;
+
+import org.apache.skywalking.oap.server.core.zipkin.ZipkinServiceRelationTraffic;
+import zipkin.server.storage.cassandra.CassandraClient;
+import zipkin.server.storage.cassandra.CassandraTableHelper;
+
+import java.util.List;
+
+public class RemoteServiceNameQueryExecutor extends BaseQueryExecutor {
+  private final Query<String> query;
+
+  public RemoteServiceNameQueryExecutor(CassandraClient client, CassandraTableHelper tableHelper) {
+    super(client, tableHelper);
+    this.query = buildQuery(
+        () -> "select " + ZipkinServiceRelationTraffic.REMOTE_SERVICE_NAME +
+            " from " + tableHelper.getTableForRead(ZipkinServiceRelationTraffic.INDEX_NAME) +
+            " where " + ZipkinServiceRelationTraffic.SERVICE_NAME + " = ?" +
+            " limit " + NAME_QUERY_MAX_SIZE,
+        row -> row.getString(ZipkinServiceRelationTraffic.REMOTE_SERVICE_NAME)
+    );
+  }
+
+  public List<String> get(String serviceName) {
+    return executeSync(query, serviceName);
+  }
+}

--- a/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/ServiceNameQueryExecutor.java
+++ b/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/ServiceNameQueryExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.storage.cassandra.dao.executor;
+
+import org.apache.skywalking.oap.server.core.zipkin.ZipkinServiceTraffic;
+import zipkin.server.storage.cassandra.CassandraClient;
+import zipkin.server.storage.cassandra.CassandraTableHelper;
+
+import java.util.List;
+
+public class ServiceNameQueryExecutor extends BaseQueryExecutor {
+  private final Query<String> query;
+
+  public ServiceNameQueryExecutor(CassandraClient client, CassandraTableHelper tableHelper) {
+    super(client, tableHelper);
+    query = buildQuery(
+        () -> "select " + ZipkinServiceTraffic.SERVICE_NAME + " from " +
+            tableHelper.getTableForRead(ZipkinServiceTraffic.INDEX_NAME) + " limit " + NAME_QUERY_MAX_SIZE,
+        resultSet -> resultSet.getString(ZipkinServiceTraffic.SERVICE_NAME)
+    );
+  }
+
+  public List<String> get() {
+    return executeSync(query);
+  }
+}

--- a/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/SingleTraceQueryExecutor.java
+++ b/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/SingleTraceQueryExecutor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.storage.cassandra.dao.executor;
+
+import org.apache.skywalking.oap.server.core.zipkin.ZipkinSpanRecord;
+import zipkin.server.storage.cassandra.CassandraClient;
+import zipkin.server.storage.cassandra.CassandraTableHelper;
+import zipkin2.Span;
+
+import java.util.List;
+
+public class SingleTraceQueryExecutor extends BaseQueryExecutor {
+  private final Query<Span> query;
+  public SingleTraceQueryExecutor(CassandraClient client, CassandraTableHelper tableHelper) {
+    super(client, tableHelper);
+    this.query = buildQuery(
+        () -> "select * from " + tableHelper.getTableForRead(ZipkinSpanRecord.INDEX_NAME) +
+            " where " + ZipkinSpanRecord.TRACE_ID + " = ?" +
+            " limit " + NAME_QUERY_MAX_SIZE,
+        this::buildSpan
+    );
+  }
+
+  public List<Span> get(String traceId) {
+    return executeSync(query, traceId);
+  }
+}

--- a/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/SpanNameQueryExecutor.java
+++ b/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/SpanNameQueryExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.storage.cassandra.dao.executor;
+
+import org.apache.skywalking.oap.server.core.zipkin.ZipkinServiceSpanTraffic;
+import zipkin.server.storage.cassandra.CassandraClient;
+import zipkin.server.storage.cassandra.CassandraTableHelper;
+
+import java.util.List;
+
+public class SpanNameQueryExecutor extends BaseQueryExecutor {
+  private final Query<String> query;
+
+  public SpanNameQueryExecutor(CassandraClient client, CassandraTableHelper tableHelper) {
+    super(client, tableHelper);
+    this.query = buildQuery(
+        () -> "select " + ZipkinServiceSpanTraffic.SPAN_NAME +
+            " from " + tableHelper.getTableForRead(ZipkinServiceSpanTraffic.INDEX_NAME) +
+            " where " + ZipkinServiceSpanTraffic.SERVICE_NAME + " = ?" +
+            " limit " + NAME_QUERY_MAX_SIZE,
+        row -> row.getString(ZipkinServiceSpanTraffic.SPAN_NAME)
+    );
+  }
+
+  public List<String> get(String serviceName) {
+    return executeSync(query, serviceName);
+  }
+}

--- a/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/TraceIDByAnnotationQueryExecutor.java
+++ b/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/TraceIDByAnnotationQueryExecutor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.storage.cassandra.dao.executor;
+
+import org.apache.skywalking.oap.server.core.zipkin.ZipkinSpanRecord;
+import zipkin.server.storage.cassandra.CassandraClient;
+import zipkin.server.storage.cassandra.CassandraTableHelper;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+public class TraceIDByAnnotationQueryExecutor extends BaseQueryExecutor {
+  private final Query<String> query;
+  public TraceIDByAnnotationQueryExecutor(CassandraClient client, CassandraTableHelper tableHelper) {
+    super(client, tableHelper);
+    this.query = buildQuery(
+        () -> "select " + ZipkinSpanRecord.TRACE_ID +
+            " from " + ZipkinSpanRecord.ADDITIONAL_QUERY_TABLE +
+            " where " + ZipkinSpanRecord.QUERY + " = ?" +
+            " and " + ZipkinSpanRecord.TIME_BUCKET + " >= ?" +
+            " and " + ZipkinSpanRecord.TIME_BUCKET + " <= ?",
+        row -> row.getString(ZipkinSpanRecord.TRACE_ID)
+    );
+  }
+
+  public CompletionStage<List<String>> asyncGet(String query, long startTimeBucket, long endTimeBucket) {
+    return executeAsync(this.query, query, startTimeBucket, endTimeBucket);
+  }
+}

--- a/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/TraceIDByServiceQueryExecutor.java
+++ b/zipkin-server/storage-cassandra/src/main/java/zipkin/server/storage/cassandra/dao/executor/TraceIDByServiceQueryExecutor.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.server.storage.cassandra.dao.executor;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import zipkin.server.storage.cassandra.CassandraClient;
+import zipkin.server.storage.cassandra.CassandraTableHelper;
+import zipkin.server.storage.cassandra.dao.CassandraTableExtension;
+
+import javax.annotation.CheckReturnValue;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+
+public class TraceIDByServiceQueryExecutor extends BaseQueryExecutor {
+  private final Query<String> queryWithRemoteService;
+  private final Query<String> queryWithSpan;
+  private final Query<String> queryWithSpanAndDuration;
+
+  public TraceIDByServiceQueryExecutor(CassandraClient client, CassandraTableHelper tableHelper) {
+    super(client, tableHelper);
+    String baseCql = "select trace_id from " + CassandraTableExtension.TABLE_TRACE_BY_SERVICE_SPAN
+        + " where service=? and span=? and bucket=? and ts>=? and ts<=? ";
+    this.queryWithRemoteService = buildQuery(
+        () -> "select trace_id from " + CassandraTableExtension.TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE
+            + " where service=? and remote_service=? and bucket=? and ts>=? and ts<=?",
+        row -> row.getString(0)
+    );
+    this.queryWithSpan = buildQuery(
+        () -> baseCql + " limit ?",
+        row -> row.getString(0)
+    );
+    this.queryWithSpanAndDuration = buildQuery(
+        () -> baseCql + " and duration>=? and duration<=? limit ?",
+        row -> row.getString(0)
+    );
+  }
+
+  public CompletionStage<List<String>> asyncWithRemoteService(
+      String serviceName, String remoteService, int bucket, UUID tsStart, UUID tsEnd) {
+    return executeAsync(queryWithRemoteService, serviceName, remoteService, bucket, tsStart, tsEnd);
+  }
+
+  public CompletionStage<List<String>> asyncWithSpan(
+      String serviceName, String spanName, int bucket, UUID tsStart, UUID tsEnd, int limit) {
+    return asyncSpan0(queryWithSpan, serviceName, spanName, bucket, tsStart, tsEnd, null, null, limit);
+  }
+
+  public CompletionStage<List<String>> asyncWithSpanAndDuration(
+      String serviceName, String spanName, int bucket, UUID tsStart, UUID tsEnd, long durationStart, long durationEnd, int limit) {
+    return asyncSpan0(queryWithSpanAndDuration, serviceName, spanName, bucket, tsStart, tsEnd, durationStart, durationEnd, limit);
+  }
+
+  @SuppressWarnings("CheckReturnValue")
+  private CompletionStage<List<String>> asyncSpan0(
+      Query<String> query, String serviceName, String spanName, int bucket, UUID tsStart, UUID tsEnd, Long durationStart, Long durationEnd, int limit) {
+    return this.executeAsyncWithCustomizeStatement(query, stmt -> {
+      int i = 0;
+      final BoundStatementBuilder bound = stmt.boundStatementBuilder()
+          .setString(i++, serviceName)
+          .setString(i++, spanName)
+          .setInt(i++, bucket)
+          .setUuid(i++, tsStart)
+          .setUuid(i++, tsEnd);
+
+      if (durationStart != null) {
+        bound.setLong(i++, durationStart)
+            .setLong(i++, durationEnd);
+      }
+
+      bound.setInt(i, limit)
+          .setPageSize(limit);
+
+      return bound.build();
+    });
+  }
+
+}

--- a/zipkin-server/storage-cassandra/src/main/resources/zipkin-schemas.cql
+++ b/zipkin-server/storage-cassandra/src/main/resources/zipkin-schemas.cql
@@ -3,15 +3,12 @@ CREATE KEYSPACE IF NOT EXISTS zipkin2
   AND durable_writes = false;
 
 CREATE TABLE IF NOT EXISTS zipkin_span (
-  id text,
-  table_name text,
   trace_id text,
   span_id text,
   parent_id text,
   name text,
   duration BIGINT,
   kind text,
-  timestamp_millis BIGINT,
   TIMESTAMP BIGINT,
   local_endpoint_service_name text,
   local_endpoint_ipv4 text,
@@ -25,7 +22,6 @@ CREATE TABLE IF NOT EXISTS zipkin_span (
   tags text,
   debug INT,
   shared INT,
-  time_bucket BIGINT,
   uuid_unique text,
   PRIMARY KEY(trace_id, uuid_unique)
 )
@@ -88,7 +84,6 @@ CREATE TABLE IF NOT EXISTS zipkin_service_traffic (
   AND comment = 'Secondary table for looking up all services';
 
 CREATE TABLE IF NOT EXISTS zipkin_query (
-  id text,
   trace_id text,
   query text,
   time_bucket BIGINT,


### PR DESCRIPTION
1. Improve collect throughput: Change the synchronous writing of batch data synchronization to asynchronous writing.
2. Reducing Unnecessary Fields: Reduce unnecessary field storage to reduce storage space usage.
3. Query Optimization: Split the original query method into multiple files, so that each query can be optimized better.