### PR TITLE
ci: sets supported JDK range explicitly to 11,15

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -11,17 +11,22 @@ on:
 
 jobs:
   create_release:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Prevent use of implicit GitHub Actions read-only token GITHUB_TOKEN. We don't deploy on
           # the tag MAJOR.MINOR.PATCH event, but we still need to deploy the maven-release-plugin master commit.
           token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 1  # only need the HEAD commit as license check isn't run
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'  # zulu as it supports a wide version range
+          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,23 +14,28 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Prevent use of implicit GitHub Actions read-only token GITHUB_TOKEN.
           # We push Javadocs to the gh-pages branch on commit.
           token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0  # allow build-bin/idl_to_gh_pages to get the full history
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'  # zulu as it supports a wide version range
+          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Cache NPM Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-packages-${{ hashFiles('zipkin-lens/package-lock.json') }}

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -11,10 +11,10 @@ on:
 
 jobs:
   docker_push:
-    runs-on: ubuntu-20.04  # newest available distribution, aka focal
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1  # only needed to get the sha label
       # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker

--- a/.github/workflows/helm_release.yml
+++ b/.github/workflows/helm_release.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Configure Git
         run: |
@@ -34,7 +34,7 @@ jobs:
           git remote set-url origin https://github.com/$GITHUB_REPOSITORY.git
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: charts
         env:

--- a/.github/workflows/helm_test.yml
+++ b/.github/workflows/helm_test.yml
@@ -12,10 +12,10 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Configure Git
         run: |
@@ -23,16 +23,16 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.7.2
+          version: v3.11.1
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.10
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -46,7 +46,7 @@ jobs:
         run: ct lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.8.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/readme_test.yml
+++ b/.github/workflows/readme_test.yml
@@ -27,22 +27,21 @@ jobs:
             os: windows-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      # Setup latest JDK. We do this to ensure users don't need to use the same version as our
-      # release process. Release uses JDK 11, the last version that can target 1.6 bytecode.
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 15
+          distribution: 'zulu'  # zulu as it supports a wide version range
+          java-version: '15'  # highest value allowed by maven-enforcer-plugin
       - name: Cache NPM Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-packages-${{ hashFiles('zipkin-lens/package-lock.json') }}
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -51,10 +50,10 @@ jobs:
         run: ./mvnw -T1C -q --batch-mode -DskipTests --also-make -pl zipkin-server clean package
 
   docker:
-    runs-on: ubuntu-20.04 # newest available distribution, aka focal
+    runs-on: ubuntu-22.04 # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       # Remove apt repos that are known to break from time to time.
@@ -62,21 +61,20 @@ jobs:
       - name: Remove broken apt repos
         run: |
           for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
-      # Setup latest JDK. We do this to ensure users don't need to use the same version as our
-      # release process. Release uses JDK 11, the last version that can target 1.6 bytecode.
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 15
+          distribution: 'zulu'  # zulu as it supports a wide version range
+          java-version: '15'  # most recent LTS we support
       # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
       # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
       - name: Cache NPM Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-packages-${{ hashFiles('zipkin-lens/package-lock.json') }}
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,28 +20,33 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04 # newest available distribution, aka focal
+    runs-on: ubuntu-22.04 # newest available distribution, aka jellyfish
     if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full git history for license check
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'  # zulu as it supports a wide version range
+          java-version: '15'  # highest value allowed by maven-enforcer-plugin
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Cache NPM Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-packages-${{ hashFiles('zipkin-lens/package-lock.json') }}
       - name: Test without Docker
         run: build-bin/maven_go_offline && build-bin/test -Ddocker.skip=true
   test_docker:
-    runs-on: ubuntu-20.04 # newest available distribution, aka focal
+    runs-on: ubuntu-22.04 # newest available distribution, aka jellyfish
     if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
     strategy:
       matrix:
@@ -53,11 +58,16 @@ jobs:
           - name: zipkin-storage-mysql-v1
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1 # -Dlicense.skip=true so we don't need a full clone
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'  # zulu as it supports a wide version range
+          java-version: '15'  # highest value allowed by maven-enforcer-plugin
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,11 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,16)</version>
+                  <!-- Change this to control LTS JDK versions allowed to build
+                       the project. Keep in sync with .github/workflows -->
+                  <!-- TODO: JDK 15 isn't LTS, so we want at least JDK 17.
+                       However, `./mvnw clean package -pl :zipkin` fails -->
+                  <version>[11,16)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealth.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealth.java
@@ -73,7 +73,10 @@ public class ITZipkinHealth {
 
     // ensure we don't track health in prometheus
     assertThat(scrape())
-      .doesNotContain("health");
+      // "application_ready_time_seconds" includes this test's full class name
+      // which includes its package (named health). We care about the endpoint
+      // /health not being in the results, so check for that here.
+      .doesNotContain("/health");
   }
 
   String scrape() throws InterruptedException {


### PR DESCRIPTION
Before, we were using an implicit version of the JDK when releasing, had
the pom.xml limited to a non-LTS version (15).

This sets the same up explicitly in CI, and corrects CI to use latest
action versions and ubuntu. A later change should update the ceiling
build version to an LTS, at least 17 if not 21. Currently, we can't as
there is a compilation failure. I'll look into it personally in the next
PR.