### PR TITLE
lens: updates maven config

### DIFF
--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -34,11 +34,11 @@
     <!-- Update occasionally based on LTS, but don't overrun what's in Alpine:
          https://nodejs.org/en/download/
          https://pkgs.alpinelinux.org/packages?name=nodejs&branch=edge -->
-    <node.version>14.15.3</node.version>
-    <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-    <frontend-maven-plugin.version>1.11.0</frontend-maven-plugin.version>
-    <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+    <node.version>14.21.3</node.version>
+    <exec-maven-plugin.version>3.1.1</exec-maven-plugin.version>
+    <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
+    <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
updates to latest node 14 and infra around it. To update to recent LTS requires more work I think @tacigar is on.