### PR TITLE
cassandra: updates client driver and test binary

### DIFF
--- a/docker/test-images/zipkin-cassandra/Dockerfile
+++ b/docker/test-images/zipkin-cassandra/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2021 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,6 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-# Note: Cassandra does not support Java 17 yet so use older JRE for testing
 ARG java_version=17.0.8_p7
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
@@ -35,7 +34,7 @@ FROM ghcr.io/openzipkin/java:${java_version} as install
 # Use latest stable version: https://cassandra.apache.org/download/
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG cassandra_version=4.0.9
+ARG cassandra_version=4.0.11
 ENV CASSANDRA_VERSION=$cassandra_version
 WORKDIR /install
 
@@ -45,7 +44,7 @@ RUN /tmp/install.sh && rm /tmp/install.sh
 
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-cassandra
 LABEL org.opencontainers.image.description="Cassandra on OpenJDK and Alpine Linux with Zipkin keyspaces pre-installed"
-ARG cassandra_version=4.0.7
+ARG cassandra_version=4.0.11
 LABEL cassandra-version=$cassandra_version
 ENV CASSANDRA_VERSION=$cassandra_version
 

--- a/docker/test-images/zipkin-cassandra/README.md
+++ b/docker/test-images/zipkin-cassandra/README.md
@@ -1,6 +1,6 @@
 ## zipkin-cassandra Docker image
 
-The `zipkin-cassandra` testing image runs Cassandra 3.11.x initialized with Zipkin's schema for
+The `zipkin-cassandra` testing image runs Cassandra 4.x initialized with Zipkin's schema for
 [Cassandra storage](../../../zipkin-storage/cassandra) integration.
 
 Besides norms defined in [docker-java](https://github.com/openzipkin/docker-java), this accepts the

--- a/docker/test-images/zipkin-cassandra/start-cassandra
+++ b/docker/test-images/zipkin-cassandra/start-cassandra
@@ -41,10 +41,16 @@ export HEALTHCHECK_PORT=9042
 export HEALTHCHECK_KIND=tcp
 
 echo Starting Cassandra
-# -cp 'classes:lib/*' allows layers to patch the image without packaging or overwriting jars
+# -cp 'classes:lib/*' allows layers to patch the image without packaging or
+# overwriting jars.
 #
-# We also add exports and opens from Cassandra 4, except RMI, which isn't in our JRE image.
-# See https://github.com/apache/cassandra/blob/cassandra-4.0.11/conf/jvm11-server.options
+# We also add exports and opens from both Cassandra v4 and v5, except for
+# attach, compiler and rmi because our JRE excludes these modules.
+#
+# Merging makes adding Cassandra v5 easier and lets us share a common JRE 17+
+# with other test images even if Cassandra v4 will never officially support it.
+# https://github.com/apache/cassandra/blob/cassandra-4.0.11/conf/jvm11-server.options
+# https://github.com/apache/cassandra/blob/cassandra-5.0/conf/jvm17-server.options
 exec java -cp 'classes:lib/*' ${JAVA_OPTS} \
   -Xbootclasspath/a:${JAMM_JAR} -javaagent:${JAMM_JAR} \
   -Djdk.attach.allowAttachSelf=true \
@@ -52,7 +58,8 @@ exec java -cp 'classes:lib/*' ${JAVA_OPTS} \
   --add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
   --add-exports java.base/sun.nio.ch=ALL-UNNAMED \
   --add-exports java.sql/java.sql=ALL-UNNAMED \
-  --add-opens java.base/java.lang=ALL-UNNAMED \
+  --add-exports java.base/java.lang.ref=ALL-UNNAMED \
+  --add-exports jdk.unsupported/sun.misc=ALL-UNNAMED \
   --add-opens java.base/java.lang.module=ALL-UNNAMED \
   --add-opens java.base/jdk.internal.loader=ALL-UNNAMED \
   --add-opens java.base/jdk.internal.ref=ALL-UNNAMED \
@@ -64,7 +71,11 @@ exec java -cp 'classes:lib/*' ${JAVA_OPTS} \
   --add-opens java.base/java.io=ALL-UNNAMED \
   --add-opens java.base/java.nio=ALL-UNNAMED \
   --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens java.base/java.io=ALL-UNNAMED \
+  --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
   --add-opens java.base/java.util=ALL-UNNAMED \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
   --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
   --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
   -Djava.io.tmpdir=/tmp \

--- a/docker/test-images/zipkin-cassandra/start-cassandra
+++ b/docker/test-images/zipkin-cassandra/start-cassandra
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -40,10 +40,19 @@ export HEALTHCHECK_IP=${IP}
 export HEALTHCHECK_PORT=9042
 export HEALTHCHECK_KIND=tcp
 
-jdk11_modules="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+echo Starting Cassandra
+# -cp 'classes:lib/*' allows layers to patch the image without packaging or overwriting jars
+#
+# We also add exports and opens from Cassandra 4, except RMI, which isn't in our JRE image.
+# See https://github.com/apache/cassandra/blob/cassandra-4.0.11/conf/jvm11-server.options
+exec java -cp 'classes:lib/*' ${JAVA_OPTS} \
+  -Xbootclasspath/a:${JAMM_JAR} -javaagent:${JAMM_JAR} \
+  -Djdk.attach.allowAttachSelf=true \
+  --add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
   --add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
   --add-exports java.base/sun.nio.ch=ALL-UNNAMED \
   --add-exports java.sql/java.sql=ALL-UNNAMED \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
   --add-opens java.base/java.lang.module=ALL-UNNAMED \
   --add-opens java.base/jdk.internal.loader=ALL-UNNAMED \
   --add-opens java.base/jdk.internal.ref=ALL-UNNAMED \
@@ -51,25 +60,13 @@ jdk11_modules="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
   --add-opens java.base/jdk.internal.math=ALL-UNNAMED \
   --add-opens java.base/jdk.internal.module=ALL-UNNAMED \
   --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED \
-  --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
-
-jdk17_modules="--add-opens java.base/java.io=ALL-UNNAMED \
+  --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+  --add-opens java.base/java.io=ALL-UNNAMED \
   --add-opens java.base/java.nio=ALL-UNNAMED \
   --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
   --add-opens java.base/java.util=ALL-UNNAMED \
   --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
-  --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED"
-
-echo Starting Cassandra
-# -cp 'classes:lib/*' allows layers to patch the image without packaging or overwriting jars
-#
-# We also add exports and opens from Cassandra 4, except RMI, which isn't in our JRE image.
-# See https://github.com/apache/cassandra/blob/cassandra-4.0-beta3/conf/jvm11-server.options
-exec java -cp 'classes:lib/*' ${JAVA_OPTS} \
-  -Xbootclasspath/a:${JAMM_JAR} -javaagent:${JAMM_JAR} \
-  -Djdk.attach.allowAttachSelf=true \
-  ${jdk11_modules} \
-  ${jdk17_modules} \
+  --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
   -Djava.io.tmpdir=/tmp \
   -Dcassandra-foreground=yes \
   -Dcassandra.storagedir=${PWD} \

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
     <jackson.version>2.15.0</jackson.version>
 
-    <java-driver.version>4.11.3</java-driver.version>
+    <java-driver.version>4.17.0</java-driver.version>
     <micrometer.version>1.9.3</micrometer.version>
 
     <snappy.version>1.1.10.3</snappy.version>

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,8 +15,8 @@ package zipkin2.storage.cassandra;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
+import com.datastax.oss.driver.api.core.auth.ProgrammaticPlainTextAuthProvider;
 import com.datastax.oss.driver.api.core.config.DriverOption;
-import com.datastax.oss.driver.internal.core.auth.ProgrammaticPlainTextAuthProvider;
 import java.util.Map;
 import java.util.Set;
 import zipkin2.Call;

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,8 +15,8 @@ package zipkin2.storage.cassandra;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.auth.Authenticator;
+import com.datastax.oss.driver.api.core.auth.ProgrammaticPlainTextAuthProvider;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
-import com.datastax.oss.driver.internal.core.auth.ProgrammaticPlainTextAuthProvider;
 import java.nio.ByteBuffer;
 import org.junit.Test;
 import zipkin2.CheckResult;


### PR DESCRIPTION
This updates to the latest Datastax driver and updates our test image to latest cassandra 4.x version. This also cleans up where our test image had leftovers from previous versions of cassandra and JREs.

I'm intentionally not updating the jre to a newer version, yet, because we should make sure things work on 17.