### PR TITLE
Moves build and docker images to latest Java 21

### DIFF
--- a/.github/workflows/readme_test.yml
+++ b/.github/workflows/readme_test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '17'  # Most recent LTS (TODO: change to 21 including docker images as a separate step)
+          java-version: '21'  # Most recent LTS
       - name: Cache NPM Packages
         uses: actions/cache@v3
         with:
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '17'  # Most recent LTS (TODO: change to 21 including docker images as a separate step)
+          java-version: '21'  # Most recent LTS
       # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
       # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
       - name: Cache NPM Packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         include:
           - java_version: 11  # Last that can compile zipkin core to 1.6 for zipkin-reporter
             maven_args: -Prelease -Dgpg.skip
-          - java_version: 17  # Most recent LTS (TODO: change to 21 including docker images as a separate step)
+          - java_version: 21  # Most recent LTS
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '17'  # Most recent LTS (TODO: change to 21 including docker images as a separate step)
+          java-version: '21'  # Most recent LTS
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -282,7 +282,7 @@ class ServerIntegratedBenchmark {
 
     final GenericContainer<?> zipkin;
     if (RELEASE_VERSION == null) {
-      zipkin = new GenericContainer<>(parse("ghcr.io/openzipkin/java:17.0.9_p8"));
+      zipkin = new GenericContainer<>(parse("ghcr.io/openzipkin/java:21.0.1_p12"));
       List<String> classpath = new ArrayList<>();
       for (String item : System.getProperty("java.class.path").split(File.pathSeparator)) {
         Path path = Paths.get(item);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.9_p8
+ARG java_version=21.0.1_p12
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-cassandra/Dockerfile
+++ b/docker/test-images/zipkin-cassandra/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.9_p8
+ARG java_version=21.0.1_p12
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-cassandra/install.sh
+++ b/docker/test-images/zipkin-cassandra/install.sh
@@ -127,7 +127,11 @@ sed -i '/read_repair_chance/d' schema
 # with other test images even if Cassandra v4 will never officially support it.
 # https://github.com/apache/cassandra/blob/cassandra-4.0.11/conf/jvm11-server.options
 # https://github.com/apache/cassandra/blob/cassandra-5.0/conf/jvm17-server.options
+#
+# Finally, we allow security manager to prevent JRE 21 crashing when Cassandra
+# attempts ThreadAwareSecurityManager.install()
 java -cp 'classes:lib/*' -Xms64m -Xmx64m -XX:+ExitOnOutOfMemoryError -verbose:gc \
+  -Djava.security.manager=allow \
   -Djdk.attach.allowAttachSelf=true \
   --add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
   --add-exports java.base/jdk.internal.ref=ALL-UNNAMED \

--- a/docker/test-images/zipkin-cassandra/start-cassandra
+++ b/docker/test-images/zipkin-cassandra/start-cassandra
@@ -51,7 +51,11 @@ echo Starting Cassandra
 # with other test images even if Cassandra v4 will never officially support it.
 # https://github.com/apache/cassandra/blob/cassandra-4.0.11/conf/jvm11-server.options
 # https://github.com/apache/cassandra/blob/cassandra-5.0/conf/jvm17-server.options
+#
+# Finally, we allow security manager to prevent JRE 21 crashing when Cassandra
+# attempts ThreadAwareSecurityManager.install()
 exec java -cp 'classes:lib/*' ${JAVA_OPTS} \
+  -Djava.security.manager=allow \
   -Xbootclasspath/a:${JAMM_JAR} -javaagent:${JAMM_JAR} \
   -Djdk.attach.allowAttachSelf=true \
   --add-exports java.base/jdk.internal.misc=ALL-UNNAMED \

--- a/docker/test-images/zipkin-elasticsearch6/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch6/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.9_p8
+ARG java_version=21.0.1_p12
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-elasticsearch7/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch7/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.9_p8
+ARG java_version=21.0.1_p12
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-elasticsearch7/start-elasticsearch
+++ b/docker/test-images/zipkin-elasticsearch7/start-elasticsearch
@@ -33,7 +33,9 @@ export HEALTHCHECK_PORT=9200
 export HEALTHCHECK_PATH=/_cluster/health
 
 # -cp 'classes:lib/*' allows layers to patch the image without packaging or overwriting jars
+# We allow security manager (via flag to prevent JRE 21 crash) as Elasticsearch.main needs it.
 exec java -cp 'classes:lib/*' ${JAVA_OPTS} \
+  -Djava.security.manager=allow \
   -Djava.io.tmpdir=/tmp \
   -Dlog4j2.disable.jmx=true \
   -Des.path.home=$PWD -Des.path.conf=$PWD/config \

--- a/docker/test-images/zipkin-kafka/Dockerfile
+++ b/docker/test-images/zipkin-kafka/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.9_p8
+ARG java_version=21.0.1_p12
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-ui/Dockerfile
+++ b/docker/test-images/zipkin-ui/Dockerfile
@@ -22,7 +22,7 @@ ARG alpine_version=3.18.5
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=17.0.9_p8
+ARG java_version=21.0.1_p12
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
         <version>${maven-help-plugin.version}</version>
       </plugin>
 
-      <!-- Top-level to ensure our server can use JDK 1.8
+      <!-- Top-level to ensure our server can use JRE 8
              (by checking we don't accidentally use later apis) -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -461,6 +461,9 @@
         <configuration>
           <!-- Ensures root cause ends up in the console -->
           <trimStackTrace>false</trimStackTrace>
+          <!-- TODO: remove when assertj releases a new version, and includes updated bytebuddy.
+               https://github.com/mockito/mockito/issues/3119#issuecomment-1732179039 -->
+          <argLine>-Dnet.bytebuddy.experimental=true</argLine>
         </configuration>
       </plugin>
 
@@ -493,6 +496,9 @@
           <useModulePath>false</useModulePath>
           <!-- Ensures root cause ends up in the console -->
           <trimStackTrace>false</trimStackTrace>
+          <!-- TODO: remove when assertj releases a new version, and includes updated bytebuddy.
+                https://github.com/mockito/mockito/issues/3119#issuecomment-1732179039 -->
+          <argLine>-Dnet.bytebuddy.experimental=true</argLine>
         </configuration>
       </plugin>
 
@@ -510,7 +516,7 @@
                 <requireJavaVersion>
                   <!-- Change this to control LTS JDK versions allowed to build
                        the project. Keep in sync with .github/workflows -->
-                  <version>11,17</version>
+                  <version>[11,12),[17,18),[21,22)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -662,7 +668,8 @@
     <profile>
       <id>error-prone-11+</id>
       <activation>
-        <jdk>11,17</jdk>
+        <!-- Only LTS versions -->
+        <jdk>[11,12),[17,18),[21,22)</jdk>
       </activation>
       <build>
         <plugins>

--- a/zipkin/RATIONALE.md
+++ b/zipkin/RATIONALE.md
@@ -61,15 +61,16 @@ While other modules in this project are higher Java levels, the core library
 remains at 1.6. This allows the highest applicability at the cost of
 inconvenience to core library maintainers.
 
-#### Why is the compiler plugin set to source level 1.7?
+#### Why is the compiler plugin set to source level 1.8?
 JDK 11 was the last JDK to allow writing Java 1.6 bytecode. We set the default
-compile target to 1.7 in order to allow passing users to the LTS JDK 17.
+compile target to 1.8 as that's the earliest target allowed by LTS JDK 21 (it
+[removed 1.7](https://bugs.openjdk.org/browse/JDK-8173605)).
 
 We enforce 1.6 only on the `release` Maven profile. This also requires a JDK no
 later than 11. JDK 11 went out of Oracle support in September 2023, but not for
 Zulu. Hence, we use Zulu for both testing and releasing Zipkin using JDK 11.
 
-The disparity between 1.7 and 1.6 can cause some problems in maintenance. For
+The disparity between 1.8 and 1.6 can cause some problems in maintenance. For
 example, the IDE may suggest switching to diamond syntax, which will break
 compilation in 1.6. This is why the `release` profile is used in at least one
 CI matrix. The poor experience is limited to a rarely modified and smaller part

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -39,10 +39,10 @@
 
     <main.basedir>${project.basedir}/..</main.basedir>
 
-    <!-- CI should run the "release" profile during tests to ensure no 1.7 features are in use.
-         TODO: for JDK 21, bump to 1.8: https://bugs.openjdk.org/browse/JDK-8173605 -->
-    <main.java.version>1.7</main.java.version>
-    <main.signature.artifact>java17</main.signature.artifact>
+    <!-- CI should run the "release" profile during tests to ensure no 1.8
+         features are in use. -->
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -143,10 +143,10 @@
                 </goals>
                 <configuration>
                   <rules>
-                    <!-- Only 1.8 and 11 are LTS JDKs that can compile 1.6 bytecode.
+                    <!-- The only LTS JDK we support that can compile 1.6 bytecode is 11.
                          https://www.oracle.com/java/technologies/javase/12-relnote-issues.html -->
                     <requireJavaVersion>
-                      <version>1.8,11</version>
+                      <version>[11,12)</version>
                     </requireJavaVersion>
                   </rules>
                 </configuration>


### PR DESCRIPTION
This moves the build and docker images to latest Java 21. Note that the release still uses JDK 11, so that the core jar can compile to Java 1.6 for historical reporters.