### PR TITLE
docker: adds zipkin-activemq image to remove junit 4 rule dependency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,8 @@
 !/zipkin-server/target/zipkin-server-*exec.jar
 !/zipkin-server/target/zipkin-server-*slim.jar
 
+!docker/test-images/zipkin-activemq/start-activemq
+
 !docker/test-images/zipkin-cassandra/install.sh
 !docker/test-images/zipkin-cassandra/start-cassandra
 !zipkin-storage/cassandra/src/main/resources/*.cql

--- a/.github/workflows/readme_test.yml
+++ b/.github/workflows/readme_test.yml
@@ -102,6 +102,10 @@ jobs:
         env:
           DOCKER_FILE: docker/test-images/zipkin-ui/Dockerfile
           RELEASE_FROM_MAVEN_BUILD: true
+      - name: docker/test-images/zipkin-activemq/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-activemq:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-activemq:test
       - name: docker/test-images/zipkin-cassandra/README.md
         run: |
           build-bin/docker/docker_build openzipkin/zipkin-cassandra:test &&

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,6 +14,7 @@ We also provide a number images that are not for production, rather to simplify 
 integration tests. We designed these to be small and start easily. We did this by re-using the same
 base layer `openzipkin/zipkin`, and setting up schema where relevant.
 
+* [ghcr.io/openzipkin/zipkin-activemq](test-images/zipkin-activemq/README.md) - runs ActiveMQ Classic
 * [ghcr.io/openzipkin/zipkin-cassandra](test-images/zipkin-cassandra/README.md) - runs Cassandra initialized with Zipkin's schema
 * [ghcr.io/openzipkin/zipkin-elasticsearch6](test-images/zipkin-elasticsearch6/README.md) - runs Elasticsearch 6.x
 * [ghcr.io/openzipkin/zipkin-elasticsearch7](test-images/zipkin-elasticsearch7/README.md) - runs Elasticsearch 7.x

--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -27,9 +27,7 @@ $ docker-compose -f docker-compose-activemq.yml up
 ```
 
 Then configure the [ActiveMQ sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/activemq-client/src/main/java/zipkin2/reporter/activemq/ActiveMQSender.java)
-using a `host` value of `host.docker.internal` if your application is inside the docker network.
-Otherwise, an application can use the default `host` value of `localhost` to send spans to ActiveMQ
-via any protocol it accepts, such as OpenWire or AMQP.
+using a `brokerUrl` value of `failover:tcp://localhost:61616` or a non-local hostname if in docker.
 
 ## Cassandra
 
@@ -99,9 +97,7 @@ $ docker-compose -f docker-compose-rabbitmq.yml up
 ```
 
 Then configure the [RabbitMQ sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java)
-using a `host` value of `host.docker.internal` if your application is inside the docker network.
-Otherwise, an application can use the default `host` value of `localhost` to send spans to RabbitMQ
-via the AMQP protocol.
+using a `host` value of `localhost` or a non-local hostname if in docker.
 
 # Example
 

--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -15,17 +15,21 @@ View the web UI at $(docker ip):9411. Traces are stored in memory.
 To see specific traces in the UI, select "zipkin-server" in the dropdown and
 then click the "Find Traces" button.
 
-## Elasticsearch
+## ActiveMQ
 
-You can store traces in [Elasticsearch](../test-images/zipkin-elasticsearch7/README.md) instead of memory,
-using the `docker-compose-elasticsearch.yml` file. This configuration starts `zipkin`,
-`zipkin-elasticsearch` and `zipkin-dependencies` (cron job) in their own containers.
+You can collect traces from [ActiveMQ](../test-images/zipkin-activemq/README.md) in addition to HTTP, using the
+`docker-compose-activemq.yml` file. This configuration starts `zipkin` and `zipkin-activemq` in their
+own containers.
 
-To start the Elasticsearch-backed configuration, run:
-
+To add ActiveMQ configuration, run:
 ```bash
-$ docker-compose -f docker-compose-elasticsearch.yml up
+$ docker-compose -f docker-compose-activemq.yml up
 ```
+
+Then configure the [ActiveMQ sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/activemq-client/src/main/java/zipkin2/reporter/activemq/ActiveMQSender.java)
+using a `host` value of `host.docker.internal` if your application is inside the docker network.
+Otherwise, an application can use the default `host` value of `localhost` to send spans to ActiveMQ
+via any protocol it accepts, such as OpenWire or AMQP.
 
 ## Cassandra
 
@@ -37,6 +41,18 @@ To start the Cassandra-backed configuration, run:
 
 ```bash
 $ docker-compose -f docker-compose-cassandra.yml up
+```
+
+## Elasticsearch
+
+You can store traces in [Elasticsearch](../test-images/zipkin-elasticsearch7/README.md) instead of memory,
+using the `docker-compose-elasticsearch.yml` file. This configuration starts `zipkin`,
+`zipkin-elasticsearch` and `zipkin-dependencies` (cron job) in their own containers.
+
+To start the Elasticsearch-backed configuration, run:
+
+```bash
+$ docker-compose -f docker-compose-elasticsearch.yml up
 ```
 
 ## Kafka

--- a/docker/examples/docker-compose-activemq.yml
+++ b/docker/examples/docker-compose-activemq.yml
@@ -1,0 +1,40 @@
+#
+# Copyright 2015-2023 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml to add a test
+# activemq server, which is used as a span transport.
+
+version: '2.4'
+
+services:
+  activemq:
+    image: ghcr.io/openzipkin/zipkin-activemq:${TAG:-latest}
+    container_name: activemq
+    ports:  # expose the ActiveMQ port so apps can publish spans.
+      - "61616:61616"
+
+  zipkin:
+    extends:
+      file: docker-compose.yml
+      service: zipkin
+    # slim doesn't include Activemq support, so switch to the larger image
+    image: ghcr.io/openzipkin/zipkin:${TAG:-latest}
+    environment:
+      - ACTIVEMQ_URL=failover:tcp://activemq:61616
+    depends_on:
+      activemq:
+        condition: service_healthy

--- a/docker/test-images/zipkin-activemq/Dockerfile
+++ b/docker/test-images/zipkin-activemq/Dockerfile
@@ -1,0 +1,72 @@
+#
+# Copyright 2015-2021 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# java_version is used for install and runtime layers of zipkin-activemq
+#
+# Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
+# This is defined in many places because Docker has no "env" script functionality unless you use
+# docker-compose: When updating, update everywhere.
+ARG java_version=21.0.1_p12
+
+# We copy files from the context into a scratch container first to avoid a problem where docker and
+# docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
+# COPY --from= works around the issue.
+FROM scratch as scratch
+
+COPY build-bin/docker/docker-healthcheck /docker-bin/
+COPY docker/test-images/zipkin-activemq/start-activemq /docker-bin/
+
+FROM ghcr.io/openzipkin/java:${java_version} as install
+
+WORKDIR /install
+
+# Use latest version from https://activemq.apache.org/components/classic/download/
+ARG activemq_version=6.0.1
+
+# Download the distribution
+RUN \
+# Connection resets are frequent in GitHub Actions workflows \
+wget --random-wait --tries=5 -qO- \
+# Remove junk from the distribution while downloading it
+https://archive.apache.org/dist/activemq/${activemq_version}/apache-activemq-${activemq_version}-bin.tar.gz| tar xz \
+    --wildcards --exclude=examples --exclude=webapps-demo --strip=1
+
+# Note: this uses the JDK image as ActiveMQ has a module dependency on JMX,
+# which isn't in our JRE.
+FROM ghcr.io/openzipkin/java:${java_version} as zipkin-activemq
+LABEL org.opencontainers.image.description="ActiveMQ Classic on OpenJDK and Alpine Linux"
+ARG activemq_version=6.0.1
+LABEL activemq-version=$activemq_version
+
+# Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
+COPY --from=scratch /docker-bin/* /usr/local/bin/
+# We use start period of 30s to avoid marking the container unhealthy on slow or contended CI hosts
+HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthcheck"]
+ENTRYPOINT ["start-activemq"]
+
+# All content including binaries and logs write under WORKDIR
+ARG USER=activemq
+WORKDIR /${USER}
+ENV ACTIVEMQ_HOME=/${USER}
+
+# Ensure the process doesn't run as root
+RUN adduser -g '' -h ${PWD} -D ${USER}
+USER ${USER}
+
+# Copy binaries and config we installed earlier
+COPY --from=install --chown=${USER} /install .
+
+# Use to set heap, trust store or other system properties.
+ENV JAVA_OPTS="-Xms64m -Xmx64m -XX:+ExitOnOutOfMemoryError"
+EXPOSE 1883 5672 8161 61613 61614 61616

--- a/docker/test-images/zipkin-activemq/README.md
+++ b/docker/test-images/zipkin-activemq/README.md
@@ -1,0 +1,11 @@
+## zipkin-activemq Docker image
+
+The `zipkin-activemq` testing image runs ActiveMQ Classic for [ActiveMQ collector](../../../zipkin-collector/activemq)
+integration.
+
+To build `openzipkin/zipkin-activemq:test`, from the top-level of the repository, run:
+```bash
+$ DOCKER_FILE=docker/test-images/zipkin-activemq/Dockerfile build-bin/docker/docker_build openzipkin/zipkin-activemq:test
+```
+
+You can use the env variable `JAVA_OPTS` to change settings such as heap size for ActiveMQ.

--- a/docker/test-images/zipkin-activemq/start-activemq
+++ b/docker/test-images/zipkin-activemq/start-activemq
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# Copyright 2015-2020 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# ENTRYPOINT script that starts ActiveMQ
+#
+# This intentionally locates config using the current working directory, in order to consolidate
+# Dockerfile instructions to WORKDIR
+set -eu
+
+# Configure the Docker HEALTHCHECK
+# Configure the Docker HEALTHCHECK
+export HEALTHCHECK_PORT=61616
+export HEALTHCHECK_KIND=tcp
+
+echo Starting ActiveMQ
+exec bin/activemq console
+


### PR DESCRIPTION
This replaces the in-VM approach for testing activemq which has been flakey and also results in a JUnit 4 rule dependency.

Note: This uses the JDK image, not the JRE, because ActiveMQ relies on JMX even when disabled via configuration. This is a better choice than making our production JRE image include it.

Once this is deployed I can make zipkin-reporter use it per below:
 https://github.com/openzipkin/zipkin-reporter-java/pull/220

I can also change our collector tests here to use it instead of the JUnit 4 rule.