### PR TITLE
ci: moves ActiveMQ and RabbitMQ to new docker images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: zipkin-collector-activemq
           - name: zipkin-collector-kafka
           - name: zipkin-collector-rabbitmq
           - name: zipkin-storage-cassandra

--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -91,7 +91,7 @@ class ServerIntegratedBenchmark {
 
   @Test void elasticsearch() throws Exception {
     GenericContainer<?> elasticsearch =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:2.24.3"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:2.24.4"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("elasticsearch")
         .withLabel("name", "elasticsearch")
@@ -105,7 +105,7 @@ class ServerIntegratedBenchmark {
 
   @Test void cassandra3() throws Exception {
     GenericContainer<?> cassandra =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:2.24.3"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:2.24.4"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("cassandra")
         .withLabel("name", "cassandra")
@@ -119,7 +119,7 @@ class ServerIntegratedBenchmark {
 
   @Test void mysql() throws Exception {
     GenericContainer<?> mysql =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:2.24.3"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:2.24.4"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("mysql")
         .withLabel("name", "mysql")

--- a/zipkin-collector/activemq/pom.xml
+++ b/zipkin-collector/activemq/pom.xml
@@ -44,21 +44,5 @@
       <artifactId>activemq-client</artifactId>
       <version>${activemq.version}</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-broker</artifactId>
-      <version>${activemq.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Note: this is junit 4 -->
-    <dependency>
-      <groupId>org.apache.activemq.tooling</groupId>
-      <artifactId>activemq-junit</artifactId>
-      <version>${activemq.version}</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 </project>

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
@@ -92,7 +92,7 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.24.3"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.24.4"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -156,7 +156,7 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class CassandraContainer extends GenericContainer<CassandraContainer> {
     CassandraContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-cassandra:2.24.3"));
+      super(parse("ghcr.io/openzipkin/zipkin-cassandra:2.24.4"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -127,7 +127,7 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {
     ElasticsearchContainer(int majorVersion) {
-      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":2.24.3"));
+      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":2.24.4"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
@@ -113,7 +113,7 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class MySQLContainer extends GenericContainer<MySQLContainer> {
     MySQLContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-mysql:2.24.3"));
+      super(parse("ghcr.io/openzipkin/zipkin-mysql:2.24.4"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }


### PR DESCRIPTION
Notably, this removes a JUnit 4 dependency in activemq and should fix flakes related to ActiveMQ integration tests.

Fixes #3633

After this, I will rebase #3635 and hopefully it doesn't flake anymore. If so, I'll merge that and cut the pending minor.