### PR TITLE
refactor: Remove public visibility of JUnit 5 tests

### DIFF
--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
@@ -67,7 +67,8 @@ public class ITActiveMQCollector {
 
   ActiveMQCollector collector;
 
-  @BeforeEach public void start(TestInfo testInfo) {
+  @BeforeEach
+  void start(TestInfo testInfo) {
     Optional<Method> testMethod = testInfo.getTestMethod();
     if (testMethod.isPresent()) {
       this.testName = testMethod.get().getName();
@@ -78,7 +79,8 @@ public class ITActiveMQCollector {
     collector = builder().build().start();
   }
 
-  @AfterEach public void stop() throws IOException {
+  @AfterEach
+  void stop() throws IOException {
     activemq.stop();
     collector.close();
   }

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
@@ -79,8 +79,7 @@ public class ITActiveMQCollector {
     collector = builder().build().start();
   }
 
-  @AfterEach
-  void stop() throws IOException {
+  @AfterEach void stop() throws IOException {
     activemq.stop();
     collector.close();
   }

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
@@ -67,8 +67,7 @@ public class ITActiveMQCollector {
 
   ActiveMQCollector collector;
 
-  @BeforeEach
-  void start(TestInfo testInfo) {
+  @BeforeEach void start(TestInfo testInfo) {
     Optional<Method> testMethod = testInfo.getTestMethod();
     if (testMethod.isPresent()) {
       this.testName = testMethod.get().getName();

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorSamplerTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorSamplerTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static zipkin2.TestObjects.LOTS_OF_SPANS;
 
-public class CollectorSamplerTest {
+class CollectorSamplerTest {
 
   /**
    * Math.abs("8000000000000000") returns a negative, we coerse to "7fffffffffffffff" to avoid

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
@@ -47,14 +47,16 @@ public class CollectorTest {
   Collector collector;
   private TestLogger testLogger = TestLoggerFactory.getTestLogger("");
 
-  @BeforeEach public void setup() {
+  @BeforeEach
+  void setup() {
     testLogger.clearAll();
     collector = spy(
       new Collector.Builder(testLogger).metrics(metrics).storage(storage).build());
     when(collector.idString(CLIENT_SPAN)).thenReturn("1"); // to make expectations easier to read
   }
 
-  @AfterEach public void after() {
+  @AfterEach
+  void after() {
     verifyNoMoreInteractions(metrics, callback);
   }
 

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
@@ -55,8 +55,7 @@ public class CollectorTest {
     when(collector.idString(CLIENT_SPAN)).thenReturn("1"); // to make expectations easier to read
   }
 
-  @AfterEach
-  void after() {
+  @AfterEach void after() {
     verifyNoMoreInteractions(metrics, callback);
   }
 

--- a/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
+++ b/zipkin-collector/core/src/test/java/zipkin2/collector/CollectorTest.java
@@ -47,8 +47,7 @@ public class CollectorTest {
   Collector collector;
   private TestLogger testLogger = TestLoggerFactory.getTestLogger("");
 
-  @BeforeEach
-  void setup() {
+  @BeforeEach void setup() {
     testLogger.clearAll();
     collector = spy(
       new Collector.Builder(testLogger).metrics(metrics).storage(storage).build());

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorTest.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorTest.java
@@ -24,11 +24,12 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class RabbitMQCollectorTest {
+class RabbitMQCollectorTest {
 
   RabbitMQCollector collector;
 
-  @BeforeEach public void before() {
+  @BeforeEach
+  void before() {
     ConnectionFactory connectionFactory = new ConnectionFactory();
     connectionFactory.setConnectionTimeout(100);
     // We can be pretty certain RabbitMQ isn't running on localhost port 80

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorTest.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQCollectorTest.java
@@ -28,8 +28,7 @@ class RabbitMQCollectorTest {
 
   RabbitMQCollector collector;
 
-  @BeforeEach
-  void before() {
+  @BeforeEach void before() {
     ConnectionFactory connectionFactory = new ConnectionFactory();
     connectionFactory.setConnectionTimeout(100);
     // We can be pretty certain RabbitMQ isn't running on localhost port 80

--- a/zipkin-server/src/test/java/zipkin/server/ITEnableZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin/server/ITEnableZipkinServer.java
@@ -34,7 +34,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "spring.config.name=zipkin-server"
   }
 )
-public class ITEnableZipkinServer {
+class ITEnableZipkinServer {
 
   @Autowired Server server;
 

--- a/zipkin-server/src/test/java/zipkin2/collector/activemq/ZipkinActiveMQCollectorPropertiesOverrideTest.java
+++ b/zipkin-server/src/test/java/zipkin2/collector/activemq/ZipkinActiveMQCollectorPropertiesOverrideTest.java
@@ -28,8 +28,7 @@ public class ZipkinActiveMQCollectorPropertiesOverrideTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/collector/activemq/ZipkinActiveMQCollectorPropertiesOverrideTest.java
+++ b/zipkin-server/src/test/java/zipkin2/collector/activemq/ZipkinActiveMQCollectorPropertiesOverrideTest.java
@@ -28,7 +28,8 @@ public class ZipkinActiveMQCollectorPropertiesOverrideTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/collector/kafka/ZipkinKafkaCollectorPropertiesOverrideTest.java
+++ b/zipkin-server/src/test/java/zipkin2/collector/kafka/ZipkinKafkaCollectorPropertiesOverrideTest.java
@@ -28,8 +28,7 @@ public class ZipkinKafkaCollectorPropertiesOverrideTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/collector/kafka/ZipkinKafkaCollectorPropertiesOverrideTest.java
+++ b/zipkin-server/src/test/java/zipkin2/collector/kafka/ZipkinKafkaCollectorPropertiesOverrideTest.java
@@ -28,7 +28,8 @@ public class ZipkinKafkaCollectorPropertiesOverrideTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     if (context != null) context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
+++ b/zipkin-server/src/test/java/zipkin2/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
@@ -29,8 +29,7 @@ public class ZipkinRabbitMQCollectorPropertiesOverrideTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
+++ b/zipkin-server/src/test/java/zipkin2/collector/rabbitmq/ZipkinRabbitMQCollectorPropertiesOverrideTest.java
@@ -29,7 +29,8 @@ public class ZipkinRabbitMQCollectorPropertiesOverrideTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     if (context != null) context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/collector/scribe/ZipkinScribeCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/collector/scribe/ZipkinScribeCollectorConfigurationTest.java
@@ -28,7 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class ZipkinScribeCollectorConfigurationTest {
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/collector/scribe/ZipkinScribeCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/collector/scribe/ZipkinScribeCollectorConfigurationTest.java
@@ -28,8 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class ZipkinScribeCollectorConfigurationTest {
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITActuatorMappings.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITActuatorMappings.java
@@ -37,7 +37,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "spring.config.name=zipkin-server"
   }
 )
-public class ITActuatorMappings {
+class ITActuatorMappings {
   @Autowired PrometheusMeterRegistry registry;
   @Autowired Server server;
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
@@ -54,8 +54,7 @@ class ITZipkinGrpcCollector {
   @Autowired InMemoryStorage storage;
   @Autowired Server server;
 
-  @BeforeEach
-  void init() {
+  @BeforeEach void init() {
     storage.clear();
   }
 
@@ -63,8 +62,7 @@ class ITZipkinGrpcCollector {
 
   ListOfSpans request;
 
-  @BeforeEach
-  void sanityCheckCodecCompatible() throws IOException {
+  @BeforeEach void sanityCheckCodecCompatible() throws IOException {
     request = ListOfSpans.ADAPTER.decode(SpanBytesEncoder.PROTO3.encodeList(TestObjects.TRACE));
 
     assertThat(SpanBytesDecoder.PROTO3.decodeList(request.encode()))

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
@@ -50,11 +50,12 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "zipkin.collector.grpc.enabled=true"
   }
 )
-public class ITZipkinGrpcCollector {
+class ITZipkinGrpcCollector {
   @Autowired InMemoryStorage storage;
   @Autowired Server server;
 
-  @BeforeEach public void init() {
+  @BeforeEach
+  void init() {
     storage.clear();
   }
 
@@ -62,7 +63,8 @@ public class ITZipkinGrpcCollector {
 
   ListOfSpans request;
 
-  @BeforeEach public void sanityCheckCodecCompatible() throws IOException {
+  @BeforeEach
+  void sanityCheckCodecCompatible() throws IOException {
     request = ListOfSpans.ADAPTER.decode(SpanBytesEncoder.PROTO3.encodeList(TestObjects.TRACE));
 
     assertThat(SpanBytesDecoder.PROTO3.decodeList(request.encode()))

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -58,7 +58,8 @@ public class ITZipkinServer {
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(true).build();
 
-  @BeforeEach public void init() {
+  @BeforeEach
+  void init() {
     storage.clear();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -58,8 +58,7 @@ public class ITZipkinServer {
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(true).build();
 
-  @BeforeEach
-  void init() {
+  @BeforeEach void init() {
     storage.clear();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerAutocomplete.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerAutocomplete.java
@@ -45,7 +45,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "zipkin.storage.autocomplete-keys=environment,clnt/finagle.version"
   }
 )
-public class ITZipkinServerAutocomplete {
+class ITZipkinServerAutocomplete {
 
   @Autowired Server server;
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerCORS.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerCORS.java
@@ -42,7 +42,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "zipkin.query.allowed-origins=" + ITZipkinServerCORS.ALLOWED_ORIGIN
   }
 )
-public class ITZipkinServerCORS {
+class ITZipkinServerCORS {
   static final String ALLOWED_ORIGIN = "http://foo.example.com";
   static final String DISALLOWED_ORIGIN = "http://bar.example.com";
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerHttpCollectorDisabled.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerHttpCollectorDisabled.java
@@ -40,7 +40,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "zipkin.storage.type=", // cheat and test empty storage type
     "zipkin.collector.http.enabled=false"
   })
-public class ITZipkinServerHttpCollectorDisabled {
+class ITZipkinServerHttpCollectorDisabled {
 
   @Autowired Server server;
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerQueryDisabled.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerQueryDisabled.java
@@ -40,7 +40,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "zipkin.ui.enabled=false"
   }
 )
-public class ITZipkinServerQueryDisabled {
+class ITZipkinServerQueryDisabled {
   @Autowired Server server;
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerSsl.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerSsl.java
@@ -60,8 +60,7 @@ class ITZipkinServerSsl {
 
   ClientFactory clientFactory;
 
-  @BeforeEach
-  void configureClientFactory() {
+  @BeforeEach void configureClientFactory() {
     clientFactory = configureSsl(ClientFactory.builder(), armeriaSettings.getSsl()).build();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerSsl.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerSsl.java
@@ -54,13 +54,14 @@ import static zipkin2.server.internal.elasticsearch.Access.configureSsl;
     "armeria.ports[0].port=${server.port}",
     "armeria.ports[0].protocols[0]=http",
   })
-public class ITZipkinServerSsl {
+class ITZipkinServerSsl {
   @Autowired Server server;
   @Autowired ArmeriaSettings armeriaSettings;
 
   ClientFactory clientFactory;
 
-  @BeforeEach public void configureClientFactory() {
+  @BeforeEach
+  void configureClientFactory() {
     clientFactory = configureSsl(ClientFactory.builder(), armeriaSettings.getSsl()).build();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerTimeout.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerTimeout.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
     "spring.config.name=zipkin-server"
   }
 )
-public class ITZipkinServerTimeout {
+class ITZipkinServerTimeout {
   static final List<Span> TRACE = asList(TestObjects.CLIENT_SPAN);
 
   SlowSpanStore spanStore;
@@ -58,7 +58,8 @@ public class ITZipkinServerTimeout {
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(true).build();
 
-  @BeforeEach public void init() {
+  @BeforeEach
+  void init() {
     spanStore = new SlowSpanStore();
     when(storage.spanStore()).thenReturn(spanStore);
     when(storage.traces()).thenReturn(new TracesAdapter(spanStore));

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerTimeout.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerTimeout.java
@@ -58,8 +58,7 @@ class ITZipkinServerTimeout {
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(true).build();
 
-  @BeforeEach
-  void init() {
+  @BeforeEach void init() {
     spanStore = new SlowSpanStore();
     when(storage.spanStore()).thenReturn(spanStore);
     when(storage.traces()).thenReturn(new TracesAdapter(spanStore));

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinActuatorImporterTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinActuatorImporterTest.java
@@ -24,12 +24,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static zipkin2.server.internal.ZipkinActuatorImporter.PROPERTY_NAME_ACTUATOR_ENABLED;
 
 // This tests actuator integration without actually requiring a compile dep on actuator
-public class ZipkinActuatorImporterTest {
+class ZipkinActuatorImporterTest {
   ZipkinActuatorImporter zipkinActuatorImporter =
     new ZipkinActuatorImporter(ActuatorImpl.class.getName());
   GenericApplicationContext context = new GenericApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinActuatorImporterTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinActuatorImporterTest.java
@@ -29,8 +29,7 @@ class ZipkinActuatorImporterTest {
     new ZipkinActuatorImporter(ActuatorImpl.class.getName());
   GenericApplicationContext context = new GenericApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHttpConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHttpConfigurationTest.java
@@ -37,8 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ZipkinHttpConfigurationTest {
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHttpConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHttpConfigurationTest.java
@@ -34,10 +34,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ZipkinHttpConfigurationTest {
+class ZipkinHttpConfigurationTest {
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinModuleImporterTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinModuleImporterTest.java
@@ -23,8 +23,7 @@ class ZipkinModuleImporterTest {
   ZipkinModuleImporter zipkinModuleImporter = new ZipkinModuleImporter();
   GenericApplicationContext context = new GenericApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinModuleImporterTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinModuleImporterTest.java
@@ -19,11 +19,12 @@ import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.GenericApplicationContext;
 
-public class ZipkinModuleImporterTest {
+class ZipkinModuleImporterTest {
   ZipkinModuleImporter zipkinModuleImporter = new ZipkinModuleImporter();
   GenericApplicationContext context = new GenericApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorConfigurationTest.java
@@ -27,11 +27,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ZipkinActiveMQCollectorConfigurationTest {
+class ZipkinActiveMQCollectorConfigurationTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorConfigurationTest.java
@@ -31,8 +31,7 @@ class ZipkinActiveMQCollectorConfigurationTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorPropertiesTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/activemq/ZipkinActiveMQCollectorPropertiesTest.java
@@ -25,7 +25,7 @@ import zipkin2.server.internal.InMemoryConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class ZipkinActiveMQCollectorPropertiesTest {
+class ZipkinActiveMQCollectorPropertiesTest {
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
   /** This prevents an empty ACTIVEMQ_URL variable from being mistaken as a real one */

--- a/zipkin-server/src/test/java/zipkin2/server/internal/banner/ZipkinBannerTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/banner/ZipkinBannerTest.java
@@ -22,8 +22,9 @@ import org.springframework.boot.ansi.AnsiOutput;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ZipkinBannerTest {
-  @AfterEach public void tearDown() {
+class ZipkinBannerTest {
+  @AfterEach
+  void tearDown() {
     AnsiOutput.setEnabled(AnsiOutput.Enabled.DETECT);
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/banner/ZipkinBannerTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/banner/ZipkinBannerTest.java
@@ -23,8 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ZipkinBannerTest {
-  @AfterEach
-  void tearDown() {
+  @AfterEach void tearDown() {
     AnsiOutput.setEnabled(AnsiOutput.Enabled.DETECT);
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
@@ -55,14 +55,15 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "zipkin.self-tracing.message-timeout=100ms",
     "zipkin.self-tracing.traces-per-second=100"
   })
-public class ITZipkinSelfTracing {
+class ITZipkinSelfTracing {
   @Autowired TracingStorageComponent storage;
   @Autowired AsyncZipkinSpanHandler zipkinSpanHandler;
   @Autowired Server server;
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
 
-  @BeforeEach public void clear() {
+  @BeforeEach
+  void clear() {
     inMemoryStorage().clear();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
@@ -62,8 +62,7 @@ class ITZipkinSelfTracing {
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
 
-  @BeforeEach
-  void clear() {
+  @BeforeEach void clear() {
     inMemoryStorage().clear();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchClientInitialization.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchClientInitialization.java
@@ -23,7 +23,7 @@ import zipkin2.elasticsearch.ElasticsearchStorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ITElasticsearchClientInitialization {
+class ITElasticsearchClientInitialization {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
@@ -87,8 +87,7 @@ class ITElasticsearchHealthCheck {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @BeforeEach
-  void setUp() {
+  @BeforeEach void setUp() {
     server1Health.setHealthy(true);
     server2Health.setHealthy(true);
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ITElasticsearchHealthCheck.java
@@ -43,7 +43,7 @@ import static zipkin2.server.internal.elasticsearch.TestResponses.VERSION_RESPON
 /**
  * These tests focus on http client health checks not currently in zipkin-storage-elasticsearch.
  */
-public class ITElasticsearchHealthCheck {
+class ITElasticsearchHealthCheck {
   static final Logger logger = LoggerFactory.getLogger(ITElasticsearchHealthCheck.class.getName());
   // Health check interval is 100ms, but in-flight requests in CI might take a few hundred ms
   static final ConditionFactory awaitTimeout = await().timeout(1, TimeUnit.SECONDS);
@@ -87,7 +87,8 @@ public class ITElasticsearchHealthCheck {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @BeforeEach public void setUp() {
+  @BeforeEach
+  void setUp() {
     server1Health.setHealthy(true);
     server2Health.setHealthy(true);
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
@@ -44,7 +44,8 @@ class InitialEndpointSupplierTest {
   }
 
   /** This helps ensure old setups don't break (provided they have http port 9200 open) */
-  @Test public void coersesPort9300To9200() {
+  @Test
+  void coersesPort9300To9200() {
     assertThat(new InitialEndpointSupplier(HTTP, "localhost:9300").get())
       .isEqualTo(Endpoint.of("localhost", 9200));
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/InitialEndpointSupplierTest.java
@@ -44,8 +44,7 @@ class InitialEndpointSupplierTest {
   }
 
   /** This helps ensure old setups don't break (provided they have http port 9200 open) */
-  @Test
-  void coersesPort9300To9200() {
+  @Test void coersesPort9300To9200() {
     assertThat(new InitialEndpointSupplier(HTTP, "localhost:9300").get())
       .isEqualTo(Endpoint.of("localhost", 9200));
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
@@ -40,8 +40,7 @@ import static zipkin2.server.internal.elasticsearch.ITElasticsearchDynamicCreden
 class ZipkinElasticsearchStorageConfigurationTest {
   final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/elasticsearch/ZipkinElasticsearchStorageConfigurationTest.java
@@ -37,10 +37,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static zipkin2.server.internal.elasticsearch.ITElasticsearchDynamicCredentials.pathOfResource;
 
-public class ZipkinElasticsearchStorageConfigurationTest {
+class ZipkinElasticsearchStorageConfigurationTest {
   final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ComponentHealthTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ComponentHealthTest.java
@@ -21,7 +21,7 @@ import zipkin2.Component;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ComponentHealthTest {
+class ComponentHealthTest {
   @Test void addsMessageToDetails() {
     ComponentHealth health = ComponentHealth.ofComponent(new Component() {
       @Override public CheckResult check() {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealth.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealth.java
@@ -38,14 +38,15 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "spring.config.name=zipkin-server"
   }
 )
-public class ITZipkinHealth {
+class ITZipkinHealth {
   @Autowired InMemoryStorage storage;
   @Autowired PrometheusMeterRegistry registry;
   @Autowired Server server;
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(true).build();
 
-  @BeforeEach public void init() {
+  @BeforeEach
+  void init() {
     storage.clear();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealth.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealth.java
@@ -45,8 +45,7 @@ class ITZipkinHealth {
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(true).build();
 
-  @BeforeEach
-  void init() {
+  @BeforeEach void init() {
     storage.clear();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealthDown.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealthDown.java
@@ -36,7 +36,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "zipkin.storage.elasticsearch.hosts=127.0.0.1:9999"
   }
 )
-public class ITZipkinHealthDown {
+class ITZipkinHealthDown {
   @Autowired Server server;
 
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(true).build();

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ZipkinHealthControllerTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ZipkinHealthControllerTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.server.internal.health.ComponentHealth.STATUS_DOWN;
 import static zipkin2.server.internal.health.ComponentHealth.STATUS_UP;
 
-public class ZipkinHealthControllerTest {
+class ZipkinHealthControllerTest {
   @Test void writeJsonError_writesNestedError() throws Exception {
     assertThat(ZipkinHealthController.writeJsonError("robots")).isEqualTo(""
       + "{\n"

--- a/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfigurationTest.java
@@ -25,11 +25,12 @@ import zipkin2.server.internal.InMemoryConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ZipkinKafkaCollectorConfigurationTest {
+class ZipkinKafkaCollectorConfigurationTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorConfigurationTest.java
@@ -29,8 +29,7 @@ class ZipkinKafkaCollectorConfigurationTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorPropertiesTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/kafka/ZipkinKafkaCollectorPropertiesTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ZipkinKafkaCollectorPropertiesTest {
+class ZipkinKafkaCollectorPropertiesTest {
   @Test void stringPropertiesConvertEmptyStringsToNull() {
     final ZipkinKafkaCollectorProperties properties = new ZipkinKafkaCollectorProperties();
     properties.setBootstrapServers("");

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
@@ -52,7 +52,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "spring.config.name=zipkin-server"
   }
 )
-public class ITZipkinMetrics {
+class ITZipkinMetrics {
   @Autowired InMemoryStorage storage;
   @Autowired PrometheusMeterRegistry registry;
   @Autowired Server server;

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetricsDirty.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetricsDirty.java
@@ -59,7 +59,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
 // Clearing the prometheus registry also clears the metrics themselves, not just the values, so we
 // have to use dirties context so that each test runs in a separate instance of Spring Boot.
 @DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
-public class ITZipkinMetricsDirty {
+class ITZipkinMetricsDirty {
 
   @Autowired InMemoryStorage storage;
   @Autowired PrometheusMeterRegistry registry;

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfigurationTest.java
@@ -33,7 +33,8 @@ public class ZipkinPrometheusMetricsConfigurationTest {
     context.refresh();
   }
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfigurationTest.java
@@ -33,8 +33,7 @@ public class ZipkinPrometheusMetricsConfigurationTest {
     context.refresh();
   }
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorConfigurationTest.java
@@ -27,11 +27,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ZipkinRabbitMQCollectorConfigurationTest {
+class ZipkinRabbitMQCollectorConfigurationTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorConfigurationTest.java
@@ -31,8 +31,7 @@ class ZipkinRabbitMQCollectorConfigurationTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorPropertiesTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/rabbitmq/ZipkinRabbitMQCollectorPropertiesTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ZipkinRabbitMQCollectorPropertiesTest {
+class ZipkinRabbitMQCollectorPropertiesTest {
   ZipkinRabbitMQCollectorProperties properties = new ZipkinRabbitMQCollectorProperties();
 
   @Test void uriProperlyParsedAndIgnoresOtherProperties_whenUriSet() throws Exception {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledCallTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledCallTest.java
@@ -48,7 +48,7 @@ import static zipkin2.server.internal.throttle.ThrottledCall.NOOP_CALLBACK;
 import static zipkin2.server.internal.throttle.ThrottledCall.STORAGE_THROTTLE_MAX_CONCURRENCY;
 import static zipkin2.server.internal.throttle.ThrottledStorageComponent.STORAGE_THROTTLE_MAX_QUEUE_SIZE;
 
-public class ThrottledCallTest {
+class ThrottledCallTest {
   SettableLimit limit = SettableLimit.startingAt(0);
   SimpleLimiter limiter = SimpleLimiter.newBuilder().limit(limit).build();
   LimiterMetrics limiterMetrics = new LimiterMetrics(NoopMeterRegistry.get());
@@ -57,7 +57,8 @@ public class ThrottledCallTest {
   int numThreads = 1;
   ExecutorService executor = Executors.newSingleThreadExecutor();
 
-  @AfterEach public void shutdownExecutor() {
+  @AfterEach
+  void shutdownExecutor() {
     executor.shutdown();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledCallTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledCallTest.java
@@ -57,8 +57,7 @@ class ThrottledCallTest {
   int numThreads = 1;
   ExecutorService executor = Executors.newSingleThreadExecutor();
 
-  @AfterEach
-  void shutdownExecutor() {
+  @AfterEach void shutdownExecutor() {
     executor.shutdown();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledStorageComponentTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/throttle/ThrottledStorageComponentTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class ThrottledStorageComponentTest {
+class ThrottledStorageComponentTest {
   InMemoryStorage delegate = InMemoryStorage.newBuilder().build();
   @Nullable Tracing tracing;
   NoopMeterRegistry registry = NoopMeterRegistry.get();

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -44,7 +44,7 @@ import static zipkin2.server.internal.ITZipkinServer.url;
     "server.compression.enabled=true",
     "server.compression.min-response-size=128"
   })
-public class ITZipkinUiConfiguration {
+class ITZipkinUiConfiguration {
   @Autowired Server server;
   OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
 

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
@@ -42,8 +42,7 @@ class ZipkinUiConfigurationTest {
 
   AnnotationConfigApplicationContext context;
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     if (context != null) {
       context.close();
     }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
@@ -38,11 +38,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ZipkinUiConfigurationTest {
+class ZipkinUiConfigurationTest {
 
   AnnotationConfigApplicationContext context;
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     if (context != null) {
       context.close();
     }

--- a/zipkin-server/src/test/java/zipkin2/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTest.java
@@ -27,8 +27,7 @@ class ZipkinCassandraStorageAutoConfigurationTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTest.java
@@ -23,11 +23,12 @@ import zipkin2.server.internal.cassandra3.Access;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class ZipkinCassandraStorageAutoConfigurationTest {
+class ZipkinCassandraStorageAutoConfigurationTest {
 
   AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     context.close();
   }
 

--- a/zipkin-server/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLStorageConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLStorageConfigurationTest.java
@@ -28,8 +28,7 @@ class ZipkinMySQLStorageConfigurationTest {
 
   AnnotationConfigApplicationContext context;
 
-  @AfterEach
-  void close() {
+  @AfterEach void close() {
     if (context != null) {
       context.close();
     }

--- a/zipkin-server/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLStorageConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/storage/mysql/v1/ZipkinMySQLStorageConfigurationTest.java
@@ -24,11 +24,12 @@ import zipkin2.server.internal.mysql.Access;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ZipkinMySQLStorageConfigurationTest {
+class ZipkinMySQLStorageConfigurationTest {
 
   AnnotationConfigApplicationContext context;
 
-  @AfterEach public void close() {
+  @AfterEach
+  void close() {
     if (context != null) {
       context.close();
     }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
@@ -30,7 +30,7 @@ import static zipkin2.TestObjects.FRONTEND;
 import static zipkin2.TestObjects.TODAY;
 import static zipkin2.storage.cassandra.InternalForTests.mockSession;
 
-public class CassandraSpanConsumerTest {
+class CassandraSpanConsumerTest {
   CassandraSpanConsumer consumer = spanConsumer(CassandraStorage.newBuilder());
 
   Span spanWithoutAnnotationsOrTags =

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanStoreTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanStoreTest.java
@@ -29,7 +29,7 @@ import static zipkin2.storage.cassandra.InternalForTests.mockSession;
 // TODO: tests use toString because the call composition chain is complex (includes flat mapping)
 // This could be made a little less complex if we scrub out map=>map to a list of transformations,
 // or possibly special-casing common transformations.
-public class CassandraSpanStoreTest {
+class CassandraSpanStoreTest {
   CassandraSpanStore spanStore = spanStore(CassandraStorage.newBuilder());
   QueryRequest.Builder queryBuilder = QueryRequest.newBuilder().endTs(TODAY).lookback(DAY).limit(5);
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageTest.java
@@ -25,7 +25,7 @@ import zipkin2.Component;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class CassandraStorageTest {
+class CassandraStorageTest {
 
   @Test void authProvider_defaultsToNull() {
     assertThat(CassandraStorage.newBuilder().build().authProvider)

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraUtilTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraUtilTest.java
@@ -28,7 +28,7 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.TODAY;
 
-public class CassandraUtilTest {
+class CassandraUtilTest {
   @Test void annotationKeys_emptyRequest() {
     QueryRequest request = QueryRequest.newBuilder()
       .endTs(System.currentTimeMillis())

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -124,8 +124,7 @@ class ITCassandraStorage {
     }
 
     /** Ensures data written before strict trace ID was enabled can be read */
-    @Test
-    void getTrace_retrievesBy128BitTraceId_afterSwitch(TestInfo testInfo) throws Exception {
+    @Test void getTrace_retrievesBy128BitTraceId_afterSwitch(TestInfo testInfo) throws Exception {
       List<Span> trace = accept128BitTrace(strictTraceId, testInfo);
 
       assertGetTraceReturns(trace.get(0).traceId(), trace);

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -54,7 +54,7 @@ class ITCassandraStorage {
     @Override
     @Test
     @Disabled("No consumer-side span deduplication")
-    void getTrace_deduplicates(TestInfo testInfo) {
+    public void getTrace_deduplicates(TestInfo testInfo) {
     }
 
     @Override protected void blockWhileInFlight() {
@@ -119,7 +119,7 @@ class ITCassandraStorage {
 
     /** Ensures we can still lookup fully 128-bit traces when strict trace ID id disabled */
     @Test
-    void getTraces_128BitTraceId(TestInfo testInfo) throws Exception {
+    public void getTraces_128BitTraceId(TestInfo testInfo) throws Exception {
       getTraces_128BitTraceId(accept128BitTrace(strictTraceId, testInfo), testInfo);
     }
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -51,8 +51,10 @@ class ITCassandraStorage {
       return cassandra.newStorageBuilder();
     }
 
-    @Override @Test @Disabled("No consumer-side span deduplication")
-    public void getTrace_deduplicates(TestInfo testInfo) {
+    @Override
+    @Test
+    @Disabled("No consumer-side span deduplication")
+    void getTrace_deduplicates(TestInfo testInfo) {
     }
 
     @Override protected void blockWhileInFlight() {
@@ -116,13 +118,14 @@ class ITCassandraStorage {
     }
 
     /** Ensures we can still lookup fully 128-bit traces when strict trace ID id disabled */
-    @Test public void getTraces_128BitTraceId(TestInfo testInfo) throws Exception {
+    @Test
+    void getTraces_128BitTraceId(TestInfo testInfo) throws Exception {
       getTraces_128BitTraceId(accept128BitTrace(strictTraceId, testInfo), testInfo);
     }
 
     /** Ensures data written before strict trace ID was enabled can be read */
     @Test
-    public void getTrace_retrievesBy128BitTraceId_afterSwitch(TestInfo testInfo) throws Exception {
+    void getTrace_retrievesBy128BitTraceId_afterSwitch(TestInfo testInfo) throws Exception {
       List<Span> trace = accept128BitTrace(strictTraceId, testInfo);
 
       assertGetTraceReturns(trace.get(0).traceId(), trace);

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
@@ -41,8 +41,7 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
    * {@link Span#timestamp()} == 0 is likely to be a mistake, and coerces to null. It is not helpful
    * to index rows who have no timestamp.
    */
-  @Test
-  void doesntIndexSpansMissingTimestamp(TestInfo testInfo) throws Exception {
+  @Test void doesntIndexSpansMissingTimestamp(TestInfo testInfo) throws Exception {
     String testSuffix = testSuffix(testInfo);
     accept(spanBuilder(testSuffix).timestamp(0L).duration(0L).build());
 
@@ -54,8 +53,7 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
    * one. The consumer code optimizes index inserts to only represent the interval represented by
    * the trace as opposed to each individual timestamp.
    */
-  @Test
-  void skipsRedundantIndexingInATrace(TestInfo testInfo) throws Exception {
+  @Test void skipsRedundantIndexingInATrace(TestInfo testInfo) throws Exception {
     String testSuffix = testSuffix(testInfo);
     Span[] trace = new Span[101];
     trace[0] = newClientSpan(testSuffix).toBuilder().kind(SERVER).build();
@@ -93,8 +91,7 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
       .isGreaterThanOrEqualTo(120L);
   }
 
-  @Test
-  void insertTags_SelectTags_CalculateCount(TestInfo testInfo) throws Exception {
+  @Test void insertTags_SelectTags_CalculateCount(TestInfo testInfo) throws Exception {
     String testSuffix = testSuffix(testInfo);
     Span[] trace = new Span[101];
     trace[0] = newClientSpan(testSuffix).toBuilder().kind(SERVER).build();
@@ -121,8 +118,7 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
   }
 
   /** It is easier to use a real Cassandra connection than mock a prepared statement. */
-  @Test
-  void insertEntry_niceToString() {
+  @Test void insertEntry_niceToString() {
     // This test can use fake data as it is never written to cassandra
     Span clientSpan = CLIENT_SPAN;
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITSpanConsumer.java
@@ -41,7 +41,8 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
    * {@link Span#timestamp()} == 0 is likely to be a mistake, and coerces to null. It is not helpful
    * to index rows who have no timestamp.
    */
-  @Test public void doesntIndexSpansMissingTimestamp(TestInfo testInfo) throws Exception {
+  @Test
+  void doesntIndexSpansMissingTimestamp(TestInfo testInfo) throws Exception {
     String testSuffix = testSuffix(testInfo);
     accept(spanBuilder(testSuffix).timestamp(0L).duration(0L).build());
 
@@ -53,7 +54,8 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
    * one. The consumer code optimizes index inserts to only represent the interval represented by
    * the trace as opposed to each individual timestamp.
    */
-  @Test public void skipsRedundantIndexingInATrace(TestInfo testInfo) throws Exception {
+  @Test
+  void skipsRedundantIndexingInATrace(TestInfo testInfo) throws Exception {
     String testSuffix = testSuffix(testInfo);
     Span[] trace = new Span[101];
     trace[0] = newClientSpan(testSuffix).toBuilder().kind(SERVER).build();
@@ -91,7 +93,8 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
       .isGreaterThanOrEqualTo(120L);
   }
 
-  @Test public void insertTags_SelectTags_CalculateCount(TestInfo testInfo) throws Exception {
+  @Test
+  void insertTags_SelectTags_CalculateCount(TestInfo testInfo) throws Exception {
     String testSuffix = testSuffix(testInfo);
     Span[] trace = new Span[101];
     trace[0] = newClientSpan(testSuffix).toBuilder().kind(SERVER).build();
@@ -118,7 +121,8 @@ abstract class ITSpanConsumer extends ITStorage<CassandraStorage> {
   }
 
   /** It is easier to use a real Cassandra connection than mock a prepared statement. */
-  @Test public void insertEntry_niceToString() {
+  @Test
+  void insertEntry_niceToString() {
     // This test can use fake data as it is never written to cassandra
     Span clientSpan = CLIENT_SPAN;
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/SchemaTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/SchemaTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SchemaTest {
+class SchemaTest {
   @Test void ensureKeyspaceMetadata_failsWhenVersionLessThan3_11_3() {
     CqlSession session = mock(CqlSession.class);
     Metadata metadata = mock(Metadata.class);

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/CassandraStorageBuilderTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/CassandraStorageBuilderTest.java
@@ -23,7 +23,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class CassandraStorageBuilderTest {
+class CassandraStorageBuilderTest {
   CassandraStorageBuilder<?> builder = new CassandraStorageBuilder("zipkin3") {
     @Override public StorageComponent build() {
       return null;

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/HostAndPortTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/HostAndPortTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 // Reuses inputs from com.google.common.net.HostAndPortTest
-public class HostAndPortTest {
+class HostAndPortTest {
 
   @Test void parsesHost() {
     Stream.of(

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/SessionBuilderTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/SessionBuilderTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.storage.cassandra.internal.SessionBuilder.parseContactPoints;
 
-public class SessionBuilderTest {
+class SessionBuilderTest {
   @Test void contactPoints_defaultsToLocalhost() {
     assertThat(parseContactPoints("localhost"))
       .containsExactly(new InetSocketAddress("127.0.0.1", 9042));

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/call/DeduplicatingInsertTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/call/DeduplicatingInsertTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Mockito.mock;
 
-public class DeduplicatingInsertTest {
+class DeduplicatingInsertTest {
   @Test void dedupesSameCalls() throws Exception {
     TestFactory testFactory = new TestFactory();
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/call/ResultSetFutureCallTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/internal/call/ResultSetFutureCallTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-public class ResultSetFutureCallTest {
+class ResultSetFutureCallTest {
   CompletableFuture<AsyncResultSet> future = new CompletableFuture<>();
   AsyncResultSet resultSet = mock(AsyncResultSet.class);
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchSpanConsumerTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/ElasticsearchSpanConsumerTest.java
@@ -207,8 +207,7 @@ class ElasticsearchSpanConsumerTest {
   }
 
   /** Less overhead as a span json isn't rewritten to include a millis timestamp */
-  @Test
-  void searchDisabled_doesntAddTimestampMillis() throws Exception {
+  @Test void searchDisabled_doesntAddTimestampMillis() throws Exception {
     storage.close();
     storage = ElasticsearchStorage.newBuilder(() -> WebClient.of(server.httpUri()))
       .searchEnabled(false)

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/JsonReadersTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/JsonReadersTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static zipkin2.elasticsearch.internal.JsonReaders.collectValuesNamed;
 import static zipkin2.elasticsearch.internal.JsonSerializers.JSON_FACTORY;
 
-public class JsonReadersTest {
+class JsonReadersTest {
   @Test void enterPath_nested() throws IOException {
     String content = "{\n"
       + "  \"name\" : \"Kamal\",\n"

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/JsonSerializersTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/JsonSerializersTest.java
@@ -30,7 +30,7 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.UTF_8;
 import static zipkin2.elasticsearch.internal.JsonSerializers.SPAN_PARSER;
 
-public class JsonSerializersTest {
+class JsonSerializersTest {
   @Test void span_ignoreNull_parentId() {
     String json =
       "{\n"

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/SearchResultConverterTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/SearchResultConverterTest.java
@@ -29,7 +29,7 @@ import static zipkin2.TestObjects.TODAY;
 import static zipkin2.elasticsearch.TestResponses.SPANS;
 import static zipkin2.elasticsearch.internal.JsonSerializers.JSON_FACTORY;
 
-public class SearchResultConverterTest {
+class SearchResultConverterTest {
   SearchResultConverter<Span> converter = SearchResultConverter.create(JsonSerializers.SPAN_PARSER);
 
   @Test void convert() throws IOException {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITEnsureIndexTemplate.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITEnsureIndexTemplate.java
@@ -50,8 +50,7 @@ abstract class ITEnsureIndexTemplate extends ITStorage<ElasticsearchStorage> {
     storage.clear();
   }
 
-  @Test
-  void createZipkinIndexTemplate_getTraces_returnsSuccess(TestInfo testInfo) throws Exception {
+  @Test void createZipkinIndexTemplate_getTraces_returnsSuccess(TestInfo testInfo) throws Exception {
     String testSuffix = testSuffix(testInfo);
     storage = newStorageBuilder(testInfo).templatePriority(10).build();
     try {

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/BulkCallBuilderTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/BulkCallBuilderTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static zipkin2.elasticsearch.internal.BulkCallBuilder.CHECK_FOR_ERRORS;
 import static zipkin2.elasticsearch.internal.JsonSerializers.JSON_FACTORY;
 
-public class BulkCallBuilderTest {
+class BulkCallBuilderTest {
   @Test void throwsRejectedExecutionExceptionWhenOverCapacity() {
     String response =
       "{\"took\":0,\"errors\":true,\"items\":[{\"index\":{\"_index\":\"dev-zipkin:span-2019.04.18\",\"_type\":\"span\",\"_id\":\"2511\",\"status\":429,\"error\":{\"type\":\"es_rejected_execution_exception\",\"reason\":\"rejected execution of org.elasticsearch.transport.TransportService$7@7ec1ea93 on EsThreadPoolExecutor[bulk, queue capacity = 200, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@621571ba[Running, pool size = 4, active threads = 4, queued tasks = 200, completed tasks = 3838534]]\"}}}]}";

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/BulkIndexWriterTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/BulkIndexWriterTest.java
@@ -28,7 +28,7 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.FRONTEND;
 import static zipkin2.TestObjects.TODAY;
 
-public class BulkIndexWriterTest {
+class BulkIndexWriterTest {
 
   // Our usual test span depends on currentTime for testing span stores with TTL, but we'd prefer
   // to have a fixed span here to avoid depending on business logic in test assertions.
@@ -39,7 +39,8 @@ public class BulkIndexWriterTest {
 
   ByteBufOutputStream buffer;
 
-  @BeforeEach public void setUp() {
+  @BeforeEach
+  void setUp() {
     buffer = new ByteBufOutputStream(Unpooled.buffer());
   }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/BulkIndexWriterTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/BulkIndexWriterTest.java
@@ -39,8 +39,7 @@ class BulkIndexWriterTest {
 
   ByteBufOutputStream buffer;
 
-  @BeforeEach
-  void setUp() {
+  @BeforeEach void setUp() {
     buffer = new ByteBufOutputStream(Unpooled.buffer());
   }
 

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchCallFactoryTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchCallFactoryTest.java
@@ -20,7 +20,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class SearchCallFactoryTest {
+class SearchCallFactoryTest {
   WebClient httpClient = mock(WebClient.class);
 
   SearchCallFactory client = new SearchCallFactory(new HttpCall.Factory(httpClient));

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchRequestTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/internal/client/SearchRequestTest.java
@@ -19,7 +19,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.elasticsearch.internal.JsonSerializers.OBJECT_MAPPER;
 
-public class SearchRequestTest {
+class SearchRequestTest {
 
   SearchRequest request = SearchRequest.create(asList("zipkin-2016.11.31"));
 

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/DependencyLinkV2SpanIteratorTest.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/DependencyLinkV2SpanIteratorTest.java
@@ -29,7 +29,7 @@ import static zipkin2.storage.mysql.v1.Schema.maybeGet;
 import static zipkin2.v1.V1BinaryAnnotation.TYPE_BOOLEAN;
 import static zipkin2.v1.V1BinaryAnnotation.TYPE_STRING;
 
-public class DependencyLinkV2SpanIteratorTest {
+class DependencyLinkV2SpanIteratorTest {
   Long traceIdHigh = null;
   long traceId = 1L;
   Long parentId = null;

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -57,8 +57,10 @@ class ITMySQLStorage {
       return false;
     }
 
-    @Override @Test @Disabled("No consumer-side span deduplication")
-    public void getTrace_deduplicates(TestInfo testInfo) {
+    @Override
+    @Test
+    @Disabled("No consumer-side span deduplication")
+    void getTrace_deduplicates(TestInfo testInfo) {
     }
 
     @Override public void clear() {

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -60,7 +60,7 @@ class ITMySQLStorage {
     @Override
     @Test
     @Disabled("No consumer-side span deduplication")
-    void getTrace_deduplicates(TestInfo testInfo) {
+    public void getTrace_deduplicates(TestInfo testInfo) {
     }
 
     @Override public void clear() {

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageTest.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class MySQLStorageTest {
+class MySQLStorageTest {
 
   @Test void check_failsInsteadOfThrowing() throws SQLException {
     DataSource dataSource = mock(DataSource.class);

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/SchemaTest.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/SchemaTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SchemaTest {
+class SchemaTest {
   DataSource dataSource = mock(DataSource.class);
   Schema schema = new Schema(
     dataSource,

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/SelectSpansAndAnnotationsTest.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/SelectSpansAndAnnotationsTest.java
@@ -25,7 +25,7 @@ import zipkin2.v1.V1Span;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinAnnotations.ZIPKIN_ANNOTATIONS;
 
-public class SelectSpansAndAnnotationsTest {
+class SelectSpansAndAnnotationsTest {
   @Test void processAnnotationRecord_nulls() {
     Record4<Integer, Long, String, byte[]> annotationRecord =
         annotationRecord(null, null, null, null);

--- a/zipkin-tests/src/test/java/zipkin2/AnnotationTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/AnnotationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AnnotationTest {
+class AnnotationTest {
 
   @Test void messageWhenMissingValue() {
     Throwable exception = assertThrows(NullPointerException.class, () -> {

--- a/zipkin-tests/src/test/java/zipkin2/CallTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/CallTest.java
@@ -37,7 +37,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class CallTest {
+class CallTest {
 
   @Mock Callback callback;
 

--- a/zipkin-tests/src/test/java/zipkin2/EndpointTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/EndpointTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class EndpointTest {
+class EndpointTest {
 
   @Test void missingIpv4IsNull() {
     assertThat(Endpoint.newBuilder().build().ipv4())

--- a/zipkin-tests/src/test/java/zipkin2/SpanBytesDecoderDetectorTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/SpanBytesDecoderDetectorTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static zipkin2.TestObjects.FRONTEND;
 
-public class SpanBytesDecoderDetectorTest {
+class SpanBytesDecoderDetectorTest {
   Span span1 =
       Span.newBuilder()
           .traceId("a")

--- a/zipkin-tests/src/test/java/zipkin2/SpanTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/SpanTest.java
@@ -27,7 +27,7 @@ import static zipkin2.Span.normalizeTraceId;
 import static zipkin2.TestObjects.BACKEND;
 import static zipkin2.TestObjects.FRONTEND;
 
-public class SpanTest {
+class SpanTest {
   Span base = Span.newBuilder().traceId("1").id("1").localEndpoint(FRONTEND).build();
   Span oneOfEach = Span.newBuilder()
     .traceId("7180c278b62e8f6a216a2aea45d08fc9")

--- a/zipkin-tests/src/test/java/zipkin2/codec/EncodingTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/codec/EncodingTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EncodingTest {
+class EncodingTest {
 
   @Test void emptyList_json() {
     List<byte[]> encoded = Arrays.asList();

--- a/zipkin-tests/src/test/java/zipkin2/codec/KryoTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/codec/KryoTest.java
@@ -27,7 +27,7 @@ import zipkin2.TestObjects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class KryoTest {
+class KryoTest {
 
   @Test void kryoJavaSerialization_annotation() {
     Kryo kryo = new Kryo();

--- a/zipkin-tests/src/test/java/zipkin2/codec/SpanBytesDecoderTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/codec/SpanBytesDecoderTest.java
@@ -34,7 +34,7 @@ import static zipkin2.codec.SpanBytesEncoderTest.SPAN;
 import static zipkin2.codec.SpanBytesEncoderTest.UTF8_SPAN;
 import static zipkin2.codec.SpanBytesEncoderTest.UTF_8;
 
-public class SpanBytesDecoderTest {
+class SpanBytesDecoderTest {
   Span span = SPAN;
 
   @Test void niceErrorOnTruncatedSpans_PROTO3() {

--- a/zipkin-tests/src/test/java/zipkin2/codec/V1SpanBytesDecoderTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/codec/V1SpanBytesDecoderTest.java
@@ -34,7 +34,7 @@ import static zipkin2.codec.SpanBytesEncoderTest.UTF8_SPAN;
 import static zipkin2.codec.SpanBytesEncoderTest.UTF_8;
 
 /** V1 tests for {@link SpanBytesDecoderTest} */
-public class V1SpanBytesDecoderTest {
+class V1SpanBytesDecoderTest {
   Span span = SPAN;
 
   @Test void niceErrorOnTruncatedSpans_THRIFT() {

--- a/zipkin-tests/src/test/java/zipkin2/internal/AggregateCallTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/AggregateCallTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class AggregateCallTest {
+class AggregateCallTest {
 
   @Mock Call<Void> call1, call2;
   @Mock Callback<Void> callback;

--- a/zipkin-tests/src/test/java/zipkin2/internal/DateUtilTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/DateUtilTest.java
@@ -24,7 +24,7 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.internal.DateUtil.midnightUTC;
 
-public class DateUtilTest {
+class DateUtilTest {
 
   @Test void midnightUTCTest() throws ParseException {
 

--- a/zipkin-tests/src/test/java/zipkin2/internal/DelayLimiterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/DelayLimiterTest.java
@@ -25,7 +25,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class DelayLimiterTest {
+class DelayLimiterTest {
   static final long NANOS_PER_SECOND = SECONDS.toNanos(1L);
   long nanoTime;
   SuppressionFactory suppressionFactory = new SuppressionFactory(NANOS_PER_SECOND) {

--- a/zipkin-tests/src/test/java/zipkin2/internal/DependenciesTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/DependenciesTest.java
@@ -20,7 +20,7 @@ import zipkin2.DependencyLink;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class DependenciesTest {
+final class DependenciesTest {
   @Test void dependenciesRoundTrip() {
     DependencyLink ab = DependencyLink.newBuilder().parent("a").child("b").callCount(2L).build();
     DependencyLink cd = DependencyLink.newBuilder().parent("c").child("d").errorCount(2L).build();

--- a/zipkin-tests/src/test/java/zipkin2/internal/DependencyLinkerTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/DependencyLinkerTest.java
@@ -28,7 +28,7 @@ import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DependencyLinkerTest {
+class DependencyLinkerTest {
   // in reverse order as reporting is more likely to occur this way
   static final List<Span> TRACE = asList(
     span("a", "b", "c", Kind.CLIENT, "app", "db", true),

--- a/zipkin-tests/src/test/java/zipkin2/internal/FilterTracesTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/FilterTracesTest.java
@@ -25,7 +25,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.TODAY;
 
-public class FilterTracesTest {
+class FilterTracesTest {
   QueryRequest request = QueryRequest.newBuilder().endTs(TODAY).lookback(1).limit(1).build();
 
   @Test void returnsWhenValidlyMatches() {

--- a/zipkin-tests/src/test/java/zipkin2/internal/HexCodecTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/HexCodecTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static zipkin2.internal.HexCodec.lowerHexToUnsignedLong;
 
-public class HexCodecTest {
+class HexCodecTest {
 
   @Test void lowerHexToUnsignedLong_downgrades128bitIdsByDroppingHighBits() {
     assertThat(lowerHexToUnsignedLong("463ac35c9f6413ad48485a3953bb6124"))

--- a/zipkin-tests/src/test/java/zipkin2/internal/JsonCodecTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/JsonCodecTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static zipkin2.internal.JsonCodec.exceptionReading;
 
-public class JsonCodecTest {
+class JsonCodecTest {
 
   @Test void doesntStackOverflowOnToBufferWriterBug_lessThanBytes() {
     Throwable exception = assertThrows(AssertionError.class, () -> {

--- a/zipkin-tests/src/test/java/zipkin2/internal/JsonEscaperTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/JsonEscaperTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.internal.JsonEscaper.jsonEscape;
 import static zipkin2.internal.JsonEscaper.jsonEscapedSizeInBytes;
 
-public class JsonEscaperTest {
+class JsonEscaperTest {
 
   @Test void testJsonEscapedSizeInBytes() {
     assertThat(jsonEscapedSizeInBytes(new String(new char[] {0, 'a', 1})))

--- a/zipkin-tests/src/test/java/zipkin2/internal/Proto3FieldsTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/Proto3FieldsTest.java
@@ -31,7 +31,7 @@ import static zipkin2.internal.Proto3Fields.WIRETYPE_FIXED64;
 import static zipkin2.internal.Proto3Fields.WIRETYPE_LENGTH_DELIMITED;
 import static zipkin2.internal.Proto3Fields.WIRETYPE_VARINT;
 
-public class Proto3FieldsTest {
+class Proto3FieldsTest {
   byte[] bytes = new byte[2048]; // bigger than needed to test sizeInBytes
   WriteBuffer buf = WriteBuffer.wrap(bytes);
 

--- a/zipkin-tests/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.internal.Proto3ZipkinFields.SPAN;
 
-class Proto3SpanWriterTest {
+public class Proto3SpanWriterTest {
   Proto3SpanWriter writer = new Proto3SpanWriter();
 
   /** proto messages always need a key, so the non-list form is just a single-field */

--- a/zipkin-tests/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/Proto3SpanWriterTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.internal.Proto3ZipkinFields.SPAN;
 
-public class Proto3SpanWriterTest {
+class Proto3SpanWriterTest {
   Proto3SpanWriter writer = new Proto3SpanWriter();
 
   /** proto messages always need a key, so the non-list form is just a single-field */

--- a/zipkin-tests/src/test/java/zipkin2/internal/Proto3ZipkinFieldsTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/Proto3ZipkinFieldsTest.java
@@ -31,7 +31,7 @@ import static zipkin2.TestObjects.TODAY;
 import static zipkin2.internal.Proto3Fields.WIRETYPE_LENGTH_DELIMITED;
 import static zipkin2.internal.Proto3ZipkinFields.SPAN;
 
-public class Proto3ZipkinFieldsTest {
+class Proto3ZipkinFieldsTest {
   byte[] bytes = new byte[2048]; // bigger than needed to test sizeInBytes
   WriteBuffer buf = WriteBuffer.wrap(bytes);
 

--- a/zipkin-tests/src/test/java/zipkin2/internal/ReadBufferTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/ReadBufferTest.java
@@ -21,7 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class ReadBufferTest {
+class ReadBufferTest {
   @Test void byteBuffer_limited() {
     ByteBuffer buf = ByteBuffer.wrap("glove".getBytes(UTF_8));
     buf.get();

--- a/zipkin-tests/src/test/java/zipkin2/internal/SpanNodeTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/SpanNodeTest.java
@@ -28,7 +28,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SpanNodeTest {
+class SpanNodeTest {
   List<String> messages = new ArrayList<>();
 
   Logger logger = new Logger("", null) {

--- a/zipkin-tests/src/test/java/zipkin2/internal/TraceTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/TraceTest.java
@@ -26,7 +26,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-public class TraceTest {
+class TraceTest {
 
   /**
    * Some don't propagate the server's parent ID which creates a race condition. Try to unwind it.

--- a/zipkin-tests/src/test/java/zipkin2/internal/TracesAdapterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/TracesAdapterTest.java
@@ -20,7 +20,7 @@ import zipkin2.storage.InMemoryStorage;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TracesAdapterTest {
+class TracesAdapterTest {
   InMemoryStorage storage = InMemoryStorage.newBuilder().build();
   TracesAdapter adapter = new TracesAdapter(storage);
 

--- a/zipkin-tests/src/test/java/zipkin2/internal/V1JsonSpanWriterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/V1JsonSpanWriterTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.internal.JsonCodec.UTF_8;
 
-public class V1JsonSpanWriterTest {
+class V1JsonSpanWriterTest {
   V1JsonSpanWriter writer = new V1JsonSpanWriter();
   byte[] bytes = new byte[2048]; // bigger than needed to test sizeInBytes
   WriteBuffer buf = WriteBuffer.wrap(bytes);

--- a/zipkin-tests/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
@@ -40,8 +40,7 @@ class V1ThriftSpanWriterTest {
   V1ThriftSpanWriter writer = new V1ThriftSpanWriter();
   byte[] endpointBytes = new byte[ThriftEndpointCodec.sizeInBytes(endpoint)];
 
-  @BeforeEach
-  void init() {
+  @BeforeEach void init() {
     ThriftEndpointCodec.write(endpoint, WriteBuffer.wrap(endpointBytes, 0));
   }
 

--- a/zipkin-tests/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/V1ThriftSpanWriterTest.java
@@ -31,7 +31,7 @@ import static zipkin2.internal.ThriftField.TYPE_LIST;
 import static zipkin2.internal.ThriftField.TYPE_STRING;
 import static zipkin2.internal.ThriftField.TYPE_STRUCT;
 
-public class V1ThriftSpanWriterTest {
+class V1ThriftSpanWriterTest {
   Span span = Span.newBuilder().traceId("1").id("2").build();
   Endpoint endpoint = Endpoint.newBuilder().serviceName("frontend").ip("1.2.3.4").build();
   byte[] bytes = new byte[2048]; // bigger than needed to test sizeOf
@@ -40,7 +40,8 @@ public class V1ThriftSpanWriterTest {
   V1ThriftSpanWriter writer = new V1ThriftSpanWriter();
   byte[] endpointBytes = new byte[ThriftEndpointCodec.sizeInBytes(endpoint)];
 
-  @BeforeEach public void init() {
+  @BeforeEach
+  void init() {
     ThriftEndpointCodec.write(endpoint, WriteBuffer.wrap(endpointBytes, 0));
   }
 

--- a/zipkin-tests/src/test/java/zipkin2/internal/V2SpanWriterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/V2SpanWriterTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.TODAY;
 
-public class V2SpanWriterTest {
+class V2SpanWriterTest {
   V2SpanWriter writer = new V2SpanWriter();
   byte[] bytes = new byte[2048]; // bigger than needed to test sizeInBytes
   WriteBuffer buf = WriteBuffer.wrap(bytes);

--- a/zipkin-tests/src/test/java/zipkin2/internal/WriteBufferTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/internal/WriteBufferTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class WriteBufferTest {
+class WriteBufferTest {
   // Adapted from http://stackoverflow.com/questions/8511490/calculating-length-in-utf-8-of-java-string-without-actually-encoding-it
   @Test void utf8SizeInBytes() {
     for (int codepoint = 0; codepoint <= 0x10FFFF; codepoint++) {

--- a/zipkin-tests/src/test/java/zipkin2/storage/ForwardingStorageComponentTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/storage/ForwardingStorageComponentTest.java
@@ -51,8 +51,7 @@ class ForwardingStorageComponentTest {
     }
   };
 
-  @AfterEach
-  void verifyNoExtraCalls() {
+  @AfterEach void verifyNoExtraCalls() {
     verifyNoMoreInteractions(delegate);
   }
 

--- a/zipkin-tests/src/test/java/zipkin2/storage/ForwardingStorageComponentTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/storage/ForwardingStorageComponentTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class ForwardingStorageComponentTest {
+class ForwardingStorageComponentTest {
   /**
    * This test is intentionally brittle. It should break if we add new methods on {@link
    * StorageComponent}!
@@ -51,7 +51,8 @@ public class ForwardingStorageComponentTest {
     }
   };
 
-  @AfterEach public void verifyNoExtraCalls() {
+  @AfterEach
+  void verifyNoExtraCalls() {
     verifyNoMoreInteractions(delegate);
   }
 

--- a/zipkin-tests/src/test/java/zipkin2/storage/GroupByTraceIdTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/storage/GroupByTraceIdTest.java
@@ -20,7 +20,7 @@ import zipkin2.Span;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GroupByTraceIdTest {
+class GroupByTraceIdTest {
   Span oneOne = Span.newBuilder().traceId(1, 1).id(1).build();
   Span twoOne = Span.newBuilder().traceId(2, 1).id(1).build();
   Span zeroOne = Span.newBuilder().traceId(0, 1).id(1).build();

--- a/zipkin-tests/src/test/java/zipkin2/storage/InMemoryStorageTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/storage/InMemoryStorageTest.java
@@ -32,7 +32,7 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.TODAY;
 import static zipkin2.storage.ITSpanStore.requestBuilder;
 
-public class InMemoryStorageTest {
+class InMemoryStorageTest {
   InMemoryStorage storage =
     InMemoryStorage.newBuilder().autocompleteKeys(asList("http.path")).build();
 

--- a/zipkin-tests/src/test/java/zipkin2/storage/QueryRequestTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/storage/QueryRequestTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class QueryRequestTest {
+class QueryRequestTest {
   QueryRequest.Builder queryBuilder =
     QueryRequest.newBuilder().endTs(TestObjects.TODAY).lookback(60).limit(10);
   Span span = Span.newBuilder().traceId("10").id("10").name("receive")

--- a/zipkin-tests/src/test/java/zipkin2/storage/StrictTraceIdTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/storage/StrictTraceIdTest.java
@@ -26,7 +26,7 @@ import static zipkin2.TestObjects.TODAY;
 import static zipkin2.TestObjects.TRACE;
 import static zipkin2.storage.ITSpanStore.requestBuilder;
 
-public class StrictTraceIdTest {
+class StrictTraceIdTest {
 
   @Test void filterTraces_skipsOnNoClash() {
     Span oneOne = Span.newBuilder().traceId(1, 1).id(1).build();

--- a/zipkin-tests/src/test/java/zipkin2/v1/SpanConverterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/v1/SpanConverterTest.java
@@ -23,7 +23,7 @@ import static zipkin2.TestObjects.BACKEND;
 import static zipkin2.TestObjects.FRONTEND;
 import static zipkin2.TestObjects.TODAY;
 
-public class SpanConverterTest {
+class SpanConverterTest {
   Endpoint kafka = Endpoint.newBuilder().serviceName("kafka").build();
   V2SpanConverter v2SpanConverter = new V2SpanConverter();
   V1SpanConverter v1SpanConverter = new V1SpanConverter();

--- a/zipkin-tests/src/test/java/zipkin2/v1/V1SpanConverterTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/v1/V1SpanConverterTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.BACKEND;
 import static zipkin2.TestObjects.FRONTEND;
 
-public class V1SpanConverterTest {
+class V1SpanConverterTest {
   Endpoint kafka = Endpoint.newBuilder().serviceName("kafka").build();
   V1SpanConverter v1SpanConverter = new V1SpanConverter();
 

--- a/zipkin-tests/src/test/java/zipkin2/v1/V1SpanTest.java
+++ b/zipkin-tests/src/test/java/zipkin2/v1/V1SpanTest.java
@@ -18,7 +18,7 @@ import zipkin2.Endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class V1SpanTest {
+class V1SpanTest {
   V1Span.Builder builder = V1Span.newBuilder().traceId("1").id("1");
 
   @Test void annotationEndpoint_emptyToNull() {


### PR DESCRIPTION
 Another round of removing public modifiers from tests not needed anymore in JUnit JUpiter, after https://github.com/openzipkin/zipkin/pull/3630#issuecomment-1852999850.
This helps the public modifiers that are there for a reason stand out, and stops proliferation elsewhere.

Probably best to squash merge this one; had to revert some formatting changes.