### PR TITLE
tests: removes eager upgrade to okhttp alpha 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,6 @@
     <awaitility.version>4.2.0</awaitility.version>
     <testcontainers.version>1.19.3</testcontainers.version>
     <okhttp.version>4.12.0</okhttp.version>
-    <okhttp5.version>5.0.0-alpha.11</okhttp5.version>
     <kryo.version>5.5.0</kryo.version>
     <!-- Only used for proto interop testing; wire-maven-plugin is usually behind latest. -->
     <wire.version>4.9.3</wire.version>
@@ -199,6 +198,14 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${assertj.version}</version>
+      <exclusions>
+        <!-- Use newer bytebuddy from mockito.
+             TODO: remove when assertj releases a new version -->
+        <exclusion>
+          <groupId>net.bytebuddy</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
 

--- a/zipkin-junit5/pom.xml
+++ b/zipkin-junit5/pom.xml
@@ -61,16 +61,13 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver3-junit5</artifactId>
-      <version>${okhttp5.version}</version>
-      <exclusions>
-        <!-- manage our own jupiter version -->
-        <exclusion>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
+      <!-- Intentionally not the alpha mockwebserver3 until it can coexist with
+           okhttp 3, avoiding:
+           java.lang.NoSuchMethodError: 'void okhttp3.internal.concurrent.TaskRunner.<init>(okhttp3.internal.concurrent.TaskRunner$Backend, java.util.logging.Logger, int, kotlin.jvm.internal.DefaultConstructorMarker)' -->
+      <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>

--- a/zipkin-junit5/pom.xml
+++ b/zipkin-junit5/pom.xml
@@ -66,6 +66,18 @@
            java.lang.NoSuchMethodError: 'void okhttp3.internal.concurrent.TaskRunner.<init>(okhttp3.internal.concurrent.TaskRunner$Backend, java.util.logging.Logger, int, kotlin.jvm.internal.DefaultConstructorMarker)' -->
       <artifactId>mockwebserver</artifactId>
       <version>${okhttp.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Override mockwebserver's junit only to squash CVE version -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
     </dependency>
 
     <dependency>

--- a/zipkin-junit5/src/main/java/zipkin2/junit5/HttpFailure.java
+++ b/zipkin-junit5/src/main/java/zipkin2/junit5/HttpFailure.java
@@ -13,9 +13,9 @@
  */
 package zipkin2.junit5;
 
-import mockwebserver3.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 
-import static mockwebserver3.SocketPolicy.DISCONNECT_DURING_REQUEST_BODY;
+import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_DURING_REQUEST_BODY;
 
 /**
  * Instrumentation that use {@code POST} endpoints need to survive failures. Besides simply not

--- a/zipkin-junit5/src/main/java/zipkin2/junit5/ZipkinDispatcher.java
+++ b/zipkin-junit5/src/main/java/zipkin2/junit5/ZipkinDispatcher.java
@@ -13,11 +13,12 @@
  */
 package zipkin2.junit5;
 
+import java.io.IOException;
 import okhttp3.HttpUrl;
-import mockwebserver3.Dispatcher;
-import mockwebserver3.MockResponse;
-import mockwebserver3.MockWebServer;
-import mockwebserver3.RecordedRequest;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 import okio.GzipSource;
 import zipkin2.Callback;
@@ -25,8 +26,6 @@ import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.storage.StorageComponent;
-
-import java.io.IOException;
 
 final class ZipkinDispatcher extends Dispatcher {
   private final Collector consumer;
@@ -46,15 +45,15 @@ final class ZipkinDispatcher extends Dispatcher {
       String type = request.getHeader("Content-Type");
       if (url.encodedPath().equals("/api/v1/spans")) {
         SpanBytesDecoder decoder =
-            type != null && type.contains("/x-thrift")
-                ? SpanBytesDecoder.THRIFT
-                : SpanBytesDecoder.JSON_V1;
+          type != null && type.contains("/x-thrift")
+            ? SpanBytesDecoder.THRIFT
+            : SpanBytesDecoder.JSON_V1;
         return acceptSpans(request, decoder);
       } else if (url.encodedPath().equals("/api/v2/spans")) {
         SpanBytesDecoder decoder =
-            type != null && type.contains("/x-protobuf")
-                ? SpanBytesDecoder.PROTO3
-                : SpanBytesDecoder.JSON_V2;
+          type != null && type.contains("/x-protobuf")
+            ? SpanBytesDecoder.PROTO3
+            : SpanBytesDecoder.JSON_V2;
         return acceptSpans(request, decoder);
       }
     } else { // unsupported method

--- a/zipkin-junit5/src/main/java/zipkin2/junit5/ZipkinExtension.java
+++ b/zipkin-junit5/src/main/java/zipkin2/junit5/ZipkinExtension.java
@@ -13,10 +13,16 @@
  */
 package zipkin2.junit5;
 
-import mockwebserver3.MockWebServer;
-import mockwebserver3.Dispatcher;
-import mockwebserver3.MockResponse;
-import mockwebserver3.RecordedRequest;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -26,14 +32,7 @@ import zipkin2.collector.InMemoryCollectorMetrics;
 import zipkin2.internal.Nullable;
 import zipkin2.storage.InMemoryStorage;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static mockwebserver3.SocketPolicy.KEEP_OPEN;
+import static okhttp3.mockwebserver.SocketPolicy.KEEP_OPEN;
 
 /**
  * Starts up a local Zipkin server, listening for http requests on {@link #httpUrl}.
@@ -156,13 +155,9 @@ public final class ZipkinExtension implements BeforeEachCallback, AfterEachCallb
     server.shutdown();
   }
 
-  @Override
-  public void beforeEach(ExtensionContext extensionContext) throws Exception {
-
+  @Override public void beforeEach(ExtensionContext extensionContext) {
   }
 
-  @Override
-  public void afterEach(ExtensionContext extensionContext) throws Exception {
-
+  @Override public void afterEach(ExtensionContext extensionContext) {
   }
 }


### PR DESCRIPTION
the junit5 extension was written to depend on okhttp5, which hasn't been updated in a year and introduces classpath conflicts. This reverts that, so that the extension is useable in projects that use okhttp and would otherwise conflict on the okio dep okhttp5 brings in.

We need to release a patch after this to unlock zipkin-reporter