### PR TITLE
refactor: Drop prefixless expressions in POM

### DIFF
--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -331,7 +331,7 @@
                 </goals>
                 <configuration>
                   <classifier>javadoc</classifier>
-                  <classesDirectory>${basedir}/javadoc</classesDirectory>
+                  <classesDirectory>${project.basedir}/javadoc</classesDirectory>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.maven.cleanup.PrefixlessExpressions?organizationId=T3BlbiBaaXBraW4%3D