### PR TITLE
deps: updates to supported rabbitmq client

### DIFF
--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -29,8 +29,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <!-- TODO: this version is abandoned: we have to rewrite for 5.x to avoid CVEs -->
-    <amqp-client.version>4.12.0</amqp-client.version>
+    <amqp-client.version>5.20.0</amqp-client.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
after #3619 this addresses the last server-side CVE known to trivy.