### PR TITLE
deps: temporarily update boringssl ahead of netty to fix M1 docker crash

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -146,6 +146,11 @@
           <groupId>javax.validation</groupId>
           <artifactId>validation-api</artifactId>
         </exclusion>
+        <!-- temporary until netty includes https://github.com/netty/netty/pull/13724 -->
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -157,6 +162,43 @@
       <groupId>${armeria.groupId}</groupId>
       <artifactId>armeria-grpc-protocol</artifactId>
       <version>${armeria.version}</version>
+    </dependency>
+
+    <!-- temporary until netty includes https://github.com/netty/netty/pull/13724 -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>linux-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>linux-aarch_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>osx-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>osx-aarch_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.62.Final</version>
+      <classifier>windows-x86_64</classifier>
+      <scope>runtime</scope>
     </dependency>
 
     <!--Prometheus metrics-->


### PR DESCRIPTION
temporary until netty includes https://github.com/netty/netty/pull/13724

Fixes https://github.com/openzipkin/zipkin/issues/3532