### PR TITLE
cassandra: moves to Apache Driver and fixes Apple Silicon docker crash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:  # use latest available versions and be consistent on all workflows!
         include:
           - java_version: 11  # Last that can compile zipkin core to 1.6 for zipkin-reporter
-            maven_args: -Prelease -Dgpg.skip
+            maven_args: -Prelease -Dgpg.skip -Dmaven.javadoc.skip=true
           - java_version: 21  # Most recent LTS
     steps:
       - name: Checkout Repository

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -35,7 +35,7 @@
     <unpack-proto.directory>${project.build.directory}/main/proto</unpack-proto.directory>
   </properties>
 
-  <!-- DataStax java-driver is typically behind on jackson and netty -->
+  <!-- Apache Cassandra java-driver is typically behind on jackson and netty -->
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -141,7 +141,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.datastax.oss</groupId>
+      <groupId>org.apache.cassandra</groupId>
       <artifactId>java-driver-core</artifactId>
       <version>${java-driver.version}</version>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- It's easy for Jackson dependencies to get misaligned, so we manage it ourselves. -->
     <jackson.version>2.16.0</jackson.version>
 
-    <java-driver.version>4.17.0</java-driver.version>
+    <java-driver.version>4.18.0</java-driver.version>
     <micrometer.version>1.12.0</micrometer.version>
 
     <!-- Used for Generated annotations -->

--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -5,7 +5,7 @@ This uses Cassandra 3.11.3+ features, but is tested against the latest patch of 
 
 `CassandraSpanStore.getDependencies()` returns pre-aggregated dependency links (ex via [zipkin-dependencies](https://github.com/openzipkin/zipkin-dependencies)).
 
-The implementation uses the [Datastax Java Driver 4.x](https://github.com/datastax/java-driver).
+The implementation uses the [Apache Cassandra Java Driver 4.x](https://github.com/apache/cassandra-java-driver).
 
 `zipkin2.storage.cassandra.CassandraStorage.Builder` includes defaults that will operate against a local Cassandra installation.
 

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -35,7 +35,7 @@
     <errorprone.args>-Xep:CheckReturnValue:OFF -Xep:AutoValueImmutableFields:OFF</errorprone.args>
   </properties>
 
-  <!-- DataStax java-driver is typically behind on jackson and netty -->
+  <!-- Apache Cassandra java-driver is typically behind on jackson and netty -->
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -70,7 +70,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.datastax.oss</groupId>
+      <groupId>org.apache.cassandra</groupId>
       <artifactId>java-driver-core</artifactId>
       <version>${java-driver.version}</version>
       <!-- Exclude unused graph and geo dependencies -->
@@ -79,6 +79,11 @@
           <groupId>com.esri.geometry</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <!-- temporary until https://github.com/apache/cassandra-java-driver/pull/1904 -->
+        <exclusion>
+          <groupId>com.github.jnr</groupId>
+          <artifactId>jnr-posix</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.apache.tinkerpop</groupId>
           <artifactId>*</artifactId>
@@ -86,6 +91,12 @@
         <!-- We retain reactivestreams even though we don't use it because
              Mockito dies trying to mock CqlSession without it. -->
       </exclusions>
+    </dependency>
+    <!-- temporary until https://github.com/apache/cassandra-java-driver/pull/1904 -->
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+      <version>3.1.18</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This changes the groupId of the Cassandra driver to Apache as it has been donated by DataStax recently. After upgrading the version, this updates com.github.jnr:jnr-posix to avoid a crash when running the zipkin docker container on Apple Silicon. See https://github.com/apache/cassandra-java-driver/pull/1904

```
# below crash happens after hitting the /health endpoint on zipkin and it doesn't matter if the cassandra host is present or not.
~ $  STORAGE_TYPE=cassandra3 start-zipkin

                  oo
                 oooo
                oooooo
               oooooooo
              oooooooooo
             oooooooooooo
           ooooooo  ooooooo
          oooooo     ooooooo
         oooooo       ooooooo
        oooooo   o  o   oooooo
       oooooo   oo  oo   oooooo
     ooooooo  oooo  oooo  ooooooo
    oooooo   ooooo  ooooo  ooooooo
   oooooo   oooooo  oooooo  ooooooo
  oooooooo      oo  oo      oooooooo
  ooooooooooooo oo  oo ooooooooooooo
      oooooooooooo  oooooooooooo
          oooooooo  oooooooo
              oooo  oooo

     ________ ____  _  _____ _   _
    |__  /_ _|  _ \| |/ /_ _| \ | |
      / / | || |_) | ' / | ||  \| |
     / /_ | ||  __/| . \ | || |\  |
    |____|___|_|   |_|\_\___|_| \_|

:: version 2.25.1 :: commit 82c3d7a ::

2023-12-15 05:45:58.195  INFO [/] 8 --- [oss-http-*:9411] c.l.a.s.Server                           : Serving HTTP at /0.0.0.0:9411 - http://127.0.0.1:9411/
2023-12-15 05:46:06.887  INFO [/] 8 --- [cking-tasks-2-1] c.d.o.d.i.c.c.CqlPrepareAsyncProcessor   : Adding handler to invalidate cached prepared statements on type changes
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000000000005e30, pid=8, tid=59
#
# JRE version: OpenJDK Runtime Environment (21.0.1+12) (build 21.0.1+12-alpine-r1)
# Java VM: OpenJDK 64-Bit Server VM (21.0.1+12-alpine-r1, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
# Problematic frame:
# C  [jffi11042031320136118671.so+0x7f7c]  jffi_throwExceptionByName+0xfc
--snip--
```