### PR TITLE
docker: uses health check in examples and documents dependencies job

### DIFF
--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -41,6 +41,14 @@ To start the Cassandra-backed configuration, run:
 $ docker-compose -f docker-compose-cassandra.yml up
 ```
 
+The `zipkin-dependencies` container is a scheduled task that runs every hour.
+If you want to see the dependency graph before then, you can run it manually
+in another terminal like so:
+
+```bash
+$ docker-compose -f docker-compose-cassandra.yml run --rm --no-deps --entrypoint start-zipkin-dependencies dependencies
+```
+
 ## Elasticsearch
 
 You can store traces in [Elasticsearch](../test-images/zipkin-elasticsearch7/README.md) instead of memory,
@@ -51,6 +59,14 @@ To start the Elasticsearch-backed configuration, run:
 
 ```bash
 $ docker-compose -f docker-compose-elasticsearch.yml up
+```
+
+The `zipkin-dependencies` container is a scheduled task that runs every hour.
+If you want to see the dependency graph before then, you can run it manually
+in another terminal like so:
+
+```bash
+$ docker-compose -f docker-compose-elasticsearch.yml run --rm --no-deps --entrypoint start-zipkin-dependencies dependencies
 ```
 
 ## Kafka

--- a/docker/examples/docker-compose-cassandra.yml
+++ b/docker/examples/docker-compose-cassandra.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -51,7 +51,8 @@ services:
     # Uncomment to enable request logging (TRACE shows query values)
     # command: --logging.level.com.datastax.oss.driver.internal.core.tracker.RequestLogger=TRACE
     depends_on:
-      - storage
+      storage:
+        condition: service_healthy
 
   dependencies:
     extends:
@@ -61,4 +62,5 @@ services:
       - STORAGE_TYPE=${STORAGE_TYPE:-cassandra3}
       - CASSANDRA_CONTACT_POINTS=cassandra
     depends_on:
-      - storage
+      storage:
+        condition: service_healthy

--- a/docker/examples/docker-compose-dependencies.yml
+++ b/docker/examples/docker-compose-dependencies.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -22,7 +22,8 @@ services:
   dependencies:
     image: ghcr.io/openzipkin/zipkin-dependencies
     container_name: dependencies
-    entrypoint: crond -f
+    user: root
+    entrypoint: /usr/sbin/crond -f
     # environment:
       # Uncomment to see dependency processing logs
       # - ZIPKIN_LOG_LEVEL=DEBUG

--- a/docker/examples/docker-compose-elasticsearch.yml
+++ b/docker/examples/docker-compose-elasticsearch.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -40,7 +40,8 @@ services:
       # Uncomment to see requests to and from elasticsearch
       # - ES_HTTP_LOGGING=BODY
     depends_on:
-      - storage
+      storage:
+        condition: service_healthy
 
   dependencies:
     extends:
@@ -50,4 +51,5 @@ services:
       - STORAGE_TYPE=elasticsearch
       - ES_HOSTS=elasticsearch
     depends_on:
-      - storage
+      storage:
+        condition: service_healthy

--- a/docker/examples/docker-compose-kafka.yml
+++ b/docker/examples/docker-compose-kafka.yml
@@ -41,4 +41,5 @@ services:
     environment:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
     depends_on:
-      - kafka-zookeeper
+      kafka:
+        condition: service_healthy

--- a/docker/examples/docker-compose-mysql.yml
+++ b/docker/examples/docker-compose-mysql.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -44,7 +44,8 @@ services:
       - MYSQL_USER=zipkin
       - MYSQL_PASS=zipkin
     depends_on:
-      - storage
+      storage:
+        condition: service_healthy
 
   dependencies:
     extends:
@@ -57,4 +58,5 @@ services:
       - MYSQL_USER=zipkin
       - MYSQL_PASS=zipkin
     depends_on:
-      - storage
+      storage:
+        condition: service_healthy

--- a/docker/examples/docker-compose-prometheus.yml
+++ b/docker/examples/docker-compose-prometheus.yml
@@ -30,7 +30,8 @@ services:
     ports:
       - 9090:9090
     depends_on:
-      - zipkin
+      zipkin:
+        condition: service_healthy
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
 

--- a/docker/examples/docker-compose-ui.yml
+++ b/docker/examples/docker-compose-ui.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -30,4 +30,5 @@ services:
     ports:
       - 80:80
     depends_on:
-      - zipkin
+      zipkin:
+        condition: service_healthy

--- a/docker/test-images/zipkin-elasticsearch7/README.md
+++ b/docker/test-images/zipkin-elasticsearch7/README.md
@@ -20,4 +20,7 @@ $ sudo sysctl -w vm.max_map_count=262144
 
 # If using docker-machine/Docker Toolbox/Boot2Docker, remotely adjust the same
 $ docker-machine ssh default "sudo sysctl -w vm.max_map_count=262144"
+
+# If using colima, it is similar as well
+$ colima ssh "sudo sysctl -w vm.max_map_count=262144"
 ```


### PR DESCRIPTION
This uses health check in the docker-compose examples to reduce the amount of warnings end users see.

It also fixes a minor issue on the dependencies job, as well adds instructions for how to run it manually. This is needed for folks who don't want to wait an hour to see the graph.

Fixes #3529