### PR TITLE
docker: adds ppc64le architecture to zipkin and zipkin-slim images

### DIFF
--- a/build-bin/docker_push
+++ b/build-bin/docker_push
@@ -10,10 +10,6 @@ case ${version} in
     ;;
 esac
 
-# Don't attempt ppc64le until there's a package for recent LTS versions.
-# See https://github.com/openzipkin/zipkin/issues/3443
-export DOCKER_ARCHS="amd64 arm64 s390x"
-
 build-bin/docker/docker_push openzipkin/zipkin ${version}
 DOCKER_TARGET=zipkin-slim build-bin/docker/docker_push openzipkin/zipkin-slim ${version}
 


### PR DESCRIPTION
Similar to s390x, we are adding ppc64le architecture for our zipkin and zipkin-slim images. Both of these are for the [Knative project](https://knative.dev/docs/), conceding they are best efforts because we don't have a way to test them at the moment.

Fixes #3443 cc @NishikantThorat