### PR TITLE
docker: updates Elasticsearch 7.x image to Elastic licensed 7.17.16

### DIFF
--- a/docker/test-images/zipkin-elasticsearch7/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch7/Dockerfile
@@ -27,7 +27,6 @@ FROM scratch as scratch
 COPY build-bin/docker/docker-healthcheck /docker-bin/
 COPY docker/test-images/zipkin-elasticsearch7/start-elasticsearch /docker-bin/
 COPY docker/test-images/zipkin-elasticsearch7/config/ /config/
-COPY docker/test-images/zipkin-elasticsearch7/NOTICE.txt /
 
 FROM ghcr.io/openzipkin/java:${java_version} as install
 

--- a/docker/test-images/zipkin-elasticsearch7/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch7/Dockerfile
@@ -47,6 +47,8 @@ https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsear
     --wildcards --strip=1 --exclude=*/bin && mkdir classes
 COPY --from=scratch /config/ ./config/
 
+# Use a full Java distribution rather than adding test modules to the
+# production -jre base layer used by zipkin and zipkin-slim.
 FROM ghcr.io/openzipkin/java:${java_version} as zipkin-elasticsearch7
 LABEL org.opencontainers.image.description="Elasticsearch distribution on OpenJDK and Alpine Linux"
 ARG elasticsearch7_version=7.17.16

--- a/docker/test-images/zipkin-elasticsearch7/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch7/Dockerfile
@@ -27,33 +27,34 @@ FROM scratch as scratch
 COPY build-bin/docker/docker-healthcheck /docker-bin/
 COPY docker/test-images/zipkin-elasticsearch7/start-elasticsearch /docker-bin/
 COPY docker/test-images/zipkin-elasticsearch7/config/ /config/
+COPY docker/test-images/zipkin-elasticsearch7/NOTICE.txt /
 
 FROM ghcr.io/openzipkin/java:${java_version} as install
 
 WORKDIR /install
 
-# Use latest 7.x version from https://www.elastic.co/downloads/past-releases#elasticsearch
+# Use latest 7.x version from https://www.elastic.co/downloads/past-releases#elasticsearch-no-jdk
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-#
-# TODO: 7.10.2 is the last OSS no-jdk version. To update requires a switch to non OSS.
-# See https://www.elastic.co/downloads/past-releases#elasticsearch-oss-no-jdk
-ARG elasticsearch7_version=7.10.2
+ARG elasticsearch7_version=7.17.16
 
 # Download only the OSS distribution (lacks X-Pack)
 RUN \
 # Connection resets are frequent in GitHub Actions workflows \
 wget --random-wait --tries=5 -qO- \
 # We don't download bin scripts as we customize for reasons including BusyBox problems
-https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${elasticsearch7_version}-no-jdk-linux-x86_64.tar.gz| tar xz \
+https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsearch7_version}-no-jdk-linux-x86_64.tar.gz| tar xz \
     --wildcards --strip=1 --exclude=*/bin && mkdir classes
-
 COPY --from=scratch /config/ ./config/
 
-FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-elasticsearch7
-LABEL org.opencontainers.image.description="Elasticsearch OSS distribution on OpenJDK and Alpine Linux"
-ARG elasticsearch7_version=7.10.2
+FROM ghcr.io/openzipkin/java:${java_version} as zipkin-elasticsearch7
+LABEL org.opencontainers.image.description="Elasticsearch distribution on OpenJDK and Alpine Linux"
+ARG elasticsearch7_version=7.17.16
 LABEL elasticsearch-version=$elasticsearch7_version
+
+# This image is only for testing Zipkin, but alert users anyway about the
+# Elastic license. The license ends up on disk as /elasticsearch/LICENSE.txt
+LABEL org.opencontainers.image.licenses="Elastic-License-2.0"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY --from=scratch /docker-bin/* /usr/local/bin/
@@ -74,4 +75,5 @@ COPY --from=install --chown=${USER} /install .
 
 # Use to set heap, trust store or other system properties.
 ENV JAVA_OPTS="-Xms256m -Xmx256m -XX:+ExitOnOutOfMemoryError"
+ENV LIBFFI_TMPDIR=/tmp
 EXPOSE 9200

--- a/docker/test-images/zipkin-elasticsearch7/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch7/Dockerfile
@@ -54,8 +54,7 @@ LABEL org.opencontainers.image.description="Elasticsearch distribution on OpenJD
 ARG elasticsearch7_version=7.17.16
 LABEL elasticsearch-version=$elasticsearch7_version
 
-# This image is only for testing Zipkin, but alert users anyway about the
-# Elastic license. The license ends up on disk as /elasticsearch/LICENSE.txt
+# The full license is also included in the image at /elasticsearch/LICENSE.txt.
 LABEL org.opencontainers.image.licenses="Elastic-License-2.0"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path

--- a/docker/test-images/zipkin-elasticsearch7/README.md
+++ b/docker/test-images/zipkin-elasticsearch7/README.md
@@ -11,6 +11,7 @@ $ DOCKER_FILE=docker/test-images/zipkin-elasticsearch7/Dockerfile build-bin/dock
 You can use the env variable `JAVA_OPTS` to change settings such as heap size for Elasticsearch.
 
 #### Host setup
+
 Elasticsearch is [strict](https://github.com/docker-library/docs/tree/master/elasticsearch#host-setup)
 about virtual memory. You will need to adjust accordingly (especially if you notice Elasticsearch crash!)
 
@@ -21,3 +22,10 @@ $ sudo sysctl -w vm.max_map_count=262144
 # If using docker-machine/Docker Toolbox/Boot2Docker, remotely adjust the same
 $ docker-machine ssh default "sudo sysctl -w vm.max_map_count=262144"
 ```
+
+#### License
+
+This Elasticsearch image is only made for testing features supported by Zipkin,
+and is subject to [Elastic-License-2.0](https://www.elastic.co/licensing/elastic-license).
+For more details, inspect the LICENSE.txt and NOTICE.txt in the /elasticsearch
+directory of this image.

--- a/docker/test-images/zipkin-elasticsearch7/config/elasticsearch.yml
+++ b/docker/test-images/zipkin-elasticsearch7/config/elasticsearch.yml
@@ -15,5 +15,6 @@
 network.host: 0.0.0.0
 node.name: zipkin-elasticsearch
 cluster.name: "docker-cluster"
+xpack.ml.enabled: false
 cluster.initial_master_nodes:
   - zipkin-elasticsearch

--- a/docker/test-images/zipkin-elasticsearch7/config/elasticsearch.yml
+++ b/docker/test-images/zipkin-elasticsearch7/config/elasticsearch.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -84,7 +84,7 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
         if (warningHeader != null) {
           if (IGNORE_THESE_WARNINGS.stream().noneMatch(p -> p.matcher(warningHeader).find())) {
             throw new IllegalArgumentException("Detected usage of deprecated API for request "
-              + req.toString() + ":\n" + warningHeader);
+              + req + ":\n" + warningHeader);
           }
         }
         // Convert AggregatedHttpResponse back to HttpResponse.
@@ -127,7 +127,7 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {
     ElasticsearchContainer(int majorVersion) {
-      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":2.25.0"));
+      super(parse("openzipkin/zipkin-elasticsearch7:test"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -127,7 +127,7 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {
     ElasticsearchContainer(int majorVersion) {
-      super(parse("openzipkin/zipkin-elasticsearch7:test"));
+      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":2.25.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/IgnoredDeprecationWarnings.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/IgnoredDeprecationWarnings.java
@@ -30,6 +30,9 @@ abstract class IgnoredDeprecationWarnings {
   // These will be matched using header.contains(ignored[i]), so find a unique substring of the
   // warning header for it to be ignored
   static List<Pattern> IGNORE_THESE_WARNINGS = asList(
+    // Basic license doesn't include x-pack.
+    // https://www.elastic.co/guide/en/elasticsearch/reference/7.17/security-minimal-setup.html#_enable_elasticsearch_security_features
+    compile("Elasticsearch built-in security features are not enabled."),
     compile("Elasticsearch 7\\.x will read, but not allow creation of new indices containing ':'"),
     compile("has index patterns \\[.*] matching patterns from existing older templates"),
     compile("has index patterns \\[.*] matching patterns from existing composable templates")

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/IgnoredDeprecationWarnings.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/IgnoredDeprecationWarnings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Before, we rev-locked our Elasticsearch 7.x image to the last OSS licensed version 7.10.2. This changes to the Elastic licensed current version, 7.17.16, as that's what people would run in production.

Note: As this is a test image, not a production image, usage should not violate the Elastic Basic license developers typically use, and is the default.

cc @openzipkin/elasticsearch and @xeraa