### PR TITLE
Update React libraries that can be updated with React 16

### DIFF
--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -55,7 +55,7 @@
         "react-redux": "^7.1.0",
         "react-router-dom": "^5.0.1",
         "react-scripts": "5.0.1",
-        "react-use": "^14.2.0",
+        "react-use": "17.4.2",
         "react-virtualized-auto-sizer": "1.0.20",
         "react-window": "1.8.10",
         "recharts": "^1.8.5",
@@ -18156,34 +18156,29 @@
       }
     },
     "node_modules/react-use": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/react-use/-/react-use-14.3.0.tgz",
-      "integrity": "sha512-Jx7Zl0k8dHA0UKpTVwYUThC5/V+Dt6JzCGiMHPNIhsxJGkiKuB1AQ7J7pNq4zj3l37ABd/RF+jRGThw0czrJXA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.4.2.tgz",
+      "integrity": "sha512-1jPtmWLD8OJJNYCdYLJEH/HM+bPDfJuyGwCYeJFgPmWY8ttwpgZnW5QnzgM55CYUByUiTjHxsGOnEpLl6yQaoQ==",
       "dependencies": {
-        "@types/js-cookie": "2.2.6",
-        "@xobotyi/scrollbar-width": "1.9.5",
-        "copy-to-clipboard": "^3.2.0",
-        "fast-deep-equal": "^3.1.1",
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
         "fast-shallow-equal": "^1.0.0",
         "js-cookie": "^2.2.1",
-        "nano-css": "^5.2.1",
-        "react-universal-interface": "^0.6.0",
+        "nano-css": "^5.6.1",
+        "react-universal-interface": "^0.6.2",
         "resize-observer-polyfill": "^1.5.1",
-        "screenfull": "^5.0.0",
+        "screenfull": "^5.1.0",
         "set-harmonic-interval": "^1.0.1",
-        "throttle-debounce": "^2.1.0",
+        "throttle-debounce": "^3.0.1",
         "ts-easing": "^0.2.0",
-        "tslib": "^1.10.0"
+        "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0"
+        "react": "*",
+        "react-dom": "*"
       }
-    },
-    "node_modules/react-use/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/react-virtualized-auto-sizer": {
       "version": "1.0.20",
@@ -20345,11 +20340,11 @@
       "integrity": "sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ=="
     },
     "node_modules/throttle-debounce": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
-      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/through": {

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -30,7 +30,6 @@
         "@testing-library/react-hooks": "8.0.1",
         "@types/fetch-mock": "^7.3.2",
         "@types/jest": "29.5.11",
-        "@types/node": "^13.13.0",
         "@types/react": "^16.9.23",
         "@types/react-dom": "^16.9.5",
         "@types/react-redux": "^7.1.7",
@@ -65,6 +64,7 @@
         "vizceral-react": "4.8.0"
       },
       "devDependencies": {
+        "@types/node": "20.10.5",
         "@types/react-window": "1.8.8",
         "@types/styled-components": "5.1.34",
         "typescript": "4.9.4"
@@ -4970,9 +4970,12 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.10",
@@ -20675,6 +20678,11 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -56,7 +56,7 @@
         "react-router-dom": "^5.0.1",
         "react-scripts": "5.0.1",
         "react-use": "^14.2.0",
-        "react-virtualized-auto-sizer": "1.0.7",
+        "react-virtualized-auto-sizer": "1.0.20",
         "react-window": "^1.8.8",
         "recharts": "^1.8.5",
         "redux": "^4.0.0",
@@ -18186,12 +18186,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz",
-      "integrity": "sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==",
-      "engines": {
-        "node": ">8.0.0"
-      },
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
+      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -35,10 +35,8 @@
         "@types/react-dom": "^16.9.5",
         "@types/react-redux": "^7.1.7",
         "@types/react-router-dom": "^5.1.3",
-        "@types/recharts": "^1.8.14",
         "@types/redux-mock-store": "^1.0.2",
         "@types/shortid": "0.0.32",
-        "@types/styled-components": "^5.1.0",
         "classnames": "2.3.2",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.0.1",
@@ -67,8 +65,8 @@
         "vizceral-react": "4.8.0"
       },
       "devDependencies": {
-        "@types/react-virtualized-auto-sizer": "1.0.4",
         "@types/react-window": "1.8.8",
+        "@types/styled-components": "5.1.34",
         "typescript": "4.9.4"
       }
     },
@@ -4797,14 +4795,6 @@
         "@types/d3-time": "*"
       }
     },
-    "node_modules/@types/d3-shape": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
-      "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
-      "dependencies": {
-        "@types/d3-path": "^1"
-      }
-    },
     "node_modules/@types/d3-time": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
@@ -5101,15 +5091,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/react-virtualized-auto-sizer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.4.tgz",
-      "integrity": "sha512-nhYwlFiYa8M3S+O2T9QO/e1FQUYMr/wJENUdf/O0dhRi1RS/93rjrYQFYdbUqtdFySuhrtnEDX29P6eKOttY+A==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/react-window": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
@@ -5123,15 +5104,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@types/recharts": {
-      "version": "1.8.29",
-      "resolved": "https://registry.npmjs.org/@types/recharts/-/recharts-1.8.29.tgz",
-      "integrity": "sha512-ulKklaVsnFIIhTQsQw226TnOibrddW1qUQNFVhoQEyY1Z7FRQrNecFCGt7msRuJseudzE9czVawZb17dK/aPXw==",
-      "dependencies": {
-        "@types/d3-shape": "^1",
-        "@types/react": "*"
-      }
     },
     "node_modules/@types/redux-mock-store": {
       "version": "1.0.6",
@@ -5213,6 +5185,7 @@
       "version": "5.1.34",
       "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
       "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
+      "dev": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
@@ -5222,7 +5195,8 @@
     "node_modules/@types/styled-components/node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "node_modules/@types/styled-jsx": {
       "version": "2.2.9",

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -63,12 +63,12 @@
         "redux-mock-store": "^1.5.4",
         "redux-thunk": "^2.3.0",
         "shortid": "2.2.16",
-        "styled-components": "^5.1.1",
+        "styled-components": "6.1.2",
         "vizceral-react": "^4.6.5"
       },
       "devDependencies": {
-        "@types/react-virtualized-auto-sizer": "^1.0.1",
-        "@types/react-window": "^1.8.5",
+        "@types/react-virtualized-auto-sizer": "1.0.4",
+        "@types/react-window": "1.8.8",
         "typescript": "4.9.4"
       }
     },
@@ -2448,15 +2448,10 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
-    },
     "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.17.19",
@@ -5196,6 +5191,11 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -6334,21 +6334,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-styled-components": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
-      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "lodash": "^4.17.21",
-        "picomatch": "^2.3.1"
-      },
-      "peerDependencies": {
-        "styled-components": ">= 2"
       }
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
@@ -19708,23 +19693,22 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.2.tgz",
+      "integrity": "sha512-LJjirciivbOKNuKKjheXMeNOlFspur4s2/AYW2hPyrL4RhwEFiowF9axgjeMVxX7siEoLJAitKrzpuNApJ5R/Q==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@emotion/unitless": "^0.8.0",
+        "@types/stylis": "^4.0.2",
+        "css-to-react-native": "^3.2.0",
+        "csstype": "^3.1.2",
+        "postcss": "^8.4.31",
         "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
+        "stylis": "^4.3.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 16"
       },
       "funding": {
         "type": "opencollective",
@@ -19732,28 +19716,13 @@
       },
       "peerDependencies": {
         "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
+        "react-dom": ">= 16.8.0"
       }
     },
-    "node_modules/styled-components/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/styled-components/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+    "node_modules/styled-components/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/stylehacks": {
       "version": "5.1.1",

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -64,7 +64,7 @@
         "redux-thunk": "^2.3.0",
         "shortid": "2.2.16",
         "styled-components": "6.1.2",
-        "vizceral-react": "^4.6.5"
+        "vizceral-react": "4.8.0"
       },
       "devDependencies": {
         "@types/react-virtualized-auto-sizer": "1.0.4",

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -57,7 +57,7 @@
         "react-scripts": "5.0.1",
         "react-use": "^14.2.0",
         "react-virtualized-auto-sizer": "1.0.20",
-        "react-window": "^1.8.8",
+        "react-window": "1.8.10",
         "recharts": "^1.8.5",
         "redux": "^4.0.0",
         "redux-mock-store": "^1.5.4",

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -58,7 +58,7 @@
         "react-use": "17.4.2",
         "react-virtualized-auto-sizer": "1.0.20",
         "react-window": "1.8.10",
-        "recharts": "^1.8.5",
+        "recharts": "2.10.3",
         "redux": "^4.0.0",
         "redux-mock-store": "^1.5.4",
         "redux-thunk": "^2.3.0",
@@ -4761,10 +4761,41 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
     "node_modules/@types/d3-path": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
       "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
     },
     "node_modules/@types/d3-shape": {
       "version": "1.3.12",
@@ -4773,6 +4804,16 @@
       "dependencies": {
         "@types/d3-path": "^1"
       }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "node_modules/@types/eslint": {
       "version": "8.44.9",
@@ -7758,70 +7799,113 @@
       "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
-    "node_modules/d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-interpolate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "dependencies": {
-        "d3-color": "1"
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-scale": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
-      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "dependencies": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "dependencies": {
-        "d3-path": "1"
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-time-format": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
-      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "dependencies": {
-        "d3-time": "1"
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -9496,6 +9580,14 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
     },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -10818,6 +10910,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -14078,11 +14178,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
     },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
-    },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -14167,11 +14262,6 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
-    },
-    "node_modules/math-expression-evaluator": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.4.0.tgz",
-      "integrity": "sha512-4vRUvPyxdO8cWULGTh9dZWL2tZK6LDBvj+OGHBER7poH9Qdt7kXEoj20wiz4lQUbUXQZFjPbe5mVDo9nutizCw=="
     },
     "node_modules/mdn-data": {
       "version": "2.0.14",
@@ -16857,20 +16947,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-resize-detector": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
-      "integrity": "sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==",
-      "dependencies": {
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.6.0",
-        "resize-observer-polyfill": "^1.5.0"
-      },
-      "peerDependencies": {
-        "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -18079,18 +18155,17 @@
       }
     },
     "node_modules/react-smooth": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-1.0.6.tgz",
-      "integrity": "sha512-B2vL4trGpNSMSOzFiAul9kFAsxTukL9Wyy9EXtkQy3GJr6sZqW9e1nShdVOJ3hRYamPZ94O17r3Q0bjSw3UYtg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.5.tgz",
+      "integrity": "sha512-BMP2Ad42tD60h0JW6BFaib+RJuV5dsXJK9Baxiv/HlNFjvRLqA9xrNKxVWnUIZPQfzUwGXIlU/dSYLU+54YGQA==",
       "dependencies": {
-        "lodash": "~4.17.4",
-        "prop-types": "^15.6.0",
-        "raf": "^3.4.0",
-        "react-transition-group": "^2.5.0"
+        "fast-equals": "^5.0.0",
+        "react-transition-group": "2.9.0"
       },
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0"
+        "prop-types": "^15.6.0",
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-smooth/node_modules/dom-helpers": {
@@ -18223,25 +18298,26 @@
       }
     },
     "node_modules/recharts": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-1.8.6.tgz",
-      "integrity": "sha512-UlfSEOnZRAxxaH33Fc86yHEcqN+IRauPP31NfVvlGudtwVZEIb2RFI5b1J3npQo7XyoSnkUodg3Ha6EupkV+SQ==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.10.3.tgz",
+      "integrity": "sha512-G4J96fKTZdfFQd6aQnZjo2nVNdXhp+uuLb00+cBTGLo85pChvm1+E67K3wBOHDE/77spcYb2Cy9gYWVqiZvQCg==",
       "dependencies": {
-        "classnames": "^2.2.5",
-        "core-js": "^3.4.2",
-        "d3-interpolate": "^1.3.0",
-        "d3-scale": "^2.1.0",
-        "d3-shape": "^1.2.0",
-        "lodash": "^4.17.5",
-        "prop-types": "^15.6.0",
-        "react-resize-detector": "^2.3.0",
-        "react-smooth": "^1.0.5",
-        "recharts-scale": "^0.4.2",
-        "reduce-css-calc": "^1.3.0"
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "^16.10.2",
+        "react-smooth": "^2.0.5",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0"
+        "prop-types": "^15.6.0",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/recharts-scale": {
@@ -18251,6 +18327,19 @@
       "dependencies": {
         "decimal.js-light": "^2.4.1"
       }
+    },
+    "node_modules/recharts/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
@@ -18273,29 +18362,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/reduce-css-calc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-      "integrity": "sha512-0dVfwYVOlf/LBA2ec4OwQ6p3X9mYxn/wOl2xTcLwjnPYrkgEfPx3VI4eGCH3rQLlPISG5v9I9bkZosKsNRTRKA==",
-      "dependencies": {
-        "balanced-match": "^0.4.2",
-        "math-expression-evaluator": "^1.2.14",
-        "reduce-function-call": "^1.0.1"
-      }
-    },
-    "node_modules/reduce-css-calc/node_modules/balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg=="
-    },
-    "node_modules/reduce-function-call": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.3.tgz",
-      "integrity": "sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/redux": {
@@ -20838,6 +20904,35 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.7.0",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.7.0.tgz",
+      "integrity": "sha512-nqYuTkLSdTTeACyXcCLbL7rl0y6jpzLPtTNGOtSnajdR+xxMxBdjMxDjfNJNlhR+ZU8vbXz+QejntcbY7h9/ZA==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "dependencies": {
+        "@types/d3-path": "*"
       }
     },
     "node_modules/vizceral": {

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -31,7 +31,6 @@
     "@testing-library/react-hooks": "8.0.1",
     "@types/fetch-mock": "^7.3.2",
     "@types/jest": "29.5.11",
-    "@types/node": "^13.13.0",
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
     "@types/react-redux": "^7.1.7",
@@ -87,6 +86,7 @@
     ]
   },
   "devDependencies": {
+    "@types/node": "20.10.5",
     "@types/react-window": "1.8.8",
     "@types/styled-components": "5.1.34",
     "typescript": "4.9.4"

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -58,7 +58,7 @@
     "react-scripts": "5.0.1",
     "react-use": "^14.2.0",
     "react-virtualized-auto-sizer": "1.0.20",
-    "react-window": "^1.8.8",
+    "react-window": "1.8.10",
     "recharts": "^1.8.5",
     "redux": "^4.0.0",
     "redux-mock-store": "^1.5.4",

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -65,7 +65,7 @@
     "redux-thunk": "^2.3.0",
     "shortid": "2.2.16",
     "styled-components": "6.1.2",
-    "vizceral-react": "^4.6.5"
+    "vizceral-react": "4.8.0"
   },
   "scripts": {
     "compile": "lingui compile",

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -59,7 +59,7 @@
     "react-use": "17.4.2",
     "react-virtualized-auto-sizer": "1.0.20",
     "react-window": "1.8.10",
-    "recharts": "^1.8.5",
+    "recharts": "2.10.3",
     "redux": "^4.0.0",
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.3.0",

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -57,7 +57,7 @@
     "react-router-dom": "^5.0.1",
     "react-scripts": "5.0.1",
     "react-use": "^14.2.0",
-    "react-virtualized-auto-sizer": "1.0.7",
+    "react-virtualized-auto-sizer": "1.0.20",
     "react-window": "^1.8.8",
     "recharts": "^1.8.5",
     "redux": "^4.0.0",

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -36,10 +36,8 @@
     "@types/react-dom": "^16.9.5",
     "@types/react-redux": "^7.1.7",
     "@types/react-router-dom": "^5.1.3",
-    "@types/recharts": "^1.8.14",
     "@types/redux-mock-store": "^1.0.2",
     "@types/shortid": "0.0.32",
-    "@types/styled-components": "^5.1.0",
     "classnames": "2.3.2",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.0.1",
@@ -89,8 +87,8 @@
     ]
   },
   "devDependencies": {
-    "@types/react-virtualized-auto-sizer": "1.0.4",
     "@types/react-window": "1.8.8",
+    "@types/styled-components": "5.1.34",
     "typescript": "4.9.4"
   }
 }

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -56,7 +56,7 @@
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "5.0.1",
-    "react-use": "^14.2.0",
+    "react-use": "17.4.2",
     "react-virtualized-auto-sizer": "1.0.20",
     "react-window": "1.8.10",
     "recharts": "^1.8.5",

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -64,7 +64,7 @@
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.3.0",
     "shortid": "2.2.16",
-    "styled-components": "^5.1.1",
+    "styled-components": "6.1.2",
     "vizceral-react": "^4.6.5"
   },
   "scripts": {
@@ -89,8 +89,8 @@
     ]
   },
   "devDependencies": {
-    "@types/react-virtualized-auto-sizer": "^1.0.1",
-    "@types/react-window": "^1.8.5",
+    "@types/react-virtualized-auto-sizer": "1.0.4",
+    "@types/react-window": "1.8.8",
     "typescript": "4.9.4"
   }
 }

--- a/zipkin-lens/src/components/TracePage/Timeline/Timeline.tsx
+++ b/zipkin-lens/src/components/TracePage/Timeline/Timeline.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-lens/src/components/TracePage/Timeline/Timeline.tsx
+++ b/zipkin-lens/src/components/TracePage/Timeline/Timeline.tsx
@@ -14,7 +14,7 @@
 
 import { Box, makeStyles } from '@material-ui/core';
 import React, { useCallback, useEffect, useRef } from 'react';
-import AutoSizer from 'react-virtualized-auto-sizer';
+import AutoSizer, { Size } from 'react-virtualized-auto-sizer';
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 import { useMeasure } from 'react-use';
 import { AdjustedSpan } from '../../../models/AdjustedTrace';
@@ -161,11 +161,11 @@ export const Timeline = ({
       </Box>
       <Box flex="1 1">
         <AutoSizer>
-          {({ width, height }) => (
+          {(args: Size) => (
             <List
               ref={listRef}
-              width={width}
-              height={height}
+              width={args.width}
+              height={args.height}
               itemSize={rowHeight}
               itemCount={spanRows.length}
               innerRef={listInnerRef}


### PR DESCRIPTION
Update the following packages to the latest.
These packages can work with React 16.

* react-virtualized-auto-sizer
* react-window
* react-use
* styled-components
* vizceral-react
* recharts