### PR TITLE
docker: adds Elastic licensed 8.11.3 test image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,8 @@
 !docker/test-images/zipkin-elasticsearch6/config/
 !docker/test-images/zipkin-elasticsearch7/config/
 !docker/test-images/zipkin-elasticsearch7/start-elasticsearch
+!docker/test-images/zipkin-elasticsearch8/config/
+!docker/test-images/zipkin-elasticsearch8/start-elasticsearch
 
 !docker/test-images/zipkin-kafka/install.sh
 !docker/test-images/zipkin-kafka/start-kafka-zookeeper

--- a/.github/workflows/readme_test.yml
+++ b/.github/workflows/readme_test.yml
@@ -124,6 +124,12 @@ jobs:
           build-bin/docker/docker_test_image openzipkin/zipkin-elasticsearch7:test
         env:
           DOCKER_FILE: docker/test-images/zipkin-elasticsearch7/Dockerfile
+      - name: docker/test-images/zipkin-elasticsearch8/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-elasticsearch8:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-elasticsearch8:test
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-elasticsearch8/Dockerfile
       - name: docker/test-images/zipkin-kafka/README.md
         run: |
           build-bin/docker/docker_build openzipkin/zipkin-kafka:test &&

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,6 +18,7 @@ base layer `openzipkin/zipkin`, and setting up schema where relevant.
 * [ghcr.io/openzipkin/zipkin-cassandra](test-images/zipkin-cassandra/README.md) - runs Cassandra initialized with Zipkin's schema
 * [ghcr.io/openzipkin/zipkin-elasticsearch6](test-images/zipkin-elasticsearch6/README.md) - runs Elasticsearch 6.x
 * [ghcr.io/openzipkin/zipkin-elasticsearch7](test-images/zipkin-elasticsearch7/README.md) - runs Elasticsearch 7.x
+* [ghcr.io/openzipkin/zipkin-elasticsearch8](test-images/zipkin-elasticsearch8/README.md) - runs Elasticsearch 8.x
 * [ghcr.io/openzipkin/zipkin-kafka](test-images/zipkin-kafka/README.md) - runs both Kafka+ZooKeeper
 * [ghcr.io/openzipkin/zipkin-mysql](test-images/zipkin-mysql/README.md) - runs MySQL initialized with Zipkin's schema
 * [ghcr.io/openzipkin/zipkin-rabbitmq](test-images/zipkin-rabbitmq/README.md) - runs RabbitMQ

--- a/docker/test-images/zipkin-elasticsearch8/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch8/Dockerfile
@@ -1,0 +1,79 @@
+#
+# Copyright 2015-2023 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# java_version is used for install and runtime layers of zipkin-elasticsearch8
+#
+# Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
+# This is defined in many places because Docker has no "env" script functionality unless you use
+# docker-compose: When updating, update everywhere.
+ARG java_version=21.0.1_p12
+
+# We copy files from the context into a scratch container first to avoid a problem where docker and
+# docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
+# COPY --from= works around the issue.
+FROM scratch as scratch
+
+COPY build-bin/docker/docker-healthcheck /docker-bin/
+COPY docker/test-images/zipkin-elasticsearch8/start-elasticsearch /docker-bin/
+COPY docker/test-images/zipkin-elasticsearch8/config/ /config/
+
+FROM ghcr.io/openzipkin/java:${java_version} as install
+
+WORKDIR /install
+
+# Use latest 7.x version from https://www.elastic.co/downloads/past-releases#elasticsearch
+# This is defined in many places because Docker has no "env" script functionality unless you use
+# docker-compose: When updating, update everywhere.
+ARG elasticsearch7_version=8.11.3
+
+# Download only the OSS distribution (lacks X-Pack)
+RUN \
+# Connection resets are frequent in GitHub Actions workflows \
+wget --random-wait --tries=5 -qO- \
+# We don't download bin scripts as we customize for reasons including BusyBox problems
+https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsearch7_version}-linux-x86_64.tar.gz| tar xz \
+    --wildcards --strip=1 --exclude=jdk --exclude=*/bin
+COPY --from=scratch /config/ ./config/
+
+# Use a full Java distribution rather than adding test modules to the
+# production -jre base layer used by zipkin and zipkin-slim.
+FROM ghcr.io/openzipkin/java:${java_version} as zipkin-elasticsearch8
+LABEL org.opencontainers.image.description="Elasticsearch distribution on OpenJDK and Alpine Linux"
+ARG elasticsearch7_version=8.11.3
+LABEL elasticsearch-version=$elasticsearch7_version
+
+# The full license is also included in the image at /elasticsearch/LICENSE.txt.
+LABEL org.opencontainers.image.licenses="Elastic-License-2.0"
+
+# Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
+COPY --from=scratch /docker-bin/* /usr/local/bin/
+# We use start period of 30s to avoid marking the container unhealthy on slow or contended CI hosts
+HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthcheck"]
+ENTRYPOINT ["start-elasticsearch"]
+
+# All content including binaries and logs write under WORKDIR
+ARG USER=elasticsearch
+WORKDIR /${USER}
+
+# Ensure the process doesn't run as root
+RUN adduser -g '' -h ${PWD} -D ${USER}
+USER ${USER}
+
+# Copy binaries and config we installed earlier
+COPY --from=install --chown=${USER} /install .
+
+# Use to set heap, trust store or other system properties.
+ENV ES_JAVA_OPTS="-Xms256m -Xmx256m -XX:+ExitOnOutOfMemoryError"
+ENV LIBFFI_TMPDIR=/tmp
+EXPOSE 9200

--- a/docker/test-images/zipkin-elasticsearch8/README.md
+++ b/docker/test-images/zipkin-elasticsearch8/README.md
@@ -1,0 +1,34 @@
+## zipkin-elasticsearch8 Docker image
+
+The `zipkin-elasticsearch8` testing image runs Elasticsearch 8.x for [Elasticsearch storage](../../../zipkin-storage/elasticsearch)
+integration.
+
+To build `openzipkin/zipkin-elasticsearch8:test`, from the top-level of the repository, run:
+```bash
+$ DOCKER_FILE=docker/test-images/zipkin-elasticsearch8/Dockerfile build-bin/docker/docker_build openzipkin/zipkin-elasticsearch8:test
+```
+
+You can use the env variable `ES_JAVA_OPTS` to change settings such as heap size for Elasticsearch.
+
+#### Host setup
+
+Elasticsearch is [strict](https://github.com/docker-library/docs/tree/master/elasticsearch#host-setup)
+about virtual memory. You will need to adjust accordingly (especially if you notice Elasticsearch crash!)
+
+```bash
+# If docker is running on your host machine, adjust the kernel setting directly
+$ sudo sysctl -w vm.max_map_count=262144
+
+# If using docker-machine/Docker Toolbox/Boot2Docker, remotely adjust the same
+$ docker-machine ssh default "sudo sysctl -w vm.max_map_count=262144"
+
+# If using colima, it is similar as well
+$ colima ssh "sudo sysctl -w vm.max_map_count=262144"
+```
+
+#### License
+
+This Elasticsearch image is only made for testing features supported by Zipkin,
+and is subject to [Elastic-License-2.0](https://www.elastic.co/licensing/elastic-license).
+For more details, inspect the LICENSE.txt and NOTICE.txt in the /elasticsearch
+directory of this image.

--- a/docker/test-images/zipkin-elasticsearch8/config/elasticsearch.yml
+++ b/docker/test-images/zipkin-elasticsearch8/config/elasticsearch.yml
@@ -1,0 +1,21 @@
+#
+# Copyright 2015-2023 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+network.host: 0.0.0.0
+node.name: zipkin-elasticsearch
+cluster.name: "docker-cluster"
+xpack.security.enabled: false
+xpack.ml.enabled: false
+cluster.initial_master_nodes:
+  - zipkin-elasticsearch

--- a/docker/test-images/zipkin-elasticsearch8/config/log4j2.properties
+++ b/docker/test-images/zipkin-elasticsearch8/config/log4j2.properties
@@ -1,0 +1,28 @@
+#
+# Copyright 2015-2023 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console
+
+# unsolved https://github.com/sherifabdlnaby/elastdocker/issues/108
+logger.aws.name = com.amazonaws.auth.profile.internal.BasicProfileConfigFileLoader
+logger.aws.level = error
+

--- a/docker/test-images/zipkin-elasticsearch8/start-elasticsearch
+++ b/docker/test-images/zipkin-elasticsearch8/start-elasticsearch
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# Copyright 2015-2023 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# ENTRYPOINT script that starts Elasticsearch
+#
+# This intentionally locates config using the current working directory, in order to consolidate
+# Dockerfile instructions to WORKDIR
+set -eu
+
+# Configure the Docker HEALTHCHECK
+export HEALTHCHECK_PORT=9200
+export HEALTHCHECK_PATH=/_cluster/health
+
+# This loads the ES launcher because configuration of the actual process is
+# in binary and not documented for external use.
+# See https://github.com/elastic/elasticsearch/blob/v8.11.3/server/src/main/java/org/elasticsearch/bootstrap/ServerArgs.java#L57
+#
+# Notably, this means that just like the default image, the ES daemon is not
+# pid 1
+exec java -cp 'lib/*:lib/cli-launcher/*' -XX:+UseSerialGC \
+  -Dcli.name=server \
+  -Dcli.script=$PWD/bin/elasticsearch \
+  -Dcli.libs=lib/tools/server-cli \
+  -Des.path.home=$PWD \
+  -Des.path.conf=$PWD/config \
+  -Des.distribution.type=docker \
+  org.elasticsearch.launcher.CliToolLauncher


### PR DESCRIPTION
This adds an image tagged as elasticsearch8 which is based on our Java base layer, similar to elasticsearch7 except aspects specific to Elasticsearch 8.x.

Notably, Elasticsearch 8.x requires a launcher process, and defines Java options as ES_JAVA_OPTS. Similar to 7.x Elastic requires modules not in our JRE image, so we use the full one instead.

Note: As this is a test image, not a production image, usage should not violate the Elastic Basic license developers typically use, and is the default.