### PR TITLE
docker: allows elasticsearch8 tests to delete with wildcards

### DIFF
--- a/docker/test-images/zipkin-elasticsearch8/config/elasticsearch.yml
+++ b/docker/test-images/zipkin-elasticsearch8/config/elasticsearch.yml
@@ -19,3 +19,6 @@ xpack.security.enabled: false
 xpack.ml.enabled: false
 cluster.initial_master_nodes:
   - zipkin-elasticsearch
+# This is a test image, so we are not afraid to delete all indices. Avoids:
+#   Wildcard expressions or all indices are not allowed
+action.destructive_requires_name: false

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -268,6 +268,8 @@ public abstract class ElasticsearchStorage extends zipkin2.storage.StorageCompon
     Set<String> toClear = new LinkedHashSet<>();
     toClear.add(indexNameFormatter().formatType(TYPE_SPAN));
     toClear.add(indexNameFormatter().formatType(TYPE_DEPENDENCY));
+    // Note: Elasticsearch 8.x requires this config to clear with wildcards:
+    // action.destructive_requires_name: false
     for (String index : toClear) clear(index);
   }
 

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/ElasticsearchStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
I checked and this is the only image change needed for tests to complete. There are a couple small things I need to add to #3552, but they are all client-side.