### PR TITLE
Adds Eureka discovery integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,10 @@
 !docker/test-images/zipkin-elasticsearch8/config/
 !docker/test-images/zipkin-elasticsearch8/start-elasticsearch
 
+!docker/test-images/zipkin-eureka/src/
+!docker/test-images/zipkin-eureka/pom.xml
+!docker/test-images/zipkin-eureka/start-eureka
+
 !docker/test-images/zipkin-kafka/install.sh
 !docker/test-images/zipkin-kafka/start-kafka-zookeeper
 

--- a/.github/workflows/readme_test.yml
+++ b/.github/workflows/readme_test.yml
@@ -124,6 +124,12 @@ jobs:
           build-bin/docker/docker_test_image openzipkin/zipkin-elasticsearch8:test
         env:
           DOCKER_FILE: docker/test-images/zipkin-elasticsearch8/Dockerfile
+      - name: docker/test-images/zipkin-eureka/README.md
+        run: |
+          build-bin/docker/docker_build openzipkin/zipkin-eureka:test &&
+          build-bin/docker/docker_test_image openzipkin/zipkin-eureka:test
+        env:
+          DOCKER_FILE: docker/test-images/zipkin-eureka/Dockerfile
       - name: docker/test-images/zipkin-kafka/README.md
         run: |
           build-bin/docker/docker_build openzipkin/zipkin-kafka:test &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,5 +119,5 @@ jobs:
         run: |
           build-bin/docker/configure_docker &&
           build-bin/maven/maven_go_offline &&
-          build-bin/maven/maven_build -pl :${{ matrix.name }} --am &&
+          build-bin/maven/maven_build install -pl :${{ matrix.name }} --am &&
           build-bin/test -Dgroups=docker -pl :${{ matrix.name }} -Dlicense.skip=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,8 +110,14 @@ jobs:
       # via forks, and login session ends up in ~/.docker. This is ok because
       # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test with Docker
-        run:
-          | # configure_test seeds NPM cache, which isn't needed for these tests
-          build-bin/maven/maven_go_offline &&
+        # configure_test seeds NPM cache, which isn't needed for these tests.
+        #
+        # What we are doing here is configuring docker, then building the
+        # module prior to testing it with docker. We do that in two passes
+        # because we want to build the module's dependencies, but not run their
+        # tests.
+        run: |
           build-bin/docker/configure_docker &&
-          build-bin/test -Dgroups=docker -pl :${{ matrix.name }} --am -Dlicense.skip=true
+          build-bin/maven/maven_go_offline &&
+          build-bin/maven/maven_build -pl :${{ matrix.name }} --am &&
+          build-bin/test -Dgroups=docker -pl :${{ matrix.name }} -Dlicense.skip=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,7 @@ jobs:
           - name: zipkin-storage-cassandra
           - name: zipkin-storage-elasticsearch
           - name: zipkin-storage-mysql-v1
+          - name: zipkin-server
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-npm-packages-${{ hashFiles('zipkin-lens/package-lock.json') }}
       - name: Test without Docker
-        run: build-bin/maven_go_offline && build-bin/test -Ddocker.skip=true ${{ matrix.maven_args }}
+        run: build-bin/maven_go_offline && build-bin/test -DexcludedGroups=docker ${{ matrix.maven_args }}
 
   test_docker:
     runs-on: ubuntu-22.04 # newest available distribution, aka jellyfish
@@ -114,4 +114,4 @@ jobs:
           | # configure_test seeds NPM cache, which isn't needed for these tests
           build-bin/maven/maven_go_offline &&
           build-bin/docker/configure_docker &&
-          build-bin/test -pl :${{ matrix.name }} --am -Dlicense.skip=true
+          build-bin/test -Dgroups=docker -pl :${{ matrix.name }} --am -Dlicense.skip=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,12 +112,11 @@ jobs:
       - name: Test with Docker
         # configure_test seeds NPM cache, which isn't needed for these tests.
         #
-        # What we are doing here is configuring docker, then building the
-        # module prior to testing it with docker. We do that in two passes
-        # because we want to build the module's dependencies, but not run their
-        # tests.
+        # What we are doing here is configuring docker, then installing the
+        # module's dependencies prior to testing it with docker. This allows
+        # us to avoid running tests except the leaf module.
         run: |
           build-bin/docker/configure_docker &&
           build-bin/maven/maven_go_offline &&
-          build-bin/maven/maven_build install -pl :${{ matrix.name }} --am &&
+          MAVEN_GOAL=install build-bin/maven/maven_build -pl :${{ matrix.name }} --am &&
           build-bin/test -Dgroups=docker -pl :${{ matrix.name }} -Dlicense.skip=true

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -91,7 +91,7 @@ class ServerIntegratedBenchmark {
 
   @Test void elasticsearch() throws Exception {
     GenericContainer<?> elasticsearch =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:2.25.2"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:2.26.0"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("elasticsearch")
         .withLabel("name", "elasticsearch")
@@ -105,7 +105,7 @@ class ServerIntegratedBenchmark {
 
   @Test void cassandra3() throws Exception {
     GenericContainer<?> cassandra =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:2.25.2"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:2.26.0"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("cassandra")
         .withLabel("name", "cassandra")
@@ -119,7 +119,7 @@ class ServerIntegratedBenchmark {
 
   @Test void mysql() throws Exception {
     GenericContainer<?> mysql =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:2.25.2"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:2.26.0"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("mysql")
         .withLabel("name", "mysql")

--- a/build-bin/docker-compose-zipkin-ui.yml
+++ b/build-bin/docker-compose-zipkin-ui.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker-compose-zipkin-ui.yml
+++ b/build-bin/docker-compose-zipkin-ui.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker_push
+++ b/build-bin/docker_push
@@ -1,6 +1,6 @@
 #!/bin/sh -ue
 #
-# Copyright 2015-2023 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker_push
+++ b/build-bin/docker_push
@@ -1,4 +1,18 @@
 #!/bin/sh -ue
+#
+# Copyright 2015-2024 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
 
 # Pushes docker as part of `deploy` or from a trigger tag
 version=${1:-master}

--- a/build-bin/docker_push
+++ b/build-bin/docker_push
@@ -1,6 +1,6 @@
 #!/bin/sh -ue
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven/maven_build
+++ b/build-bin/maven/maven_build
@@ -16,9 +16,10 @@
 set -ue
 
 export MAVEN_OPTS="$($(dirname "$0")/maven_opts)"
+maven_goal=${MAVEN_GOAL:-package}
 if [ -x ./mvnw ]; then alias mvn=${PWD}/mvnw; fi
 
 (
   if [ "${MAVEN_PROJECT_BASEDIR:-.}" != "." ]; then cd ${MAVEN_PROJECT_BASEDIR}; fi
-  mvn -T1C -q --batch-mode -DskipTests package "$@"
+  mvn -T1C -q --batch-mode -DskipTests "${maven_goal}" "$@"
 )

--- a/build-bin/maven/maven_build
+++ b/build-bin/maven/maven_build
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven_go_offline
+++ b/build-bin/maven_go_offline
@@ -1,6 +1,6 @@
 #!/bin/sh -ue
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maven_go_offline
+++ b/build-bin/maven_go_offline
@@ -1,6 +1,6 @@
 #!/bin/sh -ue
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maybe_install_npm
+++ b/build-bin/maybe_install_npm
@@ -1,6 +1,6 @@
 #!/bin/sh -ue
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/maybe_install_npm
+++ b/build-bin/maybe_install_npm
@@ -1,4 +1,18 @@
 #!/bin/sh -ue
+#
+# Copyright 2015-2024 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
 
 # This script hydrates the Maven and NPM cache to make later processes operate with less chance of
 # network problems.

--- a/build-bin/maybe_install_npm
+++ b/build-bin/maybe_install_npm
@@ -1,6 +1,6 @@
 #!/bin/sh -ue
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,6 +18,7 @@ base layer `openzipkin/zipkin`, and setting up schema where relevant.
 * [ghcr.io/openzipkin/zipkin-cassandra](test-images/zipkin-cassandra/README.md) - runs Cassandra initialized with Zipkin's schema
 * [ghcr.io/openzipkin/zipkin-elasticsearch7](test-images/zipkin-elasticsearch7/README.md) - runs Elasticsearch 7.x
 * [ghcr.io/openzipkin/zipkin-elasticsearch8](test-images/zipkin-elasticsearch8/README.md) - runs Elasticsearch 8.x
+* [ghcr.io/openzipkin/zipkin-eureka](test-images/zipkin-eureka/README.md) - runs Eureka
 * [ghcr.io/openzipkin/zipkin-kafka](test-images/zipkin-kafka/README.md) - runs both Kafka+ZooKeeper
 * [ghcr.io/openzipkin/zipkin-mysql](test-images/zipkin-mysql/README.md) - runs MySQL initialized with Zipkin's schema
 * [ghcr.io/openzipkin/zipkin-rabbitmq](test-images/zipkin-rabbitmq/README.md) - runs RabbitMQ

--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -118,6 +118,17 @@ $ docker-compose -f docker-compose-rabbitmq.yml up
 Then configure the [RabbitMQ sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java)
 using a `host` value of `localhost` or a non-local hostname if in docker.
 
+## Eureka
+
+You can register Zipkin for service discovery in [Eureka](../test-images/zipkin-eureka/README.md)
+using the `docker-compose-eureka.yml` file. This configuration starts `zipkin` and `zipkin-eureka`
+in their own containers.
+
+To register Zipkin in Eureka, run:
+```bash
+$ docker-compose -f docker-compose-eureka.yml up
+```
+
 ## Example
 
 The docker-compose configuration can be extended to host an [example application](https://github.com/openzipkin/brave-example)

--- a/docker/examples/docker-compose-eureka.yml
+++ b/docker/examples/docker-compose-eureka.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/examples/docker-compose-eureka.yml
+++ b/docker/examples/docker-compose-eureka.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/examples/docker-compose-eureka.yml
+++ b/docker/examples/docker-compose-eureka.yml
@@ -12,22 +12,28 @@
 # the License.
 #
 
-# uses 2.4 so we can use condition: service_healthy
-version: "2.4"
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml to register
+# zipkin into a test eureka server.
+
+version: '2.4'
 
 services:
+  eureka:
+    image: ghcr.io/openzipkin/zipkin-eureka:${TAG:-latest}
+    container_name: eureka
+    # Uncomment to expose the eureka port for testing
+    #    ports:
+    #      - 8761:8761
+
   zipkin:
-    # Use last build of Zipkin instead of adding a matrix build dependency
-    image: ghcr.io/openzipkin/zipkin-slim:master
-    container_name: zipkin
-  # Use fixed service and container name 'sut; so our test script can copy/pasta
-  sut:
-    # This is the image just built. It is not in a remote repository.
-    image: openzipkin/zipkin-ui:test
-    container_name: sut
+    extends:
+      file: docker-compose.yml
+      service: zipkin
     environment:
-      # This is the default value, set explicitly here for visibility
-      ZIPKIN_BASE_URL: http://zipkin:9411
+      - EUREKA_SERVICE_URL=http://eureka:8761/eureka/v2
     depends_on:
-      zipkin:
+      eureka:
         condition: service_healthy

--- a/docker/examples/docker-compose.yml
+++ b/docker/examples/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/examples/docker-compose.yml
+++ b/docker/examples/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/examples/docker-compose.yml
+++ b/docker/examples/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -31,8 +31,6 @@ services:
     # Environment settings are defined here https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md#environment-variables
     environment:
       - STORAGE_TYPE=mem
-      # Point the zipkin at the storage backend
-      - MYSQL_HOST=mysql
       # Uncomment to enable self-tracing
       # - SELF_TRACING_ENABLED=true
       # Uncomment to increase heap size

--- a/docker/test-images/zipkin-activemq/start-activemq
+++ b/docker/test-images/zipkin-activemq/start-activemq
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-activemq/start-activemq
+++ b/docker/test-images/zipkin-activemq/start-activemq
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-activemq/start-activemq
+++ b/docker/test-images/zipkin-activemq/start-activemq
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015-2023 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/Dockerfile
+++ b/docker/test-images/zipkin-eureka/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/Dockerfile
+++ b/docker/test-images/zipkin-eureka/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/Dockerfile
+++ b/docker/test-images/zipkin-eureka/Dockerfile
@@ -1,0 +1,82 @@
+#
+# Copyright 2015-2024 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# java_version is used for install and runtime base layers of eureka and eureka-slim.
+#
+# Use latest version here: https://github.com/orgs/openeureka/packages/container/package/java
+# This is defined in many places because Docker has no "env" script functionality unless you use
+# docker-compose: When updating, update everywhere.
+ARG java_version=21.0.1_p12
+
+# We copy files from the context into a scratch container first to avoid a problem where docker and
+# docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
+# COPY --from= works around the issue.
+FROM scratch as scratch
+
+COPY build-bin/docker/docker-healthcheck /docker-bin/
+COPY docker/test-images/zipkin-eureka/start-eureka /docker-bin/
+
+# We needsource because as of Eureka 2.0, there is no distribution in the
+# source repository anymore, and the war isn't functional either. The current
+# approach is to build your own with Spring Cloud.
+#
+# See https://github.com/Netflix/eureka/releases/tag/v2.0.0
+COPY build-bin/maven /code/
+COPY docker/test-images/zipkin-eureka /code/
+
+# This version is only used during the install process. Try to be consistent as it reduces layers,
+# which reduces downloads.
+FROM ghcr.io/openzipkin/java:${java_version} as install
+
+WORKDIR /code
+COPY --from=scratch /code/ .
+
+# Build the custom Eureka server
+RUN /code/maven_build && \
+    mvn -q --batch-mode -DoutputDirectory=/install/lib dependency:copy-dependencies && \
+    cp -r target/classes /install/
+
+# Use a full Java distribution rather than adding test modules to the
+# production -jre base layer used by zipkin and zipkin-slim.
+#
+# Specifically, this is about NoClassDefFoundError: org/ietf/jgss/GSSException
+FROM ghcr.io/openzipkin/java:${java_version} as zipkin-eureka
+LABEL org.opencontainers.image.description="Eureka on OpenJDK and Alpine Linux"
+
+# All content including binaries and logs write under WORKDIR
+ARG USER=eureka
+WORKDIR /${USER}
+
+# Ensure the process doesn't run as root
+RUN adduser -g '' -h ${PWD} -D ${USER}
+
+# Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
+COPY --from=scratch /docker-bin/* /usr/local/bin/
+
+# Copy binaries and config we installed earlier
+COPY --from=install --chown=${USER} /install .
+
+# We use start period of 30s to avoid marking the container unhealthy on slow or contended CI hosts
+HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthcheck"]
+ENV HEALTHCHECK_PATH=/actuator/health
+ENV HEALTHCHECK_PORT=8761
+
+ENTRYPOINT ["start-eureka"]
+
+# Switch to the runtime user
+USER ${USER}
+
+# Use to set heap, trust store or other system properties.
+ENV JAVA_OPTS="-Xms64m -Xmx64m -XX:+ExitOnOutOfMemoryError"
+EXPOSE 8761

--- a/docker/test-images/zipkin-eureka/README.md
+++ b/docker/test-images/zipkin-eureka/README.md
@@ -1,0 +1,12 @@
+## zipkin-eureka Docker image
+
+The `zipkin-eureka` testing image runs Eureka Server for service discovery
+integration of the Zipkin server. This listens on port 8761.
+
+To build `openzipkin/zipkin-eureka:test`, from the top-level of the repository, run:
+```bash
+$ DOCKER_FILE=docker/test-images/zipkin-eureka/Dockerfile build-bin/docker/docker_build openzipkin/zipkin-eureka:test
+$ docker run -p 8761:8761 --rm openzipkin/zipkin-eureka:test
+```
+
+You can use the env variable `JAVA_OPTS` to change settings such as heap size for Eureka.

--- a/docker/test-images/zipkin-eureka/pom.xml
+++ b/docker/test-images/zipkin-eureka/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015-2020 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/pom.xml
+++ b/docker/test-images/zipkin-eureka/pom.xml
@@ -1,0 +1,63 @@
+<!--
+
+    Copyright 2015-2024 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.zipkin.test</groupId>
+  <artifactId>eureka</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Netflix Eureka test binary</name>
+  <description>Netflix Eureka test binary</description>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-parent</artifactId>
+        <version>2023.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
+    </dependency>
+
+    <!-- Get rid of log warning saying to use Caffeine -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/docker/test-images/zipkin-eureka/pom.xml
+++ b/docker/test-images/zipkin-eureka/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaServer.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaServer.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaServer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@SpringBootApplication
+@EnableEurekaServer
+public class EurekaServer {
+  public static void main(String[] args) {
+    SpringApplication.run(EurekaServer.class, args);
+  }
+}

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaServer.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
+++ b/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
@@ -12,10 +12,16 @@
 # the License.
 #
 
+# Add configuration to disable as much server caching as possible. Note that
+# not all configuration here are defined by netflix/eureka, rather some are
+# specific to spring-cloud/spring-cloud-netflix.
 eureka:
   client:
     registerWithEureka: false
-    fetchRegistry: false
+    fetchRegistry: false  # in netflix/eureka this is shouldFetchRegistry
+    registryFetchIntervalSeconds: 1
+  server:
+    useReadOnlyResponseCache: false
 server:
   port: 8761
 spring:

--- a/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
+++ b/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
+++ b/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
+++ b/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
@@ -1,4 +1,3 @@
-#!/bin/sh -ue
 #
 # Copyright 2015-2024 The OpenZipkin Authors
 #
@@ -13,8 +12,25 @@
 # the License.
 #
 
-
-build-bin/maven/maven_go_offline
-export MAVEN_OPTS="$(build-bin/maven/maven_opts)"
-# Prefetch dependencies used by zipkin-ui (NPM and NodeJS binary and dependencies of our build)
-./mvnw -q --batch-mode -nsu -pl zipkin-lens generate-resources
+eureka:
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
+server:
+  port: 8761
+spring:
+  jmx:
+    # reduce startup time by excluding unexposed JMX service
+    enabled: false
+  main:
+    banner-mode: "off"
+  profiles:
+    active: "default"
+logging:
+  level:
+    # reduce chattiness
+    root: 'WARN'
+    # hush initialization warnings from BeanPostProcessorChecker
+    org.springframework.context.support: 'OFF'
+    # show startup completion
+    zipkin.test.EurekaServer: 'INFO'

--- a/docker/test-images/zipkin-eureka/start-eureka
+++ b/docker/test-images/zipkin-eureka/start-eureka
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015-2024 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/start-eureka
+++ b/docker/test-images/zipkin-eureka/start-eureka
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-eureka/start-eureka
+++ b/docker/test-images/zipkin-eureka/start-eureka
@@ -1,4 +1,4 @@
-#!/bin/sh -ue
+#!/bin/sh
 #
 # Copyright 2015-2024 The OpenZipkin Authors
 #
@@ -13,8 +13,7 @@
 # the License.
 #
 
+# ENTRYPOINT script that starts Eureka
+set -eu
 
-build-bin/maven/maven_go_offline
-export MAVEN_OPTS="$(build-bin/maven/maven_opts)"
-# Prefetch dependencies used by zipkin-ui (NPM and NodeJS binary and dependencies of our build)
-./mvnw -q --batch-mode -nsu -pl zipkin-lens generate-resources
+exec java -cp 'classes:lib/*' ${JAVA_OPTS} zipkin.test.EurekaServer "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin</groupId>
   <artifactId>zipkin-parent</artifactId>
-  <version>2.26.1-SNAPSHOT</version>
+  <version>2.27.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -493,6 +493,9 @@
             <bnd>SCRIPT_STYLE</bnd>
             <ejs>XML_STYLE</ejs>
             <css>SLASHSTAR_STYLE</css>
+            <!-- build-bin non-trivial scripts -->
+            <javadoc_to_gh_pages>SCRIPT_STYLE</javadoc_to_gh_pages>
+            <maybe_install_npm>SCRIPT_STYLE</maybe_install_npm>
             <!-- build-bin/docker -->
             <docker_block_on_health>SCRIPT_STYLE</docker_block_on_health>
             <configure_docker>SCRIPT_STYLE</configure_docker>
@@ -516,6 +519,8 @@
             <maven_release>SCRIPT_STYLE</maven_release>
             <maven_unjar>SCRIPT_STYLE</maven_unjar>
             <!-- docker/**/start-* -->
+            <start-activemq>SCRIPT_STYLE</start-activemq>
+            <start-eureka>SCRIPT_STYLE</start-eureka>
             <start-cassandra>SCRIPT_STYLE</start-cassandra>
             <start-elasticsearch>SCRIPT_STYLE</start-elasticsearch>
             <start-kafka-zookeeper>SCRIPT_STYLE</start-kafka-zookeeper>
@@ -566,8 +571,11 @@
             <exclude>src/test/resources/**</exclude>
             <exclude>**/generated/**</exclude>
             <exclude>.dockerignore</exclude>
-            <exclude>build-bin/*</exclude>
-            <exclude>charts/**</exclude>
+            <!-- trivial build-bin scripts -->
+            <exclude>build-bin/configure_deploy</exclude>
+            <exclude>build-bin/configure_test</exclude>
+            <exclude>build-bin/deploy</exclude>
+            <exclude>build-bin/test</exclude>
           </excludes>
           <strictCheck>true</strictCheck>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/activemq/pom.xml
+++ b/zipkin-collector/activemq/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector-activemq</artifactId>

--- a/zipkin-collector/activemq/pom.xml
+++ b/zipkin-collector/activemq/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/activemq/pom.xml
+++ b/zipkin-collector/activemq/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -64,7 +64,7 @@ class ActiveMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
     ActiveMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-activemq:2.25.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-activemq:2.26.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
@@ -65,9 +65,6 @@ class ActiveMQExtension implements BeforeAllCallback, AfterAllCallback {
   static final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
     ActiveMQContainer() {
       super(parse("ghcr.io/openzipkin/zipkin-activemq:2.26.0"));
-      if ("true".equals(System.getProperty("docker.skip"))) {
-        throw new TestAbortedException("${docker.skip} == true");
-      }
       withExposedPorts(ACTIVEMQ_PORT);
       waitStrategy = Wait.forListeningPorts(ACTIVEMQ_PORT);
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ITActiveMQCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,6 +34,7 @@ import javax.jms.QueueSession;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
@@ -58,6 +59,7 @@ import static zipkin2.codec.SpanBytesEncoder.THRIFT;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(60)
+@Tag("docker")
 class ITActiveMQCollector {
   @RegisterExtension ActiveMQExtension activemq = new ActiveMQExtension();
   List<Span> spans = Arrays.asList(LOTS_OF_SPANS[0], LOTS_OF_SPANS[1]);

--- a/zipkin-collector/core/pom.xml
+++ b/zipkin-collector/core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector</artifactId>

--- a/zipkin-collector/core/pom.xml
+++ b/zipkin-collector/core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/core/pom.xml
+++ b/zipkin-collector/core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector-kafka</artifactId>

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/ITKafkaCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,6 +28,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
@@ -51,6 +52,7 @@ import static zipkin2.codec.SpanBytesEncoder.THRIFT;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(60)
+@Tag("docker")
 class ITKafkaCollector {
   @RegisterExtension KafkaExtension kafka = new KafkaExtension();
 

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -92,7 +92,7 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.25.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.26.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
@@ -93,9 +93,6 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
       super(parse("ghcr.io/openzipkin/zipkin-kafka:2.26.0"));
-      if ("true".equals(System.getProperty("docker.skip"))) {
-        throw new TestAbortedException("${docker.skip} == true");
-      }
       waitStrategy = Wait.forHealthcheck();
       // 19092 is for connections from the Docker host and needs to be used as a fixed port.
       // TODO: someone who knows Kafka well, make ^^ comment better!

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/pom.xml
+++ b/zipkin-collector/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/pom.xml
+++ b/zipkin-collector/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/pom.xml
+++ b/zipkin-collector/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>

--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector-rabbitmq</artifactId>

--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/ITRabbitMQCollector.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/ITRabbitMQCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
@@ -44,6 +45,7 @@ import static zipkin2.codec.SpanBytesEncoder.THRIFT;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(60)
+@Tag("docker")
 class ITRabbitMQCollector {
   @RegisterExtension RabbitMQExtension rabbit = new RabbitMQExtension();
 

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
@@ -84,9 +84,6 @@ class RabbitMQExtension implements BeforeAllCallback, AfterAllCallback {
   static final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
     RabbitMQContainer() {
       super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:2.26.0"));
-      if ("true".equals(System.getProperty("docker.skip"))) {
-        throw new TestAbortedException("${docker.skip} == true");
-      }
       withExposedPorts(RABBIT_PORT);
       waitStrategy = Wait.forLogMessage(".*Server startup complete.*", 1);
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -83,7 +83,7 @@ class RabbitMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
     RabbitMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:2.25.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:2.26.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-collector/scribe/pom.xml
+++ b/zipkin-collector/scribe/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector-scribe</artifactId>

--- a/zipkin-collector/scribe/pom.xml
+++ b/zipkin-collector/scribe/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-collector/scribe/pom.xml
+++ b/zipkin-collector/scribe/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-junit5/pom.xml
+++ b/zipkin-junit5/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-junit5/pom.xml
+++ b/zipkin-junit5/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-junit5/pom.xml
+++ b/zipkin-junit5/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>

--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-lens</artifactId>

--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -496,7 +496,6 @@ $ RABBIT_ADDRESSES=localhost java -jar zipkin.jar
 You can enable a gRPC span collector endpoint by setting `COLLECTOR_GRPC_ENABLED=true`. The
 `zipkin.proto3.SpanService/Report` endpoint will run on the same port as normal HTTP (9411).
 
-
 Example usage:
 
 ```bash
@@ -504,6 +503,28 @@ $ COLLECTOR_GRPC_ENABLED=true java -jar zipkin.jar
 ```
 
 As this service is experimental, it is not recommended to run this in production environments.
+
+## Service Registration
+
+### Eureka
+
+Zipkin can register itself in [Eureka](https://github.com/Netflix/eureka), allowing traced services
+to discover its listen address and health state. This is enabled when `EUREKA_SERVICE_URL` is set to
+a valid v2 endpoint of the [Eureka REST API](https://github.com/Netflix/eureka/wiki/Eureka-REST-operations).
+
+| Variable                   | Instance field | Description                                                                                    |
+|----------------------------|----------------|------------------------------------------------------------------------------------------------|
+| `DISCOVERY_EUREKA_ENABLED` | N/A            | `false` disables Eureka registration. Defaults to `true`.                                      |
+| `EUREKA_SERVICE_URL`       | N/A            | v2 endpoint of Eureka, e.g. https://eureka-prod/eureka/v2. No default                          |
+| `EUREKA_APP_NAME`          | .app           | The application this instance registers to. Defaults to `zipkin`                               |
+| `EUREKA_HOSTNAME`          | .hostName      | The hostname used with `${QUERY_PORT}` to build the instance `vipAddress`. Defaults to detect. |
+| `EUREKA_INSTANCE_ID`       | .instanceId    | Defaults to `${EUREKA_HOSTNAME}:${EUREKA_APP_NAME}:${QUERY_PORT}`.                             |
+
+Example usage:
+
+```bash
+$ EUREKA_SERVICE_URL=http://localhost:8761/eureka/v2 java -jar zipkin.jar
+```
 
 ## Self-Tracing
 Self tracing exists to help troubleshoot performance of the zipkin-server. Production deployments

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-server</artifactId>
@@ -197,6 +197,13 @@
       <version>2.0.62.Final</version>
       <classifier>windows-x86_64</classifier>
       <scope>runtime</scope>
+    </dependency>
+
+    <!-- Eureka service discovery -->
+    <dependency>
+      <groupId>${armeria.groupId}</groupId>
+      <artifactId>armeria-eureka</artifactId>
+      <version>${armeria.version}</version>
     </dependency>
 
     <!--Prometheus metrics-->
@@ -377,6 +384,13 @@
       <groupId>${armeria.groupId}</groupId>
       <artifactId>armeria-junit5</artifactId>
       <version>${armeria.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import zipkin2.server.internal.activemq.ZipkinActiveMQCollectorConfiguration;
 import zipkin2.server.internal.brave.ZipkinSelfTracingConfiguration;
 import zipkin2.server.internal.cassandra3.ZipkinCassandra3StorageConfiguration;
 import zipkin2.server.internal.elasticsearch.ZipkinElasticsearchStorageConfiguration;
+import zipkin2.server.internal.eureka.ZipkinEurekaDiscoveryConfiguration;
 import zipkin2.server.internal.health.ZipkinHealthController;
 import zipkin2.server.internal.kafka.ZipkinKafkaCollectorConfiguration;
 import zipkin2.server.internal.mysql.ZipkinMySQLStorageConfiguration;
@@ -46,7 +47,8 @@ import zipkin2.server.internal.ui.ZipkinUiConfiguration;
   ZipkinRabbitMQCollectorConfiguration.class,
   ZipkinMetricsController.class,
   ZipkinHealthController.class,
-  ZipkinPrometheusMetricsConfiguration.class
+  ZipkinPrometheusMetricsConfiguration.class,
+  ZipkinEurekaDiscoveryConfiguration.class,
 })
 public class InternalZipkinConfiguration {
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/InternalZipkinConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinHttpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,7 +24,6 @@ import com.linecorp.armeria.server.cors.CorsServiceBuilder;
 import com.linecorp.armeria.server.file.HttpFile;
 import com.linecorp.armeria.server.metric.PrometheusExpositionService;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.prometheus.client.CollectorRegistry;
 import java.time.Duration;
 import java.util.Optional;
@@ -46,7 +45,6 @@ public class ZipkinHttpConfiguration {
     Optional<ZipkinHttpCollector> httpCollector,
     Optional<ZipkinHealthController> healthController,
     Optional<ZipkinMetricsController> metricsController,
-    Optional<MeterRegistry> meterRegistry,
     Optional<CollectorRegistry> collectorRegistry,
     @Value("${zipkin.query.timeout:11s}") Duration queryTimeout) {
     return sb -> {

--- a/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.eureka;
+
+import com.linecorp.armeria.server.eureka.EurekaUpdatingListener;
+import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Auto-configuration for {@link EurekaUpdatingListener}.
+ *
+ * <p>See <a href="https://armeria.dev/docs/server-service-registration#eureka-based-service-registration-with-eurekaupdatinglistener">armeria-eureka documentation</a>
+ * <p>See <a href="https://github.com/Netflix/eureka/wiki/Eureka-REST-operations">Eureka REST operations</a>
+ */
+@ConditionalOnClass(EurekaUpdatingListener.class)
+@Conditional(ZipkinEurekaDiscoveryConfiguration.EurekaServiceUrlSet.class)
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(ZipkinEurekaDiscoveryProperties.class)
+public class ZipkinEurekaDiscoveryConfiguration {
+  @Bean EurekaUpdatingListener eurekaListener(ZipkinEurekaDiscoveryProperties eureka) {
+    return eureka.toBuilder().build();
+  }
+
+  @Bean ArmeriaServerConfigurator eurekaListenerConfigurator(EurekaUpdatingListener listener) {
+    return sb -> sb.serverListener(listener);
+  }
+
+  /**
+   * This condition passes when "zipkin.discovery.eureka.url" is set to non-empty.
+   *
+   * <p>This is here because the yaml defaults this property to empty like this, and spring-boot
+   * doesn't have an option to treat empty properties as unset.
+   *
+   * <pre>{@code
+   * url: ${EUREKA_URL:}
+   * }</pre>
+   */
+  static final class EurekaServiceUrlSet implements Condition {
+    @Override public boolean matches(ConditionContext context, AnnotatedTypeMetadata a) {
+      return !isEmpty(
+        context.getEnvironment().getProperty("zipkin.discovery.eureka.service-url")) &&
+        notFalse(context.getEnvironment().getProperty("zipkin.discovery.eureka.enabled"));
+    }
+
+    private static boolean isEmpty(String s) {
+      return s == null || s.isEmpty();
+    }
+
+    private static boolean notFalse(String s) {
+      return s == null || !s.equals("false");
+    }
+  }
+}

--- a/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.eureka;
+
+import com.linecorp.armeria.server.eureka.EurekaUpdatingListener;
+import com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder;
+import java.io.Serializable;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Settings for Eureka registration.
+ * <pre>{@code
+ * zipkin.discovery.eureka:
+ *   service-url: http://eureka:8761/eureka/v2
+ *   appName: zipkin
+ *   instance-id: zipkin-prod:zipkin:9411
+ *   hostname: zipkin-prod
+ * }</pre>
+ */
+@ConfigurationProperties("zipkin.discovery.eureka")
+class ZipkinEurekaDiscoveryProperties implements Serializable { // for Spark jobs
+  /** URL of the Eureka v2 endpoint. e.g. http://eureka:8761/eureka/v2 */
+  private String serviceUrl;
+  /** The appName property of this instance of zipkin. */
+  private String appName;
+  /** The instanceId property of this instance of zipkin. */
+  private String instanceId;
+  /** The hostName property of this instance of zipkin. */
+  private String hostname;
+
+  public String getServiceUrl() {
+    return serviceUrl;
+  }
+
+  public void setServiceUrl(String serviceUrl) {
+    this.serviceUrl = emptyToNull(serviceUrl);
+  }
+
+  public String getAppName() {
+    return appName;
+  }
+
+  public void setAppName(String appName) {
+    this.appName = emptyToNull(appName);
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public void setInstanceId(String instanceId) {
+    this.instanceId = emptyToNull(instanceId);
+  }
+
+  public String getHostname() {
+    return hostname;
+  }
+
+  public void setHostname(String hostname) {
+    this.hostname = emptyToNull(hostname);
+  }
+
+  EurekaUpdatingListenerBuilder toBuilder() {
+    final EurekaUpdatingListenerBuilder result = EurekaUpdatingListener.builder(serviceUrl);
+    if (appName != null) result.appName(appName);
+    if (instanceId != null) result.instanceId(instanceId);
+    if (hostname != null) result.hostname(hostname);
+    return result;
+  }
+
+  private static String emptyToNull(String s) {
+    return "".equals(s) ? null : s;
+  }
+}

--- a/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/prometheus/ZipkinPrometheusMetricsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -59,6 +59,19 @@ zipkin:
       enabled: ${COLLECTOR_SCRIBE_ENABLED:${SCRIBE_ENABLED:false}}
       category: ${SCRIBE_CATEGORY:zipkin}
       port: ${COLLECTOR_PORT:9410}
+
+  discovery:
+    eureka:
+      enabled: ${DISCOVERY_EUREKA_ENABLED:true}
+      # URL of the Eureka v2 endpoint. e.g. http://eureka:8761/eureka/v2
+      service-url: ${EUREKA_SERVICE_URL:}
+      # The appName property of the instance
+      app-name: ${EUREKA_APP_NAME:zipkin}
+      # The instanceId property of the instance
+      instance-id: ${EUREKA_INSTANCE_ID:}
+      # The hostName property of the instance
+      hostname: ${EUREKA_HOSTNAME:}
+
   query:
     enabled: ${QUERY_ENABLED:true}
     # Timeout for requests to the query API
@@ -209,6 +222,7 @@ server:
     min-response-size: 2048
 
 armeria:
+  healthCheckPath: /health
   ports:
     - port: ${server.port}
       protocols:

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHttpConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHttpConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHttpConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ZipkinHttpConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/Access.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/Access.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/Access.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/Access.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.eureka;
+
+import com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+
+/** opens package access for testing */
+public final class Access {
+
+  /** Just registering properties to avoid automatically connecting to a Eureka server */
+  public static void registerEurekaProperties(AnnotationConfigApplicationContext context) {
+    context.register(
+        PropertyPlaceholderAutoConfiguration.class, EnableEurekaDiscoveryProperties.class);
+  }
+
+  @Configuration
+  @EnableConfigurationProperties(ZipkinEurekaDiscoveryProperties.class)
+  static class EnableEurekaDiscoveryProperties {}
+
+  public static EurekaUpdatingListenerBuilder discoveryBuilder(
+      AnnotationConfigApplicationContext context) {
+    return context.getBean(ZipkinEurekaDiscoveryProperties.class).toBuilder();
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/Access.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/Access.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.opentest4j.TestAbortedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -100,11 +99,8 @@ class ITZipkinEureka {
     zipkin.close();
     await().untilAsserted( // wait for deregistration
       () -> {
-        try (Response response = getEureka(APPS_ZIPKIN); ResponseBody body = response.body()) {
-          String failMessage = body != null ? body.toString() : response.toString();
-          assertThat(response.code())
-            .withFailMessage(failMessage)
-            .isEqualTo(404);
+        try (Response response = getEureka(APPS_ZIPKIN)) {
+          assertThat(response.code()).isEqualTo(404);
         }
       });
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
@@ -23,6 +23,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.opentest4j.TestAbortedException;
@@ -55,7 +56,8 @@ import static org.testcontainers.utility.DockerImageName.parse;
     "zipkin.query.enabled=false",
     "zipkin.ui.enabled=false"
   })
-@Testcontainers
+@Tag("docker")
+@Testcontainers(disabledWithoutDocker = true)
 @TestMethodOrder(OrderAnnotation.class) // so that deregistration tests don't flake the others.
 class ITZipkinEureka {
   /**
@@ -123,11 +125,6 @@ class ITZipkinEureka {
 
     EurekaContainer() {
       super(parse("ghcr.io/openzipkin/zipkin-eureka:2.26.0"));
-      // Allow skipping even when docker is available (to reduce runtime or run separately).
-      // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
-      if ("true".equals(System.getProperty("docker.skip"))) {
-        throw new TestAbortedException("${docker.skip} == true");
-      }
       withExposedPorts(EUREKA_PORT);
       waitStrategy = Wait.forHealthcheck();
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
@@ -101,8 +101,9 @@ class ITZipkinEureka {
     await().untilAsserted( // wait for deregistration
       () -> {
         try (Response response = getEureka(APPS_ZIPKIN); ResponseBody body = response.body()) {
+          String failMessage = body != null ? body.toString() : response.toString();
           assertThat(response.code())
-            .withFailMessage(response.toString())
+            .withFailMessage(failMessage)
             .isEqualTo(404);
         }
       });

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
@@ -62,12 +62,12 @@ class ITZipkinEureka {
    * Path under the Eureka v2 endpoint for the app named "zipkin".
    * Note that Eureka always coerces app names to uppercase.
    */
-  static final String APPS_ZIPKIN = "/apps/ZIPKIN";
+  private static final String APPS_ZIPKIN = "/apps/ZIPKIN";
+  private final OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
 
   @Container static EurekaContainer eureka = new EurekaContainer();
 
   @Autowired Server zipkin;
-  OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
 
   /** Get the serviceUrl of the Eureka container prior to booting Zipkin. */
   @DynamicPropertySource static void propertyOverride(DynamicPropertyRegistry registry) {
@@ -118,7 +118,7 @@ class ITZipkinEureka {
       .build()).execute();
   }
 
-  static final class EurekaContainer extends GenericContainer<EurekaContainer> {
+  private static final class EurekaContainer extends GenericContainer<EurekaContainer> {
     static final int EUREKA_PORT = 8761;
 
     EurekaContainer() {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
@@ -100,8 +100,10 @@ class ITZipkinEureka {
     zipkin.close();
     await().untilAsserted( // wait for deregistration
       () -> {
-        try (Response response = getEureka(APPS_ZIPKIN)) {
-          assertThat(response.code()).isEqualTo(404);
+        try (Response response = getEureka(APPS_ZIPKIN); ResponseBody body = response.body()) {
+          assertThat(response.code())
+            .withFailMessage(response.toString())
+            .isEqualTo(404);
         }
       });
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.eureka;
+
+import com.jayway.jsonpath.JsonPath;
+import com.linecorp.armeria.server.Server;
+import java.io.IOException;
+import java.time.Duration;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.opentest4j.TestAbortedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import zipkin.server.ZipkinServer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.testcontainers.utility.DockerImageName.parse;
+
+/**
+ * Integration test for Eureka, which validates with <a href="https://github.com/Netflix/eureka/wiki/Eureka-REST-operations">Eureka REST operations</a>
+ */
+@SpringBootTest(
+  classes = ZipkinServer.class,
+  webEnvironment = SpringBootTest.WebEnvironment.NONE, // RANDOM_PORT requires spring-web
+  properties = {
+    "server.port=0",
+    "spring.config.name=zipkin-server",
+    "spring.main.banner-mode=off",
+    "zipkin.storage.type=", // cheat and test empty storage type
+    "zipkin.collector.http.enabled=false",
+    "zipkin.query.enabled=false",
+    "zipkin.ui.enabled=false"
+  })
+@Testcontainers
+@TestMethodOrder(OrderAnnotation.class) // so that deregistration tests don't flake the others.
+class ITZipkinEureka {
+
+  @Container static EurekaContainer eureka = new EurekaContainer();
+
+  @Autowired Server zipkin;
+  OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
+
+  /** Get the serviceUrl of the Eureka container prior to booting Zipkin. */
+  @DynamicPropertySource static void propertyOverride(DynamicPropertyRegistry registry) {
+    registry.add("zipkin.discovery.eureka.serviceUrl", eureka::serviceUrl);
+  }
+
+  @Test @Order(1) void registersInEureka() throws Exception {
+    // Notice the app name always coerces to uppercase
+    String json = getEurekaAsString("/apps/ZIPKIN");
+
+    // Make sure the health status is OK
+    assertThat(readString(json, "$.application.instance[0].status"))
+      .isEqualTo("UP");
+
+    String zipkinHostname = zipkin.defaultHostname();
+    int zipkinPort = zipkin.activePort().localAddress().getPort();
+
+    // Note: Netflix/Eureka says use hostname, which can conflict on laptops.
+    // Armeria adopts the spring-cloud-netflix convention shown here.
+    assertThat(readString(json, "$.application.instance[0].instanceId"))
+      .isEqualTo(zipkinHostname + ":zipkin:" + zipkinPort);
+
+    // Make sure the vip address is relevant
+    assertThat(readString(json, "$.application.instance[0].vipAddress"))
+      .isEqualTo(zipkinHostname + ":" + zipkinPort);
+  }
+
+  @Test @Order(2) void deregistersOnClose() {
+    zipkin.close();
+    await().untilAsserted( // wait for deregistration
+      () -> assertThat(getEurekaAsString("/apps"))
+        .isEqualTo(
+          "{\"applications\":{\"versions__delta\":\"1\",\"apps__hashcode\":\"\",\"application\":[]}}"));
+  }
+
+  private String getEurekaAsString(String path) throws IOException {
+    try (Response response = getEureka(path); ResponseBody body = response.body()) {
+      assertThat(response.isSuccessful()).withFailMessage(response.toString()).isTrue();
+      return body != null ? body.string() : "";
+    }
+  }
+
+  private Response getEureka(String path) throws IOException {
+    return client.newCall(new Request.Builder()
+      .url(eureka.serviceUrl() + path)
+      .header("Accept", "application/json") // XML is default
+      .build()).execute();
+  }
+
+  static final class EurekaContainer extends GenericContainer<EurekaContainer> {
+    static final int EUREKA_PORT = 8761;
+
+    EurekaContainer() {
+      super(parse("ghcr.io/openzipkin/zipkin-eureka:2.26.0"));
+      // Allow skipping even when docker is available (to reduce runtime or run separately).
+      // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
+      if ("true".equals(System.getProperty("docker.skip"))) {
+        throw new TestAbortedException("${docker.skip} == true");
+      }
+      withExposedPorts(EUREKA_PORT);
+      waitStrategy = Wait.forHealthcheck();
+      withStartupTimeout(Duration.ofSeconds(60));
+    }
+
+    String serviceUrl() {
+      return "http://" + getHost() + ":" + getMappedPort(EUREKA_PORT) + "/eureka/v2";
+    }
+  }
+
+  static String readString(String json, String jsonPath) {
+    return JsonPath.compile(jsonPath).read(json);
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfigurationTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2015-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.eureka;
+
+import com.linecorp.armeria.server.eureka.EurekaUpdatingListener;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin2.server.internal.InMemoryConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class ZipkinEurekaDiscoveryConfigurationTest {
+
+  AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+  @AfterEach void close() {
+    context.close();
+  }
+
+  @Test void doesNotProvideDiscoveryComponent_whenServiceUrlUnset() {
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class).isThrownBy(() -> {
+      context.register(
+        PropertyPlaceholderAutoConfiguration.class,
+        ZipkinEurekaDiscoveryConfiguration.class,
+        InMemoryConfiguration.class);
+      context.refresh();
+      context.getBean(EurekaUpdatingListener.class);
+    });
+  }
+
+  @Test void providesDiscoveryComponent_whenServiceUrlEmptyString() {
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class).isThrownBy(() -> {
+      TestPropertyValues.of("zipkin.discovery.eureka.service-url:").applyTo(context);
+      context.register(
+        PropertyPlaceholderAutoConfiguration.class,
+        ZipkinEurekaDiscoveryConfiguration.class,
+        InMemoryConfiguration.class);
+      context.refresh();
+      context.getBean(EurekaUpdatingListener.class);
+    });
+  }
+
+  @Test void providesDiscoveryComponent_whenServiceUrlSet() {
+    TestPropertyValues.of("zipkin.discovery.eureka.service-url:http://localhost:8761/eureka/v2")
+      .applyTo(context);
+    context.register(
+      PropertyPlaceholderAutoConfiguration.class,
+      ZipkinEurekaDiscoveryConfiguration.class,
+      InMemoryConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(EurekaUpdatingListener.class)).isNotNull();
+  }
+
+  @Test void doesNotProvidesEurekaUpdatingListener_whenServiceUrlSetAndDisabled() {
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class).isThrownBy(() -> {
+      TestPropertyValues.of("zipkin.discovery.eureka.service-url:http://localhost:8761/eureka/v2")
+        .applyTo(context);
+      TestPropertyValues.of("zipkin.discovery.eureka.enabled:false").applyTo(context);
+      context.register(
+        PropertyPlaceholderAutoConfiguration.class,
+        ZipkinEurekaDiscoveryConfiguration.class,
+        InMemoryConfiguration.class);
+      context.refresh();
+      context.getBean(EurekaUpdatingListener.class);
+    });
+  }
+
+  @Test void canOverrideProperty_appName() {
+    context = createContextWithOverridenProperty("zipkin.discovery.eureka.appName:zipkin-demo");
+
+    assertThat(context.getBean(ZipkinEurekaDiscoveryProperties.class).getAppName())
+      .isEqualTo("zipkin-demo");
+  }
+
+  @Test void canOverrideProperty_instanceId() {
+    context = createContextWithOverridenProperty("zipkin.discovery.eureka.instanceId:zipkin-demo");
+
+    assertThat(context.getBean(ZipkinEurekaDiscoveryProperties.class).getInstanceId())
+      .isEqualTo("zipkin-demo");
+  }
+
+  @Test void canOverrideProperty_hostname() {
+    context = createContextWithOverridenProperty("zipkin.discovery.eureka.hostname:zipkin-demo");
+
+    assertThat(context.getBean(ZipkinEurekaDiscoveryProperties.class).getHostname())
+      .isEqualTo("zipkin-demo");
+  }
+
+  private static AnnotationConfigApplicationContext createContextWithOverridenProperty(
+    String pair) {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    TestPropertyValues.of( // Add a service-url so that the pair is read.
+      "zipkin.discovery.eureka.service-url:http://localhost:8761/eureka/v2",
+      pair
+    ).applyTo(context);
+    context.register(
+      PropertyPlaceholderAutoConfiguration.class,
+      ZipkinEurekaDiscoveryConfiguration.class
+    );
+    context.refresh();
+    return context;
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryPropertiesTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryPropertiesTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryPropertiesTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.server.internal.eureka;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ZipkinEurekaDiscoveryPropertiesTest {
+  @Test void stringPropertiesConvertEmptyStringsToNull() {
+    final ZipkinEurekaDiscoveryProperties properties = new ZipkinEurekaDiscoveryProperties();
+    properties.setServiceUrl("");
+    properties.setAppName("");
+    properties.setInstanceId("");
+    properties.setHostname("");
+    assertThat(properties.getServiceUrl()).isNull();
+    assertThat(properties.getAppName()).isNull();
+    assertThat(properties.getInstanceId()).isNull();
+    assertThat(properties.getHostname()).isNull();
+  }
+}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryPropertiesTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-server/src/test/resources/application.yml
+++ b/zipkin-server/src/test/resources/application.yml
@@ -1,4 +1,7 @@
-spring.main.web-application-type: none
+spring:
+  main:
+    banner-mode: off
+    web-application-type: none
 
 # We are using Armeria instead of Tomcat. Have it inherit the default configuration from Spring
 armeria:

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-storage-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-storage-cassandra</artifactId>

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -157,9 +157,6 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
   static final class CassandraContainer extends GenericContainer<CassandraContainer> {
     CassandraContainer() {
       super(parse("ghcr.io/openzipkin/zipkin-cassandra:2.26.0"));
-      if ("true".equals(System.getProperty("docker.skip"))) {
-        throw new TestAbortedException("${docker.skip} == true");
-      }
       addExposedPort(9042);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -156,7 +156,7 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class CassandraContainer extends GenericContainer<CassandraContainer> {
     CassandraContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-cassandra:2.25.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-cassandra:2.26.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
@@ -34,6 +35,7 @@ import static zipkin2.storage.cassandra.Schema.TABLE_TRACE_BY_SERVICE_REMOTE_SER
 import static zipkin2.storage.cassandra.Schema.TABLE_TRACE_BY_SERVICE_SPAN;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("docker")
 class ITCassandraStorage {
   static final List<String> SEARCH_TABLES = asList(
     TABLE_AUTOCOMPLETE_TAGS,

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorageHeavy.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITCassandraStorageHeavy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
@@ -41,6 +42,7 @@ import static zipkin2.storage.cassandra.InternalForTests.writeDependencyLinks;
  * keyspace. As schema installation takes ~10s, hesitate adding too many tests here.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("docker")
 class ITCassandraStorageHeavy {
 
   @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension();

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-storage-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-storage-elasticsearch</artifactId>

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -127,7 +127,7 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {
     ElasticsearchContainer(int majorVersion) {
-      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":2.25.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":2.26.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -128,9 +128,6 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
   static final class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {
     ElasticsearchContainer(int majorVersion) {
       super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":2.26.0"));
-      if ("true".equals(System.getProperty("docker.skip"))) {
-        throw new TestAbortedException("${docker.skip} == true");
-      }
       addExposedPort(9200);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,7 @@
 package zipkin2.elasticsearch.integration;
 
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,6 +23,7 @@ import zipkin2.elasticsearch.ElasticsearchStorage;
 import static zipkin2.elasticsearch.integration.ElasticsearchExtension.index;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("docker")
 class ITElasticsearchStorageV7 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchExtension elasticsearch = new ElasticsearchExtension(7);

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV8.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ITElasticsearchStorageV8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,7 @@
 package zipkin2.elasticsearch.integration;
 
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,6 +23,7 @@ import zipkin2.elasticsearch.ElasticsearchStorage;
 import static zipkin2.elasticsearch.integration.ElasticsearchExtension.index;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("docker")
 class ITElasticsearchStorageV8 extends ITElasticsearchStorage {
 
   @RegisterExtension ElasticsearchExtension elasticsearch = new ElasticsearchExtension(8);

--- a/zipkin-storage/mysql-v1/pom.xml
+++ b/zipkin-storage/mysql-v1/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-storage-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-storage-mysql-v1</artifactId>

--- a/zipkin-storage/mysql-v1/pom.xml
+++ b/zipkin-storage/mysql-v1/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/mysql-v1/pom.xml
+++ b/zipkin-storage/mysql-v1/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/ITMySQLStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import org.jooq.DSLContext;
 import org.jooq.Query;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
@@ -35,6 +36,7 @@ import static zipkin2.storage.ITDependencies.aggregateLinks;
 import static zipkin2.storage.mysql.v1.internal.generated.tables.ZipkinDependencies.ZIPKIN_DEPENDENCIES;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("docker")
 class ITMySQLStorage {
 
   @RegisterExtension MySQLExtension mysql = new MySQLExtension();

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 The OpenZipkin Authors
+ * Copyright 2015-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -113,7 +113,7 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class MySQLContainer extends GenericContainer<MySQLContainer> {
     MySQLContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-mysql:2.25.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-mysql:2.26.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
@@ -114,9 +114,6 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback {
   static final class MySQLContainer extends GenericContainer<MySQLContainer> {
     MySQLContainer() {
       super(parse("ghcr.io/openzipkin/zipkin-mysql:2.26.0"));
-      if ("true".equals(System.getProperty("docker.skip"))) {
-        throw new TestAbortedException("${docker.skip} == true");
-      }
       addExposedPort(3306);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/zipkin-storage/pom.xml
+++ b/zipkin-storage/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/pom.xml
+++ b/zipkin-storage/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/pom.xml
+++ b/zipkin-storage/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>

--- a/zipkin-tests/pom.xml
+++ b/zipkin-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-tests/pom.xml
+++ b/zipkin-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-tests/pom.xml
+++ b/zipkin-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2024 The OpenZipkin Authors
+    Copyright 2015-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015-2023 The OpenZipkin Authors
+    Copyright 2015-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>2.26.1-SNAPSHOT</version>
+    <version>2.27.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>


### PR DESCRIPTION
Zipkin can register itself in [Eureka](https://github.com/Netflix/eureka), allowing traced services to discover its listen address and health state. This is enabled when `EUREKA_SERVICE_URL` is set to a valid v2 endpoint of the [Eureka REST API](https://github.com/Netflix/eureka/wiki/Eureka-REST-operations).

| Variable                   | Instance field | Description                                                                                    |
|----------------------------|----------------|------------------------------------------------------------------------------------------------|
| `DISCOVERY_EUREKA_ENABLED` | N/A            | `false` disables Eureka registration. Defaults to `true`.                                      |
| `EUREKA_SERVICE_URL`       | N/A            | v2 endpoint of Eureka, e.g. https://eureka-prod/eureka/v2. No default                          |
| `EUREKA_APP_NAME`          | .app           | The application this instance registers to. Defaults to `zipkin`                               |
| `EUREKA_HOSTNAME`          | .hostName      | The hostname used with `${QUERY_PORT}` to build the instance `vipAddress`. Defaults to detect. |
| `EUREKA_INSTANCE_ID`       | .instanceId    | Defaults to `${EUREKA_HOSTNAME}:${EUREKA_APP_NAME}:${QUERY_PORT}`.                             |

Example usage:

```bash
$ EUREKA_SERVICE_URL=http://localhost:8761/eureka/v2 java -jar zipkin.jar
```

To aid in testing, this adds a docker image
ghcr.io/openzipkin/zipkin-eureka, and an example docker-compose configuration for it.


Fixes #1870