### PR TITLE
eureka: adds comment for follow-up regarding healthCheckPath

### DIFF
--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -222,6 +222,10 @@ server:
     min-response-size: 2048
 
 armeria:
+  # TODO: This is only to help with Eureka. After line/armeria#5369, add the
+  # same in EurekaUpdatingListenerBuilder#toBuilder and remove from here. This
+  # will remove the following log warning:
+  # WARN RejectedRouteHandler - Virtual host '*' has a duplicate route: /health
   healthCheckPath: /health
   ports:
     - port: ${server.port}


### PR DESCRIPTION
there's a hack currently in place, and it makes a log warning regardless of if eureka is in use. You can see it by going to the docker/examples directory and doing this:

```bash
$ TAG=master docker-compose -f docker-compose-eureka.yml up
--snip--
zipkin  | 2024-01-04 14:36:20:477 [main] WARN RejectedRouteHandler - Virtual host '*' has a duplicate route: /health
--snip--
```

This should be fixable by https://github.com/line/armeria/pull/5369