### PR TITLE
codec: adds offset parameter to SpanBytesEncoder.write

### DIFF
--- a/zipkin/src/main/java/zipkin2/internal/Proto3Codec.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3Codec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -31,6 +31,10 @@ public final class Proto3Codec {
 
   public byte[] write(Span span) {
     return writer.write(span);
+  }
+
+  public int write(Span span, byte[] out, int pos) {
+    return writer.write(span, out, pos);
   }
 
   public byte[] writeList(List<Span> spans) {

--- a/zipkin/src/main/java/zipkin2/internal/Proto3SpanWriter.java
+++ b/zipkin/src/main/java/zipkin2/internal/Proto3SpanWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -59,8 +59,18 @@ final class Proto3SpanWriter implements WriteBuffer.Writer<Span> {
   byte[] write(Span onlySpan) {
     int sizeOfValue = SPAN.sizeOfValue(onlySpan);
     byte[] result = new byte[sizeOfLengthDelimitedField(sizeOfValue)];
-    writeSpan(onlySpan, sizeOfValue, WriteBuffer.wrap(result));
+    write(onlySpan, result, 0, sizeOfValue);
     return result;
+  }
+
+  int write(Span onlySpan, byte[] out, int pos) {
+    return write(onlySpan, out, pos, SPAN.sizeOfValue(onlySpan));
+  }
+
+  int write(Span onlySpan, byte[] out, int pos, int sizeOfValue) {
+    WriteBuffer result = WriteBuffer.wrap(out, pos);
+    writeSpan(onlySpan, sizeOfValue, result);
+    return result.pos() - pos;
   }
 
   // prevents resizing twice

--- a/zipkin/src/main/java/zipkin2/internal/WriteBuffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/WriteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -81,7 +81,7 @@ public final class WriteBuffer {
     data[pos + 1] = (byte) HEX_DIGITS[b & 0xf];
   }
 
-  final int pos() {
+  public int pos() {
     return pos;
   }
 


### PR DESCRIPTION
This adds an offset parameter to `SpanByteEncoder.write` which allows re-use of a buffer, similar to `writeList`. This is in preparation of a change to zipkin-reporter-java which needs to update dependencies anyway. Doing this allows the async reporter to allocate less memory while accumulating spans.

```java
pubiic int write(Span span, byte[] out, int pos)
```

Note: this doesn't add a ByteBuffer or similar overload for write because the code is optimized and only implemented for byte arrays. Doing more than this would be a bigger job.