### PR TITLE
docker: set HEALTHCHECK timeouts to 1s

### DIFF
--- a/build-bin/docker/docker-healthcheck
+++ b/build-bin/docker/docker-healthcheck
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -45,11 +45,13 @@ case ${kind} in
     path=${HEALTHCHECK_PATH:-/health}
     endpoint="http://${ip}:${port}${path}"
     # Use b3:0 to ensure health checks aren't traced
-    out=$(wget -qO- "${endpoint}" --header=b3:0 2>&1)
+    # Use timeout 1s (-T 1) as the health check interval is often 1s
+    out=$(wget -T 1 -qO- "${endpoint}" --header=b3:0 2>&1)
     rc=$?
     ;;
   tcp )
-    out=$(nc -z ${ip} ${port} 2>&1)
+    # Use timeout 1s (-w 1) as the health check interval is often 1s
+    out=$(nc -w 1 -z ${ip} ${port} 2>&1)
     rc=$?
     ;;
   * )


### PR DESCRIPTION
I set the only available timeout constraints on the BusyBox v1.31.1 `wget` and `nc` commands to 1s to hopefully not accumulate hung HEALTHCHECK stuff.

See #3670