### PR TITLE
build: removes out-of-date animalsniffer and bumps deps

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -220,6 +220,7 @@
               <compilerId>javac</compilerId>
               <source>1.8</source>
               <target>1.8</target>
+              <release>8</release>
               <!-- scrub errorprone compiler args -->
               <compilerArgs />
             </configuration>

--- a/docker/test-images/zipkin-cassandra/Dockerfile
+++ b/docker/test-images/zipkin-cassandra/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -34,7 +34,7 @@ FROM ghcr.io/openzipkin/java:${java_version} as install
 # Use latest stable version: https://cassandra.apache.org/download/
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG cassandra_version=4.0.11
+ARG cassandra_version=4.1.3
 ENV CASSANDRA_VERSION=$cassandra_version
 WORKDIR /install
 
@@ -44,7 +44,7 @@ RUN /tmp/install.sh && rm /tmp/install.sh
 
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-cassandra
 LABEL org.opencontainers.image.description="Cassandra on OpenJDK and Alpine Linux with Zipkin keyspaces pre-installed"
-ARG cassandra_version=4.0.11
+ARG cassandra_version=4.1.3
 LABEL cassandra-version=$cassandra_version
 ENV CASSANDRA_VERSION=$cassandra_version
 

--- a/docker/test-images/zipkin-kafka/Dockerfile
+++ b/docker/test-images/zipkin-kafka/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -34,7 +34,7 @@ FROM ghcr.io/openzipkin/java:${java_version} as install
 #
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG kafka_version=2.8.2
+ARG kafka_version=3.6.1
 ENV KAFKA_VERSION=$kafka_version
 # Note: Scala 2.13+ supports JRE 14
 ARG scala_version=2.13
@@ -47,7 +47,7 @@ RUN /tmp/install.sh && rm /tmp/install.sh
 # Share the same base image to reduce layers used in testing
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-kafka
 LABEL org.opencontainers.image.description="Kafka and ZooKeeper on OpenJDK and Alpine Linux"
-ARG kafka_version=2.8.2
+ARG kafka_version=3.6.1
 LABEL kafka-version=$kafka_version
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path

--- a/docker/test-images/zipkin-rabbitmq/Dockerfile
+++ b/docker/test-images/zipkin-rabbitmq/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
 #
 
 # Use latest from https://hub.docker.com/_/rabbitmq/tags?page=1&name=alpine
-ARG rabbitmq_version=3.12.10
+ARG rabbitmq_version=3.12.12
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-rabbitmq/Dockerfile
+++ b/docker/test-images/zipkin-rabbitmq/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # Use latest from https://hub.docker.com/_/rabbitmq/tags?page=1&name=alpine
-ARG rabbitmq_version=3.12.12
+ARG rabbitmq_version=3.12.11
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.24.0</errorprone.version>
+    <errorprone.version>2.24.1</errorprone.version>
 
     <zipkin-proto3.version>1.0.0</zipkin-proto3.version>
 
@@ -85,7 +85,7 @@
     <!-- Test only dependencies -->
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
     <mockito.version>5.8.0</mockito.version>
-    <assertj.version>3.24.2</assertj.version>
+    <assertj.version>3.25.1</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <testcontainers.version>1.19.3</testcontainers.version>
     <okhttp.version>4.12.0</okhttp.version>
@@ -97,12 +97,11 @@
 
     <license.skip>${skipTests}</license.skip>
 
-    <animal-sniffer-maven-plugin.version>1.23</animal-sniffer-maven-plugin.version>
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.3</license-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
@@ -110,12 +109,12 @@
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-help-plugin.version>3.4.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
-    <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     <wire-maven-plugin.version>1.3</wire-maven-plugin.version>
   </properties>

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -41,14 +41,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.jvnet</groupId>
-      <artifactId>animal-sniffer-annotation</artifactId>
-      <version>1.0</version>
-      <!-- annotations are not runtime retention, so don't need a runtime dep -->
-      <scope>provided</scope>
-    </dependency>
-
     <!-- Internal classes used in SpanBytesDecoder.JSON_V[12] -->
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -61,32 +53,6 @@
 
   <build>
     <plugins>
-      <!-- Note: CI should run the "release" profile during tests to ensure no
-     Java 11 features are in use. -->
-      <!-- The core jar needs to be Java 1.6 bytecode -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>${animal-sniffer-maven-plugin.version}</version>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
-            <version>1.0</version>
-          </signature>
-          <checkTestClasses>false</checkTestClasses>
-        </configuration>
-        <executions>
-          <execution>
-            <id>animal-sniffer</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>de.qaware.maven</groupId>
         <artifactId>go-offline-maven-plugin</artifactId>

--- a/zipkin/src/main/java/zipkin2/internal/ReadBuffer.java
+++ b/zipkin/src/main/java/zipkin2/internal/ReadBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package zipkin2.internal;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import org.jvnet.animal_sniffer.IgnoreJRERequirement;
 
 import static zipkin2.internal.HexCodec.HEX_DIGITS;
 import static zipkin2.internal.JsonCodec.UTF_8;
@@ -112,7 +111,6 @@ public abstract class ReadBuffer extends InputStream {
     }
 
     // Encoding zipkin data is supported in JRE 6, but decoding isn't.
-    @IgnoreJRERequirement
     @Override boolean tryReadAscii(char[] destination, int length) {
       buf.mark(); // This is not Java 6
       for (int i = 0; i < length; i++) {
@@ -143,7 +141,6 @@ public abstract class ReadBuffer extends InputStream {
     }
 
     // Encoding zipkin data is supported in JRE 6, but decoding isn't.
-    @IgnoreJRERequirement
     @Override public long skip(long maxCount) {
       int skipped = Math.max(available(), (int) maxCount);
       buf.position(buf.position() + skipped); // This is not Java 6


### PR DESCRIPTION
We removed animalsniffer from the build, but not all of it. This completes the job, and updates other build/test related deps as well.