### PR TITLE
Fix typo in IllegalArgumentException

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
@@ -226,7 +226,7 @@ final class VersionSpecificTemplates {
   IndexTemplates get(ElasticsearchVersion version) {
     if (version.compareTo(V5_0) < 0 || version.compareTo(V9_0) >= 0) {
       throw new IllegalArgumentException(
-        "Elasticsearch versions 5-7.x are supported, was: " + version);
+        "Elasticsearch versions 5-8.x are supported, was: " + version);
     }
     return IndexTemplates.newBuilder()
       .version(version)

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/VersionSpecificTemplates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/VersionSpecificTemplatesTest.java
@@ -34,7 +34,7 @@ class VersionSpecificTemplatesTest {
   /** Unsupported, but we should test that parsing works */
   @Test void version2_unsupported() {
     assertThatThrownBy(() -> storage.versionSpecificTemplates(V2_4))
-      .hasMessage("Elasticsearch versions 5-7.x are supported, was: 2.4");
+      .hasMessage("Elasticsearch versions 5-8.x are supported, was: 2.4");
   }
 
   @Test void version5() {


### PR DESCRIPTION
It seems that exceptions are a bit outdated after Elasticsearch 8 support was added in [#3552](https://github.com/openzipkin/zipkin/pull/3552)