### PR TITLE
fixes default release version from 17 to 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
          * zipkin-server is 17, as that's the floor of Spring Boot 3. -->
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.testSource>17</maven.compiler.testSource>
     <maven.compiler.testTarget>17</maven.compiler.testTarget>
     <maven.compiler.testRelease>17</maven.compiler.testRelease>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -29,6 +29,11 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
 
+    <!-- Spring Boot 3 requires JRE 17 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
+
     <!-- Sometimes we need to override Armeria's Brave version -->
     <brave.version>6.0.0</brave.version>
     <zipkin-reporter.version>3.1.1</zipkin-reporter.version>


### PR DESCRIPTION
This was a typo and doesn't affect anything except zipkin-dependencies, as that's the only project that uses non-overridden targets, and requires version 11 (due to spark conflicts that hopefully will one day go away).