### PR TITLE
removes log4j warning message

### DIFF
--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -91,7 +91,7 @@ class ServerIntegratedBenchmark {
 
   @Test void elasticsearch() throws Exception {
     GenericContainer<?> elasticsearch =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:3.0.0"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:3.0.1"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("elasticsearch")
         .withLabel("name", "elasticsearch")
@@ -105,7 +105,7 @@ class ServerIntegratedBenchmark {
 
   @Test void cassandra3() throws Exception {
     GenericContainer<?> cassandra =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:3.0.0"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:3.0.1"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("cassandra")
         .withLabel("name", "cassandra")
@@ -119,7 +119,7 @@ class ServerIntegratedBenchmark {
 
   @Test void mysql() throws Exception {
     GenericContainer<?> mysql =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:3.0.0"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:3.0.1"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("mysql")
         .withLabel("name", "mysql")

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     <wire-maven-plugin.version>1.3</wire-maven-plugin.version>
   </properties>

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
@@ -64,7 +64,7 @@ class ActiveMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
     ActiveMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-activemq:3.0.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-activemq:3.0.1"));
       withExposedPorts(ACTIVEMQ_PORT);
       waitStrategy = Wait.forListeningPorts(ACTIVEMQ_PORT);
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
@@ -92,7 +92,7 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.0.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.0.1"));
       waitStrategy = Wait.forHealthcheck();
       // 19092 is for connections from the Docker host and needs to be used as a fixed port.
       // TODO: someone who knows Kafka well, make ^^ comment better!

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
@@ -83,7 +83,7 @@ class RabbitMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
     RabbitMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.0.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.0.1"));
       withExposedPorts(RABBIT_PORT);
       waitStrategy = Wait.forLogMessage(".*Server startup complete.*", 1);
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -113,15 +113,15 @@ exposition [text format version 0.0.4](https://prometheus.io/docs/instrumenting/
 
 Collector metrics are broken down by transport. The following are exported to the "/metrics" endpoint:
 
-Metric | Description
---- | ---
-counter.zipkin_collector.messages.$transport | cumulative messages received; should relate to messages reported by instrumented apps
-counter.zipkin_collector.messages_dropped.$transport | cumulative messages dropped; reasons include client disconnects or malformed content
-counter.zipkin_collector.bytes.$transport | cumulative message bytes
-counter.zipkin_collector.spans.$transport | cumulative spans read; should relate to messages reported by instrumented apps
-counter.zipkin_collector.spans_dropped.$transport | cumulative spans dropped; reasons include sampling or storage failures
-gauge.zipkin_collector.message_spans.$transport | last count of spans in a message
-gauge.zipkin_collector.message_bytes.$transport | last count of bytes in a message
+| Metric                                               | Description                                                                           |
+|------------------------------------------------------|---------------------------------------------------------------------------------------|
+| counter.zipkin_collector.messages.$transport         | cumulative messages received; should relate to messages reported by instrumented apps |
+| counter.zipkin_collector.messages_dropped.$transport | cumulative messages dropped; reasons include client disconnects or malformed content  |
+| counter.zipkin_collector.bytes.$transport            | cumulative message bytes                                                              |
+| counter.zipkin_collector.spans.$transport            | cumulative spans read; should relate to messages reported by instrumented apps        |
+| counter.zipkin_collector.spans_dropped.$transport    | cumulative spans dropped; reasons include sampling or storage failures                |
+| gauge.zipkin_collector.message_spans.$transport      | last count of spans in a message                                                      |
+| gauge.zipkin_collector.message_bytes.$transport      | last count of bytes in a message                                                      |
 
 ## Configuration
 We support ENV variable configuration, such as `STORAGE_TYPE=cassandra3`, as they are familiar to

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -266,6 +266,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- the "slim" jar will exclude this -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Optional, but packaged in the supported distribution -->
 
     <!-- Cassandra backend -->
@@ -466,11 +473,6 @@
     </dependency>
 
     <!-- Main code uses jul and tests log with log4j -->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jul</artifactId>

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/ITZipkinEureka.java
@@ -132,7 +132,7 @@ class ITZipkinEureka {
     static final int EUREKA_PORT = 8761;
 
     EurekaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-eureka:3.0.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-eureka:3.0.1"));
       withExposedPorts(EUREKA_PORT);
       waitStrategy = Wait.forHealthcheck();
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -156,7 +156,7 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class CassandraContainer extends GenericContainer<CassandraContainer> {
     CassandraContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-cassandra:3.0.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-cassandra:3.0.1"));
       addExposedPort(9042);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -127,7 +127,7 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {
     ElasticsearchContainer(int majorVersion) {
-      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":3.0.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":3.0.1"));
       addExposedPort(9200);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
@@ -113,7 +113,7 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class MySQLContainer extends GenericContainer<MySQLContainer> {
     MySQLContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-mysql:3.0.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-mysql:3.0.1"));
       addExposedPort(3306);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));


### PR DESCRIPTION
I noticed this testing homebrew
```bash
$ java -jar zipkin.jar
ERROR StatusLogger Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...

                  oo
                 oooo

```

Also, fixed some README fuzz and updated docker images to latest