### PR TITLE
docker: uses Armeria for end-to-end Eureka example

### DIFF
--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -124,9 +124,12 @@ You can register Zipkin for service discovery in [Eureka](../test-images/zipkin-
 using the `docker-compose-eureka.yml` file. This configuration starts `zipkin` and `zipkin-eureka`
 in their own containers.
 
-To register Zipkin in Eureka, run:
+When `zipkin` starts, it registers its endpoint into `eureka`. Then, the two [example services](#example)
+discover zipkin's endpoint from `eureka` and use it to send spans.
+
+To try this out, run:
 ```bash
-$ docker-compose -f docker-compose-eureka.yml up
+$ docker-compose -f docker-compose.yml -f docker-compose-eureka.yml up
 ```
 
 ## Example

--- a/docker/examples/docker-compose-eureka.yml
+++ b/docker/examples/docker-compose-eureka.yml
@@ -34,6 +34,33 @@ services:
       service: zipkin
     environment:
       - EUREKA_SERVICE_URL=http://eureka:8761/eureka/v2
+      - EUREKA_HOSTNAME=zipkin
     depends_on:
       eureka:
+        condition: service_healthy
+
+  # Generate traffic by hitting http://localhost:8081
+  frontend:
+    image: ghcr.io/openzipkin/brave-example:armeria
+    container_name: frontend
+    entrypoint: start-frontend
+    environment:
+      - EUREKA_SERVICE_URL=http://eureka:8761/eureka/v2
+    ports:
+      - 8081:8081
+    depends_on:
+      backend:
+        condition: service_healthy
+      zipkin:
+        condition: service_healthy
+
+  # Serves the /api endpoint the frontend uses
+  backend:
+    image: ghcr.io/openzipkin/brave-example:armeria
+    container_name: backend
+    entrypoint: start-backend
+    environment:
+      - EUREKA_SERVICE_URL=http://eureka:8761/eureka/v2
+    depends_on:
+      zipkin:
         condition: service_healthy

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -525,6 +525,10 @@ Example usage:
 $ EUREKA_SERVICE_URL=http://localhost:8761/eureka/v2 java -jar zipkin.jar
 ```
 
+If you are using a containerized environment, you may need to set `EUREKA_HOSTNAME` to avoid
+detecting the wrong hostname. For example, if using docker-compose, set `EUREKA_HOSTNAME` to
+zipkin's `container_name`.
+
 Note: Eureka server registration only includes host and port details. Tracers need to resolve this
 to the POST endpoint "/api/v2/spans".
 


### PR DESCRIPTION
Before, our Eureka example only registered zipkin, but nothing looked it up. This proves things work, using [Armeria's Eureka](https://armeria.dev/docs/client-service-discovery/) support.

code is here! https://github.com/openzipkin/brave-example/tree/master/armeria