### PR TITLE
backfills tests for behaviour on malformed due to non-string tags

### DIFF
--- a/zipkin/src/main/java/zipkin2/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin2/internal/JsonCodec.java
@@ -15,7 +15,6 @@ package zipkin2.internal;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -222,7 +221,9 @@ public final class JsonCodec {
 
   static IllegalArgumentException exceptionReading(String type, Exception e) {
     String cause = e.getMessage() == null ? "Error" : e.getMessage();
-    if (cause.contains("Expected BEGIN_OBJECT") || cause.contains("malformed")) {
+    if (cause.contains("Expected BEGIN_OBJECT")
+      || cause.contains("Expected BEGIN_ARRAY")
+      || cause.contains("malformed")) {
       cause = "Malformed";
     }
     String message = format("%s reading %s from json", cause, type);


### PR DESCRIPTION
This adds tests to prove that all zipkin collectors return errors when json is malformed due to non-string tags.

See https://github.com/openzipkin/zipkin/pull/3503#issuecomment-1894350504