### PR TITLE
docker: require auth for Eureka on EUREKA_USERNAME

### DIFF
--- a/docker/test-images/zipkin-eureka/pom.xml
+++ b/docker/test-images/zipkin-eureka/pom.xml
@@ -50,6 +50,15 @@
       <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
+    </dependency>
+
     <!-- Get rid of log warning saying to use Caffeine -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaProperties.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaProperties.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2015-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package zipkin.test;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaProperties.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaProperties.java
@@ -1,0 +1,30 @@
+package zipkin.test;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Properties for configuring and building a {@link EurekaServer}. */
+@ConfigurationProperties("eureka")
+class EurekaProperties {
+
+  /** Optional username to require. */
+  private String username;
+
+  /** Optional password to require. */
+  private String password;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+}

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
@@ -18,7 +18,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportAutoConfiguration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.User;

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
@@ -33,7 +33,7 @@ import static org.springframework.security.crypto.factory.PasswordEncoderFactori
 @Configuration
 @ConditionalOnProperty("eureka.username")
 @EnableConfigurationProperties(EurekaProperties.class)
-@Import(SecurityAutoConfiguration.class)
+@ImportAutoConfiguration(SecurityAutoConfiguration.class)
 public class EurekaSecurity {
   @Bean InMemoryUserDetailsManager userDetailsService(EurekaProperties props) {
     PasswordEncoder encoder = createDelegatingPasswordEncoder();

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
@@ -13,12 +13,12 @@
  */
 package zipkin.test;
 
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportAutoConfiguration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.User;

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.test;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.crypto.factory.PasswordEncoderFactories.createDelegatingPasswordEncoder;
+
+/** This enables security, particularly only BASIC auth, when {@code EUREKA_USERNAME} is set. */
+@Configuration
+@ConditionalOnProperty("eureka.username")
+@EnableConfigurationProperties(EurekaProperties.class)
+@Import(SecurityAutoConfiguration.class)
+public class EurekaSecurity {
+  @Bean InMemoryUserDetailsManager userDetailsService(EurekaProperties props) {
+    PasswordEncoder encoder = createDelegatingPasswordEncoder();
+    UserDetails user = User.withUsername(props.getUsername())
+      .password(encoder.encode(props.getPassword()))
+      .roles("ADMIN")
+      .build();
+    return new InMemoryUserDetailsManager(user);
+  }
+
+  /**
+   * You have to disable CSRF to allow BASIC authenticating Eureka clients to operate.
+   * <p>
+   * See <a href="https://cloud.spring.io/spring-cloud-netflix/reference/html/#securing-the-eureka-server">Securing The Eureka Server</a>
+   */
+  @Bean SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.ignoringRequestMatchers("/eureka/**"));
+    http.authorizeHttpRequests(authz -> authz.requestMatchers("/eureka/**").authenticated())
+      .httpBasic(Customizer.withDefaults());
+    return http.build();
+  }
+}

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaServer.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaServer.java
@@ -14,12 +14,23 @@
 package zipkin.test;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+import org.springframework.context.annotation.Import;
 
-@SpringBootApplication
+/**
+ * This disables automatic security configuration, deferring to {@linkplain EurekaSecurity}.
+ * Doing so allows Eureka to start as if spring-security wasn't in the classpath.
+ */
+@SpringBootApplication(
+  exclude = {SecurityAutoConfiguration.class, ManagementWebSecurityAutoConfiguration.class}
+)
 @EnableEurekaServer
+@Import(EurekaSecurity.class)
 public class EurekaServer {
+
   public static void main(String[] args) {
     SpringApplication.run(EurekaServer.class, args);
   }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
@@ -13,9 +13,12 @@
  */
 package zipkin2.server.internal.eureka;
 
+import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.server.eureka.EurekaUpdatingListener;
 import com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder;
 import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -30,8 +33,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties("zipkin.discovery.eureka")
 class ZipkinEurekaDiscoveryProperties implements Serializable { // for Spark jobs
-  /** URL of the Eureka v2 endpoint. e.g. http://eureka:8761/eureka/v2 */
-  private String serviceUrl;
+  /**
+   * URL of the Eureka v2 endpoint. e.g. http://eureka:8761/eureka/v2
+   *
+   * <p>Note: When present, {@link URI#getUserInfo() userInfo} credentials will be used for BASIC
+   * authentication. For example, if the URL is "https://myuser:mypassword@1.1.3.1/eureka/v2/",
+   * requests to Eureka will authenticate with the user "myuser" and password "mypassword".
+   */
+  private URI serviceUrl;
   /** The appName property of this instance of zipkin. */
   private String appName;
   /** The instanceId property of this instance of zipkin. */
@@ -39,12 +48,30 @@ class ZipkinEurekaDiscoveryProperties implements Serializable { // for Spark job
   /** The hostName property of this instance of zipkin. */
   private String hostname;
 
-  public String getServiceUrl() {
+  private BasicToken auth;
+
+  public URI getServiceUrl() {
     return serviceUrl;
   }
 
-  public void setServiceUrl(String serviceUrl) {
-    this.serviceUrl = emptyToNull(serviceUrl);
+  public void setServiceUrl(URI serviceUrl) {
+    if (serviceUrl.getUserInfo() != null) {
+      String[] ui = serviceUrl.getUserInfo().split(":");
+      if (ui.length == 2) {
+        auth = BasicToken.ofBasic(ui[0], ui[1]);
+      }
+    }
+    this.serviceUrl = stripBaseUrl(serviceUrl);
+  }
+
+  // Strip the credentials and any invalid query or fragment from the URI
+  static URI stripBaseUrl(URI serviceUrl) {
+    try {
+      return new URI(serviceUrl.getScheme(), null, serviceUrl.getHost(), serviceUrl.getPort(),
+        serviceUrl.getPath(), null, null);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
   }
 
   public String getAppName() {
@@ -73,6 +100,7 @@ class ZipkinEurekaDiscoveryProperties implements Serializable { // for Spark job
 
   EurekaUpdatingListenerBuilder toBuilder() {
     final EurekaUpdatingListenerBuilder result = EurekaUpdatingListener.builder(serviceUrl);
+    if (auth != null) result.auth(auth);
     if (appName != null) result.appName(appName);
     if (instanceId != null) result.instanceId(instanceId);
     if (hostname != null) result.hostname(hostname);

--- a/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/eureka/ZipkinEurekaDiscoveryProperties.java
@@ -13,12 +13,9 @@
  */
 package zipkin2.server.internal.eureka;
 
-import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.server.eureka.EurekaUpdatingListener;
 import com.linecorp.armeria.server.eureka.EurekaUpdatingListenerBuilder;
 import java.io.Serializable;
-import java.net.URI;
-import java.net.URISyntaxException;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -33,14 +30,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties("zipkin.discovery.eureka")
 class ZipkinEurekaDiscoveryProperties implements Serializable { // for Spark jobs
-  /**
-   * URL of the Eureka v2 endpoint. e.g. http://eureka:8761/eureka/v2
-   *
-   * <p>Note: When present, {@link URI#getUserInfo() userInfo} credentials will be used for BASIC
-   * authentication. For example, if the URL is "https://myuser:mypassword@1.1.3.1/eureka/v2/",
-   * requests to Eureka will authenticate with the user "myuser" and password "mypassword".
-   */
-  private URI serviceUrl;
+  /** URL of the Eureka v2 endpoint. e.g. http://eureka:8761/eureka/v2 */
+  private String serviceUrl;
   /** The appName property of this instance of zipkin. */
   private String appName;
   /** The instanceId property of this instance of zipkin. */
@@ -48,30 +39,12 @@ class ZipkinEurekaDiscoveryProperties implements Serializable { // for Spark job
   /** The hostName property of this instance of zipkin. */
   private String hostname;
 
-  private BasicToken auth;
-
-  public URI getServiceUrl() {
+  public String getServiceUrl() {
     return serviceUrl;
   }
 
-  public void setServiceUrl(URI serviceUrl) {
-    if (serviceUrl.getUserInfo() != null) {
-      String[] ui = serviceUrl.getUserInfo().split(":");
-      if (ui.length == 2) {
-        auth = BasicToken.ofBasic(ui[0], ui[1]);
-      }
-    }
-    this.serviceUrl = stripBaseUrl(serviceUrl);
-  }
-
-  // Strip the credentials and any invalid query or fragment from the URI
-  static URI stripBaseUrl(URI serviceUrl) {
-    try {
-      return new URI(serviceUrl.getScheme(), null, serviceUrl.getHost(), serviceUrl.getPort(),
-        serviceUrl.getPath(), null, null);
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException(e);
-    }
+  public void setServiceUrl(String serviceUrl) {
+    this.serviceUrl = emptyToNull(serviceUrl);
   }
 
   public String getAppName() {
@@ -100,7 +73,6 @@ class ZipkinEurekaDiscoveryProperties implements Serializable { // for Spark job
 
   EurekaUpdatingListenerBuilder toBuilder() {
     final EurekaUpdatingListenerBuilder result = EurekaUpdatingListener.builder(serviceUrl);
-    if (auth != null) result.auth(auth);
     if (appName != null) result.appName(appName);
     if (instanceId != null) result.instanceId(instanceId);
     if (hostname != null) result.hostname(hostname);


### PR DESCRIPTION
This allows the Eureka test image to accept EUREKA_USERNAME and EUREKA_PASSWORD to require authentication accordingly without requiring auth when they aren't set. This is important to test auth, but not break our tests that do not require auth.

This along with https://github.com/openzipkin/brave-example/pull/107 setup the infrastructure needed to reliably implement Eureka auth as requested in https://github.com/openzipkin/zipkin/issues/3697