### PR TITLE
docker: fixes spring config in zipkin-eureka test image

### DIFF
--- a/build-bin/docker-compose-zipkin-eureka.yml
+++ b/build-bin/docker-compose-zipkin-eureka.yml
@@ -1,0 +1,32 @@
+#
+# Copyright 2015-2024 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# uses 2.4 so we can use condition: service_healthy
+version: "2.4"
+
+# Test both authenticated and unauthenticated, as if there is a Spring problem,
+# the latter will crash. We only need to use HEALTHCHECK for this.
+services:
+  eureka:
+    image: openzipkin/zipkin-eureka:test
+    container_name: eureka
+  sut:
+    image: openzipkin/zipkin-eureka:test
+    container_name: sut
+    environment:
+      EUREKA_USERNAME: testuser
+      EUREKA_PASSWORD: testpassword
+    depends_on:
+      eureka:
+        condition: service_healthy

--- a/docker/test-images/zipkin-eureka/README.md
+++ b/docker/test-images/zipkin-eureka/README.md
@@ -6,7 +6,7 @@ integration of the Zipkin server. This listens on port 8761.
 Besides norms defined in [docker-java](https://github.com/openzipkin/docker-java), this accepts the
 following environment variables:
 
-* `EUREKA_USERNAME`: password for authenticating endpoints under "/eureka".
+* `EUREKA_USERNAME`: username for authenticating endpoints under "/eureka".
 * `EUREKA_PASSWORD`: password for authenticating endpoints under "/eureka".
 * `JAVA_OPTS`: to change settings such as heap size for Eureka.
 

--- a/docker/test-images/zipkin-eureka/README.md
+++ b/docker/test-images/zipkin-eureka/README.md
@@ -3,10 +3,15 @@
 The `zipkin-eureka` testing image runs Eureka Server for service discovery
 integration of the Zipkin server. This listens on port 8761.
 
+Besides norms defined in [docker-java](https://github.com/openzipkin/docker-java), this accepts the
+following environment variables:
+
+* `EUREKA_USERNAME`: password for authenticating endpoints under "/eureka".
+* `EUREKA_PASSWORD`: password for authenticating endpoints under "/eureka".
+* `JAVA_OPTS`: to change settings such as heap size for Eureka.
+
 To build `openzipkin/zipkin-eureka:test`, from the top-level of the repository, run:
 ```bash
 $ DOCKER_FILE=docker/test-images/zipkin-eureka/Dockerfile build-bin/docker/docker_build openzipkin/zipkin-eureka:test
 $ docker run -p 8761:8761 --rm openzipkin/zipkin-eureka:test
 ```
-
-You can use the env variable `JAVA_OPTS` to change settings such as heap size for Eureka.

--- a/docker/test-images/zipkin-eureka/pom.xml
+++ b/docker/test-images/zipkin-eureka/pom.xml
@@ -50,15 +50,6 @@
       <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-config</artifactId>
-    </dependency>
-
     <!-- Get rid of log warning saying to use Caffeine -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
@@ -28,6 +28,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+/** This enables security, particularly only BASIC auth, when {@code EUREKA_USERNAME} is set. */
 @Configuration
 @ConditionalOnProperty("eureka.username")
 @EnableConfigurationProperties(EurekaProperties.class)

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
@@ -13,12 +13,12 @@
  */
 package zipkin.test;
 
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.User;
@@ -33,7 +33,7 @@ import static org.springframework.security.crypto.factory.PasswordEncoderFactori
 @Configuration
 @ConditionalOnProperty("eureka.username")
 @EnableConfigurationProperties(EurekaProperties.class)
-@ImportAutoConfiguration(SecurityAutoConfiguration.class)
+@Import(SecurityAutoConfiguration.class)
 public class EurekaSecurity {
   @Bean InMemoryUserDetailsManager userDetailsService(EurekaProperties props) {
     PasswordEncoder encoder = createDelegatingPasswordEncoder();

--- a/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
+++ b/docker/test-images/zipkin-eureka/src/main/java/zipkin/test/EurekaSecurity.java
@@ -50,7 +50,7 @@ public class EurekaSecurity {
    * See <a href="https://cloud.spring.io/spring-cloud-netflix/reference/html/#securing-the-eureka-server">Securing The Eureka Server</a>
    */
   @Bean SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.csrf(csrf -> csrf.ignoringRequestMatchers("/eureka/**"));
+    http.csrf(csrf -> csrf.ignoringRequestMatchers("/actuator/health", "/eureka/**"));
     http.authorizeHttpRequests(authz -> authz.requestMatchers("/eureka/**").authenticated())
       .httpBasic(Customizer.withDefaults());
     return http.build();


### PR DESCRIPTION
Formerly, we didn't test the authenticated side, so some review drift passed even though authenticating would crash on startup:

```
Parameter 0 of method filterChain in zipkin.test.EurekaSecurity required a bean of type 'org.springframework.security.config.annotation.web.builders.HttpSecurity' that could not be found.
```