### PR TITLE
cassandra: adds CASSANDRA_SSL_HOSTNAME_VALIDATION

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -231,6 +231,7 @@ and applies when `STORAGE_TYPE` is set to `cassandra3`:
     * `CASSANDRA_ENSURE_SCHEMA`: Ensuring cassandra has the latest schema. If enabled tries to execute scripts in the classpath prefixed with `cassandra-schema-cql3`. Defaults to true
     * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails. No default
     * `CASSANDRA_USE_SSL`: Requires `javax.net.ssl.trustStore` and `javax.net.ssl.trustStorePassword`, defaults to false.
+    * `CASSANDRA_SSL_HOSTNAME_VALIDATION`: Controls validation of Cassandra server hostname. defaults to true.
 
 The following are tuning parameters which may not concern all users:
 

--- a/zipkin-server/src/main/java/zipkin2/server/internal/cassandra3/ZipkinCassandra3StorageConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/cassandra3/ZipkinCassandra3StorageConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -43,14 +43,10 @@ import zipkin2.storage.cassandra.CassandraStorage.SessionFactory;
 // This component is named .*Cassandra3.* even though the package already says cassandra3 because
 // Spring Boot configuration endpoints only printout the simple name of the class
 public class ZipkinCassandra3StorageConfiguration {
-
   @Bean SessionFactory sessionFactory() {
     return SessionFactory.DEFAULT;
   }
-
-  @Bean
-  @ConditionalOnMissingBean
-  StorageComponent storage(
+  @Bean @ConditionalOnMissingBean StorageComponent storage(
       ZipkinCassandra3StorageProperties properties,
       SessionFactory sessionFactory,
       @Value("${zipkin.storage.strict-trace-id:true}") boolean strictTraceId,

--- a/zipkin-server/src/main/java/zipkin2/server/internal/cassandra3/ZipkinCassandra3StorageProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/cassandra3/ZipkinCassandra3StorageProperties.java
@@ -19,101 +19,104 @@ import zipkin2.storage.cassandra.CassandraStorage;
 
 @ConfigurationProperties("zipkin.storage.cassandra3")
 class ZipkinCassandra3StorageProperties implements Serializable { // for Spark jobs
-  private static final long serialVersionUID = 0L;
+	private static final long serialVersionUID = 0L;
 
-  private String keyspace = "zipkin3";
-  private String contactPoints = "localhost";
-  private String localDc = "datacenter1";
-  private int maxConnections = 8;
-  private boolean ensureSchema = true;
-  private boolean useSsl = false;
-  private String username;
-  private String password;
-  /** See {@link CassandraStorage.Builder#indexFetchMultiplier(int)} */
-  private int indexFetchMultiplier = 3;
+	private String keyspace = "zipkin3";
+	private String contactPoints = "localhost";
+	private String localDc = "datacenter1";
+	private int maxConnections = 8;
+	private boolean ensureSchema = true;
+	private boolean useSsl = false;
+	private boolean overrideHostnameVerification = false;
+	private String username;
+	private String password;
+	/** See {@link CassandraStorage.Builder#indexFetchMultiplier(int)} */
+	private int indexFetchMultiplier = 3;
 
-  public String getKeyspace() {
-    return keyspace;
-  }
+	public String getKeyspace() {
+		return keyspace;
+	}
 
-  public void setKeyspace(String keyspace) {
-    this.keyspace = keyspace;
-  }
+	public void setKeyspace(String keyspace) {
+		this.keyspace = keyspace;
+	}
 
-  public String getContactPoints() {
-    return contactPoints;
-  }
+	public String getContactPoints() {
+		return contactPoints;
+	}
 
-  public void setContactPoints(String contactPoints) {
-    this.contactPoints = contactPoints;
-  }
+	public void setContactPoints(String contactPoints) {
+		this.contactPoints = contactPoints;
+	}
 
-  public String getLocalDc() {
-    return localDc;
-  }
+	public String getLocalDc() {
+		return localDc;
+	}
 
-  public void setLocalDc(String localDc) {
-    this.localDc = "".equals(localDc) ? null : localDc;
-  }
+	public void setLocalDc(String localDc) {
+		this.localDc = "".equals(localDc) ? null : localDc;
+	}
 
-  public int getMaxConnections() {
-    return maxConnections;
-  }
+	public int getMaxConnections() {
+		return maxConnections;
+	}
 
-  public void setMaxConnections(int maxConnections) {
-    this.maxConnections = maxConnections;
-  }
+	public void setMaxConnections(int maxConnections) {
+		this.maxConnections = maxConnections;
+	}
 
-  public boolean isEnsureSchema() {
-    return ensureSchema;
-  }
+	public boolean isEnsureSchema() {
+		return ensureSchema;
+	}
 
-  public void setEnsureSchema(boolean ensureSchema) {
-    this.ensureSchema = ensureSchema;
-  }
+	public void setEnsureSchema(boolean ensureSchema) {
+		this.ensureSchema = ensureSchema;
+	}
 
-  public boolean isUseSsl() {
-    return useSsl;
-  }
+	public boolean isUseSsl() {
+		return useSsl;
+	}
 
-  public void setUseSsl(boolean useSsl) {
-    this.useSsl = useSsl;
-  }
+	public void setUseSsl(boolean useSsl) {
+		this.useSsl = useSsl;
+	}
 
-  public String getUsername() {
-    return username;
-  }
+	public String getUsername() {
+		return username;
+	}
 
-  public void setUsername(String username) {
-    this.username = "".equals(username) ? null : username;
-  }
+	public void setUsername(String username) {
+		this.username = "".equals(username) ? null : username;
+	}
 
-  public String getPassword() {
-    return password;
-  }
+	public String getPassword() {
+		return password;
+	}
 
-  public void setPassword(String password) {
-    this.password = "".equals(password) ? null : password;
-  }
+	public void setPassword(String password) {
+		this.password = "".equals(password) ? null : password;
+	}
 
-  public int getIndexFetchMultiplier() {
-    return indexFetchMultiplier;
-  }
+	public int getIndexFetchMultiplier() {
+		return indexFetchMultiplier;
+	}
 
-  public void setIndexFetchMultiplier(int indexFetchMultiplier) {
-    this.indexFetchMultiplier = indexFetchMultiplier;
-  }
+	public void setIndexFetchMultiplier(int indexFetchMultiplier) {
+		this.indexFetchMultiplier = indexFetchMultiplier;
+	}
 
-  public CassandraStorage.Builder toBuilder() {
-    return CassandraStorage.newBuilder()
-      .keyspace(keyspace)
-      .contactPoints(contactPoints)
-      .localDc(localDc)
-      .maxConnections(maxConnections)
-      .ensureSchema(ensureSchema)
-      .useSsl(useSsl)
-      .username(username)
-      .password(password)
-      .indexFetchMultiplier(indexFetchMultiplier);
-  }
+	public boolean isOverrideHostnameVerification() {
+		return overrideHostnameVerification;
+	}
+
+	public void setOverrideHostnameVerification(boolean overrideHostnameVerification) {
+		this.overrideHostnameVerification = overrideHostnameVerification;
+	}
+
+	public CassandraStorage.Builder toBuilder() {
+		return CassandraStorage.newBuilder().keyspace(keyspace).contactPoints(contactPoints).localDc(localDc)
+				.maxConnections(maxConnections).ensureSchema(ensureSchema).useSsl(useSsl)
+				.overrideHostnameVerification(overrideHostnameVerification).username(username)
+				.password(password).indexFetchMultiplier(indexFetchMultiplier);
+	}
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/cassandra3/ZipkinCassandra3StorageProperties.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/cassandra3/ZipkinCassandra3StorageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,104 +19,111 @@ import zipkin2.storage.cassandra.CassandraStorage;
 
 @ConfigurationProperties("zipkin.storage.cassandra3")
 class ZipkinCassandra3StorageProperties implements Serializable { // for Spark jobs
-	private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
 
-	private String keyspace = "zipkin3";
-	private String contactPoints = "localhost";
-	private String localDc = "datacenter1";
-	private int maxConnections = 8;
-	private boolean ensureSchema = true;
-	private boolean useSsl = false;
-	private boolean overrideHostnameVerification = false;
-	private String username;
-	private String password;
-	/** See {@link CassandraStorage.Builder#indexFetchMultiplier(int)} */
-	private int indexFetchMultiplier = 3;
+  private String keyspace = "zipkin3";
+  private String contactPoints = "localhost";
+  private String localDc = "datacenter1";
+  private int maxConnections = 8;
+  private boolean ensureSchema = true;
+  private boolean useSsl = false;
+  private boolean sslHostnameValidation = true;
+  private String username;
+  private String password;
+  /** See {@link CassandraStorage.Builder#indexFetchMultiplier(int)} */
+  private int indexFetchMultiplier = 3;
 
-	public String getKeyspace() {
-		return keyspace;
-	}
+  public String getKeyspace() {
+    return keyspace;
+  }
 
-	public void setKeyspace(String keyspace) {
-		this.keyspace = keyspace;
-	}
+  public void setKeyspace(String keyspace) {
+    this.keyspace = keyspace;
+  }
 
-	public String getContactPoints() {
-		return contactPoints;
-	}
+  public String getContactPoints() {
+    return contactPoints;
+  }
 
-	public void setContactPoints(String contactPoints) {
-		this.contactPoints = contactPoints;
-	}
+  public void setContactPoints(String contactPoints) {
+    this.contactPoints = contactPoints;
+  }
 
-	public String getLocalDc() {
-		return localDc;
-	}
+  public String getLocalDc() {
+    return localDc;
+  }
 
-	public void setLocalDc(String localDc) {
-		this.localDc = "".equals(localDc) ? null : localDc;
-	}
+  public void setLocalDc(String localDc) {
+    this.localDc = "".equals(localDc) ? null : localDc;
+  }
 
-	public int getMaxConnections() {
-		return maxConnections;
-	}
+  public int getMaxConnections() {
+    return maxConnections;
+  }
 
-	public void setMaxConnections(int maxConnections) {
-		this.maxConnections = maxConnections;
-	}
+  public void setMaxConnections(int maxConnections) {
+    this.maxConnections = maxConnections;
+  }
 
-	public boolean isEnsureSchema() {
-		return ensureSchema;
-	}
+  public boolean isEnsureSchema() {
+    return ensureSchema;
+  }
 
-	public void setEnsureSchema(boolean ensureSchema) {
-		this.ensureSchema = ensureSchema;
-	}
+  public void setEnsureSchema(boolean ensureSchema) {
+    this.ensureSchema = ensureSchema;
+  }
 
-	public boolean isUseSsl() {
-		return useSsl;
-	}
+  public boolean isUseSsl() {
+    return useSsl;
+  }
 
-	public void setUseSsl(boolean useSsl) {
-		this.useSsl = useSsl;
-	}
+  public void setUseSsl(boolean useSsl) {
+    this.useSsl = useSsl;
+  }
 
-	public String getUsername() {
-		return username;
-	}
+  public boolean isSslHostnameValidation() {
+    return sslHostnameValidation;
+  }
 
-	public void setUsername(String username) {
-		this.username = "".equals(username) ? null : username;
-	}
+  public void setSslHostnameValidation(boolean sslHostnameValidation) {
+    this.sslHostnameValidation = sslHostnameValidation;
+  }
 
-	public String getPassword() {
-		return password;
-	}
+  public String getUsername() {
+    return username;
+  }
 
-	public void setPassword(String password) {
-		this.password = "".equals(password) ? null : password;
-	}
+  public void setUsername(String username) {
+    this.username = "".equals(username) ? null : username;
+  }
 
-	public int getIndexFetchMultiplier() {
-		return indexFetchMultiplier;
-	}
+  public String getPassword() {
+    return password;
+  }
 
-	public void setIndexFetchMultiplier(int indexFetchMultiplier) {
-		this.indexFetchMultiplier = indexFetchMultiplier;
-	}
+  public void setPassword(String password) {
+    this.password = "".equals(password) ? null : password;
+  }
 
-	public boolean isOverrideHostnameVerification() {
-		return overrideHostnameVerification;
-	}
+  public int getIndexFetchMultiplier() {
+    return indexFetchMultiplier;
+  }
 
-	public void setOverrideHostnameVerification(boolean overrideHostnameVerification) {
-		this.overrideHostnameVerification = overrideHostnameVerification;
-	}
+  public void setIndexFetchMultiplier(int indexFetchMultiplier) {
+    this.indexFetchMultiplier = indexFetchMultiplier;
+  }
 
-	public CassandraStorage.Builder toBuilder() {
-		return CassandraStorage.newBuilder().keyspace(keyspace).contactPoints(contactPoints).localDc(localDc)
-				.maxConnections(maxConnections).ensureSchema(ensureSchema).useSsl(useSsl)
-				.overrideHostnameVerification(overrideHostnameVerification).username(username)
-				.password(password).indexFetchMultiplier(indexFetchMultiplier);
-	}
+  public CassandraStorage.Builder toBuilder() {
+    return CassandraStorage.newBuilder()
+      .keyspace(keyspace)
+      .contactPoints(contactPoints)
+      .localDc(localDc)
+      .maxConnections(maxConnections)
+      .ensureSchema(ensureSchema)
+      .useSsl(useSsl)
+      .sslHostnameValidation(sslHostnameValidation)
+      .username(username)
+      .password(password)
+      .indexFetchMultiplier(indexFetchMultiplier);
+  }
 }

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -140,6 +140,8 @@ zipkin:
       index-fetch-multiplier: ${CASSANDRA_INDEX_FETCH_MULTIPLIER:3}
       # Using ssl for connection, rely on Keystore
       use-ssl: ${CASSANDRA_USE_SSL:false}
+      # Override hostname verification in Cassandra setting
+      override-hostname-verification: ${CASSANDRA_OVERRIDE_HOSTNAME:false}
     cassandra3:
       # Comma separated list of host addresses part of Cassandra cluster. Ports default to 9042 but you can also specify a custom port with 'host:port'.
       contact-points: ${CASSANDRA_CONTACT_POINTS:localhost}
@@ -157,6 +159,8 @@ zipkin:
       index-fetch-multiplier: ${CASSANDRA_INDEX_FETCH_MULTIPLIER:3}
       # Using ssl for connection, rely on Keystore
       use-ssl: ${CASSANDRA_USE_SSL:false}
+      # Override hostname verification in Cassandra setting
+      override-hostname-verification: ${CASSANDRA_OVERRIDE_HOSTNAME:false}
     elasticsearch:
       # host is left unset intentionally, to defer the decision
       hosts: ${ES_HOSTS:}

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -115,33 +115,6 @@ zipkin:
     mem:
       # Maximum number of spans to keep in memory.  When exceeded, oldest traces (and their spans) will be purged.
       max-spans: ${MEM_MAX_SPANS:500000}
-    cassandra:
-      # Comma separated list of host addresses part of Cassandra cluster. Ports default to 9042 but you can also specify a custom port with 'host:port'.
-      contact-points: ${CASSANDRA_CONTACT_POINTS:localhost}
-      # Name of the datacenter that will be considered "local" for load balancing.
-      local-dc: ${CASSANDRA_LOCAL_DC:datacenter1}
-      # Will throw an exception on startup if authentication fails.
-      username: ${CASSANDRA_USERNAME:}
-      password: ${CASSANDRA_PASSWORD:}
-      keyspace: ${CASSANDRA_KEYSPACE:zipkin}
-      # Max pooled connections per datacenter-local host.
-      max-connections: ${CASSANDRA_MAX_CONNECTIONS:8}
-      # Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema.cql.
-      ensure-schema: ${CASSANDRA_ENSURE_SCHEMA:true}
-      # 7 days in seconds
-      span-ttl: ${CASSANDRA_SPAN_TTL:604800}
-      # 3 days in seconds
-      index-ttl: ${CASSANDRA_INDEX_TTL:259200}
-      # the maximum trace index metadata entries to cache
-      index-cache-max: ${CASSANDRA_INDEX_CACHE_MAX:100000}
-      # how long to cache index metadata about a trace. 1 minute in seconds
-      index-cache-ttl: ${CASSANDRA_INDEX_CACHE_TTL:60}
-      # how many more index rows to fetch than the user-supplied query limit
-      index-fetch-multiplier: ${CASSANDRA_INDEX_FETCH_MULTIPLIER:3}
-      # Using ssl for connection, rely on Keystore
-      use-ssl: ${CASSANDRA_USE_SSL:false}
-      # Override hostname verification in Cassandra setting
-      override-hostname-verification: ${CASSANDRA_OVERRIDE_HOSTNAME_VERIFICATION:false}
     cassandra3:
       # Comma separated list of host addresses part of Cassandra cluster. Ports default to 9042 but you can also specify a custom port with 'host:port'.
       contact-points: ${CASSANDRA_CONTACT_POINTS:localhost}
@@ -159,8 +132,8 @@ zipkin:
       index-fetch-multiplier: ${CASSANDRA_INDEX_FETCH_MULTIPLIER:3}
       # Using ssl for connection, rely on Keystore
       use-ssl: ${CASSANDRA_USE_SSL:false}
-      # Override hostname verification in Cassandra setting
-      override-hostname-verification: ${CASSANDRA_OVERRIDE_HOSTNAME_VERIFICATION:false}
+      # Controls validation of Cassandra server hostname
+      ssl-hostname-validation: ${CASSANDRA_SSL_HOSTNAME_VALIDATION:true}
     elasticsearch:
       # host is left unset intentionally, to defer the decision
       hosts: ${ES_HOSTS:}

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -141,7 +141,7 @@ zipkin:
       # Using ssl for connection, rely on Keystore
       use-ssl: ${CASSANDRA_USE_SSL:false}
       # Override hostname verification in Cassandra setting
-      override-hostname-verification: ${CASSANDRA_OVERRIDE_HOSTNAME:false}
+      override-hostname-verification: ${CASSANDRA_OVERRIDE_HOSTNAME_VERIFICATION:false}
     cassandra3:
       # Comma separated list of host addresses part of Cassandra cluster. Ports default to 9042 but you can also specify a custom port with 'host:port'.
       contact-points: ${CASSANDRA_CONTACT_POINTS:localhost}
@@ -160,7 +160,7 @@ zipkin:
       # Using ssl for connection, rely on Keystore
       use-ssl: ${CASSANDRA_USE_SSL:false}
       # Override hostname verification in Cassandra setting
-      override-hostname-verification: ${CASSANDRA_OVERRIDE_HOSTNAME:false}
+      override-hostname-verification: ${CASSANDRA_OVERRIDE_HOSTNAME_VERIFICATION:false}
     elasticsearch:
       # host is left unset intentionally, to defer the decision
       hosts: ${ES_HOSTS:}

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/BaseITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/BaseITZipkinEureka.java
@@ -81,12 +81,10 @@ abstract class BaseITZipkinEureka {
     this.serviceUrl = serviceUrl;
   }
 
-  @BeforeEach void awaitRegistration() {
+  @Test @Order(1) void registersInEureka() throws IOException {
     // The zipkin server may start before Eureka processes the registration
     await().until(this::getEurekaZipkinAppAsString, (s) -> true);
-  }
 
-  @Test @Order(1) void registersInEureka() throws IOException {
     String json = getEurekaZipkinAppAsString();
 
     // Make sure the health status is OK

--- a/zipkin-server/src/test/java/zipkin2/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -123,5 +123,31 @@ class ZipkinCassandraStorageAutoConfigurationTest {
 
     assertThat(context.getBean(CassandraStorage.class).autocompleteCardinality)
       .isEqualTo(5000);
+  }
+
+  @Test void useSsl() {
+    TestPropertyValues.of(
+        "zipkin.storage.type:cassandra3",
+        "zipkin.storage.cassandra3.use-ssl:true")
+      .applyTo(context);
+    Access.registerCassandra3(context);
+    context.refresh();
+
+    assertThat(context.getBean(CassandraStorage.class).useSsl).isTrue();
+    assertThat(context.getBean(CassandraStorage.class).sslHostnameValidation).isTrue();
+  }
+
+  @Test void sslHostnameValidation_canSetToFalse() {
+    TestPropertyValues.of(
+        "zipkin.storage.type:cassandra3",
+        "zipkin.storage.cassandra3.use-ssl:true",
+        "zipkin.storage.cassandra3.ssl-hostname-validation:false"
+      )
+      .applyTo(context);
+    Access.registerCassandra3(context);
+    context.refresh();
+
+    assertThat(context.getBean(CassandraStorage.class).useSsl).isTrue();
+    assertThat(context.getBean(CassandraStorage.class).sslHostnameValidation).isFalse();
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
@@ -92,7 +92,7 @@ public final class CassandraStorage extends StorageComponent {
         authProvider = new ProgrammaticPlainTextAuthProvider(username, password);
       }
       return new CassandraStorage(strictTraceId, searchEnabled, autocompleteKeys, autocompleteTtl,
-        autocompleteCardinality, contactPoints, localDc, poolingOptions(), authProvider, useSsl,
+        autocompleteCardinality, contactPoints, localDc, poolingOptions(), authProvider, useSsl, overrideHostnameVerification,
         sessionFactory, keyspace, ensureSchema, maxTraceCols, indexFetchMultiplier);
     }
   }
@@ -105,6 +105,7 @@ public final class CassandraStorage extends StorageComponent {
   final Map<DriverOption, Integer> poolingOptions;
   @Nullable final AuthProvider authProvider;
   final boolean useSsl;
+  final boolean overrideHostnameVerification;
   final String keyspace;
   final boolean ensureSchema;
 
@@ -114,7 +115,7 @@ public final class CassandraStorage extends StorageComponent {
 
   CassandraStorage(boolean strictTraceId, boolean searchEnabled, Set<String> autocompleteKeys,
     int autocompleteTtl, int autocompleteCardinality, String contactPoints, String localDc,
-    Map<DriverOption, Integer> poolingOptions, AuthProvider authProvider, boolean useSsl,
+    Map<DriverOption, Integer> poolingOptions, AuthProvider authProvider, boolean useSsl, boolean overrideHostnameVerification,
     SessionFactory sessionFactory, String keyspace, boolean ensureSchema, int maxTraceCols,
     int indexFetchMultiplier) {
     // Assign generic configuration for all storage components
@@ -130,6 +131,7 @@ public final class CassandraStorage extends StorageComponent {
     this.poolingOptions = poolingOptions;
     this.authProvider = authProvider;
     this.useSsl = useSsl;
+    this.overrideHostnameVerification = overrideHostnameVerification;
     this.ensureSchema = ensureSchema;
     this.keyspace = keyspace;
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -92,8 +92,9 @@ public final class CassandraStorage extends StorageComponent {
         authProvider = new ProgrammaticPlainTextAuthProvider(username, password);
       }
       return new CassandraStorage(strictTraceId, searchEnabled, autocompleteKeys, autocompleteTtl,
-        autocompleteCardinality, contactPoints, localDc, poolingOptions(), authProvider, useSsl, overrideHostnameVerification,
-        sessionFactory, keyspace, ensureSchema, maxTraceCols, indexFetchMultiplier);
+        autocompleteCardinality, contactPoints, localDc, poolingOptions(), authProvider, useSsl,
+        sslHostnameValidation, sessionFactory, keyspace, ensureSchema, maxTraceCols,
+        indexFetchMultiplier);
     }
   }
 
@@ -105,7 +106,7 @@ public final class CassandraStorage extends StorageComponent {
   final Map<DriverOption, Integer> poolingOptions;
   @Nullable final AuthProvider authProvider;
   final boolean useSsl;
-  final boolean overrideHostnameVerification;
+  final boolean sslHostnameValidation;
   final String keyspace;
   final boolean ensureSchema;
 
@@ -115,9 +116,9 @@ public final class CassandraStorage extends StorageComponent {
 
   CassandraStorage(boolean strictTraceId, boolean searchEnabled, Set<String> autocompleteKeys,
     int autocompleteTtl, int autocompleteCardinality, String contactPoints, String localDc,
-    Map<DriverOption, Integer> poolingOptions, AuthProvider authProvider, boolean useSsl, boolean overrideHostnameVerification,
-    SessionFactory sessionFactory, String keyspace, boolean ensureSchema, int maxTraceCols,
-    int indexFetchMultiplier) {
+    Map<DriverOption, Integer> poolingOptions, AuthProvider authProvider, boolean useSsl,
+    boolean sslHostnameValidation, SessionFactory sessionFactory, String keyspace,
+    boolean ensureSchema, int maxTraceCols, int indexFetchMultiplier) {
     // Assign generic configuration for all storage components
     this.strictTraceId = strictTraceId;
     this.searchEnabled = searchEnabled;
@@ -131,7 +132,7 @@ public final class CassandraStorage extends StorageComponent {
     this.poolingOptions = poolingOptions;
     this.authProvider = authProvider;
     this.useSsl = useSsl;
-    this.overrideHostnameVerification = overrideHostnameVerification;
+    this.sslHostnameValidation = sslHostnameValidation;
     this.ensureSchema = ensureSchema;
     this.keyspace = keyspace;
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
@@ -64,7 +64,8 @@ final class DefaultSessionFactory implements CassandraStorage.SessionFactory {
       cassandra.localDc,
       cassandra.poolingOptions,
       cassandra.authProvider,
-      cassandra.useSsl
+      cassandra.useSsl,
+      cassandra.overrideHostnameVerification
     );
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -65,7 +65,7 @@ final class DefaultSessionFactory implements CassandraStorage.SessionFactory {
       cassandra.poolingOptions,
       cassandra.authProvider,
       cassandra.useSsl,
-      cassandra.overrideHostnameVerification
+      cassandra.sslHostnameValidation
     );
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/CassandraStorageBuilder.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/CassandraStorageBuilder.java
@@ -41,7 +41,8 @@ public abstract class CassandraStorageBuilder<B extends CassandraStorageBuilder<
   protected String localDc = "datacenter1";
   @Nullable protected String username, password;
   protected boolean useSsl = false;
-
+  
+  protected boolean overrideHostnameVerification = false;
   protected String keyspace;
   protected boolean ensureSchema = true;
 
@@ -138,11 +139,20 @@ public abstract class CassandraStorageBuilder<B extends CassandraStorageBuilder<
   }
 
   /** Use ssl for connection. Defaults to false. */
-  public B useSsl(boolean useSsl) {
-    this.useSsl = useSsl;
+  public B overrideHostnameVerification(boolean overrideHostnameVerification) {
+    this.overrideHostnameVerification = overrideHostnameVerification;
     return (B) this;
   }
-
+  
+  /** Dsable HostName verification for Cassandra
+   * 
+   * 
+   */
+  public B useSsl(boolean useSsl) {
+	    this.useSsl = useSsl;
+	    return (B) this;
+	  }
+  
   /** Keyspace to store span and index data. Defaults to "zipkin3" */
   public B keyspace(String keyspace) {
     if (keyspace == null) throw new NullPointerException("keyspace == null");

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/CassandraStorageBuilder.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/CassandraStorageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,8 +41,8 @@ public abstract class CassandraStorageBuilder<B extends CassandraStorageBuilder<
   protected String localDc = "datacenter1";
   @Nullable protected String username, password;
   protected boolean useSsl = false;
-  
-  protected boolean overrideHostnameVerification = false;
+  protected boolean sslHostnameValidation = true;
+
   protected String keyspace;
   protected boolean ensureSchema = true;
 
@@ -139,20 +139,17 @@ public abstract class CassandraStorageBuilder<B extends CassandraStorageBuilder<
   }
 
   /** Use ssl for connection. Defaults to false. */
-  public B overrideHostnameVerification(boolean overrideHostnameVerification) {
-    this.overrideHostnameVerification = overrideHostnameVerification;
+  public B useSsl(boolean useSsl) {
+    this.useSsl = useSsl;
     return (B) this;
   }
-  
-  /** Dsable HostName verification for Cassandra
-   * 
-   * 
-   */
-  public B useSsl(boolean useSsl) {
-	    this.useSsl = useSsl;
-	    return (B) this;
-	  }
-  
+
+  /** Controls validation of Cassandra server hostname. Defaults to true. */
+  public B sslHostnameValidation(boolean sslHostnameValidation) {
+    this.sslHostnameValidation = sslHostnameValidation;
+    return (B) this;
+  }
+
   /** Keyspace to store span and index data. Defaults to "zipkin3" */
   public B keyspace(String keyspace) {
     if (keyspace == null) throw new NullPointerException("keyspace == null");

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/SessionBuilder.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/SessionBuilder.java
@@ -80,8 +80,11 @@ public final class SessionBuilder {
 
     if (useSsl) config = config.withClass(SSL_ENGINE_FACTORY_CLASS, DefaultSslEngineFactory.class);
     
-    if (overrideHostnameVerification) config = config.withClass(SSL_HOSTNAME_VALIDATION, DefaultSslEngineFactory.class);
-
+    if (overrideHostnameVerification) 
+    	config = config.withBoolean(SSL_HOSTNAME_VALIDATION, true);
+    else
+    	config = config.withBoolean(SSL_HOSTNAME_VALIDATION, false);
+    
     // Log categories can enable query logging
     Logger requestLogger = LoggerFactory.getLogger(SessionBuilder.class);
     if (requestLogger.isDebugEnabled()) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/SessionBuilder.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/internal/SessionBuilder.java
@@ -14,6 +14,7 @@
 package zipkin2.storage.cassandra.internal;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
@@ -38,7 +39,7 @@ import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.REQUES
 import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.REQUEST_TRACKER_CLASS;
 import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.REQUEST_WARN_IF_SET_KEYSPACE;
 import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS;
-
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.SSL_HOSTNAME_VALIDATION;
 public final class SessionBuilder {
   /** Returns a connected session. Closes the cluster if any exception occurred. */
   public static CqlSession buildSession(
@@ -46,7 +47,8 @@ public final class SessionBuilder {
     String localDc,
     Map<DriverOption, Integer> poolingOptions,
     @Nullable AuthProvider authProvider,
-    boolean useSsl
+    boolean useSsl,
+    boolean overrideHostnameVerification
   ) {
     // Some options aren't supported by builder methods. In these cases, we use driver config
     // See https://groups.google.com/a/lists.datastax.com/forum/#!topic/java-driver-user/Z8HrCDX47Q0
@@ -77,6 +79,8 @@ public final class SessionBuilder {
     config = config.withBoolean(REQUEST_DEFAULT_IDEMPOTENCE, true);
 
     if (useSsl) config = config.withClass(SSL_ENGINE_FACTORY_CLASS, DefaultSslEngineFactory.class);
+    
+    if (overrideHostnameVerification) config = config.withClass(SSL_HOSTNAME_VALIDATION, DefaultSslEngineFactory.class);
 
     // Log categories can enable query logging
     Logger requestLogger = LoggerFactory.getLogger(SessionBuilder.class);


### PR DESCRIPTION
This adds `CASSANDRA_SSL_HOSTNAME_VALIDATION` with the same behavior as defined in cassandra's [SSL_HOSTNAME_VALIDATION](https://github.com/apache/cassandra-java-driver/blob/8d5849cb38995b312f29314d18256c0c3e94cf07/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java#L230), with the same default value of true.

Thanks @priyavivek2307 for starting this on #3457. I tried to re-use that PR, but it was too old and github closed it when I tried to rebase. Thanks also to @ankit-gautam23 for the review.