### PR TITLE
deps: bumps to latest library versions, notably slf4j

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.25.1</version>
+      <version>3.25.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <jackson.version>2.16.1</jackson.version>
 
     <java-driver.version>4.18.0</java-driver.version>
-    <micrometer.version>1.1.9</micrometer.version>
+    <micrometer.version>1.12.2</micrometer.version>
 
     <!-- Used for Generated annotations -->
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,14 +65,14 @@
     <jackson.version>2.16.1</jackson.version>
 
     <java-driver.version>4.18.0</java-driver.version>
-    <micrometer.version>1.12.1</micrometer.version>
+    <micrometer.version>1.1.9</micrometer.version>
 
     <!-- Used for Generated annotations -->
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
-    <spring-boot.version>3.2.1</spring-boot.version>
-    <spring.version>6.1.2</spring.version>
+    <spring-boot.version>3.2.2</spring-boot.version>
+    <spring.version>6.1.3</spring.version>
 
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
@@ -81,18 +81,18 @@
     -->
     <mariadb-java-client.version>3.3.2</mariadb-java-client.version>
     <HikariCP.version>5.1.0</HikariCP.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>2.0.11</slf4j.version>
     <auto-value.version>1.10.4</auto-value.version>
     <git-commit-id.version>4.9.10</git-commit-id.version>
 
     <!-- Test only dependencies -->
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
-    <mockito.version>5.8.0</mockito.version>
+    <mockito.version>5.9.0</mockito.version>
     <assertj.version>3.25.1</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <testcontainers.version>1.19.3</testcontainers.version>
     <okhttp.version>4.12.0</okhttp.version>
-    <kryo.version>5.5.0</kryo.version>
+    <kryo.version>5.6.0</kryo.version>
     <!-- Only used for proto interop testing; wire-maven-plugin is usually behind latest. -->
     <wire.version>4.9.3</wire.version>
     <gson.version>2.10.1</gson.version>
@@ -129,13 +129,13 @@
 
   <organization>
     <name>OpenZipkin</name>
-    <url>http://zipkin.io/</url>
+    <url>https://zipkin.io/</url>
   </organization>
 
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/zipkin-collector/core/pom.xml
+++ b/zipkin-collector/core/pom.xml
@@ -36,12 +36,24 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
-    <!-- TODO: abandoned dependency -->
     <dependency>
-      <groupId>uk.org.lidalia</groupId>
+      <groupId>com.github.valfirst</groupId>
       <artifactId>slf4j-test</artifactId>
-      <version>1.2.0</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <classpathDependencyExcludes>
+            <classpathDependencyExcludes>org.slf4j:slf4j-simple</classpathDependencyExcludes>
+          </classpathDependencyExcludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -68,15 +68,18 @@
       </dependency>
 
       <dependency>
-        <groupId>io.zipkin.brave</groupId>
-        <artifactId>brave</artifactId>
-        <version>${brave.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- reconcile armeria and spring-boot versions -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${micrometer.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -221,7 +224,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>${micrometer.version}</version>
     </dependency>
 
     <dependency>
@@ -232,7 +234,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>${micrometer.version}</version>
     </dependency>
 
     <dependency>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -468,7 +468,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.8.0</version>
+      <version>2.9.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -64,22 +64,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>de.qaware.maven</groupId>
-        <artifactId>go-offline-maven-plugin</artifactId>
-        <configuration>
-          <dynamicDependencies>
-            <DynamicDependency>
-              <groupId>org.codehaus.mojo.signature</groupId>
-              <artifactId>java16</artifactId>
-              <version>1.0</version>
-              <type>signature</type>
-              <repositoryType>MAIN</repositoryType>
-            </DynamicDependency>
-          </dynamicDependencies>
-        </configuration>
-      </plugin>
-
       <!-- Use of gson is internal only -->
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
SLF4J maintains than an upgrade from 1.x to 2.x is compatible, with some caveats about implementations matching. By upgrading, we can move off an abandoned test dependency.

This also updates other dependencies that were slightly out of date.