### PR TITLE
deps: fixes to easy lens CVEs

### DIFF
--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -43,7 +43,7 @@
         "history": "^4.10.1",
         "http-proxy-middleware": "2.0.6",
         "lodash": "4.17.21",
-        "moment": "2.29.0",
+        "moment": "^2.29.4",
         "node-fetch": "2.6.7",
         "prettier": "3.1.1",
         "prop-types": "15.8.1",
@@ -9854,9 +9854,9 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -14456,9 +14456,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz",
-      "integrity": "sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }

--- a/zipkin-lens/package-lock.json
+++ b/zipkin-lens/package-lock.json
@@ -61,6 +61,7 @@
         "redux-thunk": "^2.3.0",
         "shortid": "2.2.16",
         "styled-components": "6.1.2",
+        "three": "0.125.0",
         "vizceral-react": "4.8.0"
       },
       "devDependencies": {
@@ -2450,21 +2451,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -20342,9 +20328,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.106.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.106.2.tgz",
-      "integrity": "sha512-4Tlx43uoxnIaZFW2Bzkd1rXsatvVHEWAZJy8LuE+s6Q8c66ogNnhfq1bHiBKPAnXP230LD11H/ScIZc2LZMviA=="
+      "version": "0.125.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.125.0.tgz",
+      "integrity": "sha512-qL36qUGsPQ/Ofo/RZdXwHwM7A8wzUSAIyawtjIebJSPvounUQeneSqxI0aBY2iwKpseGy+RUtj3C5f/z4poyXw=="
     },
     "node_modules/throat": {
       "version": "6.0.2",
@@ -20927,7 +20913,7 @@
         "hammerjs": "^2.0.8",
         "lodash": "^4.17.14",
         "numeral": "^1.5.3",
-        "three": "^0.106.2"
+        "three": "^0.125.0"
       }
     },
     "node_modules/vizceral-react": {

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -44,7 +44,7 @@
     "history": "^4.10.1",
     "http-proxy-middleware": "2.0.6",
     "lodash": "4.17.21",
-    "moment": "2.29.0",
+    "moment": "^2.29.4",
     "node-fetch": "2.6.7",
     "prettier": "3.1.1",
     "prop-types": "15.8.1",

--- a/zipkin-lens/package.json
+++ b/zipkin-lens/package.json
@@ -62,6 +62,7 @@
     "redux-thunk": "^2.3.0",
     "shortid": "2.2.16",
     "styled-components": "6.1.2",
+    "three": "0.125.0",
     "vizceral-react": "4.8.0"
   },
   "scripts": {


### PR DESCRIPTION
I ran trivy as we are about to release again, this leaves us with only 2 detected CVEs.

The remaining ones are indirect dependencies from [react-scripts](https://www.npmjs.com/package/react-scripts), not recently released and only used at build time.

Note: three was bumped manually, so may accidentally be reverted on a future change. Please run `trivy repo .` when you are making future changes.

```
package-lock.json (npm)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 1, CRITICAL: 0)

┌───────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────┐
│  Library  │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                         Title                         │
├───────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────┤
│ nth-check │ CVE-2021-3803  │ HIGH     │ fixed  │ 1.0.2             │ 2.0.1         │ inefficient regular expression complexity             │
│           │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2021-3803             │
├───────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────┤
│ postcss   │ CVE-2023-44270 │ MEDIUM   │        │ 7.0.39            │ 8.4.31        │ An issue was discovered in PostCSS before 8.4.31. The │
│           │                │          │        │                   │               │ vulnerability af ......                               │
│           │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-44270            │
└───────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────┘

```

```bash
$ npm ls postcss nth-check
npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1, but package-lock.json was generated for lockfileVersion@3. I'll try to do my best with it!
zipkin-lens@0.0.1 /Users/adrian/oss/zipkin/zipkin-lens
├─┬ react-scripts@5.0.1
│ ├─┬ @svgr/webpack@5.5.0
│ │ └─┬ @svgr/plugin-svgo@5.5.0
│ │   └─┬ svgo@1.3.2
│ │     └─┬ css-select@2.1.0
│ │       └── nth-check@1.0.2 
│ ├─┬ css-loader@6.8.1
│ │ └── postcss@8.4.32  deduped
│ ├─┬ css-minimizer-webpack-plugin@3.4.1
│ │ └── postcss@8.4.32  deduped
│ ├─┬ html-webpack-plugin@5.5.4
│ │ └─┬ pretty-error@4.0.0
│ │   └─┬ renderkid@3.0.0
│ │     └─┬ css-select@4.3.0
│ │       └── nth-check@2.1.1 
│ ├── postcss@8.4.32 
│ ├─┬ resolve-url-loader@4.0.0
│ │ └── postcss@7.0.39 
│ └─┬ tailwindcss@3.3.6
│   └── postcss@8.4.32  deduped
└─┬ styled-components@6.1.2
  └── postcss@8.4.32  deduped
```