### PR TITLE
docker: allow elasticsearch test image to use 512m

### DIFF
--- a/docker/test-images/zipkin-elasticsearch7/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch7/Dockerfile
@@ -74,6 +74,6 @@ USER ${USER}
 COPY --from=install --chown=${USER} /install .
 
 # Use to set heap, trust store or other system properties.
-ENV JAVA_OPTS="-Xms256m -Xmx512m -XX:+ExitOnOutOfMemoryError"
+ENV JAVA_OPTS="-Xms512m -Xmx512m -XX:+ExitOnOutOfMemoryError"
 ENV LIBFFI_TMPDIR=/tmp
 EXPOSE 9200

--- a/docker/test-images/zipkin-elasticsearch7/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch7/Dockerfile
@@ -74,6 +74,6 @@ USER ${USER}
 COPY --from=install --chown=${USER} /install .
 
 # Use to set heap, trust store or other system properties.
-ENV JAVA_OPTS="-Xms256m -Xmx256m -XX:+ExitOnOutOfMemoryError"
+ENV JAVA_OPTS="-Xms256m -Xmx512m -XX:+ExitOnOutOfMemoryError"
 ENV LIBFFI_TMPDIR=/tmp
 EXPOSE 9200

--- a/docker/test-images/zipkin-elasticsearch8/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch8/Dockerfile
@@ -74,6 +74,6 @@ USER ${USER}
 COPY --from=install --chown=${USER} /install .
 
 # Use to set heap, trust store or other system properties.
-ENV ES_JAVA_OPTS="-Xms256m -Xmx256m -XX:+ExitOnOutOfMemoryError"
+ENV ES_JAVA_OPTS="-Xms256m -Xmx512m -XX:+ExitOnOutOfMemoryError"
 ENV LIBFFI_TMPDIR=/tmp
 EXPOSE 9200

--- a/docker/test-images/zipkin-elasticsearch8/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch8/Dockerfile
@@ -74,6 +74,6 @@ USER ${USER}
 COPY --from=install --chown=${USER} /install .
 
 # Use to set heap, trust store or other system properties.
-ENV ES_JAVA_OPTS="-Xms256m -Xmx512m -XX:+ExitOnOutOfMemoryError"
+ENV ES_JAVA_OPTS="-Xms512m -Xmx512m -XX:+ExitOnOutOfMemoryError"
 ENV LIBFFI_TMPDIR=/tmp
 EXPOSE 9200


### PR DESCRIPTION
the heavy dependencies job bumped the ceiling which was formerly 256m. this doubles it, as we want a small image but a functional one!

```
24/01/24 05:03:26 INFO ElasticsearchExtension: STDOUT: [2024-01-24T05:03:26,177][INFO ][o.e.i.b.HierarchyCircuitBreakerService] [zipkin-elasticsearch] attempting to trigger G1GC due to high heap usage [258705064]
24/01/24 05:03:26 INFO ElasticsearchExtension: STDOUT: [2024-01-24T05:03:26,192][INFO ][o.e.i.b.HierarchyCircuitBreakerService] [zipkin-elasticsearch] GC did bring memory usage down, before [258705064], after [197468696], allocations [6], duration [15]
```