### PR TITLE
ES_HTTP_LOGGING appears broken

### DIFF
--- a/docker/test-images/zipkin-mysql/Dockerfile
+++ b/docker/test-images/zipkin-mysql/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -37,7 +37,7 @@ HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthche
 ENTRYPOINT ["start-mysql"]
 
 # Use latest from https://pkgs.alpinelinux.org/packages?name=mysql
-ARG mysql_version=10.11.5
+ARG mysql_version=10.11.6-r0
 LABEL mysql-version=$mysql_version
 ENV MYSQL_VERSION=$mysql_version
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     -->
     <mariadb-java-client.version>3.3.2</mariadb-java-client.version>
     <HikariCP.version>5.1.0</HikariCP.version>
-    <slf4j.version>2.0.11</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <auto-value.version>1.10.4</auto-value.version>
     <git-commit-id.version>4.9.10</git-commit-id.version>
 

--- a/zipkin-collector/core/pom.xml
+++ b/zipkin-collector/core/pom.xml
@@ -37,9 +37,9 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.valfirst</groupId>
+      <groupId>uk.org.lidalia</groupId>
       <artifactId>slf4j-test</artifactId>
-      <version>3.0.1</version>
+      <version>1.2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -258,6 +258,11 @@
       <artifactId>jul-to-slf4j</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
 
     <!-- the "exec" jar will exclude this -->
     <dependency>

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -264,6 +264,8 @@ logging:
     com.linecorp.armeria.server.Server: 'INFO'
     # # and when registered in Eureka
     com.linecorp.armeria.server.eureka.EurekaUpdatingListener: 'INFO'
+    # # and when http-logging is enabled
+    com.linecorp.armeria.client.logging.LoggingClient: 'INFO'
     # kafka is quite chatty, so we switch everything off by default
     org.apache.kafka: 'OFF'
 #     # investigate /api/v2/dependencies


### PR DESCRIPTION
There were basically 2 issues:
 - mix of SLF4J 1.x and SALF4J 2.x: binary nothing breaks but at runtime, the provider is not discovered, since most of the dependencies (armenia, ...) still use SLF4J 1.x, switched to that
 - the `com.linecorp.armeria.client.logging.LoggingClient` logger with `INFO` level is needed in order to log the HTTP requests (headers, body, etc)

Sample logs (request body):
```
zipkin         | {"index":{"_index":"zipkin-span-2024-01-30","_id":"536225a52dbf288f-a973c94cfea8cb9782098ed69b70ec8e"}}
zipkin         | {"timestamp_millis":1706650740662,"_q":["wr","ws","http.method","http.method=GET","http.path","http.path=/zipkin/api/v2/traces"],"traceId":"536225a52dbf288f","id":"536225a52dbf288f","kind":"SER
VER","name":"get /zipkin/api/v2/traces","timestamp":1706650740662116,"duration":381428,"localEndpoint":{"serviceName":"zipkin-server","ipv4":"172.18.0.3"},"remoteEndpoint":{"ipv4":"172.18.0.1","port":41546},"an
notations":[{"timestamp":1706650740662245,"value":"wr"},{"timestamp":1706650741041160,"value":"ws"}],"tags":{"http.method":"GET","http.path":"/zipkin/api/v2/traces"}}
zipkin         | }
zipkin         | 2024-01-30T21:39:02.175Z  INFO [/] 1 --- [orker-epoll-2-5] c.l.a.c.l.LoggingClient                  : [creqId=4fd0f854, chanId=fbe5b66c, laddr=172.18.0.3:52428, raddr=elasticsearch/172.18.0.2:9
200][http://elasticsearch:9200/_bulk#POST] Response: {startTime=2024-01-30T21:39:02.173Z(1706650742173292), length=313B, duration=1285µs(1285103ns), totalDuration=182ms(182880090ns), headers=[:status=200, x-ela
stic-product=Elasticsearch, content-type=application/json, content-encoding=gzip, content-length=313], content={"errors":false,"took":159,"items":[{"index":{"_index":"zipkin-span-2024-01-30","_id":"536225a52dbf
288f-da49c98df47203e6e632b8d8b392a319","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":34,"_primary_term":17,"status":201}},{"index":{"_index":"zipkin-span-2024-01-30",
"_id":"536225a52dbf288f-22efa2babd65cf0f145f1830e9f96fa0","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":32,"_primary_term":17,"status":201}},{"index":{"_index":"zipki
n-span-2024-01-30","_id":"536225a52dbf288f-ce4c65a171114a4df3020cee57ad5ad3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":32,"_primary_term":17,"status":201}},{"inde
x":{"_index":"zipkin-span-2024-01-30","_id":"536225a52dbf288f-a973c94cfea8cb9782098ed69b70ec8e","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":36,"_primary_term":17,"s
tatus":201}}]}}
zipkin         | 2024-01-30T21:39:05.447Z  INFO [/] 1 --- [orker-epoll-2-5] c.l.a.c.l.LoggingClient                  : [creqId=3eec49c0, sreqId=95fb6523, chanId=fbe5b66c, laddr=172.18.0.3:52428, raddr=elasticse
arch/172.18.0.2:9200][http://elasticsearch:9200/_cluster/health/zipkin*span-*#GET] Request: {startTime=2024-01-30T21:39:05.443Z(1706650745443233), length=0B, duration=874µs(874386ns), scheme=none+h1c, name=get-
cluster-health, headers=[:method=GET, :path=/_cluster/health/zipkin*span-*, :authority=elasticsearch:9200, b3=8f069f5f99c68239-5951f64cf3e5a4c4-0-8f069f5f99c68239, accept-encoding=gzip,deflate,x-snappy-framed,
user-agent=armeria/1.26.4], content=}
zipkin         | 2024-01-30T21:39:05.448Z  INFO [/] 1 --- [orker-epoll-2-5] c.l.a.c.l.LoggingClient                  : [creqId=3eec49c0, sreqId=95fb6523, chanId=fbe5b66c, laddr=172.18.0.3:52428, raddr=elasticse
arch/172.18.0.2:9200][http://elasticsearch:9200/_cluster/health/zipkin*span-*#GET] Response: {startTime=2024-01-30T21:39:05.446Z(1706650745446854), length=228B, duration=155µs(155915ns), totalDuration=3776µs(37
76869ns), headers=[:status=200, x-elastic-product=Elasticsearch, content-type=application/json, content-encoding=gzip, content-length=228], content={"cluster_name":"docker-cluster","status":"yellow","timed_out"
:false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":5,"active_shards":5,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":5,"delayed_unassigned_shards":0,"number_of_pendi
ng_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":50.0}}
Gracefully stopping... (press Ctrl+C again to force)
```