### PR TITLE
deps: changes to armeria-brave6

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -167,7 +167,7 @@
     </dependency>
     <dependency>
       <groupId>${armeria.groupId}</groupId>
-      <artifactId>armeria-brave</artifactId>
+      <artifactId>armeria-brave6</artifactId>
       <version>${armeria.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
`com.linecorp.armeria:armeria-brave` now defaults to brave 5, which in the server is no problem as we imported the brave bom. however, to prevent accidents we should depend on the replacement `com.linecorp.armeria:armeria-brave6`

```
< [INFO] +- com.linecorp.armeria:armeria-brave:jar:1.27.1:compile
< [INFO] |  \- com.linecorp.armeria:armeria-brave5:jar:1.27.1:compile
< [INFO] |     \- io.zipkin.brave:brave-instrumentation-http:jar:6.0.0:compile
---
> [INFO] +- com.linecorp.armeria:armeria-brave6:jar:1.27.1:compile
> [INFO] |  \- io.zipkin.brave:brave-instrumentation-http:jar:6.0.0:compile
```

See https://github.com/line/armeria/pull/5438 cc @openzipkin/armeria as if any of you are using instrumentation, you should make sure to change your deps similarly or get no free version updates from armeria anymore!