### PR TITLE
Fixes logging glitches and updates docker images

### DIFF
--- a/build-bin/docker-compose-zipkin.yml
+++ b/build-bin/docker-compose-zipkin.yml
@@ -23,7 +23,7 @@ services:
   # Use fixed service and container name 'sut; so our test script can copy/pasta
   sut:
     container_name: sut
-    image: ghcr.io/openzipkin/alpine:3.19.0
+    image: ghcr.io/openzipkin/alpine:3.19.1
     entrypoint: /bin/sh
     # Keep the container running until HEALTHCHECK passes
     command: "-c \"sleep 5m\""

--- a/docker/test-images/zipkin-elasticsearch8/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch8/Dockerfile
@@ -17,7 +17,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=21.0.1_p12
+ARG java_version=21.0.2_p13
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -35,16 +35,14 @@ WORKDIR /install
 # Use latest 8.x version from https://www.elastic.co/downloads/past-releases#elasticsearch
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG elasticsearch7_version=8.12.0
-# TODO ^^ match java_version with others and remove this comment on 8.13.1
-# See https://github.com/elastic/elasticsearch/pull/104347
+ARG elasticsearch8_version=8.12.1
 
 # Download only the OSS distribution (lacks X-Pack)
 RUN \
 # Connection resets are frequent in GitHub Actions workflows \
 wget --random-wait --tries=5 -qO- \
 # We don't download bin scripts as we customize for reasons including BusyBox problems
-https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsearch7_version}-linux-x86_64.tar.gz| tar xz \
+https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsearch8_version}-linux-x86_64.tar.gz| tar xz \
     --wildcards --strip=1 --exclude=jdk --exclude=*/bin
 COPY --from=scratch /config/ ./config/
 
@@ -52,8 +50,8 @@ COPY --from=scratch /config/ ./config/
 # production -jre base layer used by zipkin and zipkin-slim.
 FROM ghcr.io/openzipkin/java:${java_version} as zipkin-elasticsearch8
 LABEL org.opencontainers.image.description="Elasticsearch distribution on OpenJDK and Alpine Linux"
-ARG elasticsearch7_version=8.12.0
-LABEL elasticsearch-version=$elasticsearch7_version
+ARG elasticsearch8_version=8.12.1
+LABEL elasticsearch-version=$elasticsearch8_version
 
 # The full license is also included in the image at /elasticsearch/LICENSE.txt.
 LABEL org.opencontainers.image.licenses="Elastic-License-2.0"

--- a/docker/test-images/zipkin-eureka/pom.xml
+++ b/docker/test-images/zipkin-eureka/pom.xml
@@ -60,6 +60,13 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
       <version>4.1.0</version>
+      <exclusions>
+        <!-- dodge spring-jcl conflict error -->
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Get rid of log warning saying to use Caffeine -->

--- a/docker/test-images/zipkin-mysql/Dockerfile
+++ b/docker/test-images/zipkin-mysql/Dockerfile
@@ -15,7 +15,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG alpine_version=3.19.0
+ARG alpine_version=3.19.1
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-ui/Dockerfile
+++ b/docker/test-images/zipkin-ui/Dockerfile
@@ -15,7 +15,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG alpine_version=3.19.0
+ARG alpine_version=3.19.1
 
 # java_version is used during the installation process to build or download the zipkin-lens jar.
 #

--- a/zipkin-server/src/main/resources/simplelogger.properties
+++ b/zipkin-server/src/main/resources/simplelogger.properties
@@ -13,3 +13,7 @@ org.slf4j.simpleLogger.showShortLogName=true
 org.slf4j.simpleLogger.log.com.linecorp.armeria=WARN
 # But allow to say it's ready to serve requests
 org.slf4j.simpleLogger.log.com.linecorp.armeria.server.Server=INFO
+# # and when registered in Eureka
+org.slf4j.simpleLogger.log.com.linecorp.armeria.server.eureka.EurekaUpdatingListener=INFO
+# # and when http-logging is enabled
+org.slf4j.simpleLogger.log.com.linecorp.armeria.client.logging.LoggingClient=INFO


### PR DESCRIPTION
This does a few things that polish docker test images and logging:

* updates base layers to Alpine 3.19.1
* uses Elasticsearch 8.12.1 which allows re-use of a consistent JRE
* Fixes logging glitch in zipkin-eureka
* Fixes ES_HTTP_LOGGING in zipkin-slim (which uses simplelogger)