### PR TITLE
eureka: comments why we aren't currently solving bad UX

### DIFF
--- a/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
+++ b/docker/test-images/zipkin-eureka/src/main/resources/application.yaml
@@ -22,6 +22,9 @@ eureka:
     registryFetchIntervalSeconds: 1
   server:
     useReadOnlyResponseCache: false
+    # We could set myUrl to avoid this server thinking it is also an
+    # unavailable replica. However, the effect of doing so is worse.
+    # See https://github.com/spring-cloud/spring-cloud-netflix/issues/4251
 server:
   port: 8761
 spring:


### PR DESCRIPTION
Our test image shows the server twice, once as a failed replica. This is despite adding several properties. However, alternatives in the current codebase are worse, at least alternatives I'm aware of. I opened https://github.com/spring-cloud/spring-cloud-netflix/issues/4251 to capture notes, though not really expecting a lot of follow-up. I'm commenting this, just to save another person a bunch of debugging to several poor ends.

![poop](https://github.com/openzipkin/zipkin/assets/64215/c2a7fade-4d9b-4ff8-9757-b10a7646ce61)
