### PR TITLE
grpc: enables collector by default

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin</groupId>
   <artifactId>zipkin-parent</artifactId>
-  <version>3.0.7-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/zipkin-collector/activemq/pom.xml
+++ b/zipkin-collector/activemq/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector-activemq</artifactId>

--- a/zipkin-collector/core/pom.xml
+++ b/zipkin-collector/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector</artifactId>

--- a/zipkin-collector/kafka/pom.xml
+++ b/zipkin-collector/kafka/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector-kafka</artifactId>

--- a/zipkin-collector/pom.xml
+++ b/zipkin-collector/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>

--- a/zipkin-collector/rabbitmq/pom.xml
+++ b/zipkin-collector/rabbitmq/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector-rabbitmq</artifactId>

--- a/zipkin-collector/scribe/pom.xml
+++ b/zipkin-collector/scribe/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-collector-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-collector-scribe</artifactId>

--- a/zipkin-junit5/pom.xml
+++ b/zipkin-junit5/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>

--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-lens</artifactId>

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -111,7 +111,8 @@ exposition [text format version 0.0.4](https://prometheus.io/docs/instrumenting/
 
 ### Collector
 
-Collector metrics are broken down by transport. The following are exported to the "/metrics" endpoint:
+Collector metrics are broken down by transport, where the defaults are "http" and "grpc". The
+following are exported to the "/metrics" endpoint:
 
 | Metric                                               | Description                                                                           |
 |------------------------------------------------------|---------------------------------------------------------------------------------------|

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -378,7 +378,9 @@ As this feature is experimental, it is not recommended to run this in production
 ## Collector
 
 ### HTTP Collector
-The HTTP collector is enabled by default. It accepts spans via `POST /api/v1/spans` and `POST /api/v2/spans`.
+The HTTP collector is enabled by default. It accepts spans via `POST /api/v1/spans` and
+`POST /api/v2/spans`, on the `${QUERY_PORT}` which defaults to 9411.
+
 The HTTP collector supports the following configuration:
 
 | Property                        | Environment Variable     | Description                                              |
@@ -494,17 +496,18 @@ Example usage:
 $ RABBIT_ADDRESSES=localhost java -jar zipkin.jar
 ```
 
-### gRPC Collector (Experimental)
-You can enable a gRPC span collector endpoint by setting `COLLECTOR_GRPC_ENABLED=true`. The
-`zipkin.proto3.SpanService/Report` endpoint will run on the same port as normal HTTP (9411).
+### gRPC Collector
 
-Example usage:
+The gRPC collector is enabled by default. It accepts spans via `zipkin.proto3.SpanService/Report`,
+on the `${QUERY_PORT}` which defaults to 9411.
 
-```bash
-$ COLLECTOR_GRPC_ENABLED=true java -jar zipkin.jar
-```
+The gRPC collector supports the following configuration:
 
-As this service is experimental, it is not recommended to run this in production environments.
+| Variable                 | Description                                            |
+|--------------------------|--------------------------------------------------------|
+| `COLLECTOR_GRPC_ENABLED` | `false` disables the gRPC service. Defaults to `true`. |
+
+The proto definition is here: https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto
 
 ## Service Registration
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-server</artifactId>

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinGrpcCollector.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinGrpcCollector.java
@@ -30,7 +30,7 @@ import zipkin2.collector.CollectorSampler;
 import zipkin2.storage.StorageComponent;
 
 /** Collector for receiving spans on a gRPC endpoint. */
-@ConditionalOnProperty(name = "zipkin.collector.grpc.enabled") // disabled by default
+@ConditionalOnProperty(name = "zipkin.collector.grpc.enabled", matchIfMissing = true)
 final class ZipkinGrpcCollector {
 
   @Bean ArmeriaServerConfigurator grpcCollectorConfigurator(StorageComponent storage,
@@ -56,7 +56,8 @@ final class ZipkinGrpcCollector {
       this.metrics = metrics;
     }
 
-    @Override protected CompletionStage<ByteBuf> handleMessage(ServiceRequestContext ctx, ByteBuf bytes) {
+    @Override
+    protected CompletionStage<ByteBuf> handleMessage(ServiceRequestContext ctx, ByteBuf bytes) {
       metrics.incrementMessages();
       metrics.incrementBytes(bytes.readableBytes());
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -26,11 +26,11 @@ zipkin:
       # Optional password to connect to the broker
       password: ${ACTIVEMQ_PASSWORD:}
     http:
-      # Set to false to disable creation of spans via HTTP collector API
+      # Set false to disable creation of spans via HTTP collector API
       enabled: ${COLLECTOR_HTTP_ENABLED:${HTTP_COLLECTOR_ENABLED:true}}
     grpc:
-      # Set to true to enable the GRPC collector
-      enabled: ${COLLECTOR_GRPC_ENABLED:false}
+      # Set false to disable the GRPC collector
+      enabled: ${COLLECTOR_GRPC_ENABLED:true}
     kafka:
       enabled: ${COLLECTOR_KAFKA_ENABLED:true}
       # Kafka bootstrap broker list, comma-separated host:port values. Setting this activates the

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
@@ -104,7 +104,7 @@ class ITZipkinGrpcCollector {
         assertThat(responseBody.exhausted()).isTrue(); // We expect a single response
 
         // Now, verify the Length-Prefixed-Message
-        assertThat(compressedFlag).isEqualTo(0); // server didn't compress
+        assertThat(compressedFlag).isZero(); // server didn't compress
         assertThat(messageLength).isZero(); // there are no fields in ReportResponse
       }
     }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
@@ -144,7 +144,14 @@ class ITZipkinMetrics {
     String metrics = getAsString("/metrics");
 
     assertThat(readJson(metrics)).containsOnlyKeys(
-      "gauge.zipkin_collector.message_spans.http"
+      "gauge.zipkin_collector.message_spans.grpc"
+      , "gauge.zipkin_collector.message_bytes.grpc"
+      , "counter.zipkin_collector.messages.grpc"
+      , "counter.zipkin_collector.bytes.grpc"
+      , "counter.zipkin_collector.spans.grpc"
+      , "counter.zipkin_collector.messages_dropped.grpc"
+      , "counter.zipkin_collector.spans_dropped.grpc"
+      , "gauge.zipkin_collector.message_spans.http"
       , "gauge.zipkin_collector.message_bytes.http"
       , "counter.zipkin_collector.messages.http"
       , "counter.zipkin_collector.bytes.http"

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-storage-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-storage-cassandra</artifactId>

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-storage-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-storage-elasticsearch</artifactId>

--- a/zipkin-storage/mysql-v1/pom.xml
+++ b/zipkin-storage/mysql-v1/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.zipkin2</groupId>
     <artifactId>zipkin-storage-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-storage-mysql-v1</artifactId>

--- a/zipkin-storage/pom.xml
+++ b/zipkin-storage/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>

--- a/zipkin-tests/pom.xml
+++ b/zipkin-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin</groupId>
     <artifactId>zipkin-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.zipkin.zipkin2</groupId>


### PR DESCRIPTION
The grpc service hasn't had any requests for change since introduction, and the code in armeria is stable. This enables the gRPC service by default (on both slim and normal builds as it only needs armeria).

This moves it out of experimental (something I neglected to do in 3.0, but better late than never).

cc @openzipkin/armeria 