### PR TITLE
disables the spring banner in tests via empty banner.txt

### DIFF
--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITActuatorMappings.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITActuatorMappings.java
@@ -35,7 +35,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
   }
 )
 class ITActuatorMappings {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinGrpcCollector.java
@@ -46,7 +46,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
   }
 )
 class ITZipkinGrpcCollector {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServer.java
@@ -47,7 +47,6 @@ import static zipkin2.TestObjects.UTF_8;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
   }
 )
 public class ITZipkinServer {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerAutocomplete.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerAutocomplete.java
@@ -42,7 +42,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     "zipkin.storage.autocomplete-keys=environment,clnt/finagle.version"
   }
 )

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerCORS.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerCORS.java
@@ -39,7 +39,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     "zipkin.query.allowed-origins=" + ITZipkinServerCORS.ALLOWED_ORIGIN
   }
 )

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerHttpCollectorDisabled.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerHttpCollectorDisabled.java
@@ -37,7 +37,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     "zipkin.storage.type=", // cheat and test empty storage type
     "zipkin.collector.http.enabled=false"
   })

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerQueryDisabled.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerQueryDisabled.java
@@ -36,7 +36,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     "zipkin.query.enabled=false",
     "zipkin.ui.enabled=false"
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerSsl.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerSsl.java
@@ -40,7 +40,6 @@ import static zipkin2.server.internal.elasticsearch.Access.configureSsl;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     // TODO: use normal spring.server properties after https://github.com/line/armeria/issues/1834
     "armeria.ssl.enabled=true",
     "armeria.ssl.key-store=classpath:keystore.p12",

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerTimeout.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ITZipkinServerTimeout.java
@@ -44,7 +44,6 @@ import static org.mockito.Mockito.when;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     "zipkin.query.timeout=1ms"
   }
 )

--- a/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/brave/ITZipkinSelfTracing.java
@@ -50,7 +50,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     "zipkin.self-tracing.enabled=true",
     "zipkin.self-tracing.message-timeout=100ms",
     "zipkin.self-tracing.traces-per-second=100"

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/BaseITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/BaseITZipkinEureka.java
@@ -55,7 +55,6 @@ import static org.testcontainers.utility.DockerImageName.parse;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     "zipkin.storage.type=", // cheat and test empty storage type
     "zipkin.collector.http.enabled=false",
     "zipkin.query.enabled=false",

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealth.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealth.java
@@ -36,7 +36,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
   }
 )
 class ITZipkinHealth {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealthDown.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ITZipkinHealthDown.java
@@ -32,7 +32,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     "zipkin.storage.type=elasticsearch",
     "zipkin.storage.elasticsearch.hosts=127.0.0.1:9999"
   }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetrics.java
@@ -49,7 +49,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
   }
 )
 class ITZipkinMetrics {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetricsDirty.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/prometheus/ITZipkinMetricsDirty.java
@@ -53,7 +53,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
   }
 )
 // Clearing the prometheus registry also clears the metrics themselves, not just the values, so we

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -40,7 +40,6 @@ import static zipkin2.server.internal.ITZipkinServer.url;
   properties = {
     "server.port=0",
     "spring.config.name=zipkin-server",
-    "spring.main.banner-mode=off",
     "zipkin.ui.base-path=/foozipkin",
     "server.compression.enabled=true",
     "server.compression.min-response-size=128"

--- a/zipkin-server/src/test/resources/application.yml
+++ b/zipkin-server/src/test/resources/application.yml
@@ -1,6 +1,5 @@
 spring:
   main:
-    banner-mode: off
     web-application-type: none
 
 # We are using Armeria instead of Tomcat. Have it inherit the default configuration from Spring


### PR DESCRIPTION
Before, running tests required careful configuration or your screen will fill up with this:

```
  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v3.2.2)
```

per https://github.com/spring-projects/spring-boot/issues/39583, by adding an empty src/test/resources/banner.txt, we are sure this won't happen.

This is better than asking people to redirect output to a log file, as normal use in IDE is easier when you can see the logs by default. It is also helpful in CI to be able to see logs without the complexity of searching for file artifacts after failure.

There was mention of a possible ["application context caching"](https://github.com/spring-projects/spring-boot/issues/39583#issuecomment-1959816321) problem when you don't show the spring banner in tests, but we hid it before more laboriously without issues. I think whatever problem that is doesn't apply here.