### PR TITLE
Switch logging to SLF4J 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
     <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
 
     <!-- update together -->
-    <spring-boot.version>3.2.2</spring-boot.version>
-    <spring.version>6.1.3</spring.version>
+    <spring-boot.version>3.2.3</spring-boot.version>
+    <spring.version>6.1.4</spring.version>
 
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
@@ -81,7 +81,7 @@
     -->
     <mariadb-java-client.version>3.3.2</mariadb-java-client.version>
     <HikariCP.version>5.1.0</HikariCP.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>2.0.12</slf4j.version>
     <auto-value.version>1.10.4</auto-value.version>
     <git-commit-id.version>4.9.10</git-commit-id.version>
 

--- a/zipkin-collector/core/pom.xml
+++ b/zipkin-collector/core/pom.xml
@@ -37,9 +37,9 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>uk.org.lidalia</groupId>
+      <groupId>com.github.valfirst</groupId>
       <artifactId>slf4j-test</artifactId>
-      <version>1.2.0</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -129,19 +129,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-log4j2</artifactId>
       <version>${spring-boot.version}</version>
-      <exclusions>
-        <!-- spring boot configures slf4j2 not slf4j -->
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j2-impl</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- spring boot configures slf4j2 not slf4j -->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
     </dependency>
 
     <!-- More efficient, gRPC ready server with brave tracing built-in -->


### PR DESCRIPTION
Switch logging to SLF4J 2.x (follow up on https://github.com/openzipkin/zipkin/issues/3712 and https://github.com/openzipkin/zipkin/pull/3714), retested with the test image:

```
zipkin         |      ________ ____  _  _____ _   _
zipkin         |     |__  /_ _|  _ \| |/ /_ _| \ | |
zipkin         |       / / | || |_) | ' / | ||  \| |
zipkin         |      / /_ | ||  __/| . \ | || |\  |
zipkin         |     |____|___|_|   |_|\_\___|_| \_|
zipkin         |
zipkin         | :: version 3.1.0-SNAPSHOT :: commit 72795f7 ::

....

zipkin         | {"index":{"_index":"zipkin-span-2024-02-24","_id":"3ebf9f6ff120b6ca-0954acc1f45717e84235a44ed8f413a2"}}
zipkin         | {"timestamp_millis":1708787255869,"_q":["error","error=[zipkin-elasticsearch][172.18.0.2:9300][indices:data/read/search[phase/query]]"],"traceId":"3ebf9f6ff120b6ca","parentId":"3ebf9f6ff120b6ca
","id":"808543d49f671bea","name":"get-traces","timestamp":1708787255869281,"duration":53455,"localEndpoint":{"serviceName":"zipkin-server","ipv4":"172.18.0.3"},"tags":{"error":"[zipkin-elasticsearch][172.18.0.2
:9300][indices:data/read/search[phase/query]]"}}
zipkin         | {"index":{"_index":"zipkin-span-2024-02-24","_id":"3ebf9f6ff120b6ca-35ea19e6b7a8340c2b0c67a28134dc8a"}}
zipkin         | {"timestamp_millis":1708787255853,"_q":["wr","ws","error","error=500","http.method","http.method=GET","http.path","http.path=/zipkin/api/v2/traces","http.status_code","http.status_code=500"],"t
raceId":"3ebf9f6ff120b6ca","id":"3ebf9f6ff120b6ca","kind":"SERVER","name":"get /zipkin/api/v2/traces","timestamp":1708787255853270,"duration":82670,"localEndpoint":{"serviceName":"zipkin-server","ipv4":"172.18.
0.3"},"remoteEndpoint":{"ipv4":"172.18.0.1","port":47008},"annotations":[{"timestamp":1708787255853361,"value":"wr"},{"timestamp":1708787255935496,"value":"ws"}],"tags":{"error":"500","http.method":"GET","http.
path":"/zipkin/api/v2/traces","http.status_code":"500"}}
zipkin         | }
zipkin         | 2024-02-24T15:07:37.437Z  INFO [/] 1 --- [orker-epoll-2-5] c.l.a.c.l.LoggingClient                  : [creqId=aeb752b3, chanId=c2bca7d7, laddr=172.18.0.3:45596, raddr=elasticsearch/172.18.0.2:9
200][http://elasticsearch:9200/_bulk#POST] Response: {startTime=2024-02-24T15:07:37.434Z(1708787257434963), length=283B, duration=1545µs(1545122ns), totalDuration=79326µs(79326545ns), headers=[:status=200, x-el
astic-product=Elasticsearch, content-type=application/json, content-encoding=gzip, content-length=283], content={"errors":false,"took":64,"items":[{"index":{"_index":"zipkin-span-2024-02-24","_id":"3ebf9f6ff120
b6ca-a46806f2ecb9728ca7b94cad99c50694","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"zipkin-span-2024-02-24","_
id":"3ebf9f6ff120b6ca-0954acc1f45717e84235a44ed8f413a2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1,"status":201}},{"index":{"_index":"zipkin-sp
an-2024-02-24","_id":"3ebf9f6ff120b6ca-35ea19e6b7a8340c2b0c67a28134dc8a","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}]}}
zipkin         | 2024-02-24T15:07:40.414Z  INFO [/] 1 --- [orker-epoll-2-5] c.l.a.c.l.LoggingClient                  : [creqId=253f2172, sreqId=c1860fbd, chanId=c2bca7d7, laddr=172.18.0.3:45596, raddr=elasticse
arch/172.18.0.2:9200][http://elasticsearch:9200/_cluster/health/zipkin*span-*#GET] Request: {startTime=2024-02-24T15:07:40.396Z(1708787260396870), length=0B, duration=2870µs(2870642ns), scheme=none+h1c, name=ge
t-cluster-health, headers=[:method=GET, :path=/_cluster/health/zipkin*span-*, :authority=elasticsearch:9200, b3=f272022be0d8fd1f-ef256ad5b06fd05b-0-f272022be0d8fd1f, accept-encoding=gzip,deflate,x-snappy-framed
, user-agent=armeria/1.27.1], content=}
zipkin         | 2024-02-24T15:07:40.415Z  INFO [/] 1 --- [orker-epoll-2-5] c.l.a.c.l.LoggingClient                  : [creqId=253f2172, sreqId=c1860fbd, chanId=c2bca7d7, laddr=172.18.0.3:45596, raddr=elasticse
arch/172.18.0.2:9200][http://elasticsearch:9200/_cluster/health/zipkin*span-*#GET] Response: {startTime=2024-02-24T15:07:40.408Z(1708787260408665), length=229B, duration=1222µs(1222818ns), totalDuration=13006µs
(13006688ns), headers=[:status=200, x-elastic-product=Elasticsearch, content-type=application/json, content-encoding=gzip, content-length=229], content={"cluster_name":"docker-cluster","status":"yellow","timed_
out":false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":10,"active_shards":10,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":10,"delayed_unassigned_shards":0,"number_o
f_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":50.0}}
zipkin         | 2024-02-24T15:07:45.469Z  INFO [/] 1 --- [orker-epoll-2-5] c.l.a.c.l.LoggingClient                  : [creqId=ec348be8, sreqId=117bf707, chanId=c2bca7d7, laddr=172.18.0.3:45596, raddr=elasticse
arch/172.18.0.2:9200][http://elasticsearch:9200/_cluster/health/zipkin*span-*#GET] Request: {startTime=2024-02-24T15:07:45.464Z(1708787265464576), length=0B, duration=846µs(846863ns), scheme=none+h1c, name=get-
cluster-health, headers=[:method=GET, :path=/_cluster/health/zipkin*span-*, :authority=elasticsearch:9200, b3=5d19ec7c7f5706fd-bc738919d39edcfc-0-5d19ec7c7f5706fd, accept-encoding=gzip,deflate,x-snappy-framed,
user-agent=armeria/1.27.1], content=}
zipkin         | 2024-02-24T15:07:45.469Z  INFO [/] 1 --- [orker-epoll-2-5] c.l.a.c.l.LoggingClient                  : [creqId=ec348be8, sreqId=117bf707, chanId=c2bca7d7, laddr=172.18.0.3:45596, raddr=elasticse
arch/172.18.0.2:9200][http://elasticsearch:9200/_cluster/health/zipkin*span-*#GET] Response: {startTime=2024-02-24T15:07:45.468Z(1708787265468212), length=229B, duration=160µs(160931ns), totalDuration=3796µs(37
96531ns), headers=[:status=200, x-elastic-product=Elasticsearch, content-type=application/json, content-encoding=gzip, content-length=229], content={"cluster_name":"docker-cluster","status":"yellow","timed_out"
:false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":10,"active_shards":10,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":10,"delayed_unassigned_shards":0,"number_of_pe
nding_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":50.0}}
```