### PR TITLE
docker: fixes native library config

### DIFF
--- a/.github/workflows/test_readme.yml
+++ b/.github/workflows/test_readme.yml
@@ -105,13 +105,17 @@ jobs:
       - name: docker/README.md - openzipkin/zipkin
         run: |
           build-bin/docker/docker_build openzipkin/zipkin:test &&
-          build-bin/docker/docker_test_image openzipkin/zipkin:test
+          build-bin/docker/docker_test_image openzipkin/zipkin:test &&
+          docker run --rm --entrypoint=/bin/sh openzipkin/zipkin:test \
+            -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*'
         env:
           RELEASE_FROM_MAVEN_BUILD: true
       - name: docker/README.md - openzipkin/zipkin-slim
         run: |
           build-bin/docker/docker_build openzipkin/zipkin-slim:test &&
-          build-bin/docker/docker_test_image openzipkin/zipkin-slim:test
+          build-bin/docker/docker_test_image openzipkin/zipkin-slim:test &&
+          docker run --rm --entrypoint=/bin/sh openzipkin/zipkin-slim:test \
+            -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*'
         env:
           DOCKER_TARGET: zipkin-slim
           RELEASE_FROM_MAVEN_BUILD: true

--- a/.github/workflows/test_readme.yml
+++ b/.github/workflows/test_readme.yml
@@ -107,7 +107,7 @@ jobs:
           build-bin/docker/docker_build openzipkin/zipkin:test &&
           build-bin/docker/docker_test_image openzipkin/zipkin:test &&
           docker run --rm --entrypoint=/bin/sh openzipkin/zipkin:test \
-            -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*'
+            -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*' || true
         env:
           RELEASE_FROM_MAVEN_BUILD: true
       - name: docker/README.md - openzipkin/zipkin-slim
@@ -115,7 +115,7 @@ jobs:
           build-bin/docker/docker_build openzipkin/zipkin-slim:test &&
           build-bin/docker/docker_test_image openzipkin/zipkin-slim:test &&
           docker run --rm --entrypoint=/bin/sh openzipkin/zipkin-slim:test \
-            -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*'
+            -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*' || true
         env:
           DOCKER_TARGET: zipkin-slim
           RELEASE_FROM_MAVEN_BUILD: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,10 +46,18 @@ ENV RELEASE_FROM_MAVEN_BUILD=$release_from_maven_build
 ARG version=master
 ENV VERSION=$version
 ENV MAVEN_PROJECT_BASEDIR=/code
-RUN /code/build-bin/maven/maven_build_or_unjar io.zipkin zipkin-server ${VERSION} exec && \
+ARG TARGETARCH
+RUN test "${TARGETARCH}" != "" && \
+    /code/build-bin/maven/maven_build_or_unjar io.zipkin zipkin-server ${VERSION} exec && \
     mv zipkin-server zipkin && \
     /code/build-bin/maven/maven_build_or_unjar io.zipkin zipkin-server ${VERSION} slim && \
-    mv zipkin-server zipkin-slim
+    mv zipkin-server zipkin-slim && \
+    # Copy tcnative deps to slim: 1.1MB more libs when pared to current platform.
+    cp zipkin/BOOT-INF/lib/*tcnative*.jar zipkin-slim/BOOT-INF/lib/ && \
+    # Remove any unused platform-specific jars. This results in none for s390x or non-linux.
+    rm */BOOT-INF/lib/*windows* */BOOT-INF/lib/*osx* && \
+    if [ "${TARGETARCH}" != "amd64" ]; then rm */BOOT-INF/lib/*x86*; fi && \
+    if [ "${TARGETARCH}" != "arm64" ]; then rm */BOOT-INF/lib/*a64* */BOOT-INF/lib/*aarch*; fi
 
 # Almost everything is common between the slim and normal build
 FROM ghcr.io/openzipkin/java:${java_version}-jre as base-server

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -626,7 +626,7 @@
               <classifier>slim</classifier>
               <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
               <excludeGroupIds>
-                com.google.auto.value,com.google.guava,io.dropwizard.metrics,com.datastax.oss,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
+                com.google.auto.value,com.google.guava,io.dropwizard.metrics,org.apache.cassandra,com.github.jnr,org.ow2.asm,org.jooq,javax.xml.bind,org.mariadb.jdbc,com.zaxxer,org.apache.activemq,org.apache.geronimo.specs,org.fusesource.hawtbuf,org.apache.kafka,com.github.luben,org.lz4,org.xerial.snappy,com.rabbitmq,jakarta.annotation,org.apache.thrift,org.apache.logging.log4j
               </excludeGroupIds>
               <excludes>
                 <!-- Actuator -->
@@ -656,11 +656,14 @@
                 <!-- Unnecessary netty deps -->
                 <dependency>
                   <groupId>io.netty</groupId>
-                  <artifactId>netty-tcnative-boringssl-static</artifactId>
+                  <artifactId>netty-codec-haproxy</artifactId>
                 </dependency>
+
+                <!-- removes boringssl from jar as all archs end up too big
+                     we add this back in docker -->
                 <dependency>
                   <groupId>io.netty</groupId>
-                  <artifactId>netty-codec-haproxy</artifactId>
+                  <artifactId>netty-tcnative-boringssl-static</artifactId>
                 </dependency>
 
                 <!-- Unnecessary micrometer deps -->


### PR DESCRIPTION
This pares down the native libraries on our docker zipkin images to only those needed by linux and the target architecture.

This also improves the zipkin-slim image by correcting its accidental inclusion of cassandra dependencies, and enabling netty tcnative


Current zipkin arm64: note: unrelated os and archs
```bash
$ docker run --rm --entrypoint=/bin/sh ghcr.io/openzipkin/zipkin:master -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*'
20	netty-resolver-dns-native-macos-4.1.106.Final-osx-aarch_64.jar
1100	netty-tcnative-boringssl-static-2.0.63.Final-linux-aarch_64.jar
976	netty-tcnative-boringssl-static-2.0.63.Final-osx-aarch_64.jar
44	netty-transport-native-epoll-4.1.106.Final-linux-aarch_64.jar
28	netty-transport-native-kqueue-4.1.106.Final-osx-aarch_64.jar
76	netty-transport-native-unix-common-4.1.106.Final-linux-aarch_64.jar
72	netty-transport-native-unix-common-4.1.106.Final-osx-aarch_64.jar
216	jnr-x86asm-1.0.2.jar
420	native-linux-x86_64-1.15.0.jar
20	netty-resolver-dns-native-macos-4.1.106.Final-osx-x86_64.jar
1188	netty-tcnative-boringssl-static-2.0.63.Final-linux-x86_64.jar
1088	netty-tcnative-boringssl-static-2.0.63.Final-osx-x86_64.jar
976	netty-tcnative-boringssl-static-2.0.63.Final-windows-x86_64.jar
40	netty-transport-native-epoll-4.1.106.Final-linux-x86_64.jar
28	netty-transport-native-kqueue-4.1.106.Final-osx-x86_64.jar
72	netty-transport-native-unix-common-4.1.106.Final-linux-x86_64.jar
72	netty-transport-native-unix-common-4.1.106.Final-osx-x86_64.jar
88	jnr-a64asm-1.0.0.jar
```

New zipkin arm64:
```
$ docker run --rm --entrypoint=/bin/sh openzipkin/zipkin:test -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*'
1100	netty-tcnative-boringssl-static-2.0.63.Final-linux-aarch_64.jar
44	netty-transport-native-epoll-4.1.106.Final-linux-aarch_64.jar
76	netty-transport-native-unix-common-4.1.106.Final-linux-aarch_64.jar
88	jnr-a64asm-1.0.0.jar
du: *x86*: No such file or directory
```

New zipkin amd64:
```
du: *aarch*: No such file or directory
du: *a64*: No such file or directory
216	jnr-x86asm-1.0.2.jar
420	native-linux-x86_64-1.15.0.jar
1188	netty-tcnative-boringssl-static-2.0.63.Final-linux-x86_64.jar
40	netty-transport-native-epoll-4.1.106.Final-linux-x86_64.jar
72	netty-transport-native-unix-common-4.1.106.Final-linux-x86_64.jar
```

Current zipkin-slim (note: no boringssl, also extra junk from cassandra)
```bash
$ docker run --rm --entrypoint=/bin/sh ghcr.io/openzipkin/zipkin-slim:master -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*'
20	netty-resolver-dns-native-macos-4.1.106.Final-osx-aarch_64.jar
44	netty-transport-native-epoll-4.1.106.Final-linux-aarch_64.jar
28	netty-transport-native-kqueue-4.1.106.Final-osx-aarch_64.jar
76	netty-transport-native-unix-common-4.1.106.Final-linux-aarch_64.jar
72	netty-transport-native-unix-common-4.1.106.Final-osx-aarch_64.jar
420	native-linux-x86_64-1.15.0.jar
20	netty-resolver-dns-native-macos-4.1.106.Final-osx-x86_64.jar
40	netty-transport-native-epoll-4.1.106.Final-linux-x86_64.jar
28	netty-transport-native-kqueue-4.1.106.Final-osx-x86_64.jar
72	netty-transport-native-unix-common-4.1.106.Final-linux-x86_64.jar
72	netty-transport-native-unix-common-4.1.106.Final-osx-x86_64.jar
du: *a64*: No such file or directory
```

New zipkin-slim arm64:
```
$ docker run --rm --entrypoint=/bin/sh openzipkin/zipkin-slim:test -c 'cd BOOT-INF/lib && du -sk *aarch* *x86* *a64*'
1100	netty-tcnative-boringssl-static-2.0.63.Final-linux-aarch_64.jar
44	netty-transport-native-epoll-4.1.106.Final-linux-aarch_64.jar
76	netty-transport-native-unix-common-4.1.106.Final-linux-aarch_64.jar
88	jnr-a64asm-1.0.0.jar
```

New zipkin-slim amd64:
```
du: *aarch*: No such file or directory
420	native-linux-x86_64-1.15.0.jar
1188	netty-tcnative-boringssl-static-2.0.63.Final-linux-x86_64.jar
40	netty-transport-native-epoll-4.1.106.Final-linux-x86_64.jar
72	netty-transport-native-unix-common-4.1.106.Final-linux-x86_64.jar
```
