### PR TITLE
cassandra: adds log statement to help debug schema install failure

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/Schema.java
@@ -101,6 +101,7 @@ final class Schema {
       }
     }
     if (version == null) throw new RuntimeException("No nodes in the cluster");
+    LOG.info("Detected Cassandra version {}", version);
     return version;
   }
 

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -53,6 +53,13 @@ abstract class ITEnsureSchema extends ITStorage<CassandraStorage> {
   abstract CqlSession session();
 
   @Test void installsKeyspaceWhenMissing() {
+    Schema.ensureExists(storage.keyspace, true, session());
+
+    KeyspaceMetadata metadata = session().getMetadata().getKeyspace(storage.keyspace).get();
+    assertThat(metadata).isNotNull();
+  }
+
+  @Test void installsKeyspaceWhenMissing_searchDisabled() {
     Schema.ensureExists(storage.keyspace, false, session());
 
     KeyspaceMetadata metadata = session().getMetadata().getKeyspace(storage.keyspace).get();


### PR DESCRIPTION
I'm not on a good enough network at the moment to pull cassandra's image, but after this is merged, troubleshooting #3412 should be easier with normal docker and logging config