### PR TITLE
cassandra: log in console when search enabled, but SASI disabled

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/BodyIsExceptionMessage.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/BodyIsExceptionMessage.java
@@ -11,6 +11,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zipkin2.internal.ClosedComponentException;
 
 import static com.linecorp.armeria.common.HttpStatus.BAD_REQUEST;
 import static com.linecorp.armeria.common.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -29,7 +30,10 @@ final class BodyIsExceptionMessage implements ExceptionHandlerFunction {
     if (cause instanceof IllegalArgumentException) {
       return HttpResponse.of(BAD_REQUEST, ANY_TEXT_TYPE, message);
     } else {
-      LOGGER.warn("Unexpected error handling request.", cause);
+      // Don't fill logs with exceptions about closed components.
+      if (!(cause instanceof ClosedComponentException)) {
+        LOGGER.warn("Unexpected error handling {} {}", req.method(), req.path());
+      }
 
       return HttpResponse.of(INTERNAL_SERVER_ERROR, ANY_TEXT_TYPE, message);
     }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/health/ComponentHealth.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/health/ComponentHealth.java
@@ -4,12 +4,16 @@
  */
 package zipkin2.server.internal.health;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import zipkin2.Call;
 import zipkin2.CheckResult;
 import zipkin2.Component;
+import zipkin2.internal.ClosedComponentException;
 import zipkin2.internal.Nullable;
 
 final class ComponentHealth {
+  static final Logger LOGGER = LoggerFactory.getLogger(ComponentHealth.class);
   static final String STATUS_UP = "UP", STATUS_DOWN = "DOWN";
 
   static ComponentHealth ofComponent(Component component) {
@@ -23,7 +27,13 @@ final class ComponentHealth {
     }
     if (t == null) return new ComponentHealth(component.toString(), STATUS_UP, null);
     String message = t.getMessage();
-    String error = t.getClass().getName() + (message != null ? ": " + message : "");
+    String error;
+    if (t instanceof ClosedComponentException) {
+      error = message;
+    } else {
+      error = t.getClass().getSimpleName() + (message != null ? ": " + message : "");
+    }
+    LOGGER.debug(error);
     return new ComponentHealth(component.toString(), STATUS_DOWN, error);
   }
 

--- a/zipkin-server/src/main/resources/zipkin-server-shared.yml
+++ b/zipkin-server/src/main/resources/zipkin-server-shared.yml
@@ -251,6 +251,8 @@ logging:
     com.datastax.oss.driver.internal.core.DefaultMavenCoordinates: 'WARN'
     # We exclude Geo codec and Graph extensions to keep size down
     com.datastax.oss.driver.internal.core.context.InternalDriverContext: 'WARN'
+    # Avoid logs about adding handlers
+    com.datastax.oss.driver.internal.core.cql.CqlPrepareAsyncProcessor: 'WARN'
     # Use of native clocks in Cassandra is not insightful
     com.datastax.oss.driver.internal.core.time.Clock: 'WARN'
     # Unless it's serious we don't want to know

--- a/zipkin-server/src/test/java/zipkin2/server/internal/health/ComponentHealthTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/health/ComponentHealthTest.java
@@ -20,8 +20,7 @@ class ComponentHealthTest {
       }
     });
 
-    assertThat(health.error)
-      .isEqualTo("java.io.IOException: socket disconnect");
+    assertThat(health.error).isEqualTo("IOException: socket disconnect");
   }
 
   @Test void doesntAddNullMessageToDetails() {
@@ -31,7 +30,6 @@ class ComponentHealthTest {
       }
     });
 
-    assertThat(health.error)
-      .isEqualTo("com.linecorp.armeria.common.ClosedSessionException");
+    assertThat(health.error).isEqualTo("ClosedSessionException");
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/CassandraStorage.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import zipkin2.Call;
 import zipkin2.CheckResult;
+import zipkin2.internal.ClosedComponentException;
 import zipkin2.internal.Nullable;
 import zipkin2.storage.AutocompleteTags;
 import zipkin2.storage.ServiceAndSpanNames;
@@ -19,7 +20,6 @@ import zipkin2.storage.SpanConsumer;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StorageComponent;
 import zipkin2.storage.Traces;
-import zipkin2.storage.cassandra.internal.CassandraStorageBuilder;
 import zipkin2.storage.cassandra.internal.call.ResultSetFutureCall;
 
 /**
@@ -47,8 +47,6 @@ public final class CassandraStorage extends StorageComponent {
   }
 
   public static final class Builder extends CassandraStorageBuilder<Builder> {
-    SessionFactory sessionFactory = SessionFactory.DEFAULT;
-
     Builder() {
       super(Schema.DEFAULT_KEYSPACE);
     }
@@ -70,22 +68,8 @@ public final class CassandraStorage extends StorageComponent {
       return super.ensureSchema(ensureSchema);
     }
 
-    /** Override to control how sessions are created. */
-    public Builder sessionFactory(SessionFactory sessionFactory) {
-      if (sessionFactory == null) throw new NullPointerException("sessionFactory == null");
-      this.sessionFactory = sessionFactory;
-      return this;
-    }
-
     @Override public CassandraStorage build() {
-      AuthProvider authProvider = null;
-      if (username != null) {
-        authProvider = new ProgrammaticPlainTextAuthProvider(username, password);
-      }
-      return new CassandraStorage(strictTraceId, searchEnabled, autocompleteKeys, autocompleteTtl,
-        autocompleteCardinality, contactPoints, localDc, poolingOptions(), authProvider, useSsl,
-        sslHostnameValidation, sessionFactory, keyspace, ensureSchema, maxTraceCols,
-        indexFetchMultiplier);
+      return new CassandraStorage(this);
     }
   }
 
@@ -99,39 +83,36 @@ public final class CassandraStorage extends StorageComponent {
   final boolean useSsl;
   final boolean sslHostnameValidation;
   final String keyspace;
-  final boolean ensureSchema;
-
   final int maxTraceCols, indexFetchMultiplier;
 
   final LazySession session;
 
-  CassandraStorage(boolean strictTraceId, boolean searchEnabled, Set<String> autocompleteKeys,
-    int autocompleteTtl, int autocompleteCardinality, String contactPoints, String localDc,
-    Map<DriverOption, Integer> poolingOptions, AuthProvider authProvider, boolean useSsl,
-    boolean sslHostnameValidation, SessionFactory sessionFactory, String keyspace,
-    boolean ensureSchema, int maxTraceCols, int indexFetchMultiplier) {
+  CassandraStorage(CassandraStorageBuilder<?> builder) {
     // Assign generic configuration for all storage components
-    this.strictTraceId = strictTraceId;
-    this.searchEnabled = searchEnabled;
-    this.autocompleteKeys = autocompleteKeys;
-    this.autocompleteTtl = autocompleteTtl;
-    this.autocompleteCardinality = autocompleteCardinality;
+    this.strictTraceId = builder.strictTraceId;
+    this.searchEnabled = builder.searchEnabled;
+    this.autocompleteKeys = builder.autocompleteKeys;
+    this.autocompleteTtl = builder.autocompleteTtl;
+    this.autocompleteCardinality = builder.autocompleteCardinality;
 
     // Assign configuration used to create a session
-    this.contactPoints = contactPoints;
-    this.localDc = localDc;
-    this.poolingOptions = poolingOptions;
-    this.authProvider = authProvider;
-    this.useSsl = useSsl;
-    this.sslHostnameValidation = sslHostnameValidation;
-    this.ensureSchema = ensureSchema;
-    this.keyspace = keyspace;
+    this.contactPoints = builder.contactPoints;
+    this.localDc = builder.localDc;
+    this.poolingOptions = builder.poolingOptions();
+    if (builder.username != null) {
+      this.authProvider = new ProgrammaticPlainTextAuthProvider(builder.username, builder.password);
+    } else {
+      this.authProvider = null;
+    }
+    this.useSsl = builder.useSsl;
+    this.sslHostnameValidation = builder.sslHostnameValidation;
+    this.keyspace = builder.keyspace;
 
     // Assign configuration used to control queries
-    this.maxTraceCols = maxTraceCols;
-    this.indexFetchMultiplier = indexFetchMultiplier;
+    this.maxTraceCols = builder.maxTraceCols;
+    this.indexFetchMultiplier = builder.indexFetchMultiplier;
 
-    this.session = new LazySession(sessionFactory, this);
+    this.session = new LazySession(this, builder.sessionFactory, builder.ensureSchema);
   }
 
   /** close is typically called from a different thread */
@@ -202,7 +183,7 @@ public final class CassandraStorage extends StorageComponent {
   }
 
   @Override public CheckResult check() {
-    if (closeCalled) throw new IllegalStateException("closed");
+    if (closeCalled) throw new ClosedComponentException();
     try {
       session.healthCheck();
     } catch (Throwable e) {

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/DefaultSessionFactory.java
@@ -5,48 +5,11 @@
 package zipkin2.storage.cassandra;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.data.UdtValue;
-import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
-import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
-import com.datastax.oss.driver.api.core.type.codec.registry.MutableCodecRegistry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import zipkin2.storage.cassandra.internal.SessionBuilder;
 
-import static zipkin2.Call.propagateIfFatal;
-
-/**
- * Creates a session and ensures schema if configured. Closes the cluster and session if any
- * exception occurred.
- */
 final class DefaultSessionFactory implements CassandraStorage.SessionFactory {
-  static final Logger LOG = LoggerFactory.getLogger(DefaultSessionFactory.class);
-
-  /**
-   * Creates a session and ensures schema if configured. Closes the cluster and session if any
-   * exception occurred.
-   */
   @Override public CqlSession create(CassandraStorage cassandra) {
-    CqlSession session = null;
-    try {
-      session = buildSession(cassandra);
-
-      String keyspace = cassandra.keyspace;
-      if (cassandra.ensureSchema) {
-        Schema.ensureExists(keyspace, cassandra.searchEnabled, session);
-      } else {
-        LOG.debug("Skipping schema check on keyspace {} as ensureSchema was false", keyspace);
-      }
-
-      session.execute("USE " + keyspace);
-      initializeUDTs(session, keyspace);
-
-      return session;
-    } catch (RuntimeException | Error e) { // don't leak on unexpected exception!
-      propagateIfFatal(e);
-      if (session != null) session.close();
-      throw e;
-    }
+    return buildSession(cassandra);
   }
 
   static CqlSession buildSession(CassandraStorage cassandra) {
@@ -58,20 +21,5 @@ final class DefaultSessionFactory implements CassandraStorage.SessionFactory {
       cassandra.useSsl,
       cassandra.sslHostnameValidation
     );
-  }
-
-  static void initializeUDTs(CqlSession session, String keyspace) {
-    KeyspaceMetadata ks = session.getMetadata().getKeyspace(keyspace).get();
-    MutableCodecRegistry codecRegistry =
-      (MutableCodecRegistry) session.getContext().getCodecRegistry();
-
-    TypeCodec<UdtValue> annotationUDTCodec =
-      codecRegistry.codecFor(ks.getUserDefinedType("annotation").get());
-    codecRegistry.register(new AnnotationCodec(annotationUDTCodec));
-
-    LOG.debug("Registering endpoint and annotation UDTs to keyspace {}", keyspace);
-    TypeCodec<UdtValue> endpointUDTCodec =
-      codecRegistry.codecFor(ks.getUserDefinedType("endpoint").get());
-    codecRegistry.register(new EndpointCodec(endpointUDTCodec));
   }
 }

--- a/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/LazySession.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin2/storage/cassandra/LazySession.java
@@ -6,32 +6,52 @@ package zipkin2.storage.cassandra;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import java.util.function.BiFunction;
+import zipkin2.internal.ClosedComponentException;
 import zipkin2.storage.cassandra.CassandraStorage.SessionFactory;
 
+import static zipkin2.Call.propagateIfFatal;
 import static zipkin2.storage.cassandra.Schema.TABLE_SPAN;
 
 final class LazySession {
-  final SessionFactory sessionFactory;
   final CassandraStorage storage;
+  final SessionFactory sessionFactory;
+  final BiFunction<CassandraStorage, CqlSession, Schema.Metadata> ensureSchema;
+
   volatile CqlSession session;
   volatile PreparedStatement healthCheck; // guarded by session
   volatile Schema.Metadata metadata; // guarded by session
 
-  LazySession(SessionFactory sessionFactory, CassandraStorage storage) {
+  LazySession(CassandraStorage storage, SessionFactory sessionFactory,
+    BiFunction<CassandraStorage, CqlSession, Schema.Metadata> ensureSchema) {
     this.sessionFactory = sessionFactory;
+    this.ensureSchema = ensureSchema;
     this.storage = storage;
   }
 
+  /** Creates a session and ensures schema if configured. */
   CqlSession get() {
-    if (session == null) {
-      synchronized (this) {
-        if (session == null) {
-          session = sessionFactory.create(storage);
-          // cached here to warn only once when schema problems exist
-          metadata = Schema.readMetadata(session, storage.keyspace);
-          healthCheck = session.prepare("SELECT trace_id FROM " + TABLE_SPAN + " limit 1");
-        }
+    if (session != null) return session;
+    synchronized (this) {
+      if (session != null) return session; // lost race
+      session = sessionFactory.create(storage);
+
+      // If we got this far, the session is healthy. So, everything below only happens once.
+      try {
+        metadata = ensureSchema.apply(storage, session);
+        session.execute("USE " + storage.keyspace);
+        Schema.initializeUDTs(session, storage.keyspace);
+        healthCheck = session.prepare("SELECT trace_id FROM " + TABLE_SPAN + " limit 1");
+      } catch (RuntimeException | Error e) {
+        propagateIfFatal(e);
+        // An error here was from installing or validating the schema. To ensure we don't repeat
+        // failed commands, close, but don't null the session. For example, repeating may look like
+        // an upgrade due to the first failure, and distract from the original problem.
+        session.close();
       }
+    }
+    if (session.isClosed()) {
+      throw new ClosedComponentException("Session initialization failed. See server logs");
     }
     return session;
   }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraSpanConsumerTest.java
@@ -4,8 +4,13 @@
  */
 package zipkin2.storage.cassandra;
 
+import com.datastax.oss.driver.api.core.CqlSession;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import zipkin2.Call;
 import zipkin2.Span;
 import zipkin2.internal.AggregateCall;
@@ -18,10 +23,16 @@ import static org.assertj.core.api.Assertions.tuple;
 import static zipkin2.TestObjects.BACKEND;
 import static zipkin2.TestObjects.FRONTEND;
 import static zipkin2.TestObjects.TODAY;
-import static zipkin2.storage.cassandra.InternalForTests.mockSession;
 
+@ExtendWith(MockitoExtension.class)
 class CassandraSpanConsumerTest {
-  CassandraSpanConsumer consumer = spanConsumer(CassandraStorage.newBuilder());
+  @Mock CqlSession session;
+  Schema.Metadata metadata = new Schema.Metadata(true, true);
+  CassandraSpanConsumer consumer;
+
+  @BeforeEach void setup() {
+    consumer = spanConsumer(CassandraStorage.newBuilder());
+  }
 
   Span spanWithoutAnnotationsOrTags =
     Span.newBuilder()
@@ -208,7 +219,9 @@ class CassandraSpanConsumerTest {
       .isInstanceOf(ResultSetFutureCall.class);
   }
 
-  static CassandraSpanConsumer spanConsumer(CassandraStorage.Builder builder) {
-    return new CassandraSpanConsumer(builder.sessionFactory(storage -> mockSession()).build());
+  CassandraSpanConsumer spanConsumer(CassandraStorage.Builder builder) {
+    return new CassandraSpanConsumer(session, metadata, builder.strictTraceId,
+      builder.searchEnabled, builder.autocompleteKeys, builder.autocompleteTtl,
+      builder.autocompleteCardinality);
   }
 }

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageBuilderTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraStorageBuilderTest.java
@@ -2,7 +2,7 @@
  * Copyright The OpenZipkin Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-package zipkin2.storage.cassandra.internal;
+package zipkin2.storage.cassandra;
 
 import java.util.List;
 import java.util.function.Function;

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/ITEnsureSchema.java
@@ -5,6 +5,7 @@
 package zipkin2.storage.cassandra;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -44,14 +45,14 @@ abstract class ITEnsureSchema extends ITStorage<CassandraStorage> {
   abstract CqlSession session();
 
   @Test void installsKeyspaceWhenMissing() {
-    Schema.ensureExists(storage.keyspace, true, session());
+    Schema.ensureExists(session(), storage.keyspace, true);
 
     KeyspaceMetadata metadata = session().getMetadata().getKeyspace(storage.keyspace).get();
     assertThat(metadata).isNotNull();
   }
 
   @Test void installsKeyspaceWhenMissing_searchDisabled() {
-    Schema.ensureExists(storage.keyspace, false, session());
+    Schema.ensureExists(session(), storage.keyspace, false);
 
     KeyspaceMetadata metadata = session().getMetadata().getKeyspace(storage.keyspace).get();
     assertThat(metadata).isNotNull();
@@ -61,7 +62,7 @@ abstract class ITEnsureSchema extends ITStorage<CassandraStorage> {
     session().execute("CREATE KEYSPACE " + storage.keyspace
       + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
 
-    Schema.ensureExists(storage.keyspace, false, session());
+    Schema.ensureExists(session(), storage.keyspace, false);
 
     KeyspaceMetadata metadata = session().getMetadata().getKeyspace(storage.keyspace).get();
     assertThat(metadata.getTable(TABLE_SPAN)).isNotNull();
@@ -77,7 +78,7 @@ abstract class ITEnsureSchema extends ITStorage<CassandraStorage> {
     session().execute("CREATE KEYSPACE " + storage.keyspace
       + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
 
-    Schema.ensureExists(storage.keyspace, true, session());
+    Schema.ensureExists(session(), storage.keyspace, true);
 
     KeyspaceMetadata metadata = session().getMetadata().getKeyspace(storage.keyspace).get();
 
@@ -88,21 +89,25 @@ abstract class ITEnsureSchema extends ITStorage<CassandraStorage> {
   }
 
   @Test void upgradesOldSchema_autocomplete() {
-    Schema.applyCqlFile(storage.keyspace, session(), "/zipkin2-schema.cql");
-    Schema.applyCqlFile(storage.keyspace, session(), "/zipkin2-schema-indexes-original.cql");
+    Version version = Schema.ensureVersion(session().getMetadata());
+    Schema.applyCqlFile(version, storage.keyspace, session(), "/zipkin2-schema.cql");
+    Schema.applyCqlFile(version, storage.keyspace, session(),
+      "/zipkin2-schema-indexes-original.cql");
 
-    Schema.ensureExists(storage.keyspace, true, session());
+    Schema.ensureExists(session(), storage.keyspace, true);
 
     KeyspaceMetadata metadata = session().getMetadata().getKeyspace(storage.keyspace).get();
     assertThat(Schema.hasUpgrade1_autocompleteTags(metadata)).isTrue();
   }
 
   @Test void upgradesOldSchema_remoteService() {
-    Schema.applyCqlFile(storage.keyspace, session(), "/zipkin2-schema.cql");
-    Schema.applyCqlFile(storage.keyspace, session(), "/zipkin2-schema-indexes-original.cql");
-    Schema.applyCqlFile(storage.keyspace, session(), "/zipkin2-schema-upgrade-1.cql");
+    Version version = Schema.ensureVersion(session().getMetadata());
+    Schema.applyCqlFile(version, storage.keyspace, session(), "/zipkin2-schema.cql");
+    Schema.applyCqlFile(version, storage.keyspace, session(),
+      "/zipkin2-schema-indexes-original.cql");
+    Schema.applyCqlFile(version, storage.keyspace, session(), "/zipkin2-schema-upgrade-1.cql");
 
-    Schema.ensureExists(storage.keyspace, true, session());
+    Schema.ensureExists(session(), storage.keyspace, true);
 
     KeyspaceMetadata metadata = session().getMetadata().getKeyspace(storage.keyspace).get();
     assertThat(Schema.hasUpgrade2_remoteService(metadata)).isTrue();
@@ -110,9 +115,11 @@ abstract class ITEnsureSchema extends ITStorage<CassandraStorage> {
 
   /** This tests we don't accidentally rely on new indexes such as autocomplete tags */
   @Test void worksWithOldSchema(TestInfo testInfo) throws Exception {
+    Version version = Schema.ensureVersion(session().getMetadata());
     String testSuffix = testSuffix(testInfo);
-    Schema.applyCqlFile(storage.keyspace, session(), "/zipkin2-schema.cql");
-    Schema.applyCqlFile(storage.keyspace, session(), "/zipkin2-schema-indexes-original.cql");
+    Schema.applyCqlFile(version, storage.keyspace, session(), "/zipkin2-schema.cql");
+    Schema.applyCqlFile(version, storage.keyspace, session(),
+      "/zipkin2-schema-indexes-original.cql");
 
     // Ensure the storage component is functional before proceeding
     CheckResult check = storage.check();

--- a/zipkin/src/main/java/zipkin2/internal/ClosedComponentException.java
+++ b/zipkin/src/main/java/zipkin2/internal/ClosedComponentException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.internal;
+
+public final class ClosedComponentException extends IllegalStateException {
+  static final long serialVersionUID = -4636520624634625689L;
+
+  /** Convenience constructor that ensures the message is never null. */
+  public ClosedComponentException() {
+    this(null);
+  }
+
+  public ClosedComponentException(String message) {
+    super(message != null ? message : "closed");
+  }
+}


### PR DESCRIPTION
Before, you couldn't see any error when a health check fails in cassandra for an unresolvable reason. Now you do, including the statement that failed.

This is important as we cannot enable SASI on a running cluster. It must be enabled in whatever starts cassandra.

Fixes https://github.com/openzipkin/zipkin/issues/3412

```bash
$ STORAGE_TYPE=cassandra3 java -jar ./zipkin-server/target/zipkin-server-*exec.jar

                  oo
                 oooo
                oooooo
               oooooooo
              oooooooooo
             oooooooooooo
           ooooooo  ooooooo
          oooooo     ooooooo
         oooooo       ooooooo
        oooooo   o  o   oooooo
       oooooo   oo  oo   oooooo
     ooooooo  oooo  oooo  ooooooo
    oooooo   ooooo  ooooo  ooooooo
   oooooo   oooooo  oooooo  ooooooo
  oooooooo      oo  oo      oooooooo
  ooooooooooooo oo  oo ooooooooooooo
      oooooooooooo  oooooooooooo
          oooooooo  oooooooo
              oooo  oooo

     ________ ____  _  _____ _   _
    |__  /_ _|  _ \| |/ /_ _| \ | |
      / / | || |_) | ' / | ||  \| |
     / /_ | ||  __/| . \ | || |\  |
    |____|___|_|   |_|\_\___|_| \_|

:: version 3.1.1-SNAPSHOT :: commit 47e1668 ::

2024-03-07T08:02:22.739+08:00  INFO [/] 83635 --- [oss-http-*:9411] c.l.a.s.Server                           : Serving HTTP at /[0:0:0:0:0:0:0:0%0]:9411 - http://127.0.0.1:9411/
2024-03-07T08:02:40.128+08:00  INFO [/] 83635 --- [cking-tasks-2-1] z.s.c.Schema                             : Detected Cassandra version 4.1.4
2024-03-07T08:02:40.128+08:00  INFO [/] 83635 --- [cking-tasks-2-1] z.s.c.Schema                             : Installing schema /zipkin2-schema.cql for keyspace zipkin2
2024-03-07T08:02:46.044+08:00  INFO [/] 83635 --- [cking-tasks-2-1] z.s.c.Schema                             : Installing indexes /zipkin2-schema-indexes.cql for keyspace zipkin2
2024-03-07T08:02:47.184+08:00 ERROR [/] 83635 --- [cking-tasks-2-1] z.s.c.Schema                             : Failed to execute [CREATE CUSTOM INDEX IF NOT EXISTS ON zipkin2.span (l_service) USING 'org.apache.cassandra.index.sasi.SASIIndex'
   WITH OPTIONS = {'mode': 'PREFIX'}]: SASI indexes are disabled. Enable in cassandra.yaml to use.
```