### PR TITLE
docker: fixes ui example which extracted lens to the wrong path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 **
 
 # Scripts that run within Docker
+!build-bin/maybe_install_npm
 !build-bin/maven/maven_build
 !build-bin/maven/maven_build_or_unjar
 !build-bin/maven/maven_opts
@@ -48,11 +49,22 @@
 !zipkin-collector/kafka/src/main/**
 !zipkin-collector/rabbitmq/src/main/**
 !zipkin-collector/scribe/src/main/**
-!zipkin-junit/src/main/**
+!zipkin-junit5/src/main/**
 !zipkin-storage/src/main/**
 !zipkin-storage/cassandra/src/main/**
 !zipkin-storage/mysql-v1/src/main/**
 !zipkin-storage/elasticsearch/src/main/**
 !zipkin-server/src/main/**
 !zipkin-tests/src/main/**
+!zipkin-lens/javadoc/**
+!zipkin-lens/public/**
+!zipkin-lens/src/**
+!zipkin-lens/.linguirc
+!zipkin-lens/.npmrc
+!zipkin-lens/index.html
+!zipkin-lens/package-lock.json
+!zipkin-lens/package.json
+!zipkin-lens/pom.xml
+!zipkin-lens/tsconfig.json
+!zipkin-lens/vite.config.ts
 !**/pom.xml

--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -90,7 +90,7 @@ class ServerIntegratedBenchmark {
 
   @Test void elasticsearch() throws Exception {
     GenericContainer<?> elasticsearch =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:3.0.6"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:3.1.0"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("elasticsearch")
         .withLabel("name", "elasticsearch")
@@ -104,7 +104,7 @@ class ServerIntegratedBenchmark {
 
   @Test void cassandra3() throws Exception {
     GenericContainer<?> cassandra =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:3.0.6"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:3.1.0"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("cassandra")
         .withLabel("name", "cassandra")
@@ -118,7 +118,7 @@ class ServerIntegratedBenchmark {
 
   @Test void mysql() throws Exception {
     GenericContainer<?> mysql =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:3.0.6"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:3.1.0"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("mysql")
         .withLabel("name", "mysql")

--- a/build-bin/maybe_install_npm
+++ b/build-bin/maybe_install_npm
@@ -13,7 +13,6 @@
 # the License.
 #
 
-
 # This script hydrates the Maven and NPM cache to make later processes operate with less chance of
 # network problems.
 arch=$(uname -m)
@@ -29,11 +28,13 @@ esac
 # ARM64 is not supported with musl, yet https://github.com/nodejs/node/blob/master/BUILDING.md
 # Workaround this by installing node and npm directly. See issue #3166
 if [ ${arch} = "arm64" ] && [ -f /etc/alpine-release ]; then
-  # Get the version of nodejs the build uses. Note: this takes time as it downloads Maven plugins.
-  node_version=$(mvn help:evaluate -Dexpression=node.version -q -DforceStdout -pl zipkin-lens)
 
-  # Defensively avoid arm64+alpine problems with posix_spawn
-  export MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+  export MAVEN_OPTS="$($(dirname "$0")/maven/maven_opts)"
+  if [ -x ./mvnw ]; then alias mvn=${PWD}/mvnw; fi
+  if [ "${MAVEN_PROJECT_BASEDIR:-.}" != "." ]; then cd ${MAVEN_PROJECT_BASEDIR}; fi
+
+  # Get the version of nodejs the build uses. Note: this takes time as it downloads Maven plugins.
+  node_version=$(mvn help:evaluate -Dexpression=node.version -DskipTests -q -DforceStdout -pl zipkin-lens)
 
   set -x
   # Repos for https://pkgs.alpinelinux.org/packages?name=nodejs are already in the base image.

--- a/docker/examples/docker-compose-ui.yml
+++ b/docker/examples/docker-compose-ui.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 The OpenZipkin Authors
+# Copyright 2015-2024 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/test-images/zipkin-ui/Dockerfile
+++ b/docker/test-images/zipkin-ui/Dockerfile
@@ -32,9 +32,8 @@ FROM scratch as scratch
 COPY build-bin/ /build-bin/
 COPY build-bin/docker/docker-healthcheck /docker-bin/
 COPY docker/test-images/zipkin-ui/start-nginx /docker-bin/
-COPY pom.xml /code/
-COPY zipkin-lens/ /code/zipkin-lens/
 COPY docker/test-images/zipkin-ui/nginx.conf /conf.d/zipkin.conf.template
+COPY . /code/
 
 # This version is only used during the install process. Try to be consistent as it reduces layers,
 # which reduces downloads.
@@ -55,8 +54,9 @@ ENV RELEASE_FROM_MAVEN_BUILD=$release_from_maven_build
 # Version of the artifact to unjar. Ex. "2.4.5" or "2.4.5-SNAPSHOT" "master" to use the pom version.
 ARG version=master
 ENV VERSION=$version
-ENV MAVEN_PROJECT_BASEDIR=/code/zipkin-lens
-RUN /build-bin/maven/maven_build_or_unjar io.zipkin zipkin-lens ${VERSION}
+ENV MAVEN_PROJECT_BASEDIR=/code
+RUN if [ "${RELEASE_FROM_MAVEN_BUILD}" == "false" ]; then /build-bin/maybe_install_npm; fi; \
+    /build-bin/maven/maven_build_or_unjar io.zipkin zipkin-lens ${VERSION}
 
 FROM ghcr.io/openzipkin/alpine:$alpine_version as zipkin-ui
 LABEL org.opencontainers.image.description="NGINX on Alpine Linux hosting the Zipkin UI with Zipkin API proxy_pass"
@@ -73,7 +73,7 @@ HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthche
 ENTRYPOINT ["start-nginx"]
 
 # Add content and setup NGINX
-COPY --from=install /install/zipkin-lens/ /var/www/html/zipkin/
+COPY --from=install /install/zipkin-lens/* /var/www/html/zipkin/
 COPY --from=scratch /conf.d/ /etc/nginx/conf.d/
 RUN apk add --update --no-cache nginx=~${nginx_version} && \
     mkdir -p /var/tmp/nginx && chown -R nginx:nginx /var/tmp/nginx

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
@@ -63,7 +63,7 @@ class ActiveMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
     ActiveMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-activemq:3.0.6"));
+      super(parse("ghcr.io/openzipkin/zipkin-activemq:3.1.0"));
       withExposedPorts(ACTIVEMQ_PORT);
       waitStrategy = Wait.forListeningPorts(ACTIVEMQ_PORT);
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
@@ -92,7 +92,7 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.0.6"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.1.0"));
       waitStrategy = Wait.forHealthcheck();
       // 19092 is for connections from the Docker host and needs to be used as a fixed port.
       // TODO: someone who knows Kafka well, make ^^ comment better!

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
@@ -83,7 +83,7 @@ class RabbitMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
     RabbitMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.0.6"));
+      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.1.0"));
       withExposedPorts(RABBIT_PORT);
       waitStrategy = Wait.forLogMessage(".*Server startup complete.*", 1);
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-lens/README.md
+++ b/zipkin-lens/README.md
@@ -2,7 +2,7 @@
 
 Zipkin-lens is the UI for [Zipkin](https://github.com/openzipkin/zipkin). It is a modern replacement of the [classic](https://github.com/openzipkin-attic/zipkin-classic) UI which has proved its merit since the beginning of the Zipkin project.
 
-Here are a couple example screen shots:
+Here are a couple example screenshots:
 
 <img width="1920" alt="Search Screen" src="https://user-images.githubusercontent.com/64215/49579677-4602de00-f990-11e8-81b7-dd782ce91227.png">
 <img width="1920" alt="Trace Detail Screen" src="https://user-images.githubusercontent.com/64215/49579684-4d29ec00-f990-11e8-8799-5c53a503413e.png">
@@ -35,6 +35,13 @@ Builds the app for production to the `build` folder.<br />
 It correctly bundles React in production mode and optimizes the build for the best performance.
 
 ## Build tips
+
+### Maven build
+
+This project is not published to NPM, rather Maven, as the primary consumer is [zipkin-server](../zipkin-server).
+`../mvnw clean install` installs and builds via NPM. The resulting assets, such as index.html, are
+placed into the "zipkin-lens" directory of zipkin-lens.jar. This is published on release as
+[io.zipkin:zipkin-lens](https://central.sonatype.com/search?q=io.zipkin%3Azipkin-lens).
 
 ### Use the production node version
 
@@ -101,8 +108,13 @@ ProxyPassReverse "/proxy/foo/myzipkin"  "http://localhost:9411/zipkin/"
 For the reverse proxy configuration to work, Zipkin needs to be started with the `zipkin.ui.basepath`
 parameter pointing to the proxy path:
 
-```
+```bash
 java -jar zipkin.jar --zipkin.ui.basepath=/proxy/foo/myzipkin
+```
+
+or via docker
+```bash
+docker run -e ZIPKIN_UI_BASEPATH=/proxy/foo/myzipkin -p 9411:9411 openzipkin/zipkin
 ```
 
 ## Authentication / Authorization

--- a/zipkin-lens/pom.xml
+++ b/zipkin-lens/pom.xml
@@ -25,7 +25,7 @@
 
   <artifactId>zipkin-lens</artifactId>
   <name>Zipkin Lens</name>
-  <description>Repackages Zipkin Lens into a jar so we can use it in Spring Boot</description>
+  <description>Repackages Zipkin Lens into a jar, so we can use it in zipkin-server</description>
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
@@ -158,7 +158,7 @@
         <executions>
           <execution>
             <id>copy NPM build to zipkin-lens directory</id>
-            <!-- This needs to happen after compile or it could copy an empty directory! -->
+            <!-- This needs to happen after compile, or it could copy an empty directory! -->
             <phase>prepare-package</phase>
             <goals>
               <goal>copy-resources</goal>
@@ -171,6 +171,28 @@
                   <directory>build</directory>
                 </resource>
               </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- remove the META-INF directory, as this is just static assets -->
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>
@@ -262,21 +284,7 @@
                 <configuration>
                   <executable>npm</executable>
                   <arguments>
-                    <argument>install  --legacy-peer-deps</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-              <execution>
-                <id>npm lint</id>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <phase>compile</phase>
-                <configuration>
-                  <executable>npm</executable>
-                  <arguments>
-                    <argument>run</argument>
-                    <argument>lint</argument>
+                    <argument>install</argument>
                   </arguments>
                 </configuration>
               </execution>
@@ -291,21 +299,6 @@
                   <arguments>
                     <argument>run</argument>
                     <argument>build</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-              <execution>
-                <id>npm run test</id>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <phase>test</phase>
-                <configuration>
-                  <executable>npm</executable>
-                  <skip>${npm.skipTests}</skip>
-                  <arguments>
-                    <argument>run</argument>
-                    <argument>test</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/BaseITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/BaseITZipkinEureka.java
@@ -148,7 +148,7 @@ abstract class BaseITZipkinEureka {
     static final int EUREKA_PORT = 8761;
 
     EurekaContainer(Map<String, String> env) {
-      super(parse("ghcr.io/openzipkin/zipkin-eureka:3.0.6"));
+      super(parse("ghcr.io/openzipkin/zipkin-eureka:3.1.0"));
       withEnv(env);
       withExposedPorts(EUREKA_PORT);
       waitStrategy = Wait.forHealthcheck();

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraContainer.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraContainer.java
@@ -42,7 +42,7 @@ class CassandraContainer extends GenericContainer<CassandraContainer> {
   CqlSession globalSession;
 
   CassandraContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-cassandra:3.0.6"));
+    super(parse("ghcr.io/openzipkin/zipkin-cassandra:3.1.0"));
     addExposedPort(9042);
     waitStrategy = Wait.forHealthcheck();
     withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -126,7 +126,7 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {
     ElasticsearchContainer(int majorVersion) {
-      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":3.0.6"));
+      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":3.1.0"));
       addExposedPort(9200);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
@@ -112,7 +112,7 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class MySQLContainer extends GenericContainer<MySQLContainer> {
     MySQLContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-mysql:3.0.6"));
+      super(parse("ghcr.io/openzipkin/zipkin-mysql:3.1.0"));
       addExposedPort(3306);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));


### PR DESCRIPTION
We introduced a glitch I'm not sure when which extracted the UI to the wrong directory in our zipkin-ui test image

This would 404 because the index isn't at /index.html rather /zipkin-lens/index.html

This fixes that, as well some glitches I noticed in the build, for example being no longer able to build this in alpine.

Before
```bash
$ docker run --rm --entrypoint /bin/sh  ghcr.io/openzipkin/zipkin-ui:3.1.0 -c 'find /var/www/html'
/var/www/html
/var/www/html/zipkin
/var/www/html/zipkin/META-INF
/var/www/html/zipkin/META-INF/MANIFEST.MF
/var/www/html/zipkin/zipkin-lens
/var/www/html/zipkin/zipkin-lens/static
/var/www/html/zipkin/zipkin-lens/static/js
/var/www/html/zipkin/zipkin-lens/static/js/index.51c4d5b0.js
/var/www/html/zipkin/zipkin-lens/static/media
/var/www/html/zipkin/zipkin-lens/static/media/zipkin-logo.76388cfe.png
/var/www/html/zipkin/zipkin-lens/static/css
/var/www/html/zipkin/zipkin-lens/static/css/index.a7aa86b4.css
/var/www/html/zipkin/zipkin-lens/favicon.ico
/var/www/html/zipkin/zipkin-lens/index.html
```

After
```bash
$ docker run --rm --entrypoint /bin/sh  openzipkin/zipkin-ui:test -c 'find /var/www/html'
/var/www/html
/var/www/html/zipkin
/var/www/html/zipkin/static
/var/www/html/zipkin/static/js
/var/www/html/zipkin/static/js/index.51c4d5b0.js
/var/www/html/zipkin/static/media
/var/www/html/zipkin/static/media/zipkin-logo.76388cfe.png
/var/www/html/zipkin/static/css
/var/www/html/zipkin/static/css/index.a7aa86b4.css
/var/www/html/zipkin/favicon.ico
/var/www/html/zipkin/index.html
```