### PR TITLE
Use relative URLs in vite config

### DIFF
--- a/zipkin-lens/vite.config.ts
+++ b/zipkin-lens/vite.config.ts
@@ -17,7 +17,7 @@ import {defineConfig} from 'vite'
 import * as path from "path";
 
 // baseUrl is the default path to lookup assets.
-const baseUrl = process.env.BASE_URL || '/zipkin';
+const baseUrl = process.env.BASE_URL || './';
 // basePath is the default path to get dynamic resources from zipkin.
 const basePath = process.env.BASE_PATH || baseUrl;
 


### PR DESCRIPTION
Fixes #3742 

Note, I'm fine with reverting vite if it seems like it needs more baking, just sending this in case it helps since it was small.

I didn't check with an actual reverse proxy since it's a bit tedious, I ran

`ZIPKIN_UI_BASEPATH=/foo java -jar zipkin-server/target/zipkin-server-3.1.1-SNAPSHOT-exec.jar`

and saw this `index.html`. It's definitely not thorough testing tbh

```
<!--

    Copyright 2015-2024 The OpenZipkin Authors

    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
    in compliance with the License. You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing, software distributed under the License
    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
    or implied. See the License for the specific language governing permissions and limitations under
    the License.

-->
<!DOCTYPE html>
<html>
  <head>
    <base href="/foo/">
    <meta charset="utf-8" />
    <link rel="icon" href="./favicon.ico" />
    <script type="module" crossorigin src="./static/js/index.6af42604.js"></script>
    <link rel="stylesheet" href="./static/css/index.a7aa86b4.css">
  </head>
  <body>
    <noscript>You need to enable JavaScript to run this app.</noscript>
    <div id="root"></div>

  </body>
</html>
```