### PR TITLE
Fixed base path variable

### DIFF
--- a/zipkin-lens/index.html
+++ b/zipkin-lens/index.html
@@ -16,12 +16,10 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script>
-      window.BASE_URL = document.querySelector('base').getAttribute('href');
-    </script>
     <base href="/zipkin" >
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
+    <title>Zipkin</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/zipkin-lens/index.html
+++ b/zipkin-lens/index.html
@@ -16,6 +16,9 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <script>
+      window.BASE_URL = document.querySelector('base').getAttribute('href');
+    </script>
     <base href="/zipkin" >
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />

--- a/zipkin-lens/vite.config.ts
+++ b/zipkin-lens/vite.config.ts
@@ -44,12 +44,6 @@ export default defineConfig(() => {
     test: {
       environment: 'happy-dom'
     },
-    plugins: [
-      {
-        name: 'Replace head.base.href with BASE_PATH variable',
-        transformIndexHtml: html => html.replace('href="/zipkin"', `href="${basePath}"`)
-      },
-    ],
     base: baseUrl,
     build: {
       outDir: 'build',
@@ -57,7 +51,9 @@ export default defineConfig(() => {
       assetsDir: "static",
       rollupOptions: {
         output: {
-          assetFileNames({name}) {
+          assetFileNames({name}: {
+            name: string
+          }) {
             if (name?.includes('.css')) return 'static/css/[name].[hash].css'
             if (name?.includes('.png')) return 'static/media/[name].[hash].png'
             return 'static/[name].[hash][extname]'

--- a/zipkin-lens/vite.config.ts
+++ b/zipkin-lens/vite.config.ts
@@ -18,7 +18,6 @@ import * as path from "path";
 
 // baseUrl is the default path to lookup assets.
 const baseUrl = process.env.BASE_URL || '/zipkin';
-// basePath is the default path to get dynamic resources from zipkin.
 
 const zipkinProxyConfig = {
   target: process.env.API_BASE || 'http://localhost:9411',

--- a/zipkin-lens/vite.config.ts
+++ b/zipkin-lens/vite.config.ts
@@ -13,20 +13,19 @@
  */
 /// <reference types="vitest" />
 
-import {defineConfig} from 'vite'
+import {defineConfig, UserConfig} from 'vite'
 import * as path from "path";
 
 // baseUrl is the default path to lookup assets.
 const baseUrl = process.env.BASE_URL || '/zipkin';
 // basePath is the default path to get dynamic resources from zipkin.
-const basePath = process.env.BASE_PATH || baseUrl;
 
 const zipkinProxyConfig = {
   target: process.env.API_BASE || 'http://localhost:9411',
   changeOrigin: true,
 };
 
-export default defineConfig(() => {
+export default defineConfig(():UserConfig => {
   // https://vitejs.dev/config/
   return {
     server: {
@@ -41,6 +40,7 @@ export default defineConfig(() => {
         src: path.resolve('src/'),
       },
     },
+    // @ts-ignore
     test: {
       environment: 'happy-dom'
     },
@@ -51,9 +51,7 @@ export default defineConfig(() => {
       assetsDir: "static",
       rollupOptions: {
         output: {
-          assetFileNames({name}: {
-            name: string
-          }) {
+          assetFileNames({name}):string {
             if (name?.includes('.css')) return 'static/css/[name].[hash].css'
             if (name?.includes('.png')) return 'static/media/[name].[hash].png'
             return 'static/[name].[hash][extname]'

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -171,9 +171,9 @@ public class ZipkinUiConfiguration {
       String content = StreamUtils.copyToString(stream, UTF_8);
       if (DEFAULT_BASEPATH.equals(basePath)) return content;
 
-      // Rebase any href inside index.html to the indicated value
-      String baseTagValue = "/".equals(basePath) ? "/" : basePath;
-      return content.replaceAll(DEFAULT_BASEPATH, baseTagValue);
+      // Rebase any href or src in index.html that starts with DEFAULT_BASEPATH
+      String baseTagValue = "/".equals(basePath) ? "" : basePath;
+      return content.replaceAll("=\"" + DEFAULT_BASEPATH, "=\"" + baseTagValue);
     }
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -175,7 +175,7 @@ public class ZipkinUiConfiguration {
       // html-webpack-plugin seems to strip out quotes from the base tag when compiling so be
       // careful with this matcher.
       return content.replaceAll(
-        "<base href=[^>]+>", "<base href=\"" + baseTagValue + "\">"
+        "/zipkin/", baseTagValue
       );
     }
   }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -172,8 +172,8 @@ public class ZipkinUiConfiguration {
       if (DEFAULT_BASEPATH.equals(basePath)) return content;
 
       // Rebase any href inside index.html to the indicated value
-      String baseTagValue = "/".equals(basePath) ? "/" : basePath + "/";
-      return content.replaceAll("/zipkin/", baseTagValue);
+      String baseTagValue = "/".equals(basePath) ? "/" : basePath;
+      return content.replaceAll(DEFAULT_BASEPATH, baseTagValue);
     }
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -171,12 +171,9 @@ public class ZipkinUiConfiguration {
       String content = StreamUtils.copyToString(stream, UTF_8);
       if (DEFAULT_BASEPATH.equals(basePath)) return content;
 
+      // Rebase any href inside index.html to the indicated value
       String baseTagValue = "/".equals(basePath) ? "/" : basePath + "/";
-      // html-webpack-plugin seems to strip out quotes from the base tag when compiling so be
-      // careful with this matcher.
-      return content.replaceAll(
-        "/zipkin/", baseTagValue
-      ).replaceAll( "<base href=[^>]+>", "<base href=\"" + baseTagValue + "\">");
+      return content.replaceAll("/zipkin/", baseTagValue);
     }
   }
 }

--- a/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ui/ZipkinUiConfiguration.java
@@ -176,7 +176,7 @@ public class ZipkinUiConfiguration {
       // careful with this matcher.
       return content.replaceAll(
         "/zipkin/", baseTagValue
-      );
+      ).replaceAll( "<base href=[^>]+>", "<base href=\"" + baseTagValue + "\">");
     }
   }
 }

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ITZipkinUiConfiguration.java
@@ -120,9 +120,19 @@ class ITZipkinUiConfiguration {
    * index.html
    */
   @Test void replacesBaseTag() throws Exception {
-    assertThat(get("/zipkin/index.html").body().string())
-      .isEqualToIgnoringWhitespace(stringFromClasspath(getClass(), "zipkin-lens/index.html")
-        .replace("<base href=\"/\" />", "<base href=\"/foozipkin/\">"));
+    assertThat(get("/zipkin/index.html").body().string()).isEqualTo("""
+      <!-- simplified version of /zipkin-lens/index.html -->
+      <html>
+        <head>
+          <base href="/foozipkin/">
+          <link rel="icon" href="/foozipkin/favicon.ico">
+          <script type="module" crossorigin="" src="/foozipkin/static/js/index.js"></script>
+          <link rel="stylesheet" href="/foozipkin/static/css/index.css">
+        </head>
+        <body>zipkin-lens</body>
+      </html>
+      """
+    );
   }
 
   /** index.html is served separately. This tests other content is also loaded from the classpath. */

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
@@ -154,7 +154,7 @@ class ZipkinUiConfigurationTest {
     context = createContextWithOverridenProperty("zipkin.ui.basepath:/foo/bar");
 
     assertThat(serveIndex().contentUtf8()).isEqualTo("""
-      <!-- simplified version of /foo/bar-lens/index.html -->
+      <!-- simplified version of /zipkin-lens/index.html -->
       <html>
         <head>
           <base href="/foo/bar/">
@@ -178,8 +178,19 @@ class ZipkinUiConfigurationTest {
   @Test void canOverrideProperty_specialCaseRoot() {
     context = createContextWithOverridenProperty("zipkin.ui.basepath:/");
 
-    assertThat(serveIndex().contentUtf8())
-      .contains("<base href=\"/\">");
+    assertThat(serveIndex().contentUtf8()).isEqualTo("""
+      <!-- simplified version of /zipkin-lens/index.html -->
+      <html>
+        <head>
+          <base href="/">
+          <link rel="icon" href="/favicon.ico">
+          <script type="module" crossorigin="" src="/static/js/index.js"></script>
+          <link rel="stylesheet" href="/static/css/index.css">
+        </head>
+        <body>zipkin-lens</body>
+      </html>
+      """
+    );
   }
 
   AggregatedHttpResponse serveIndex(Cookie... cookies) {

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
@@ -154,7 +154,7 @@ class ZipkinUiConfigurationTest {
     context = createContextWithOverridenProperty("zipkin.ui.basepath:/foo/bar");
 
     assertThat(serveIndex().contentUtf8()).isEqualTo("""
-      <!-- simplified version of /zipkin-lens/index.html -->
+      <!-- simplified version of /foo/bar-lens/index.html -->
       <html>
         <head>
           <base href="/foo/bar/">

--- a/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/ui/ZipkinUiConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 The OpenZipkin Authors
+ * Copyright 2015-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -153,8 +153,19 @@ class ZipkinUiConfigurationTest {
   @Test void canOverrideProperty_basePath() {
     context = createContextWithOverridenProperty("zipkin.ui.basepath:/foo/bar");
 
-    assertThat(serveIndex().contentUtf8())
-      .contains("<base href=\"/foo/bar/\">");
+    assertThat(serveIndex().contentUtf8()).isEqualTo("""
+      <!-- simplified version of /zipkin-lens/index.html -->
+      <html>
+        <head>
+          <base href="/foo/bar/">
+          <link rel="icon" href="/foo/bar/favicon.ico">
+          <script type="module" crossorigin="" src="/foo/bar/static/js/index.js"></script>
+          <link rel="stylesheet" href="/foo/bar/static/css/index.css">
+        </head>
+        <body>zipkin-lens</body>
+      </html>
+      """
+    );
   }
 
   @Test void lensCookieOverridesIndex() {

--- a/zipkin-server/src/test/resources/zipkin-lens/index.html
+++ b/zipkin-server/src/test/resources/zipkin-lens/index.html
@@ -1,6 +1,10 @@
+<!-- simplified version of /zipkin-lens/index.html -->
 <html>
   <head>
-    <base href="/" />
+    <base href="/zipkin/">
+    <link rel="icon" href="/zipkin/favicon.ico">
+    <script type="module" crossorigin="" src="/zipkin/static/js/index.js"></script>
+    <link rel="stylesheet" href="/zipkin/static/css/index.css">
   </head>
   <body>zipkin-lens</body>
 </html>


### PR DESCRIPTION
## Description

This pr solves the issues with the base uri path. In React Scripts everything depended from a so called base tag. This base tag was rewritten when serving the frontend leading to the JavaScript and CSS being loaded from the rewritten tag in the Java code.  This pr simply takes all resource links and points them to a new location that is set via the properties.


## What does this pr not solve

During my testing I realized that you still need a proxy that rewrites the paths and fetches them from the original location. Only the paths in the index.html are rewritten. So the resource location needs to be configured via proxy config but this seems to be also the case before.


Closes #3742 