### PR TITLE
Fix ServerIntegratedBenchmark

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -179,6 +179,44 @@
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- overrides from zipkin-server project are not picked up here so redefine -->
+    <!-- temporary until netty-4.1.108.Final -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.63.Final</version>
+      <classifier>linux-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.63.Final</version>
+      <classifier>linux-aarch_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.63.Final</version>
+      <classifier>osx-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.63.Final</version>
+      <classifier>osx-aarch_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.63.Final</version>
+      <classifier>windows-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -324,7 +324,7 @@ class ServerIntegratedBenchmark {
       .withNetworkAliases("zipkin")
       .withExposedPorts(9411)
       .withEnv(env)
-      .waitingFor(Wait.forHealthcheck());
+      .waitingFor(Wait.forHttp("/health"));
     containers.add(zipkin);
     return zipkin;
   }

--- a/benchmarks/src/test/resources/log4j2.properties
+++ b/benchmarks/src/test/resources/log4j2.properties
@@ -1,0 +1,23 @@
+#
+# Copyright 2015-2024 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/benchmarks/src/test/resources/simplelogger.properties
+++ b/benchmarks/src/test/resources/simplelogger.properties
@@ -1,6 +1,0 @@
-# See https://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html for the full list of config options
-
-org.slf4j.simpleLogger.logFile=System.out
-org.slf4j.simpleLogger.defaultLogLevel=info
-org.slf4j.simpleLogger.showDateTime=true
-org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS


### PR DESCRIPTION
Fixes #3646 

I found some issues

- log backend is log4j, not simple logger so lack of file prevented any logging to debug. I figured replacing the config is better than tracking out the log4j transitive
- The netty version override didn't seem to be kicking in. Sorry, I'm not generally experienced with Maven and also rusty in Java so just redefining is the only approach I could find
- Something about the healthcheck change doesn't seem to interact well with testcontainers. Doing a direct ping without involving curl instead seems fine to me