### PR TITLE
docker: fix cassandra pip install and bump all images

### DIFF
--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -81,7 +81,7 @@ class ServerIntegratedBenchmark {
 
   @Test void elasticsearch() throws Exception {
     GenericContainer<?> elasticsearch =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:3.1.0"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-elasticsearch7:3.1.1"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("elasticsearch")
         .withLabel("name", "elasticsearch")
@@ -95,7 +95,7 @@ class ServerIntegratedBenchmark {
 
   @Test void cassandra3() throws Exception {
     GenericContainer<?> cassandra =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:3.1.0"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-cassandra:3.1.1"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("cassandra")
         .withLabel("name", "cassandra")
@@ -109,7 +109,7 @@ class ServerIntegratedBenchmark {
 
   @Test void mysql() throws Exception {
     GenericContainer<?> mysql =
-      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:3.1.0"))
+      new GenericContainer<>(parse("ghcr.io/openzipkin/zipkin-mysql:3.1.1"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("mysql")
         .withLabel("name", "mysql")
@@ -147,7 +147,7 @@ class ServerIntegratedBenchmark {
     // Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
     // Use same version as in docker/examples/docker-compose-prometheus.yml
     GenericContainer<?> prometheus =
-      new GenericContainer<>(parse("quay.io/prometheus/prometheus:v2.48.0"))
+      new GenericContainer<>(parse("quay.io/prometheus/prometheus:v2.51.2"))
         .withNetwork(Network.SHARED)
         .withNetworkAliases("prometheus")
         .withExposedPorts(9090)
@@ -157,7 +157,7 @@ class ServerIntegratedBenchmark {
 
     // Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
     // Use same version as in docker/examples/docker-compose-prometheus.yml
-    GenericContainer<?> grafana = new GenericContainer<>(parse("quay.io/giantswarm/grafana:7.5.4"))
+    GenericContainer<?> grafana = new GenericContainer<>(parse("quay.io/giantswarm/grafana:7.5.9"))
       .withNetwork(Network.SHARED)
       .withNetworkAliases("grafana")
       .withExposedPorts(3000)
@@ -169,7 +169,7 @@ class ServerIntegratedBenchmark {
     // Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
     // Use same version as in docker/examples/docker-compose-prometheus.yml
     GenericContainer<?> grafanaDashboards =
-      new GenericContainer<>(parse("quay.io/cilium/alpine-curl:v1.8.0"))
+      new GenericContainer<>(parse("quay.io/cilium/alpine-curl:v1.9.0"))
         .withNetwork(Network.SHARED)
         .withWorkingDirectory("/tmp")
         .withLogConsumer(new Slf4jLogConsumer(LOG))

--- a/docker/examples/docker-compose-prometheus.yml
+++ b/docker/examples/docker-compose-prometheus.yml
@@ -16,7 +16,7 @@ services:
   prometheus:
     # Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
     # Use latest from https://quay.io/repository/prometheus/prometheus?tab=tags
-    image: quay.io/prometheus/prometheus:v2.48.0
+    image: quay.io/prometheus/prometheus:v2.51.2
     container_name: prometheus
     ports:
       - 9090:9090
@@ -29,7 +29,7 @@ services:
   grafana:
     # Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
     # Use latest from https://quay.io/repository/app-sre/grafana?tab=tags
-    image: quay.io/giantswarm/grafana:7.5.4
+    image: quay.io/giantswarm/grafana:7.5.9
     container_name: grafana
     ports:
       - 3000:3000
@@ -43,7 +43,7 @@ services:
     # This is an arbitrary small image that has curl installed
     # Use a quay.io mirror to prevent build outages due to Docker Hub pull quotas
     # Use latest from https://quay.io/repository/quay.io/rackspace/curl?tab=tags
-    image: quay.io/cilium/alpine-curl:v1.8.0
+    image: quay.io/cilium/alpine-curl:v1.9.0
     container_name: setup_grafana_datasource
     depends_on:
       - grafana

--- a/docker/test-images/zipkin-activemq/Dockerfile
+++ b/docker/test-images/zipkin-activemq/Dockerfile
@@ -23,7 +23,7 @@ FROM ghcr.io/openzipkin/java:${java_version} as install
 WORKDIR /install
 
 # Use latest version from https://activemq.apache.org/components/classic/download/
-ARG activemq_version=6.0.1
+ARG activemq_version=6.1.1
 
 # Download the distribution
 RUN \
@@ -37,7 +37,7 @@ https://archive.apache.org/dist/activemq/${activemq_version}/apache-activemq-${a
 # which isn't in our JRE.
 FROM ghcr.io/openzipkin/java:${java_version} as zipkin-activemq
 LABEL org.opencontainers.image.description="ActiveMQ Classic on OpenJDK and Alpine Linux"
-ARG activemq_version=6.0.1
+ARG activemq_version=6.1.1
 LABEL activemq-version=$activemq_version
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path

--- a/docker/test-images/zipkin-cassandra/install.sh
+++ b/docker/test-images/zipkin-cassandra/install.sh
@@ -170,13 +170,16 @@ is_cassandra_alive() {
 is_cassandra_alive || exit 1
 
 echo "*** Installing cqlsh"
-apk add --update --no-cache python3
+# cqlsh 4.x is not compatible with Python 3.12 by default.
+# See https://issues.apache.org/jira/browse/CASSANDRA-19206
+python3_version=3.11
+apk add --update --no-cache python3=~${python3_version}
 # Installing cqlsh requires cffi package. Normally this doesn't need
 # to be compiled, but something isn't right with aarch64 when installing
 # cqlsh it needs to build cffi. To unblock support for aarch64, adding
 # the following are necessary for compiling cffi. If pip someday changes and
 # doesn't compile cffi on aarch64 then we can remove these dependencies.
-apk add --update --no-cache gcc python3-dev musl-dev libffi-dev
+apk add --update --no-cache gcc python3-dev=~${python3_version} musl-dev libffi-dev
 # PEP 668 protects against mixing system and pip packages. Setup virtual env to avoid this.
 python3 -m venv .venv
 . .venv/bin/activate

--- a/docker/test-images/zipkin-cassandra/install.sh
+++ b/docker/test-images/zipkin-cassandra/install.sh
@@ -47,7 +47,7 @@ cat > pom.xml <<-'EOF'
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>5.13.0</version>
+      <version>5.14.0</version>
     </dependency>
     <!-- log4j not logback -->
     <dependency>
@@ -170,7 +170,7 @@ is_cassandra_alive() {
 is_cassandra_alive || exit 1
 
 echo "*** Installing cqlsh"
-apk add --update --no-cache python3 py3-pip
+apk add --update --no-cache python3
 # Installing cqlsh requires cffi package. Normally this doesn't need
 # to be compiled, but something isn't right with aarch64 when installing
 # cqlsh it needs to build cffi. To unblock support for aarch64, adding
@@ -180,6 +180,7 @@ apk add --update --no-cache gcc python3-dev musl-dev libffi-dev
 # PEP 668 protects against mixing system and pip packages. Setup virtual env to avoid this.
 python3 -m venv .venv
 . .venv/bin/activate
+python3 -m ensurepip --upgrade
 pip install -Iq cqlsh
 cql() {
   cqlsh "$@" 127.0.0.1 ${temp_native_transport_port}

--- a/docker/test-images/zipkin-elasticsearch7/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch7/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /install
 # Use latest 7.x version from https://www.elastic.co/downloads/past-releases#elasticsearch-no-jdk
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG elasticsearch7_version=7.17.18
+ARG elasticsearch7_version=7.17.20
 
 # Download only the OSS distribution (lacks X-Pack)
 RUN \
@@ -41,7 +41,7 @@ COPY --from=scratch /config/ ./config/
 # production -jre base layer used by zipkin and zipkin-slim.
 FROM ghcr.io/openzipkin/java:${java_version} as zipkin-elasticsearch7
 LABEL org.opencontainers.image.description="Elasticsearch distribution on OpenJDK and Alpine Linux"
-ARG elasticsearch7_version=7.17.18
+ARG elasticsearch7_version=7.17.20
 LABEL elasticsearch-version=$elasticsearch7_version
 
 # The full license is also included in the image at /elasticsearch/LICENSE.txt.

--- a/docker/test-images/zipkin-elasticsearch8/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch8/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /install
 # Use latest 8.x version from https://www.elastic.co/downloads/past-releases#elasticsearch
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG elasticsearch8_version=8.12.2
+ARG elasticsearch8_version=8.13.2
 
 # Download only the OSS distribution (lacks X-Pack)
 RUN \
@@ -41,7 +41,7 @@ COPY --from=scratch /config/ ./config/
 # production -jre base layer used by zipkin and zipkin-slim.
 FROM ghcr.io/openzipkin/java:${java_version} as zipkin-elasticsearch8
 LABEL org.opencontainers.image.description="Elasticsearch distribution on OpenJDK and Alpine Linux"
-ARG elasticsearch8_version=8.12.2
+ARG elasticsearch8_version=8.13.2
 LABEL elasticsearch-version=$elasticsearch8_version
 
 # The full license is also included in the image at /elasticsearch/LICENSE.txt.

--- a/docker/test-images/zipkin-eureka/pom.xml
+++ b/docker/test-images/zipkin-eureka/pom.xml
@@ -29,7 +29,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -37,7 +37,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.0.0-jre</version>
+        <version>33.1.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
-      <version>4.1.0</version>
+      <version>4.1.1</version>
       <exclusions>
         <!-- dodge spring-jcl conflict error -->
         <exclusion>

--- a/docker/test-images/zipkin-eureka/pom.xml
+++ b/docker/test-images/zipkin-eureka/pom.xml
@@ -49,6 +49,11 @@
         <artifactId>httpclient</artifactId>
         <version>4.5.14</version>
       </dependency>
+      <dependency>
+        <groupId>software.amazon.ion</groupId>
+        <artifactId>ion-java</artifactId>
+        <version>1.5.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/docker/test-images/zipkin-mysql/Dockerfile
+++ b/docker/test-images/zipkin-mysql/Dockerfile
@@ -28,7 +28,7 @@ HEALTHCHECK --interval=1s --start-period=30s --timeout=5s CMD ["docker-healthche
 ENTRYPOINT ["start-mysql"]
 
 # Use latest from https://pkgs.alpinelinux.org/packages?name=mysql (without the -r[0-9])
-ARG mysql_version=10.11.6
+ARG mysql_version=10.11.7
 LABEL mysql-version=$mysql_version
 ENV MYSQL_VERSION=$mysql_version
 

--- a/docker/test-images/zipkin-rabbitmq/Dockerfile
+++ b/docker/test-images/zipkin-rabbitmq/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Use latest from https://hub.docker.com/_/rabbitmq/tags?page=1&name=alpine
-ARG rabbitmq_version=3.13.0
+ARG rabbitmq_version=3.13.1
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
+++ b/zipkin-collector/activemq/src/test/java/zipkin2/collector/activemq/ActiveMQExtension.java
@@ -54,7 +54,7 @@ class ActiveMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
     ActiveMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-activemq:3.1.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-activemq:3.1.1"));
       withExposedPorts(ACTIVEMQ_PORT);
       waitStrategy = Wait.forListeningPorts(ACTIVEMQ_PORT);
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
+++ b/zipkin-collector/kafka/src/test/java/zipkin2/collector/kafka/KafkaExtension.java
@@ -83,7 +83,7 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.1.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.1.1"));
       waitStrategy = Wait.forHealthcheck();
       // 19092 is for connections from the Docker host and needs to be used as a fixed port.
       // TODO: someone who knows Kafka well, make ^^ comment better!

--- a/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
+++ b/zipkin-collector/rabbitmq/src/test/java/zipkin2/collector/rabbitmq/RabbitMQExtension.java
@@ -74,7 +74,7 @@ class RabbitMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
     RabbitMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.1.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.1.1"));
       withExposedPorts(RABBIT_PORT);
       waitStrategy = Wait.forLogMessage(".*Server startup complete.*", 1);
       withStartupTimeout(Duration.ofSeconds(60));

--- a/zipkin-server/src/test/java/zipkin2/server/internal/eureka/BaseITZipkinEureka.java
+++ b/zipkin-server/src/test/java/zipkin2/server/internal/eureka/BaseITZipkinEureka.java
@@ -139,7 +139,7 @@ abstract class BaseITZipkinEureka {
     static final int EUREKA_PORT = 8761;
 
     EurekaContainer(Map<String, String> env) {
-      super(parse("ghcr.io/openzipkin/zipkin-eureka:3.1.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-eureka:3.1.1"));
       withEnv(env);
       withExposedPorts(EUREKA_PORT);
       waitStrategy = Wait.forHealthcheck();

--- a/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraContainer.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin2/storage/cassandra/CassandraContainer.java
@@ -33,7 +33,7 @@ class CassandraContainer extends GenericContainer<CassandraContainer> {
   CqlSession globalSession;
 
   CassandraContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-cassandra:3.1.0"));
+    super(parse("ghcr.io/openzipkin/zipkin-cassandra:3.1.1"));
     addExposedPort(9042);
     waitStrategy = Wait.forHealthcheck();
     withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin2/elasticsearch/integration/ElasticsearchExtension.java
@@ -117,7 +117,7 @@ class ElasticsearchExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {
     ElasticsearchContainer(int majorVersion) {
-      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":3.1.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-elasticsearch" + majorVersion + ":3.1.1"));
       addExposedPort(9200);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
+++ b/zipkin-storage/mysql-v1/src/test/java/zipkin2/storage/mysql/v1/MySQLExtension.java
@@ -103,7 +103,7 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class MySQLContainer extends GenericContainer<MySQLContainer> {
     MySQLContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-mysql:3.1.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-mysql:3.1.1"));
       addExposedPort(3306);
       waitStrategy = Wait.forHealthcheck();
       withLogConsumer(new Slf4jLogConsumer(LOGGER));


### PR DESCRIPTION
cqlsh 4.x is not compatible with Python 3.12 by default.

See https://issues.apache.org/jira/browse/CASSANDRA-19206