### PR TITLE
Restores tcnative accidentally left out of 3.2.0

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -136,11 +136,6 @@
           <groupId>javax.validation</groupId>
           <artifactId>validation-api</artifactId>
         </exclusion>
-        <!-- temporary until netty-4.1.108.Final -->
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-tcnative-boringssl-static</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
noticed on this https://github.com/openzipkin/zipkin-aws/actions/runs/8675192619/job/23788344847?pr=218