### PR TITLE
docker: fixes building zipkin from source on arm64

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,7 @@ ENV VERSION=$version
 ENV MAVEN_PROJECT_BASEDIR=/code
 ARG TARGETARCH
 RUN test "${TARGETARCH}" != "" && \
+    if [ "${RELEASE_FROM_MAVEN_BUILD}" == "false" ]; then /code/build-bin/maybe_install_npm; fi; \
     /code/build-bin/maven/maven_build_or_unjar io.zipkin zipkin-server ${VERSION} exec && \
     mv zipkin-server zipkin && \
     /code/build-bin/maven/maven_build_or_unjar io.zipkin zipkin-server ${VERSION} slim && \


### PR DESCRIPTION
somehow we didn't copy the same thing needed from the zipkin-ui Dockerfile. zipkin-lens needs node on arm64