### PR TITLE
docker: updates zipkin-cassandra test image to 4.1.8

### DIFF
--- a/docker/test-images/zipkin-cassandra/Dockerfile
+++ b/docker/test-images/zipkin-cassandra/Dockerfile
@@ -25,8 +25,7 @@ FROM ghcr.io/openzipkin/java:${java_version} as install
 # Use latest stable version: https://cassandra.apache.org/download/
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-# TODO: revlocked, so probably put effort into 5.x instead
-ARG cassandra_version=4.1.7
+ARG cassandra_version=4.1.8
 ENV CASSANDRA_VERSION=$cassandra_version
 WORKDIR /install
 
@@ -36,7 +35,7 @@ RUN /tmp/install.sh && rm /tmp/install.sh
 
 FROM ghcr.io/openzipkin/java:${java_version}-jre as zipkin-cassandra
 LABEL org.opencontainers.image.description="Cassandra on OpenJDK and Alpine Linux with Zipkin keyspaces pre-installed"
-ARG cassandra_version=4.1.7
+ARG cassandra_version=4.1.8
 LABEL cassandra-version=$cassandra_version
 ENV CASSANDRA_VERSION=$cassandra_version
 

--- a/docker/test-images/zipkin-cassandra/install.sh
+++ b/docker/test-images/zipkin-cassandra/install.sh
@@ -53,7 +53,7 @@ cat > pom.xml <<-'EOF'
       <artifactId>jna</artifactId>
       <version>5.16.0</version>
     </dependency>
-    <!-- Use latest to work with JRE 21 -->
+    <!-- Use latest to work with JRE 21 per CASSANDRA-18329 -->
     <dependency>
       <groupId>com.github.jbellis</groupId>
       <artifactId>jamm</artifactId>
@@ -73,10 +73,12 @@ mvn -q --batch-mode -DoutputDirectory=lib \
     org.apache.maven.plugins:maven-dependency-plugin:3.8.1:copy-dependencies
 rm pom.xml
 
-# Patch Cassandra 4.1's ObjectSizes.java to work with newer jamm.
+# Get a version of ObjectSizes.java that compiles with jamm 0.4.0
 wget --random-wait --tries=5 -qO ObjectSizes.java \
   https://raw.githubusercontent.com/apache/cassandra/refs/tags/cassandra-5.0.3/src/java/org/apache/cassandra/utils/ObjectSizes.java
+# Rename a public method back to the same name as used in Cassandra 4.1.
 sed -i 's/sizeOnHeapExcludingDataOf/sizeOnHeapExcludingData/g' ObjectSizes.java
+# Compile it into classes, which overrides the same class from Cassandra 4.1.
 javac -cp 'lib/*' -d classes ObjectSizes.java
 
 # Make sure you use relative paths in references like this, so that installation


### PR DESCRIPTION
If you just update to 4.1.8 and change nothing else, you'll crash like this:

```
14.33 [2025-02-16 11:04:06,099] ERROR Exception encountered during startup (org.apache.cassandra.service.CassandraDaemon)
14.33 java.lang.UnsupportedOperationException: can't get field offset on a hidden class: private final org.apache.cassandra.db.ClusteringComparator org.apache.cassandra.db.ClusteringComparator$$Lambda/0x000000e0012f5220.arg$1
14.33 	at jdk.unsupported/sun.misc.Unsafe.objectFieldOffset(Unsafe.java:652)
14.33 	at org.github.jamm.MemoryLayoutSpecification.sizeOfInstanceWithUnsafe(MemoryLayoutSpecification.java:108)
14.33 	at org.github.jamm.MemoryLayoutSpecification.sizeOfWithUnsafe(MemoryLayoutSpecification.java:89)
14.33 	at org.github.jamm.MemoryMeter.measure(MemoryMeter.java:217)
14.33 	at org.github.jamm.MemoryMeter.measureDeep(MemoryMeter.java:259)
14.33 	at org.apache.cassandra.utils.ObjectSizes.measureDeep(ObjectSizes.java:219)
14.33 	at org.apache.cassandra.cql3.QueryProcessor.measurePstmnt(QueryProcessor.java:912)
14.33 	at org.apache.cassandra.cql3.QueryProcessor.parseAndPrepare(QueryProcessor.java:445)
14.33 	at org.apache.cassandra.cql3.QueryProcessor.prepareInternal(QueryProcessor.java:414)
14.33 	at org.apache.cassandra.cql3.QueryProcessor.executeInternal(QueryProcessor.java:452)
14.33 	at org.apache.cassandra.db.SystemKeyspace.checkHealth(SystemKeyspace.java:1087)
14.33 	at org.apache.cassandra.service.StartupChecks$13.execute(StartupChecks.java:630)
14.33 	at org.apache.cassandra.service.StartupChecks.verify(StartupChecks.java:174)
14.33 	at org.apache.cassandra.service.CassandraDaemon.runStartupChecks(CassandraDaemon.java:499)
14.33 	at org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:253)
14.33 	at org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:744)
14.33 	at org.apache.cassandra.service.CassandraDaemon.main(CassandraDaemon.java:878)
```

This is due ultimately to needing to upgrade jamm, which had some signature drift. [CASSANDRA-18329](https://issues.apache.org/jira/browse/CASSANDRA-18329) fixes this in 5.0, but not in 4.1.

[CASSANDRA-18329](https://issues.apache.org/jira/browse/CASSANDRA-18329) fixed this particularly by [updating call sites to jamm in ObjectSizes.java](https://github.com/apache/cassandra/commit/600f4d9a690dbd887d5e6298fe67e6bba982033d#diff-1122d7d3efe9721af7244d373e66378f7e90cb05fd65859a52e8a3ea58a7c8f9).

We use JRE 21 in our test image even though cassandra 4.1 doesn't really support it, to save base layers. The easiest way to fix this was to grab the ObjectSizes.java file from 5.0.3 and the revert their renaming of a public method so it could be a drop in patch.