### PR TITLE
Fix invalid comparison of Elasticsearch version string

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/BaseVersion.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin2/elasticsearch/BaseVersion.java
@@ -69,10 +69,13 @@ public abstract class BaseVersion {
         if (enterPath(parser, "version") != null) {
           while (parser.nextToken() != null) {
             if (parser.currentToken() == JsonToken.VALUE_STRING) {
-              if (parser.currentName() == "distribution") {
-                distribution = parser.getText();
-              } else if (parser.currentName() == "number") {
-                version = parser.getText();
+              switch (parser.currentName()) {
+                case "distribution":
+                  distribution = parser.getText();
+                  break;
+                case "number":
+                  version = parser.getText();
+                  break;
               }
             }
           }


### PR DESCRIPTION
Must use equals() or switch-case to compare Strings.

See https://github.com/openzipkin/zipkin/issues/3796#issuecomment-3227538965