### PR TITLE
Switch from OSSRH to Sonatype Central Portal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,8 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           # SONATYPE_USER=<sonatype account token>
           # * deploys snapshots and releases to Sonatype
-          # * needs access to io.zipkin via OSSRH-16669
-          # * generate via https://oss.sonatype.org/#profile;User%20Token
+          # * needs access to io.zipkin namespace
+          # * generate token at https://central.sonatype.com
           # * referenced in .settings.xml
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           # SONATYPE_PASSWORD=<password to sonatype account token>

--- a/.settings.xml
+++ b/.settings.xml
@@ -15,7 +15,7 @@
       <passphrase>${env.GPG_PASSPHRASE}</passphrase>
     </server>
     <server>
-      <id>ossrh</id>
+      <id>central</id>
       <username>${env.SONATYPE_USER}</username>
       <password>${env.SONATYPE_PASSWORD}</password>
     </server>

--- a/README.md
+++ b/README.md
@@ -215,10 +215,10 @@ Server artifacts are under the maven group id `io.zipkin`
 Library artifacts are under the maven group id `io.zipkin.zipkin2`
 
 ### Library Releases
-Releases are at [Sonatype](https://oss.sonatype.org/content/repositories/releases) and [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.zipkin%22)
+Releases are at [Maven Central](https://central.sonatype.com/search?q=zipkin&namespace=io.zipkin)
 
 ### Library Snapshots
-Snapshots are uploaded to [Sonatype](https://oss.sonatype.org/content/repositories/snapshots) after
+Snapshots are uploaded to [Sonatype](https://central.sonatype.com/repository/maven-snapshots/) after
 commits to master.
 
 ### Docker Images

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ This repo uses semantic versions. Please keep this in mind when choosing version
    which creates commits, `MAJOR.MINOR.PATCH` tag, and increments the version (maven-release-plugin).
 
    The `MAJOR.MINOR.PATCH` tag triggers [`build-bin/deploy`](build-bin/deploy), which does the following:
-     * Publishes jars to https://oss.sonatype.org/content/repositories/releases [`build-bin/maven/maven_deploy`](build-bin/maven/maven_deploy)
+     * Publishes jars to Sonatype [`build-bin/maven/maven_deploy`](build-bin/maven/maven_deploy)
        * Later, the same jars synchronize to Maven Central
      * Publishes Javadoc to https://zipkin.io/brave into a versioned subdirectory
      * Pushes images to Docker registries [`build-bin/docker_push`](build-bin/docker_push)
@@ -39,7 +39,7 @@ look at the notes in [.github/workflows/deploy.yml] and check the [org secrets](
 
 ### Troubleshooting invalid credentials
 
-If you receive a '401 unauthorized' failure from OSSRH, it is likely
+If you receive a '401 unauthorized' failure from Sonatype, it is likely
 `SONATYPE_USER` or `SONATYPE_PASSWORD` entries are invalid, or possibly the
 user associated with them does not have rights to upload.
 

--- a/build-bin/maven/maven_unjar
+++ b/build-bin/maven/maven_unjar
@@ -68,12 +68,6 @@ if ! test -f ${artifact_id}.jar && [ ${is_release} = "true" ]; then
   echo "*** Resolving ${qualified_jar} from Maven default repositories..."
   ${mvn_get} || true
 
-  # Don't add load to Sonatype releases repository except when central sync is delayed
-  if ! test -f ${local_repo_path}; then
-    echo "*** Resolving ${qualified_jar} from Maven Sonatype releases repository..."
-    ${mvn_get} -DremoteRepositories=https://oss.sonatype.org/content/repositories/releases
-  fi
-
   cp ${local_repo_path} ${artifact_id}.jar
 fi
 

--- a/build-bin/mlc_config.json
+++ b/build-bin/mlc_config.json
@@ -7,9 +7,6 @@
       "pattern": "https://stackoverflow.com/questions/tagged/spring-boot"
     },
     {
-      "pattern": "https://oss.sonatype.org/content/repositories/snapshots"
-    },
-    {
       "pattern": "http://localhost:9411/api/v[12]/spans"
     },
     {

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
     <wire-maven-plugin.version>1.3</wire-maven-plugin.version>
   </properties>
 
@@ -151,13 +151,9 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
   </distributionManagement>
 
   <issueManagement>
@@ -288,9 +284,9 @@
         </plugin>
 
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${nexus-staging-maven-plugin.version}</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${central-publishing-maven-plugin.version}</version>
         </plugin>
 
         <plugin>
@@ -679,17 +675,16 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
               <!-- Zipkin release is about ~100M mostly from the two server distributions. Default
                    will timeout after 5 minutes, which can trigger fairly easily with this size. -->
-              <stagingProgressPauseDurationSeconds>20</stagingProgressPauseDurationSeconds>
-              <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <waitMaxTime>30</waitMaxTime>
             </configuration>
           </plugin>
 


### PR DESCRIPTION
OSSRH (oss.sonatype.org) was shut down June 30, 2025. This replaces nexus-staging-maven-plugin with central-publishing-maven-plugin and updates all references accordingly.

Manual steps already completed:
 * Generated token at https://central.sonatype.com account settings
 * Updated SONATYPE_USER/SONATYPE_PASSWORD at https://github.com/organizations/openzipkin/settings/secrets/actions
 * Enabled SNAPSHOTs at https://central.sonatype.com/publishing/namespaces (io.zipkin)