### PR TITLE
Updates Zipkin to run on JRE 25, floor JDK 21

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '17'  # earliest LTS supported by Spring Boot 3
+          java-version: '21'  # Earliest LTS that can compile Zipkin
       - name: Cache local Maven repository
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-jdk-17-maven-
+          key: ${{ runner.os }}-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-21-maven-
       - name: Create Release
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Prevent use of implicit GitHub Actions read-only GITHUB_TOKEN
           # because maven-release-plugin pushes commits to master.
           token: ${{ secrets.GH_TOKEN }}
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
           java-version: '17'  # earliest LTS supported by Spring Boot 3
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,13 +30,13 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '17'  # earliest LTS supported by Spring Boot 3
+          java-version: '21'  # Earliest LTS that can compile Zipkin
       - name: Cache local Maven repository
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-jdk-17-maven-
+          key: ${{ runner.os }}-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-21-maven-
       - name: Cache NPM Packages
         uses: actions/cache@v5
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Prevent use of implicit GitHub Actions read-only GITHUB_TOKEN
           # because javadoc_to_gh_pages pushes commits to the gh-pages branch.
@@ -27,18 +27,18 @@ jobs:
           # See https://github.com/actions/checkout/issues/578
           fetch-depth: 0
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
           java-version: '17'  # earliest LTS supported by Spring Boot 3
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-17-maven-
       - name: Cache NPM Packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           # yamllint disable-line rule:line-length

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04  # newest available distribution, aka noble
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       # Don't attempt to cache Docker. Sensitive information can be stolen
       # via forks, and login session ends up in ~/.docker. This is ok because
       # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Lint
         run: |
           build-bin/configure_lint

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,15 +28,15 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
-      - uses: actions/cache@v4
+        uses: actions/checkout@v6
+      - uses: actions/cache@v5
         name: Cache Trivy Database
         with:
           path: .trivy
           key: ${{ runner.os }}-trivy
           restore-keys: ${{ runner.os }}-trivy
       - name: Run Trivy vulnerability and secret scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         id: trivy
         env:  # See https://github.com/aquasecurity/trivy/discussions/7668
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,24 +32,24 @@ jobs:
         include:
           - java_version: 17  # earliest LTS supported by Spring Boot 3
             maven_args: -Prelease -Dgpg.skip
-          - java_version: 21  # Most recent LTS
+          - java_version: 25  # Most recent LTS
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
           java-version: ${{ matrix.java_version }}
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           # yamllint disable-line rule:line-length
           key: ${{ runner.os }}-jdk-${{ matrix.java_version }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-${{ matrix.java_version }}-maven-
       - name: Cache NPM Packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           # yamllint disable-line rule:line-length
@@ -76,14 +76,14 @@ jobs:
           - name: zipkin-server
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '21'  # Most recent LTS
+          java-version: '25'  # Most recent LTS
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           # yamllint disable-line rule:line-length

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false  # don't fail fast as some failures are LTS specific
       matrix:  # match with maven-enforcer-plugin rules in pom.xml
         include:
-          - java_version: 17  # earliest LTS supported by Spring Boot 3
+          - java_version: 21  # Earliest LTS that can compile Zipkin
             maven_args: -Prelease -Dgpg.skip
           - java_version: 25  # Most recent LTS
     steps:

--- a/.github/workflows/test_readme.yml
+++ b/.github/workflows/test_readme.yml
@@ -38,15 +38,15 @@ jobs:
             os: windows-2022
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '21'  # Most recent LTS
+          java-version: '25'  # Most recent LTS
           cache: 'maven'
       - name: Cache NPM Packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           # yamllint disable-line rule:line-length
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       # Remove apt repos that are known to break from time to time.
       # See https://github.com/actions/virtual-environments/issues/323
       - name: Remove broken apt repos
@@ -72,16 +72,16 @@ jobs:
           do sudo rm $apt_file
           done
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '21'  # Most recent LTS
+          java-version: '25'  # Most recent LTS
           cache: 'maven'
       # Don't attempt to cache Docker. Sensitive information can be stolen
       # via forks, and login session ends up in ~/.docker. This is ok because
       # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Cache NPM Packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           # yamllint disable-line rule:line-length

--- a/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
+++ b/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java
@@ -277,7 +277,7 @@ class ServerIntegratedBenchmark {
 
     final GenericContainer<?> zipkin;
     if (RELEASE_VERSION == null) {
-      zipkin = new GenericContainer<>(parse("ghcr.io/openzipkin/java:21.0.10_p7"));
+      zipkin = new GenericContainer<>(parse("ghcr.io/openzipkin/java:25.0.2_p10"));
       List<String> classpath = new ArrayList<>();
       for (String item : System.getProperty("java.class.path").split(File.pathSeparator)) {
         Path path = Paths.get(item);

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -37,7 +37,7 @@ if [ -n "${DOCKER_TARGET}" ]; then
 fi
 
 # When non-empty, becomes the base layer including tag appropriate for the image being built.
-# e.g. ghcr.io/openzipkin/java:21.0.10_p7-jre
+# e.g. ghcr.io/openzipkin/java:25.0.2_p10-jre
 #
 # This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.12.3
 # See https://docs.docker.com/glossary/#parent-image
@@ -55,7 +55,7 @@ if [ -n "${ALPINE_VERSION}" ]; then
   docker_args="${docker_args} --build-arg alpine_version=${ALPINE_VERSION}"
 fi
 
-# When non-empty, becomes the build-arg java_version. e.g. "21.0.10_p7"
+# When non-empty, becomes the build-arg java_version. e.g. "25.0.2_p10"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/java
 if [ -n "${JAVA_VERSION}" ]; then
   docker_args="${docker_args} --build-arg java_version=${JAVA_VERSION}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=21.0.10_p7
+ARG java_version=25.0.2_p10
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-activemq/Dockerfile
+++ b/docker/test-images/zipkin-activemq/Dockerfile
@@ -8,7 +8,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=21.0.10_p7
+ARG java_version=25.0.2_p10
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-elasticsearch8/Dockerfile
+++ b/docker/test-images/zipkin-elasticsearch8/Dockerfile
@@ -8,7 +8,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=21.0.10_p7
+ARG java_version=25.0.2_p10
 
 FROM ghcr.io/openzipkin/java:${java_version} AS install
 

--- a/docker/test-images/zipkin-eureka/Dockerfile
+++ b/docker/test-images/zipkin-eureka/Dockerfile
@@ -8,7 +8,7 @@
 # Use latest version here: https://github.com/orgs/openeureka/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=21.0.10_p7
+ARG java_version=25.0.2_p10
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-kafka/Dockerfile
+++ b/docker/test-images/zipkin-kafka/Dockerfile
@@ -8,7 +8,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=21.0.10_p7
+ARG java_version=25.0.2_p10
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-opensearch2/Dockerfile
+++ b/docker/test-images/zipkin-opensearch2/Dockerfile
@@ -8,7 +8,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=21.0.10_p7
+ARG java_version=25.0.2_p10
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-opensearch2/Dockerfile
+++ b/docker/test-images/zipkin-opensearch2/Dockerfile
@@ -8,7 +8,7 @@
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=25.0.2_p10
+ARG java_version=21.0.10_p7
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-ui/Dockerfile
+++ b/docker/test-images/zipkin-ui/Dockerfile
@@ -13,7 +13,7 @@ ARG alpine_version=3.23.3
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=21.0.10_p7
+ARG java_version=25.0.2_p10
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/docker/test-images/zipkin-uiproxy/Dockerfile
+++ b/docker/test-images/zipkin-uiproxy/Dockerfile
@@ -13,7 +13,7 @@ ARG alpine_version=3.23.3
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/java
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=21.0.10_p7
+ARG java_version=25.0.2_p10
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/pom.xml
+++ b/pom.xml
@@ -420,13 +420,13 @@
           </execution>
         </executions>
         <configuration>
-          <systemProperties>
+          <systemPropertyVariables>
             <!-- Gives better context when there's an exception such as AbortedStreamException.
                  Set globally as we have failures sometimes in storage-elasticsearch and sometimes
                  in zipkin-server tests (same code used two places).
             -->
             <com.linecorp.armeria.verboseExceptions>always</com.linecorp.armeria.verboseExceptions>
-          </systemProperties>
+          </systemPropertyVariables>
           <!-- workaround to SUREFIRE-1831 -->
           <useModulePath>false</useModulePath>
           <!-- Ensures root cause ends up in the console -->
@@ -448,7 +448,7 @@
                 <requireJavaVersion>
                   <!-- Change this to control LTS JDK versions allowed to build
                        the project. Keep in sync with .github/workflows -->
-                  <version>[17,18),[21,22)</version>
+                  <version>[17,18),[21,22),[25,26)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -462,8 +462,6 @@
         <version>${license-maven-plugin.version}</version>
         <configuration>
           <skip>${license.skip}</skip>
-          <!-- session.executionRootDirectory resolves properly even with nested modules -->
-          <header>${main.basedir}/src/etc/header.txt</header>
           <mapping>
             <!-- Don't use javadoc style as this makes code formatters break it by adding tags! -->
             <java>SLASHSTAR_STYLE</java>
@@ -473,10 +471,13 @@
             <tsx>SLASHSTAR_STYLE</tsx>
             <bnd>SCRIPT_STYLE</bnd>
             <ejs>XML_STYLE</ejs>
+            <conf>SCRIPT_STYLE</conf>
             <css>SLASHSTAR_STYLE</css>
             <!-- build-bin non-trivial scripts -->
             <javadoc_to_gh_pages>SCRIPT_STYLE</javadoc_to_gh_pages>
             <maybe_install_npm>SCRIPT_STYLE</maybe_install_npm>
+            <configure_lint>SCRIPT_STYLE</configure_lint>
+            <lint>SCRIPT_STYLE</lint>
             <!-- build-bin/docker -->
             <docker_block_on_health>SCRIPT_STYLE</docker_block_on_health>
             <configure_docker>SCRIPT_STYLE</configure_docker>
@@ -507,58 +508,69 @@
             <start-kafka-zookeeper>SCRIPT_STYLE</start-kafka-zookeeper>
             <start-mysql>SCRIPT_STYLE</start-mysql>
             <start-nginx>SCRIPT_STYLE</start-nginx>
+            <start-opensearch>SCRIPT_STYLE</start-opensearch>
             <start-zipkin>SCRIPT_STYLE</start-zipkin>
             <!-- docker/**/docker-healthcheck -->
             <docker-healthcheck>SCRIPT_STYLE</docker-healthcheck>
           </mapping>
-          <excludes>
-            <exclude>**/simplelogger.properties</exclude>
-            <exclude>**/continuous-build.yml</exclude>
-            <exclude>**/*.dockerignore</exclude>
-            <exclude>.editorconfig</exclude>
-            <exclude>.gitattributes</exclude>
-            <exclude>.gitignore</exclude>
-            <exclude>.github/**</exclude>
-            <exclude>.mvn/**</exclude>
-            <exclude>mvnw*</exclude>
-            <exclude>etc/header.txt</exclude>
-            <exclude>**/nginx.conf</exclude>
-            <exclude>**/.idea/**</exclude>
-            <exclude>**/node_modules/**</exclude>
-            <exclude>**/build/**</exclude>
-            <exclude>**/dist/**</exclude>
-            <exclude>**/coverage/**</exclude>
-            <exclude>**/.babelrc</exclude>
-            <exclude>**/.bowerrc</exclude>
-            <exclude>**/.editorconfig</exclude>
-            <exclude>**/.env.development</exclude>
-            <exclude>**/.eslintignore</exclude>
-            <exclude>**/.eslintrc</exclude>
-            <exclude>**/.eslintrc</exclude>
-            <exclude>**/.eslintrc.js</exclude>
-            <exclude>**/.linguirc</exclude>
-            <exclude>**/testdata/**/*.json</exclude>
-            <exclude>**/test/data/**/*.json</exclude>
-            <exclude>**/src/translations/**</exclude>
-            <exclude>LICENSE</exclude>
-            <exclude>**/*.md</exclude>
-            <exclude>**/*.bnd</exclude>
-            <exclude>**/src/main/resources/zipkin.txt</exclude>
-            <exclude>**/src/main/resources/*.yml</exclude>
-            <exclude>**/spring.factories</exclude>
-            <!-- Cassandra integration tests break when license headers are present -->
-            <exclude>**/src/main/resources/*.cql</exclude>
-            <exclude>kafka_*/**</exclude>
-            <exclude>**/nohup.out</exclude>
-            <exclude>src/test/resources/**</exclude>
-            <exclude>**/generated/**</exclude>
-            <exclude>.dockerignore</exclude>
-            <!-- trivial build-bin scripts -->
-            <exclude>build-bin/configure_deploy</exclude>
-            <exclude>build-bin/configure_test</exclude>
-            <exclude>build-bin/deploy</exclude>
-            <exclude>build-bin/test</exclude>
-          </excludes>
+          <licenseSets>
+            <licenseSet>
+              <!-- session.executionRootDirectory resolves properly even with nested modules -->
+              <header>${main.basedir}/src/etc/header.txt</header>
+              <excludes>
+                <exclude>**/simplelogger.properties</exclude>
+                <exclude>**/continuous-build.yml</exclude>
+                <exclude>**/*.dockerignore</exclude>
+                <exclude>.editorconfig</exclude>
+                <exclude>.gitattributes</exclude>
+                <exclude>.gitignore</exclude>
+                <exclude>.github/**</exclude>
+                <exclude>.mvn/**</exclude>
+                <exclude>mvnw*</exclude>
+                <exclude>etc/header.txt</exclude>
+                <exclude>**/nginx.conf</exclude>
+                <exclude>**/.idea/**</exclude>
+                <exclude>**/node_modules/**</exclude>
+                <exclude>**/build/**</exclude>
+                <exclude>**/dist/**</exclude>
+                <exclude>**/coverage/**</exclude>
+                <exclude>**/.babelrc</exclude>
+                <exclude>**/.bowerrc</exclude>
+                <exclude>**/.editorconfig</exclude>
+                <exclude>**/.env.development</exclude>
+                <exclude>**/.eslintignore</exclude>
+                <exclude>**/.eslintrc</exclude>
+                <exclude>**/.eslintrc</exclude>
+                <exclude>**/.eslintrc.js</exclude>
+                <exclude>**/.linguirc</exclude>
+                <exclude>**/testdata/**/*.json</exclude>
+                <exclude>**/test/data/**/*.json</exclude>
+                <exclude>**/src/translations/**</exclude>
+                <exclude>LICENSE</exclude>
+                <exclude>**/*.md</exclude>
+                <exclude>**/*.bnd</exclude>
+                <exclude>**/src/main/resources/zipkin.txt</exclude>
+                <exclude>**/src/main/resources/*.yml</exclude>
+                <exclude>**/spring.factories</exclude>
+                <!-- Cassandra integration tests break when license headers are present -->
+                <exclude>**/src/main/resources/*.cql</exclude>
+                <exclude>kafka_*/**</exclude>
+                <exclude>**/nohup.out</exclude>
+                <exclude>src/test/resources/**</exclude>
+                <exclude>**/generated/**</exclude>
+                <exclude>.dockerignore</exclude>
+                <!-- config files without code -->
+                <exclude>**/*.conf</exclude>
+                <!-- trivial build-bin scripts -->
+                <exclude>build-bin/configure_deploy</exclude>
+                <exclude>build-bin/configure_lint</exclude>
+                <exclude>build-bin/configure_test</exclude>
+                <exclude>build-bin/deploy</exclude>
+                <exclude>build-bin/lint</exclude>
+                <exclude>build-bin/test</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
           <strictCheck>true</strictCheck>
         </configuration>
         <dependencies>
@@ -610,7 +622,7 @@
       <id>error-prone-17+</id>
       <activation>
         <!-- Only LTS versions that work with errorprone -->
-        <jdk>[17,18),[21,22)</jdk>
+        <jdk>[17,18),[21,22),[25,26)</jdk>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.42.0</errorprone.version>
+    <errorprone.version>2.48.0</errorprone.version>
 
     <zipkin-proto3.version>1.0.0</zipkin-proto3.version>
 
@@ -448,7 +448,7 @@
                 <requireJavaVersion>
                   <!-- Change this to control LTS JDK versions allowed to build
                        the project. Keep in sync with .github/workflows -->
-                  <version>[17,18),[21,22),[25,26)</version>
+                  <version>[21,22),[25,26)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -619,10 +619,10 @@
     </profile>
 
     <profile>
-      <id>error-prone-17+</id>
+      <id>error-prone-21+</id>
       <activation>
         <!-- Only LTS versions that work with errorprone -->
-        <jdk>[17,18),[21,22),[25,26)</jdk>
+        <jdk>[21,22),[25,26)</jdk>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,49 @@
             <fork>true</fork>
             <showWarnings>true</showWarnings>
           </configuration>
+          <executions>
+            <execution>
+              <!-- only use errorprone on main source tree -->
+              <id>default-compile</id>
+              <phase>compile</phase>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+              <configuration>
+                <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                <compilerArgs>
+                  <arg>-XDcompilePolicy=simple</arg>
+                  <arg>--should-stop=ifError=FLOW</arg>
+                  <arg>-Xplugin:ErrorProne ${errorprone.args}</arg>
+                  <!-- below needed per https://errorprone.info/docs/installation -->
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                </compilerArgs>
+                <annotationProcessorPaths>
+                  <processorPath>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_core</artifactId>
+                    <version>${errorprone.version}</version>
+                  </processorPath>
+                  <!-- auto-value is placed here even though not needed for all projects as
+                       configuring along with errorprone is tricky in subprojects -->
+                  <processorPath>
+                    <groupId>com.google.auto.value</groupId>
+                    <artifactId>auto-value</artifactId>
+                    <version>${auto-value.version}</version>
+                  </processorPath>
+                </annotationProcessorPaths>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- Uploads occur as a last step (which also adds checksums) -->
@@ -616,66 +659,6 @@
       <modules>
         <module>benchmarks</module>
       </modules>
-    </profile>
-
-    <profile>
-      <id>error-prone</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>${maven-compiler-plugin.version}</version>
-            <inherited>true</inherited>
-            <configuration>
-              <fork>true</fork>
-              <showWarnings>true</showWarnings>
-            </configuration>
-            <executions>
-              <execution>
-                <!-- only use errorprone on main source tree -->
-                <id>default-compile</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>compile</goal>
-                </goals>
-                <configuration>
-                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                  <compilerArgs>
-                    <arg>-XDcompilePolicy=simple</arg>
-                    <arg>--should-stop=ifError=FLOW</arg>
-                    <arg>-Xplugin:ErrorProne ${errorprone.args}</arg>
-                    <!-- below needed per https://errorprone.info/docs/installation -->
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                  </compilerArgs>
-                  <annotationProcessorPaths>
-                    <processorPath>
-                      <groupId>com.google.errorprone</groupId>
-                      <artifactId>error_prone_core</artifactId>
-                      <version>${errorprone.version}</version>
-                    </processorPath>
-                    <!-- auto-value is placed here eventhough not needed for all projects as
-                         configuring along with errorprone is tricky in subprojects -->
-                    <processorPath>
-                      <groupId>com.google.auto.value</groupId>
-                      <artifactId>auto-value</artifactId>
-                      <version>${auto-value.version}</version>
-                    </processorPath>
-                  </annotationProcessorPaths>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -619,11 +619,7 @@
     </profile>
 
     <profile>
-      <id>error-prone-21+</id>
-      <activation>
-        <!-- Only LTS versions that work with errorprone -->
-        <jdk>[21,22),[25,26)</jdk>
-      </activation>
+      <id>error-prone</id>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,7 @@
                   <arg>-XDcompilePolicy=simple</arg>
                   <arg>--should-stop=ifError=FLOW</arg>
                   <arg>-Xplugin:ErrorProne ${errorprone.args}</arg>
+                  <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
                   <!-- below needed per https://errorprone.info/docs/installation -->
                   <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                   <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>


### PR DESCRIPTION
JDK 25 can still compile down to Java 8 so we don't need anything special here.

This also updates all test images we can to run on 25, except those who use SecurityManager:
* Elasticsearch (all versions) and OpenSearch
* Cassandra 4.x (we don't use 5.x and figuring that out is out of scope)

** This repo floor is bytecode 8: brave and zipkin-reporter-java are the only ones IIRC that must compile bytecode 1.6