### PR TITLE
Bump armeria to 1.38.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <zipkin-proto3.version>1.0.0</zipkin-proto3.version>
 
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
-    <armeria.version>1.37.0</armeria.version>
+    <armeria.version>1.38.0</armeria.version>
     <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
     <netty.version>4.2.12.Final</netty.version>
 


### PR DESCRIPTION
This solves an issue when http compression is enabled for opensearch/elasticsearch, where armeria would not recognize the response `content-encoding` header thus failing to decompress the message.

Closes #3796